### PR TITLE
- fixed Search doesn't handle in-app link resolution

### DIFF
--- a/Mlem/Views/Tabs/Search/Search View.swift
+++ b/Mlem/Views/Tabs/Search/Search View.swift
@@ -38,6 +38,7 @@ struct SearchView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationTitle("Search")
         }
+        .handleLemmyLinkResolution(navigationPath: $navigationPath)
         .searchable(text: getSearchTextBinding(), prompt: "Search for communities")
         .onSubmit(of: .search) {
             performSearch()


### PR DESCRIPTION

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains

# Pull Request Information
The new search tab is awesome but the in-app link handling was a bit forgotten!

Now when you press a Lemmy link while in the search tab the link will open in app

## About this Pull Request
**Describe what this PR contains in as much detail as possible**

## Screenshots and Videos
**In case this PR changes something in the UI, please include screenshots or videos of this new feature**

## Additional Context
**Any additional context you'd like to add to help us review this PR**
