### PR TITLE
fix #199 - ensure access token is not written to insecure disk location

### DIFF
--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -8,11 +8,17 @@
 import Foundation
 
 struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
-    var id: Int
-
+    let id: Int
     let instanceLink: URL
-
-    var accessToken: String
-
+    let accessToken: String
     let username: String
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.instanceLink, forKey: .instanceLink)
+        try container.encode("redacted", forKey: .accessToken)
+        try container.encode(self.username, forKey: .username)
+    }
 }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #199
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This addresses the concern raised in #199

As we're now storing the access token in the keychain (and retrieving it during start-up) we should not be storing it in JSON. This change ensures we write `"redacted"` into the file on disk instead of the real token.

## Additional context

The way we read/write to disk at start-up could do with some TLC, but for now this addresses the immediate concern.