### PR TITLE
fixed large posts making web complex tappable *everywhere*

### DIFF
--- a/Mlem/Views/Shared/Cached Image With Nsfw Filter.swift
+++ b/Mlem/Views/Shared/Cached Image With Nsfw Filter.swift
@@ -35,6 +35,7 @@ struct CachedImageWithNsfwFilter: View {
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                     .overlay(RoundedRectangle(cornerRadius: 8)
                         .stroke(Color(UIColor.secondarySystemBackground), lineWidth: 1))
+                    .allowsHitTesting(false)
             } placeholder: {
                 ProgressView()
             }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - fixed #168

# Pull Request Information

## About this Pull Request
Disabled hit detection on image in CachedImageWithNsfwFilter. Something about the ZStack (I think) was causing the hit bounds detection to ignore clipping. Tapping anywhere on the image still works because the onTapGesture applies to the parent view.
