### PR TITLE
- made deep-linking handling for community links much much more reliable

### DIFF
--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -161,11 +161,12 @@ struct HandleLemmyLinkResolution: ViewModifier {
                     defer { appState.isShowingToast = false }
                     var lookup = url.absoluteString
                     lookup = lookup.replacingOccurrences(of: "mlem://", with: "https://")
-                    if !lookup.contains("http") {
-                        // something fishy is going on. I think the markdown view is playing with us!
-                        if lookup.contains("@") && !lookup.contains("!") {
-                            lookup = "!\(lookup)".replacingOccurrences(of: "/c/", with: "").replacingOccurrences(of: "mailto:", with: "")
-                        }
+                    if lookup.contains("@") && !lookup.contains("!") {
+                        // SUS I think this might be a community link
+                        let processedLookup = lookup
+                            .replacing(/.*\/c\//, with: "")
+                            .replacingOccurrences(of: "mailto:", with: "")
+                        lookup = "!\(processedLookup)"
                     }
 
                     print("lookup: \(lookup) (original: \(url.absoluteString))")


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #24 
- [ ] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information
Made a few changes to the way I'm handling community links to clean them out more before we try resolving them,
this fixed the example page from the issue failing to open the community in app:

https://lemmy.guide/link?target=!programmer_humor@programming.dev

https://lemmy.guide/link?target=!liftoff@lemmy.world

This is mostly a temp patch to a system that needs some real work, I think this patch would cover most real-world cases until we have time to really look into the federated way of handling links (plus I really want the example links working, it feel unprofessional to leave them broken 🤣 )

