### PR TITLE
Refresh token flow (and bonus switch accounts)

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		507573982A5AD60100AA7ABD /* ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507573972A5AD60100AA7ABD /* ErrorAlert.swift */; };
 		508845CF2A3641160088E483 /* JSONDecoder+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508845CE2A3641160088E483 /* JSONDecoder+Default.swift */; };
 		50EC39B22A346DDC00E014C2 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EC39B12A346DDC00E014C2 /* URLHandler.swift */; };
+		50F2851C2A5C5C1500CF8865 /* TokenRefreshView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F2851B2A5C5C1500CF8865 /* TokenRefreshView.swift */; };
 		50F830F82A4C92BF00D67099 /* FeedTrackerItemProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F830F72A4C92BF00D67099 /* FeedTrackerItemProviding.swift */; };
 		50F830FA2A4C935C00D67099 /* FeedTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F830F92A4C935C00D67099 /* FeedTracker.swift */; };
 		630737892A1CD1E900039852 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630737882A1CD1E900039852 /* String.swift */; };
@@ -322,6 +323,7 @@
 		507573972A5AD60100AA7ABD /* ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlert.swift; sourceTree = "<group>"; };
 		508845CE2A3641160088E483 /* JSONDecoder+Default.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+Default.swift"; sourceTree = "<group>"; };
 		50EC39B12A346DDC00E014C2 /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
+		50F2851B2A5C5C1500CF8865 /* TokenRefreshView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRefreshView.swift; sourceTree = "<group>"; };
 		50F830F72A4C92BF00D67099 /* FeedTrackerItemProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedTrackerItemProviding.swift; sourceTree = "<group>"; };
 		50F830F92A4C935C00D67099 /* FeedTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedTracker.swift; sourceTree = "<group>"; };
 		630737882A1CD1E900039852 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
@@ -1261,6 +1263,7 @@
 				03BAA2392A57DC1400D48252 /* TimestampView.swift */,
 				6374570F2A18CB6600B69C03 /* Custom Text Field.swift */,
 				B11D72822A49FAA7009DC22F /* Cached Image With Nsfw Filter.swift */,
+				50F2851B2A5C5C1500CF8865 /* TokenRefreshView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1740,6 +1743,7 @@
 				6318EDC727EE4E1500BFCAE8 /* Post.swift in Sources */,
 				6372186C2A3A2AAD008C4816 /* SaveComment.swift in Sources */,
 				6DD8677A2A5083A200BEB00F /* Community Sidebar Link.swift in Sources */,
+				50F2851C2A5C5C1500CF8865 /* TokenRefreshView.swift in Sources */,
 				507573962A5AD5CF00AA7ABD /* ContextualError.swift in Sources */,
 				63F0C7AF2A05256C00A18C5D /* Decode Data from File.swift in Sources */,
 				CD3FBCE92A4B482700B2063F /* Generic Merge.swift in Sources */,

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "c3864b8882bc69f5edfe5c70e18786c91d228b28",
-        "version" : "12.1.3"
+        "revision" : "f67266f176af4add9f7a7020486826d82d562473",
+        "version" : "12.1.2"
       }
     },
     {

--- a/Mlem/App State.swift
+++ b/Mlem/App State.swift
@@ -11,20 +11,9 @@ import AlertToast
 
 class AppState: ObservableObject {
 
-    @Published var currentActiveAccount: SavedAccount? {
-        didSet {
-            if let newAccount = currentActiveAccount {
-                Task {
-                    let request = GetSiteRequest(account: newAccount)
-                    if let response = try? await APIClient().perform(request: request) {
-                        await MainActor.run {
-                            enableDownvote = response.siteView.localSite.enableDownvotes
-                        }
-                    }
-                }
-            }
-        }
-    }
+    @AppStorage("defaultAccountId") var defaultAccountId: Int?
+    @Binding private var selectedAccount: SavedAccount?
+    @Published private(set) var currentActiveAccount: SavedAccount
     
     @Published var contextualError: ContextualError?
     
@@ -33,4 +22,43 @@ class AppState: ObservableObject {
     @Published var toast: AlertToast?
 
     @Published var enableDownvote: Bool = true
+    
+    /// Initialises our app state
+    /// - Parameters:
+    ///   - defaultAccount: The account the application should start with
+    ///   - selectedAccount: A `Binding` to the selected account at the `Window` level
+    init(defaultAccount: SavedAccount, selectedAccount: Binding<SavedAccount?>) {
+        _selectedAccount = selectedAccount
+        self.currentActiveAccount = defaultAccount
+        accountUpdated()
+    }
+    
+    func setActiveAccount(_ account: SavedAccount) {
+        // update our stored token and set the account...
+        AppConstants.keychain["\(account.id)_accessToken"] = account.accessToken
+        self.currentActiveAccount = account
+        defaultAccountId = currentActiveAccount.id
+
+        // if the account we just set is not the existing one from the session
+        // then the user is switching accounts, so we pass the value up to the
+        // `Window` layer which will re-create our `ContentView` and the new
+        // account will restart on the feed page with a clean slate
+        if account.id != selectedAccount?.id {
+            self.selectedAccount = account
+            return
+        }
+        
+        accountUpdated()
+    }
+    
+    private func accountUpdated() {
+        Task {
+            let request = GetSiteRequest(account: currentActiveAccount)
+            if let response = try? await APIClient().perform(request: request) {
+                await MainActor.run {
+                    enableDownvote = response.siteView.localSite.enableDownvotes
+                }
+            }
+        }
+    }
 }

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -26,39 +26,31 @@ struct ContentView: View {
                     Label("Feeds", systemImage: "scroll")
                         .environment(\.symbolVariants, tabSelection == 1 ? .fill : .none)
                 }.tag(1)
-
-            if let currentActiveAccount = appState.currentActiveAccount {
-                InboxView(account: currentActiveAccount)
-                    .tabItem {
-                        Label("Inbox", systemImage: "mail.stack")
-                            .environment(\.symbolVariants, tabSelection == 2 ? .fill : .none)
-                    }.tag(2)
-
-                NavigationView {
-                    ProfileView(account: currentActiveAccount)
-                } .tabItem {
-                    Label(computeUsername(account: currentActiveAccount), systemImage: "person.circle")
-                        .environment(\.symbolVariants, tabSelection == 3 ? .fill : .none)
-                }.tag(3)
-                
-                NavigationView {
-                    SearchView(account: currentActiveAccount)
-                } .tabItem {
-                    Label("Search", systemImage: tabSelection == 4 ? "text.magnifyingglass" : "magnifyingglass")
-                }.tag(4)
-            }
+            
+            InboxView()
+                .tabItem {
+                    Label("Inbox", systemImage: "mail.stack")
+                        .environment(\.symbolVariants, tabSelection == 2 ? .fill : .none)
+                }.tag(2)
+            
+            NavigationView {
+                ProfileView(userID: appState.currentActiveAccount.id)
+            } .tabItem {
+                Label(computeUsername(account: appState.currentActiveAccount), systemImage: "person.circle")
+                    .environment(\.symbolVariants, tabSelection == 3 ? .fill : .none)
+            }.tag(3)
+            
+            NavigationView {
+                SearchView()
+            } .tabItem {
+                Label("Search", systemImage: tabSelection == 4 ? "text.magnifyingglass" : "magnifyingglass")
+            }.tag(4)
 
             SettingsView()
                 .tabItem {
                     Label("Settings", systemImage: "gear")
-                        .environment(\.symbolVariants, tabSelection == 4 ? .fill : .none)
+                        .environment(\.symbolVariants, tabSelection == 5 ? .fill : .none)
                 }.tag(5)
-        }
-        .onAppear {
-            if appState.currentActiveAccount == nil,
-               let account = accountsTracker.savedAccounts.first {
-                appState.currentActiveAccount = account
-            }
         }
         .onChange(of: appState.contextualError) { handle($0) }
         .alert(using: $errorAlert) { content in
@@ -73,7 +65,7 @@ struct ContentView: View {
         }
         .sheet(item: $expiredSessionAccount) { account in
             TokenRefreshView(account: account) { updatedAccount in
-                appState.currentActiveAccount = updatedAccount
+                appState.setActiveAccount(updatedAccount)
             }
         }
         .environment(\.openURL, OpenURLAction(handler: didReceiveURL))

--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -17,119 +17,68 @@ struct HandleLemmyLinksDisplay: ViewModifier {
 
     // swiftlint:disable function_body_length
     func body(content: Content) -> some View {
-        let account = appState.currentActiveAccount ?? savedAccounts.savedAccounts.first
-        return content
+        content
             .navigationDestination(for: APICommunityView.self) { context in
-                if let account = account {
-                    CommunityView(account: account, community: context.community, feedType: .all)
-                        .environmentObject(appState)
-                        .environmentObject(filtersTracker)
-                        .environmentObject(CommunitySearchResultsTracker())
-                        .environmentObject(favoriteCommunitiesTracker)
-                } else {
-                    Text("You must be signed in to view this community")
-                }
-            }
-            .navigationDestination(for: APICommunity.self) { community in
-                if let account = account {
-                    CommunityView(account: account, community: community, feedType: .all)
-                        .environmentObject(appState)
-                        .environmentObject(filtersTracker)
-                        .environmentObject(CommunitySearchResultsTracker())
-                        .environmentObject(favoriteCommunitiesTracker)
-                } else {
-                    Text("You must be signed in to view this community")
-                }
-            }
-            .navigationDestination(for: CommunityLinkWithContext.self) { context in
-                if let account = account {
-                    CommunityView(account: account, community: context.community, feedType: context.feedType)
-                        .environmentObject(appState)
-                        .environmentObject(filtersTracker)
-                        .environmentObject(CommunitySearchResultsTracker())
-                        .environmentObject(favoriteCommunitiesTracker)
-                } else {
-                    Text("You must be signed in to view this community")
-                }
-            }
-            .navigationDestination(for: CommunitySidebarLinkWithContext.self) { context in
-                if let account = account {
-                    CommunitySidebarView(
-                        account: account,
-                        community: context.community,
-                        communityDetails: context.communityDetails)
+                CommunityView(community: context.community, feedType: .all)
                     .environmentObject(appState)
                     .environmentObject(filtersTracker)
                     .environmentObject(CommunitySearchResultsTracker())
                     .environmentObject(favoriteCommunitiesTracker)
-                } else {
-                    Text("You must be signed in to view this community")
-                }
+            }
+            .navigationDestination(for: APICommunity.self) { community in
+                CommunityView(community: community, feedType: .all)
+                    .environmentObject(appState)
+                    .environmentObject(filtersTracker)
+                    .environmentObject(CommunitySearchResultsTracker())
+                    .environmentObject(favoriteCommunitiesTracker)
+            }
+            .navigationDestination(for: CommunityLinkWithContext.self) { context in
+                CommunityView(community: context.community, feedType: context.feedType)
+                    .environmentObject(appState)
+                    .environmentObject(filtersTracker)
+                    .environmentObject(CommunitySearchResultsTracker())
+                    .environmentObject(favoriteCommunitiesTracker)
+            }
+            .navigationDestination(for: CommunitySidebarLinkWithContext.self) { context in
+                CommunitySidebarView(
+                    community: context.community,
+                    communityDetails: context.communityDetails)
+                .environmentObject(appState)
+                .environmentObject(filtersTracker)
+                .environmentObject(CommunitySearchResultsTracker())
+                .environmentObject(favoriteCommunitiesTracker)
             }
             .navigationDestination(for: APIPostView.self) { post in
-                if let account = account {
-                    ExpandedPost(
-                        account: account,
-                        post: post
-                    )
-                    .environmentObject(
-                        PostTracker(shouldPerformMergeSorting: false, initialItems: [post])
-                    )
-                    .environmentObject(appState)
-                } else {
-                    Text("You must be signed in to view this post")
-                }
+                ExpandedPost(
+                    post: post,
+                    feedType: .constant(.all)
+                )
+                .environmentObject(
+                    PostTracker(shouldPerformMergeSorting: false, initialItems: [post])
+                )
+                .environmentObject(appState)
             }
             .navigationDestination(for: APIPost.self) { post in
-                if let account = account {
-                    LazyLoadExpandedPost(
-                        account: account,
-                        post: post
-                    )
+                LazyLoadExpandedPost(post: post)
                     .environmentObject(appState)
-                } else {
-                    Text("You must be signed in to view this post")
-                }
             }
             .navigationDestination(for: PostLinkWithContext.self) { post in
-                if let account = account {
-                    ExpandedPost(
-                        account: account,
-                        post: post.post
-                    )
-                        .environmentObject(post.postTracker)
-                        .environmentObject(appState)
-                } else {
-                    Text("You must be signed in to view this post")
-                }
-            }
-            .navigationDestination(for: LazyLoadPostLinkWithContext.self) { post in
-                if let account = account {
-                    LazyLoadExpandedPost(
-                        account: account,
-                        post: post.post
-                    )
+                ExpandedPost(post: post.post, feedType: post.feedType)
                     .environmentObject(post.postTracker)
                     .environmentObject(appState)
-                } else {
-                    Text("You must be signed in to view this post")
-                }
+            }
+            .navigationDestination(for: LazyLoadPostLinkWithContext.self) { post in
+                LazyLoadExpandedPost(post: post.post)
+                    .environmentObject(post.postTracker)
+                    .environmentObject(appState)
             }
             .navigationDestination(for: APIPerson.self) { user in
-                if let account = account {
-                    UserView(userID: user.id, account: account)
-                        .environmentObject(appState)
-                } else {
-                    Text("You must be signed in to view this user")
-                }
+                UserView(userID: user.id)
+                    .environmentObject(appState)
             }
             .navigationDestination(for: UserModeratorLink.self) { user in
-                if let account = account {
-                    UserModeratorView(account: account, userDetails: user.user, moderatedCommunities: user.moderatedCommunities)
-                        .environmentObject(appState)
-                } else {
-                    Text("You must be signed in to view this user")
-                }
+                UserModeratorView(userDetails: user.user, moderatedCommunities: user.moderatedCommunities)
+                    .environmentObject(appState)
             }
     }
     // swiftlint:enable function_body_length
@@ -147,69 +96,66 @@ struct HandleLemmyLinkResolution: ViewModifier {
 
     @MainActor
     func didReceiveURL(_ url: URL) -> OpenURLAction.Result {
-        let account = appState.currentActiveAccount ?? savedAccounts.savedAccounts.first
+        let account = appState.currentActiveAccount
         // let's try keep peps in the app!
-        if let account = account {
-            if url.absoluteString.contains(["lem", "/c/", "/u/", "/post/", "@"]) {
-                // this link is sus! let's go
-                // but first let's let the user know what's happning!
-                appState.toast = AlertToast(displayMode: .hud, type: .loading, title: "Redirecting... please wait")
-                appState.isShowingToast = true
-                Task(priority: .userInitiated) {
-                    defer { appState.isShowingToast = false }
-                    var lookup = url.absoluteString
-                    lookup = lookup.replacingOccurrences(of: "mlem://", with: "https://")
-                    if lookup.contains("@") && !lookup.contains("!") {
-                        // SUS I think this might be a community link
-                        let processedLookup = lookup
-                            .replacing(/.*\/c\//, with: "")
-                            .replacingOccurrences(of: "mailto:", with: "")
-                        lookup = "!\(processedLookup)"
+        if url.absoluteString.contains(["lem", "/c/", "/u/", "/post/", "@"]) {
+            // this link is sus! let's go
+            // but first let's let the user know what's happning!
+            appState.toast = AlertToast(displayMode: .hud, type: .loading, title: "Redirecting... please wait")
+            appState.isShowingToast = true
+            Task(priority: .userInitiated) {
+                defer { appState.isShowingToast = false }
+                var lookup = url.absoluteString
+                lookup = lookup.replacingOccurrences(of: "mlem://", with: "https://")
+                if lookup.contains("@") && !lookup.contains("!") {
+                    // SUS I think this might be a community link
+                    let processedLookup = lookup
+                        .replacing(/.*\/c\//, with: "")
+                        .replacingOccurrences(of: "mailto:", with: "")
+                    lookup = "!\(processedLookup)"
+                }
+                
+                print("lookup: \(lookup) (original: \(url.absoluteString))")
+                // Wooo this is a lemmy server we're talking to! time to pasre this url and push it to the stack
+                do {
+                    let resolution = try await APIClient().perform(request: ResolveObjectRequest(account: account, query: lookup))
+                    
+                    // this is gonna be a bit of an ugly if switch but oh well for now
+                    if let post = resolution.post {
+                        // wop wop that was a post link!
+                        return navigationPath.wrappedValue.append(post)
+                    } else if let community = resolution.community {
+                        return navigationPath.wrappedValue.append(community)
+                    } else if let user = resolution.person?.person {
+                        return navigationPath.wrappedValue.append(user)
                     }
-
-                    print("lookup: \(lookup) (original: \(url.absoluteString))")
-                    // Wooo this is a lemmy server we're talking to! time to pasre this url and push it to the stack
-                    do {
-                        let resolution = try await APIClient().perform(request: ResolveObjectRequest(account: account, query: lookup))
-
-                        // this is gonna be a bit of an ugly if switch but oh well for now
-                        if let post = resolution.post {
-                            // wop wop that was a post link!
-                            return navigationPath.wrappedValue.append(post)
-                        } else if let community = resolution.community {
-                            return navigationPath.wrappedValue.append(community)
-                        } else if let user = resolution.person?.person {
-                            return navigationPath.wrappedValue.append(user)
+                    // else if let d = resolution.comment {
+                    // hmm I don't think we can do that right now!
+                    // so I'll skip and let the system open it instead
+                    // }
+                } catch {
+                    appState.contextualError = .init(underlyingError: error)
+                }
+                
+                // if all else fails fallback!
+                let outcome = URLHandler.handle(url)
+                if outcome.action != nil {
+                    if url.scheme == "mlem" {
+                        // if we got here then someone intentionally wanted to open this in mlem but now we need to tell him we have no idea how to open it
+                        DispatchQueue.main.asyncAfter(deadline: .now()) {
+                            appState.toast = AlertToast(displayMode: .hud, type: .error(.red), title: "Couldn't resolve link")
+                            appState.isShowingToast = true
                         }
-                        // else if let d = resolution.comment {
-                            // hmm I don't think we can do that right now!
-                            // so I'll skip and let the system open it instead
-                        // }
-                    } catch {
-                        appState.contextualError = .init(underlyingError: error)
-                    }
-
-                    // if all else fails fallback!
-                    let outcome = URLHandler.handle(url)
-                    if outcome.action != nil {
-                        if url.scheme == "mlem" {
-                            // if we got here then someone intentionally wanted to open this in mlem but now we need to tell him we have no idea how to open it
-                            DispatchQueue.main.asyncAfter(deadline: .now()) {
-                                appState.toast = AlertToast(displayMode: .hud, type: .error(.red), title: "Couldn't resolve link")
-                                appState.isShowingToast = true
-                            }
-                        } else {
-                            // if we failed to open it let the system try!
-                            OpenURLAction(handler: { _ in .systemAction }).callAsFunction(url)
-                        }
+                    } else {
+                        // if we failed to open it let the system try!
+                        OpenURLAction(handler: { _ in .systemAction }).callAsFunction(url)
                     }
                 }
-                // since this is a sus link we need to ask the lemmy servers about it, so for now we ask the system to forget-'bout-itt
-                return .discarded
             }
-
+            // since this is a sus link we need to ask the lemmy servers about it, so for now we ask the system to forget-'bout-itt
+            return .discarded
         }
-
+        
         let outcome = URLHandler.handle(url)
         return outcome.result
     }

--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -49,10 +49,7 @@ struct HandleLemmyLinksDisplay: ViewModifier {
                 .environmentObject(favoriteCommunitiesTracker)
             }
             .navigationDestination(for: APIPostView.self) { post in
-                ExpandedPost(
-                    post: post,
-                    feedType: .constant(.all)
-                )
+                ExpandedPost(post: post)
                 .environmentObject(
                     PostTracker(shouldPerformMergeSorting: false, initialItems: [post])
                 )
@@ -63,7 +60,7 @@ struct HandleLemmyLinksDisplay: ViewModifier {
                     .environmentObject(appState)
             }
             .navigationDestination(for: PostLinkWithContext.self) { post in
-                ExpandedPost(post: post.post, feedType: post.feedType)
+                ExpandedPost(post: post.post)
                     .environmentObject(post.postTracker)
                     .environmentObject(appState)
             }

--- a/Mlem/Logic/Networking/Get Community Details.swift
+++ b/Mlem/Logic/Networking/Get Community Details.swift
@@ -9,8 +9,7 @@ import Foundation
 
 func loadCommunityDetails(
     community: APICommunity,
-    account: SavedAccount,
-    appState: AppState
+    account: SavedAccount
 ) async throws -> GetCommunityResponse {
     do {
         let request = GetCommunityRequest(account: account, communityId: community.id)

--- a/Mlem/Logic/Remove Community from Favorites.swift
+++ b/Mlem/Logic/Remove Community from Favorites.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-func unfavoriteCommunity(account: SavedAccount, community: APICommunity, favoritedCommunitiesTracker: FavoriteCommunitiesTracker) {
+func unfavoriteCommunity(community: APICommunity, favoritedCommunitiesTracker: FavoriteCommunitiesTracker) {
     favoritedCommunitiesTracker.favoriteCommunities.removeAll(where: { $0.community.id == community.id })
 }

--- a/Mlem/MlemApp.swift
+++ b/Mlem/MlemApp.swift
@@ -19,7 +19,7 @@ struct MlemApp: App {
 
     var body: some Scene {
         WindowGroup {
-            Window()
+            Window(selectedAccount: accountsTracker.defaultAccount)
                 .environmentObject(accountsTracker)
                 .onAppear {
                     var imageConfig = ImagePipeline.Configuration.withDataCache(name: "main", sizeLimit: AppConstants.cacheSize)

--- a/Mlem/Models/ReplyTos/ReplyToCommentReply.swift
+++ b/Mlem/Models/ReplyTos/ReplyToCommentReply.swift
@@ -10,12 +10,10 @@ import SwiftUI
 
 struct ReplyToCommentReply: ReplyTo {
     let commentReply: APICommentReplyView
-    let account: SavedAccount
     let appState: AppState
     
     func embeddedView() -> AnyView {
-        return AnyView(InboxReplyView(account: account,
-                                      reply: commentReply,
+        return AnyView(InboxReplyView(reply: commentReply,
                                       menuFunctions: [])
             .padding(.horizontal))
     }
@@ -24,7 +22,7 @@ struct ReplyToCommentReply: ReplyTo {
         try await postCommentWithoutTracker(postId: commentReply.post.id,
                                             commentId: commentReply.comment.id,
                                             commentContents: commentContents,
-                                            account: account,
+                                            account: appState.currentActiveAccount,
                                             appState: appState)
     }
 }

--- a/Mlem/Models/ReplyTos/ReplyToFeedPost.swift
+++ b/Mlem/Models/ReplyTos/ReplyToFeedPost.swift
@@ -9,9 +9,10 @@ import Foundation
 import SwiftUI
 
 struct ReplyToFeedPost: ReplyTo {
+    
+    @EnvironmentObject var appState: AppState
+    
     let post: APIPostView
-    let account: SavedAccount
-    let appState: AppState
     
     func embeddedView() -> AnyView {
         return AnyView(LargePost(postView: post, isExpanded: true)
@@ -23,7 +24,7 @@ struct ReplyToFeedPost: ReplyTo {
             postId: post.post.id,
             commentId: nil,
             commentContents: commentContents,
-            account: account,
+            account: appState.currentActiveAccount,
             appState: appState)
     }
 }

--- a/Mlem/Models/ReplyTos/ReplyToMention.swift
+++ b/Mlem/Models/ReplyTos/ReplyToMention.swift
@@ -10,12 +10,10 @@ import SwiftUI
 
 struct ReplyToMention: ReplyTo {
     let mention: APIPersonMentionView
-    let account: SavedAccount
     let appState: AppState
     
     func embeddedView() -> AnyView {
-        return AnyView(InboxMentionView(account: account,
-                                        mention: mention,
+        return AnyView(InboxMentionView(mention: mention,
                                         menuFunctions: [])
             .padding(.horizontal))
     }
@@ -24,7 +22,7 @@ struct ReplyToMention: ReplyTo {
         try await postCommentWithoutTracker(postId: mention.post.id,
                                             commentId: mention.comment.id,
                                             commentContents: commentContents,
-                                            account: account,
+                                            account: appState.currentActiveAccount,
                                             appState: appState)
     }
 }

--- a/Mlem/Models/Trackers/Saved Account Tracker.swift
+++ b/Mlem/Models/Trackers/Saved Account Tracker.swift
@@ -6,10 +6,18 @@
 //
 
 import Foundation
+import SwiftUI
 
 class SavedAccountTracker: ObservableObject {
+    
+    @AppStorage("defaultAccountId") var defaultAccountId: Int?
+    
     @Published var savedAccounts: [SavedAccount]
 
+    var defaultAccount: SavedAccount? {
+        savedAccounts.first(where: { $0.id == defaultAccountId })
+    }
+    
     init() {
         _savedAccounts = .init(wrappedValue: SavedAccountTracker.loadAccounts())
     }

--- a/Mlem/Views/Shared/Composer/CommentComposerView.swift
+++ b/Mlem/Views/Shared/Composer/CommentComposerView.swift
@@ -33,18 +33,13 @@ struct CommentComposerView: View {
 
     func submitPost() async {
         do {
-            guard let account = appState.currentActiveAccount else {
-                print("Cannot Submit, No Active Account")
-                return
-            }
-            
             isSubmitting = true
             
             try await postComment(
                 to: post,
                 commentContents: replybody,
                 commentTracker: commentTracker,
-                account: account,
+                account: appState.currentActiveAccount,
                 appState: appState)
                 
                 print("Reply Successful")
@@ -75,18 +70,15 @@ struct CommentComposerView: View {
                         .padding()
                         
                         Spacer()
-
+                        
                         // Comment Context
-                        if let account = appState.currentActiveAccount {
-                            FeedPost(postView: post,
-                                     account: account,
-                                     showPostCreator: true,
-                                     showCommunity: true,
-                                     showInteractionBar: false,
-                                     enableSwipeActions: false,
-                                     isDragging: Binding.constant(false),
-                                     replyToPost: nil)
-                        }
+                        FeedPost(postView: post,
+                                 showPostCreator: true,
+                                 showCommunity: true,
+                                 showInteractionBar: false,
+                                 enableSwipeActions: false,
+                                 isDragging: Binding.constant(false),
+                                 replyToPost: nil)
                     }
                     
                     // Loading Indicator

--- a/Mlem/Views/Shared/Composer/MessageComposerView.swift
+++ b/Mlem/Views/Shared/Composer/MessageComposerView.swift
@@ -13,7 +13,6 @@ struct MessageComposerView: View {
     @EnvironmentObject var appState: AppState
     
     // MARK: Parameters
-    let account: SavedAccount
     let recipient: APIPerson
     
     // MARK: State and other
@@ -90,7 +89,12 @@ struct MessageComposerView: View {
         do {
             isSubmitting = true
             
-            try await sendPrivateMessage(content: messageBody, recipient: recipient, account: account, appState: appState)
+            try await sendPrivateMessage(
+                content: messageBody,
+                recipient: recipient,
+                account: appState.currentActiveAccount,
+                appState: appState
+            )
             
             print("Post Successful")
             

--- a/Mlem/Views/Shared/Composer/PostComposerView.swift
+++ b/Mlem/Views/Shared/Composer/PostComposerView.swift
@@ -58,11 +58,6 @@ struct PostComposerView: View {
     
     func submitPost() async {
         do {
-            guard let account = appState.currentActiveAccount else {
-                print("Cannot Submit, No Active Account")
-                return
-            }
-            
             guard postTitle.trimmed.isNotEmpty else {
                 errorDialogMessage = "You need to enter a title for your post."
                 isShowingErrorDialog = true
@@ -83,7 +78,7 @@ struct PostComposerView: View {
                                postURL: postURL.trimmed,
                                postIsNSFW: isNSFW,
                                postTracker: postTracker,
-                               account: account)
+                               account: appState.currentActiveAccount)
             
             print("Post Successful")
             

--- a/Mlem/Views/Shared/Composer/ReportComposerView.swift
+++ b/Mlem/Views/Shared/Composer/ReportComposerView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct ReportComposerView: View {
-    // parameters
-    var account: SavedAccount
     
     var reportedPost: APIPostView?
     var reportedComment: APICommentView?
@@ -25,7 +23,12 @@ struct ReportComposerView: View {
         do {
             isSubmitting = true
             
-            _ = try await reportPost(postId: post.post.id, account: account, reason: reportReason, appState: appState)
+            _ = try await reportPost(
+                postId: post.post.id,
+                account: appState.currentActiveAccount,
+                reason: reportReason,
+                appState: appState
+            )
             
             dismiss()
             
@@ -39,7 +42,12 @@ struct ReportComposerView: View {
         do {
             isSubmitting = true
             
-            _ = try await reportComment(commentId: comment.comment.id, account: account, reason: reportReason, appState: appState)
+            _ = try await reportComment(
+                commentId: comment.comment.id,
+                account: appState.currentActiveAccount,
+                reason: reportReason,
+                appState: appState
+            )
             
             dismiss()
             
@@ -61,7 +69,6 @@ struct ReportComposerView: View {
                         if let post = reportedPost {
                             FeedPost(
                                 postView: post,
-                                account: account,
                                 showPostCreator: true,
                                 showCommunity: true,
                                 showInteractionBar: false,
@@ -71,7 +78,6 @@ struct ReportComposerView: View {
                             )
                         } else if let comment = reportedComment {
                             CommentItem(
-                                account: account,
                                 hierarchicalComment: HierarchicalComment(comment: comment, children: []),
                                 postContext: nil,
                                 depth: 0,

--- a/Mlem/Views/Shared/TokenRefreshView.swift
+++ b/Mlem/Views/Shared/TokenRefreshView.swift
@@ -1,0 +1,185 @@
+// 
+//  TokenRefreshView.swift
+//  Mlem
+//
+//  Created by mormaer on 10/07/2023.
+//  
+//
+
+import SwiftUI
+
+struct TokenRefreshView: View {
+    
+    enum ViewState {
+        case initial
+        case refreshing
+        case success
+        case incorrectPassword
+    }
+    
+    @EnvironmentObject var appState: AppState
+    
+    @Environment(\.dismiss) var dismiss
+    
+    let account: SavedAccount
+    let refreshedAccount: (SavedAccount) -> Void
+    
+    @State private var password = ""
+    @State private var viewState: ViewState = .initial
+    
+    var body: some View {
+        VStack {
+            ScrollView(showsIndicators: false) {
+                header
+                informationText
+                passwordField
+            }
+            
+            Spacer()
+            cancelButton
+        }
+        .multilineTextAlignment(.center)
+        .padding()
+        .interactiveDismissDisabled()
+    }
+    
+    // MARK: - Subviews
+    
+    @ViewBuilder
+    private var header: some View {
+        switch viewState {
+        case .initial, .incorrectPassword:
+            Image(systemName: "exclamationmark.triangle")
+                .resizable()
+                .foregroundColor(.red)
+                .frame(width: 100, height: 100)
+                .padding(.vertical, 50)
+        case .refreshing:
+            ProgressView()
+                .controlSize(.large)
+                .frame(width: 100, height: 100)
+                .padding(.vertical, 50)
+        case .success:
+            Image(systemName: "checkmark.circle.fill")
+                .resizable()
+                .foregroundColor(.green)
+                .frame(width: 100, height: 100)
+                .padding(.vertical, 50)
+        }
+    }
+    
+    private var informationText: some View {
+        let text: String
+        
+        switch viewState {
+        case .initial, .incorrectPassword:
+            text = """
+        Your current session has expired, you will need to log in to continue.\n
+        Please enter the password for\n\(account.username)@\(account.instanceLink.host() ?? "")
+        """
+        case .refreshing:
+            text = "Setting up your new session..."
+        case .success:
+            text = "New session created"
+        }
+        
+        // using an ideal height below so that it can expand further if needed
+        // but won't collapse for the shorter phrases to keep things a bit less... jiggly
+        
+        return Text(text)
+            .font(.body)
+            .padding(.bottom, 16)
+            .frame(idealHeight: 150)
+    }
+    
+    @ViewBuilder
+    private var passwordField: some View {
+        VStack {
+            SecureField("Password", text: $password)
+                .textContentType(.password)
+                .submitLabel(.continue)
+                .textFieldStyle(.roundedBorder)
+                .disabled(shouldDisableControls)
+                .onSubmit {
+                    updateViewState(.refreshing)
+                    Task {
+                        do {
+                            let token = try await refreshToken(with: password)
+                            updateViewState(.success)
+                            await didReceive(token)
+                        } catch {
+                            AppConstants.hapticManager.notificationOccurred(.error)
+                            
+                            if case let APIClientError.response(apiError, _) = error,
+                               apiError.error == "password_incorrect" {
+                                updateViewState(.incorrectPassword)
+                                return
+                            }
+                            
+                            updateViewState(.initial)
+                        }
+                    }
+                }
+        }
+        
+        if viewState == .incorrectPassword {
+            Text("The password you entered was incorrect")
+                .font(.footnote)
+                .foregroundColor(.red)
+        }
+    }
+    
+    private var cancelButton: some View {
+        Button("Cancel") {
+            dismiss()
+        }
+        .disabled(shouldDisableControls)
+    }
+    
+    // MARK: - Private methods
+    
+    private func refreshToken(with newPassword: String) async throws -> String {
+        let request = LoginRequest(
+            instanceURL: account.instanceLink,
+            username: account.username,
+            password: password,
+            totpToken: nil
+        )
+        
+        return try await APIClient().perform(request: request).jwt
+    }
+    
+    private func didReceive(_ newToken: String) async {
+        // small artifical delay so the user sees confirmation of success
+        AppConstants.hapticManager.notificationOccurred(.success)
+        try? await Task.sleep(for: .seconds(0.5))
+        
+        await MainActor.run {
+            refreshedAccount(
+                .init(
+                    id: account.id,
+                    instanceLink: account.instanceLink,
+                    accessToken: newToken,
+                    username: account.username
+                )
+            )
+            dismiss()
+        }
+    }
+    
+    private func updateViewState(_ newValue: ViewState) {
+        withAnimation {
+            viewState = newValue
+        }
+    }
+    
+    private var shouldDisableControls: Bool {
+        switch viewState {
+        case .refreshing, .success:
+            // disable the password field and cancel buttons while calls are in-flight
+            return true
+        case .initial, .incorrectPassword:
+            return false
+        }
+    }
+}

--- a/Mlem/Views/Tabs/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feed Root.swift
@@ -17,44 +17,24 @@ struct FeedRoot: View {
 
     @State var navigationPath = NavigationPath()
 
-    @State var isShowingInstanceAdditionSheet: Bool = false
-
     @State var rootDetails: CommunityLinkWithContext?
     @State var isShowingToast: Bool = false
 
     var body: some View {
 
         NavigationSplitView {
-            AccountsPage(isShowingInstanceAdditionSheet: $isShowingInstanceAdditionSheet)
-        } content: {
-            if appState.currentActiveAccount != nil {
-                CommunityListView(
-                    account: appState.currentActiveAccount!,
-                    selectedCommunity: $rootDetails
-                ).id(appState.currentActiveAccount!.id)
-            } else {
-                Text("You need to be signed in to browse Lemmy")
-                Button {
-                    isShowingInstanceAdditionSheet.toggle()
-                } label: {
-                    Label("Sign in", systemImage: "person.badge.plus")
-                }
-            }
+            CommunityListView(selectedCommunity: $rootDetails)
+                .id(appState.currentActiveAccount.id)
         } detail: {
-            if rootDetails != nil {
-                NavigationStack(path: $navigationPath) {
-                    CommunityView(account: appState.currentActiveAccount!,
-                                  community: rootDetails!.community,
-                                  feedType: rootDetails?.feedType ?? .all
-                    )
-                    .environmentObject(appState)
-                    .handleLemmyViews()
-                }
-                .id(rootDetails!.id + appState.currentActiveAccount!.id)
-            } else {
-                Text("Please selecte a community")
-                    .id(appState.currentActiveAccount?.id ?? 0)
+            NavigationStack(path: $navigationPath) {
+                CommunityView(
+                    community: rootDetails!.community,
+                    feedType: rootDetails?.feedType ?? .all
+                )
+                .environmentObject(appState)
+                .handleLemmyViews()
             }
+            .id(rootDetails!.id + appState.currentActiveAccount.id)
         }
         .handleLemmyLinkResolution(
             navigationPath: $navigationPath
@@ -71,32 +51,11 @@ struct FeedRoot: View {
                     shortcutItemToProcess?.type ??
                     "nothing to see here"
                 ) ?? defaultFeed
-                var detailsViewToDisplay: CommunityLinkWithContext?
-                if appState.currentActiveAccount != nil {
-                    detailsViewToDisplay = CommunityLinkWithContext(community: nil, feedType: feedType)
-                }
-                rootDetails = detailsViewToDisplay
+                rootDetails = CommunityLinkWithContext(community: nil, feedType: feedType)
                 shortcutItemToProcess = nil
             }
         }
         .onOpenURL { url in
-            if appState.currentActiveAccount == nil {
-                if let account = accountsTracker.savedAccounts.first {
-                    appState.currentActiveAccount = account
-                }
-            }
-
-            guard appState.currentActiveAccount != nil else {
-                appState.toast = AlertToast(
-                    displayMode: .hud,
-                    type: .loading,
-                    title: "You need to sign in to open links in app"
-                )
-
-                appState.isShowingToast = true
-                return
-            }
-
             DispatchQueue.main.asyncAfter(deadline: .now()) {
                 if rootDetails == nil {
                     rootDetails = CommunityLinkWithContext(community: nil, feedType: defaultFeed)
@@ -108,13 +67,9 @@ struct FeedRoot: View {
                 .didReceiveURL(url)
             }
         }
-        .sheet(isPresented: $isShowingInstanceAdditionSheet) {
-            AddSavedInstanceView(isShowingSheet: $isShowingInstanceAdditionSheet)
-        }
         .onChange(of: phase) { newPhase in
             if newPhase == .active {
-                if appState.currentActiveAccount != nil,
-                   let shortcutItem = FeedType(rawValue:
+                if let shortcutItem = FeedType(rawValue:
                                                 shortcutItemToProcess?.type ??
                                                "nothing to see here"
                    ) {

--- a/Mlem/Views/Tabs/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feed Root.swift
@@ -26,15 +26,19 @@ struct FeedRoot: View {
             CommunityListView(selectedCommunity: $rootDetails)
                 .id(appState.currentActiveAccount.id)
         } detail: {
-            NavigationStack(path: $navigationPath) {
-                CommunityView(
-                    community: rootDetails!.community,
-                    feedType: rootDetails?.feedType ?? .all
-                )
-                .environmentObject(appState)
-                .handleLemmyViews()
+            if let rootDetails {
+                NavigationStack(path: $navigationPath) {
+                    CommunityView(
+                        community: rootDetails.community,
+                        feedType: rootDetails.feedType
+                    )
+                    .environmentObject(appState)
+                    .handleLemmyViews()
+                }
+                .id(rootDetails.id + appState.currentActiveAccount.id)
+            } else {
+                Text("Please select a community") 
             }
-            .id(rootDetails!.id + appState.currentActiveAccount.id)
         }
         .handleLemmyLinkResolution(
             navigationPath: $navigationPath

--- a/Mlem/Views/Tabs/Inbox/Feed/All Items Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/All Items Feed View.swift
@@ -44,11 +44,11 @@ extension InboxView {
                 Group {
                     switch item.type {
                     case .mention(let mention):
-                        inboxMentionViewWithInteraction(account: account, mention: mention)
+                        inboxMentionViewWithInteraction(mention: mention)
                     case .message(let message):
                         inboxMessageViewWithInteraction(message: message)
                     case .reply(let reply):
-                        inboxReplyViewWithInteraction(account: account, reply: reply)
+                        inboxReplyViewWithInteraction(reply: reply)
                     }
                 }
                 

--- a/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Mention View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Mention View.swift
@@ -11,7 +11,6 @@ struct InboxMentionView: View {
     let spacing: CGFloat = 10
     let userAvatarWidth: CGFloat = 30
     
-    let account: SavedAccount
     let mention: APIPersonMentionView
     let menuFunctions: [MenuFunction]
     
@@ -20,8 +19,7 @@ struct InboxMentionView: View {
     
     var iconName: String { mention.personMention.read ? "quote.bubble" : "quote.bubble.fill" }
     
-    init(account: SavedAccount, mention: APIPersonMentionView, menuFunctions: [MenuFunction]) {
-        self.account = account
+    init(mention: APIPersonMentionView, menuFunctions: [MenuFunction]) {
         self.mention = mention
         self.menuFunctions = menuFunctions
         

--- a/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Message View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Message View.swift
@@ -11,14 +11,12 @@ struct InboxMessageView: View {
     let spacing: CGFloat = 10
     let userAvatarWidth: CGFloat = 30
     
-    let account: SavedAccount
     let message: APIPrivateMessageView
     let menuFunctions: [MenuFunction]
     
     var iconName: String { message.privateMessage.read ? "envelope.open" : "envelope.fill" }
     
-    init(account: SavedAccount, message: APIPrivateMessageView, menuFunctions: [MenuFunction]) {
-        self.account = account
+    init(message: APIPrivateMessageView, menuFunctions: [MenuFunction]) {
         self.message = message
         self.menuFunctions = menuFunctions
     }

--- a/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Reply View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Reply View.swift
@@ -13,7 +13,6 @@ struct InboxReplyView: View {
     let spacing: CGFloat = 10
     let userAvatarWidth: CGFloat = 30
     
-    let account: SavedAccount
     let reply: APICommentReplyView
     let menuFunctions: [MenuFunction]
     
@@ -22,8 +21,7 @@ struct InboxReplyView: View {
     
     var iconName: String { reply.commentReply.read ? "arrowshape.turn.up.right" : "arrowshape.turn.up.right.fill" }
     
-    init(account: SavedAccount, reply: APICommentReplyView, menuFunctions: [MenuFunction]) {
-        self.account = account
+    init(reply: APICommentReplyView, menuFunctions: [MenuFunction]) {
         self.reply = reply
         self.menuFunctions = menuFunctions
         

--- a/Mlem/Views/Tabs/Inbox/Feed/Mentions Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Mentions Feed View.swift
@@ -44,15 +44,15 @@ extension InboxView {
     func mentionsListView() -> some View {
         ForEach(mentionsTracker.items) { mention in
             VStack(spacing: 0) {
-                inboxMentionViewWithInteraction(account: account, mention: mention)
+                inboxMentionViewWithInteraction(mention: mention)
                 Divider()
             }
         }
     }
     
-    func inboxMentionViewWithInteraction(account: SavedAccount, mention: APIPersonMentionView) -> some View {
+    func inboxMentionViewWithInteraction(mention: APIPersonMentionView) -> some View {
         NavigationLink(value: LazyLoadPostLinkWithContext(post: mention.post, postTracker: dummyPostTracker)) {
-            InboxMentionView(account: account, mention: mention, menuFunctions: genMentionMenuGroup(mention: mention))
+            InboxMentionView(mention: mention, menuFunctions: genMentionMenuGroup(mention: mention))
                 .padding(.vertical, AppConstants.postAndCommentSpacing)
                 .padding(.horizontal)
                 .background(Color.systemBackground)

--- a/Mlem/Views/Tabs/Inbox/Feed/Messages Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Messages Feed View.swift
@@ -53,7 +53,7 @@ extension InboxView {
     
     @ViewBuilder
     func inboxMessageViewWithInteraction(message: APIPrivateMessageView) -> some View {
-        InboxMessageView(account: account, message: message, menuFunctions: genMessageMenuGroup(message: message))
+        InboxMessageView(message: message, menuFunctions: genMessageMenuGroup(message: message))
             .padding(.vertical, AppConstants.postAndCommentSpacing)
             .padding(.horizontal)
             .background(Color.systemBackground)

--- a/Mlem/Views/Tabs/Inbox/Feed/Replies Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Replies Feed View.swift
@@ -48,16 +48,16 @@ extension InboxView {
     func repliesListView() -> some View {
         ForEach(repliesTracker.items) { reply in
             VStack(spacing: 0) {
-                inboxReplyViewWithInteraction(account: account, reply: reply)
+                inboxReplyViewWithInteraction(reply: reply)
 
                 Divider()
             }
         }
     }
     
-    func inboxReplyViewWithInteraction(account: SavedAccount, reply: APICommentReplyView) -> some View {
+    func inboxReplyViewWithInteraction(reply: APICommentReplyView) -> some View {
         NavigationLink(value: LazyLoadPostLinkWithContext(post: reply.post, postTracker: dummyPostTracker)) {
-            InboxReplyView(account: account, reply: reply, menuFunctions: genCommentReplyMenuGroup(commentReply: reply))
+            InboxReplyView(reply: reply, menuFunctions: genCommentReplyMenuGroup(commentReply: reply))
                 .padding(.vertical, AppConstants.postAndCommentSpacing)
                 .padding(.horizontal)
                 .background(Color.systemBackground)

--- a/Mlem/Views/Tabs/Inbox/Inbox View Logic.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View Logic.swift
@@ -35,6 +35,8 @@ extension InboxView {
             print("Failed while loading feed (request cancelled)")
             errorOccurred = true
             errorMessage = "Request was cancelled, try refreshing"
+        } catch APIClientError.invalidSession {
+            appState.contextualError = .init(underlyingError: APIClientError.invalidSession)
         } catch let message {
             print(message)
             errorOccurred = true
@@ -44,25 +46,25 @@ extension InboxView {
     
     func refreshRepliesTracker() async throws {
         if curTab == .all || curTab == .replies {
-            try await repliesTracker.refresh(account: account)
+            try await repliesTracker.refresh(account: appState.currentActiveAccount)
         }
     }
     
     func refreshMentionsTracker() async throws {
         if curTab == .all || curTab == .mentions {
-            try await mentionsTracker.refresh(account: account)
+            try await mentionsTracker.refresh(account: appState.currentActiveAccount)
         }
     }
     
     func refreshMessagesTracker() async throws {
         if curTab == .all || curTab == .messages {
-            try await messagesTracker.refresh(account: account)
+            try await messagesTracker.refresh(account: appState.currentActiveAccount)
         }
     }
     
     func loadTrackerPage(tracker: InboxTracker) async {
         do {
-            try await tracker.loadNextPage(account: account)
+            try await tracker.loadNextPage(account: appState.currentActiveAccount)
             aggregateAllTrackers()
             // TODO: make that call above return the new items and do a nice neat merge sort that doesn't re-merge the whole damn array
         } catch let message {
@@ -109,7 +111,7 @@ extension InboxView {
                 let operation = commentReply.myVote == inputOp ? ScoringOperation.resetVote : inputOp
                 try await _ = rateCommentReply(commentReply: commentReply,
                                                operation: operation,
-                                               account: account,
+                                               account: appState.currentActiveAccount,
                                                commentReplyTracker: repliesTracker,
                                                appState: appState)
                 // TODO: more granular/less expensive merge options
@@ -125,7 +127,7 @@ extension InboxView {
             do {
                 try await sendMarkCommentReplyAsReadRequest(commentReply: commentReplyView,
                                                             read: !commentReplyView.commentReply.read,
-                                                            account: account,
+                                                            account: appState.currentActiveAccount,
                                                             commentReplyTracker: repliesTracker,
                                                             appState: appState)
                 
@@ -148,7 +150,7 @@ extension InboxView {
                 let operation = mention.myVote == inputOp ? ScoringOperation.resetVote : inputOp
                 try await ratePersonMention(personMention: mention,
                                             operation: operation,
-                                            account: account,
+                                            account: appState.currentActiveAccount,
                                             mentionsTracker: mentionsTracker,
                                             appState: appState)
                 
@@ -162,7 +164,7 @@ extension InboxView {
             do {
                 try await sendMarkPersonMentionAsReadRequest(personMention: mention,
                                                              read: !mention.personMention.read,
-                                                             account: account,
+                                                             account: appState.currentActiveAccount,
                                                              mentionTracker: mentionsTracker,
                                                              appState: appState)
                 
@@ -189,7 +191,7 @@ extension InboxView {
             do {
                 try await sendMarkPrivateMessageAsReadRequest(messageView: message,
                                                               read: !message.privateMessage.read,
-                                                              account: account,
+                                                              account: appState.currentActiveAccount,
                                                               messagesTracker: messagesTracker,
                                                               appState: appState)
                 

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -31,9 +31,6 @@ struct InboxView: View {
     // MARK: Global
     @EnvironmentObject var appState: AppState
     
-    // MARK: Parameters
-    let account: SavedAccount
-    
     // MARK: Internal
     // id of the last account loaded with
     @State var lastKnownAccountId: Int = 0
@@ -112,18 +109,17 @@ struct InboxView: View {
             case .commentReply(let commentReplyingTo):
                 if let commentReply = commentReplyingTo {
                     let replyTo = ReplyToCommentReply(commentReply: commentReply,
-                                                      account: account,
                                                       appState: appState)
                     GeneralCommentComposerView(replyTo: replyTo)
                 }
             case .mention(let mentionReplyingTo):
                 if let mentionReply = mentionReplyingTo {
-                    let replyTo = ReplyToMention(mention: mentionReply, account: account, appState: appState)
+                    let replyTo = ReplyToMention(mention: mentionReply, appState: appState)
                     GeneralCommentComposerView(replyTo: replyTo)
                 }
             case .message(let personReplyingTo):
                 if let recipient = personReplyingTo {
-                    MessageComposerView(account: account, recipient: recipient)
+                    MessageComposerView(recipient: recipient)
                         .presentationDetents([.medium, .large])
                 }
             }
@@ -134,13 +130,13 @@ struct InboxView: View {
             if mentionsTracker.items.isEmpty ||
                 messagesTracker.items.isEmpty ||
                 repliesTracker.items.isEmpty  ||
-                lastKnownAccountId != account.id {
+                lastKnownAccountId != appState.currentActiveAccount.id {
                 print("Inbox tracker is empty")
                 await refreshFeed()
             } else {
                 print("Inbox tracker is not empty")
             }
-            lastKnownAccountId = account.id
+            lastKnownAccountId = appState.currentActiveAccount.id
         }
     }
     

--- a/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Interaction Bar.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Interaction Bar.swift
@@ -14,6 +14,7 @@ import Foundation
  */
 struct CommentInteractionBar: View {
     // environment
+    @EnvironmentObject var appState: AppState
     @EnvironmentObject var commentTracker: CommentTracker
 
     // constants
@@ -23,7 +24,6 @@ struct CommentInteractionBar: View {
 
     // parameters
     let commentView: APICommentView
-    let account: SavedAccount
 
     let displayedScore: Int
     let displayedVote: ScoringOperation
@@ -60,7 +60,7 @@ struct CommentInteractionBar: View {
     }
     
     func canDeleteComment() -> Bool {
-        if commentView.creator.id != account.id {
+        if commentView.creator.id != appState.currentActiveAccount.id {
             return false
         }
         

--- a/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item Logic.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item Logic.swift
@@ -14,7 +14,7 @@ extension CommentItem {
             try await _ = rateComment(
                 commentId: hierarchicalComment.commentView.id,
                 operation: operation,
-                account: account,
+                account: appState.currentActiveAccount,
                 commentTracker: commentTracker,
                 appState: appState
             )
@@ -29,7 +29,7 @@ extension CommentItem {
             // to avoid having to explicitly refer to our own module
             try await _ = Mlem.deleteComment(
                 comment: hierarchicalComment.commentView,
-                account: account,
+                account: appState.currentActiveAccount,
                 commentTracker: commentTracker,
                 appState: appState
             )
@@ -115,7 +115,7 @@ extension CommentItem {
             dirty = true
 
             do {
-                try await sendSaveCommentRequest(account: account,
+                try await sendSaveCommentRequest(account: appState.currentActiveAccount,
                                                  commentId: hierarchicalComment.id,
                                                  save: dirtySaved,
                                                  commentTracker: commentTracker)
@@ -192,7 +192,7 @@ extension CommentItem {
         }
         
         // delete
-        if hierarchicalComment.commentView.creator.id == account.id {
+        if hierarchicalComment.commentView.creator.id == appState.currentActiveAccount.id {
             ret.append(MenuFunction(
                 text: "Delete",
                 imageName: "trash",

--- a/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
@@ -39,7 +39,6 @@ struct CommentItem: View {
 
     // MARK: Parameters
 
-    let account: SavedAccount
     let hierarchicalComment: HierarchicalComment
     let postContext: APIPostView? // TODO: redundant with comment.post?
     let depth: Int
@@ -54,8 +53,7 @@ struct CommentItem: View {
     // MARK: Computed
 
     // init needed to get dirty and clean aligned
-    init(account: SavedAccount,
-         hierarchicalComment: HierarchicalComment,
+    init(hierarchicalComment: HierarchicalComment,
          postContext: APIPostView?,
          depth: Int,
          showPostContext: Bool,
@@ -65,7 +63,6 @@ struct CommentItem: View {
          enableSwipeActions: Bool = true,
          replyToComment: ((APICommentView) -> Void)?
     ) {
-        self.account = account
         self.hierarchicalComment = hierarchicalComment
         self.postContext = postContext
         self.depth = depth
@@ -105,7 +102,6 @@ struct CommentItem: View {
 
                     if showInteractionBar {
                         CommentInteractionBar(commentView: hierarchicalComment.commentView,
-                                              account: account,
                                               displayedScore: displayedScore,
                                               displayedVote: displayedVote,
                                               displayedSaved: displayedSaved,
@@ -146,7 +142,7 @@ struct CommentItem: View {
             )
             .border(width: depth == 0 ? 0 : 2, edges: [.leading], color: threadingColors[depth % threadingColors.count])
             .sheet(isPresented: $isComposingReport) {
-                ReportComposerView(account: account, reportedPost: nil, reportedComment: hierarchicalComment.commentView)
+                ReportComposerView(reportedPost: nil, reportedComment: hierarchicalComment.commentView)
             }
             
             Divider()
@@ -198,7 +194,6 @@ struct CommentItem: View {
             LazyVStack(spacing: 0) {
                 ForEach(hierarchicalComment.children) { child in
                     CommentItem(
-                        account: account,
                         hierarchicalComment: child,
                         postContext: postContext,
                         depth: depth + 1,

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
@@ -16,8 +16,6 @@ struct CommunitySection: Identifiable {
 }
 
 struct CommunityListView: View {
-    let account: SavedAccount
-
     @EnvironmentObject var favoritedCommunitiesTracker: FavoriteCommunitiesTracker
     @EnvironmentObject var appState: AppState
     @Environment(\.openURL) var openURL
@@ -37,12 +35,9 @@ struct CommunityListView: View {
 
     @Binding var selectedCommunity: CommunityLinkWithContext?
 
-    init(account: SavedAccount,
-         testCommunities: [APICommunity]? = nil,
+    init(testCommunities: [APICommunity]? = nil,
          selectedCommunity: Binding<CommunityLinkWithContext?>
     ) {
-        self.account = account
-
         if testCommunities != nil {
             self._subscribedCommunities = State(initialValue: testCommunities!)
             self.hasTestCommunities = true
@@ -56,7 +51,6 @@ struct CommunityListView: View {
                 HStack {
                     List(selection: $selectedCommunity) {
                         HomepageFeedRowView(
-                            account: account,
                             feedType: .subscribed,
                             iconName: "house.circle.fill",
                             iconColor: .red,
@@ -64,14 +58,12 @@ struct CommunityListView: View {
                         )
                             .id("top") // For "scroll to top" sidebar item
                         HomepageFeedRowView(
-                            account: account,
                             feedType: .local,
                             iconName: "building.2.crop.circle.fill",
                             iconColor: .green,
                             description: "Local communities from your server"
                         )
                         HomepageFeedRowView(
-                            account: account,
                             feedType: .all,
                             iconName: "cloud.circle.fill",
                             iconColor: .blue,
@@ -89,7 +81,6 @@ struct CommunityListView: View {
                                     id: \.id
                                 ) { listedCommunity in
                                     CommuntiyFeedRowView(
-                                        account: account,
                                         community: listedCommunity,
                                         subscribed: subscribedCommunities.contains(listedCommunity),
                                         communitySubscriptionChanged: self.hydrateCommunityData
@@ -133,7 +124,7 @@ struct CommunityListView: View {
                 CommunitySection(
                     viewId: "favorites",
                     sidebarEntry: FavoritesSidebarEntry(
-                        account: account,
+                        account: appState.currentActiveAccount,
                         favoritesTracker: favoritedCommunitiesTracker,
                         sidebarLabel: nil,
                         sidebarIcon: "star.fill"
@@ -174,7 +165,7 @@ struct CommunityListView: View {
             var communitiesPage = 1
             repeat {
                 let request = ListCommunitiesRequest(
-                    account: account,
+                    account: appState.currentActiveAccount,
                     sort: nil,
                     page: communitiesPage,
                     limit: communitiesRequestCount,
@@ -379,10 +370,8 @@ struct CommunityListViewPreview: PreviewProvider {
         generateFakeFavoritedCommunity(id: 20, namePrefix: fakeCommunityPrefixes[20]),
         generateFakeFavoritedCommunity(id: 10, namePrefix: fakeCommunityPrefixes[10])
     ])
-    static let savedAccount = SavedAccount(id: 0, instanceLink: URL(string: "lemmy.com")!, accessToken: "abcdefg", username: "Test Account")
     static var previews: some View {
         CommunityListView(
-            account: savedAccount,
             testCommunities: fakeCommunityPrefixes.enumerated().map({ index, element in
                 generateFakeCommunity(id: index, namePrefix: element)
             }),

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Components/CommunityListRowViews.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Components/CommunityListRowViews.swift
@@ -30,7 +30,6 @@ struct FavoriteStarButtonStyle: ButtonStyle {
 }
 
 struct CommuntiyFeedRowView: View {
-    let account: SavedAccount
     let community: APICommunity
     let subscribed: Bool
     let communitySubscriptionChanged: (APICommunity, Bool) -> Void
@@ -97,16 +96,19 @@ struct CommuntiyFeedRowView: View {
 
     private func toggleFavorite() {
         if isFavorited() {
-            unfavoriteCommunity(account: account, community: community, favoritedCommunitiesTracker: favoritesTracker)
+            unfavoriteCommunity(community: community, favoritedCommunitiesTracker: favoritesTracker)
             UIAccessibility.post(notification: .announcement, argument: "Un-favorited \(community.name)")
         } else {
-            favoriteCommunity(account: account, community: community, favoritedCommunitiesTracker: favoritesTracker)
+            favoriteCommunity(account: appState.currentActiveAccount, community: community, favoritedCommunitiesTracker: favoritesTracker)
             UIAccessibility.post(notification: .announcement, argument: "Favorited \(community.name)")
         }
     }
 
     internal func isFavorited() -> Bool {
-        return getFavoritedCommunities(account: account, favoritedCommunitiesTracker: favoritesTracker).contains(community)
+        return getFavoritedCommunities(
+            account: appState.currentActiveAccount,
+            favoritedCommunitiesTracker: favoritesTracker
+        ).contains(community)
     }
 
     private func subscribe(communityId: Int, shouldSubscribe: Bool) async {
@@ -115,7 +117,7 @@ struct CommuntiyFeedRowView: View {
 
         do {
             let request = FollowCommunityRequest(
-                account: account,
+                account: appState.currentActiveAccount,
                 communityId: communityId,
                 follow: shouldSubscribe
             )
@@ -131,7 +133,6 @@ struct CommuntiyFeedRowView: View {
 }
 
 struct HomepageFeedRowView: View {
-    let account: SavedAccount
     let feedType: FeedType
     let iconName: String
     let iconColor: Color

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
@@ -68,18 +68,8 @@ struct CommunityView: View {
             .refreshable {
                 Task(priority: .userInitiated) {
                     isRefreshing = true
-
-                    try await postTracker.refresh(
-                        account: account,
-                        communityId: community?.id,
-                        sort: postSortType,
-                        type: feedType,
-                        filtering: { postView in
-                            !postView.post.name.contains(filtersTracker.filteredKeywords)
-                        }
-                    )
-
-                    isRefreshing = false
+                    defer { isRefreshing = false }
+                    await refreshFeed()
                 }
             }
             .onAppear {

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Block Community Button.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Block Community Button.swift
@@ -12,7 +12,6 @@ struct BlockCommunityButton: View {
     @EnvironmentObject var appState: AppState
 
     // parameters
-    @State var account: SavedAccount
     @Binding var communityDetails: APICommunityView?
 
     var body: some View {
@@ -44,7 +43,7 @@ struct BlockCommunityButton: View {
     private func block(communityId: Int, shouldBlock: Bool) async {
         do {
             let request = BlockCommunityRequest(
-                account: account,
+                account: appState.currentActiveAccount,
                 communityId: communityId,
                 block: shouldBlock
             )

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar View.swift
@@ -8,8 +8,10 @@
 import SwiftUI
 
 struct CommunitySidebarView: View {
+    
+    @EnvironmentObject var appState: AppState
+    
     // parameters
-    let account: SavedAccount
     let community: APICommunity
     @State var communityDetails: GetCommunityResponse?
 
@@ -42,7 +44,7 @@ struct CommunitySidebarView: View {
     
     private func loadCommunity() async {
         do {
-            let request = GetCommunityRequest(account: account, communityId: community.id)
+            let request = GetCommunityRequest(account: appState.currentActiveAccount, communityId: community.id)
             communityDetails = try await APIClient().perform(request: request)
         } catch APIClientError.networking {
             errorMessage = "Network error occurred, check your internet and retry"
@@ -178,12 +180,6 @@ struct SidebarPreview: PreviewProvider {
     
     static var previews: some View {
         CommunitySidebarView(
-            account: SavedAccount(
-                id: 0,
-                instanceLink: URL(string: "https://lemmy.foo.com/")!,
-                accessToken: "abcd",
-                username: "foobar"
-            ),
             community: previewCommunity,
             communityDetails:
                 GetCommunityResponse(

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Subscribe Button.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Subscribe Button.swift
@@ -7,17 +7,11 @@
 
 import SwiftUI
 
-internal enum CommandError: Error {
-    case receivedUnexpectedResponseFromServer
-}
-
 struct SubscribeButton: View {
     @EnvironmentObject var appState: AppState
 
     @Binding var communityDetails: APICommunityView?
-
-    @State var account: SavedAccount
-
+    
     var body: some View {
         if let communityDetails {
             if communityDetails.subscribed == .notSubscribed {
@@ -49,7 +43,7 @@ struct SubscribeButton: View {
     private func subscribe(communityId: Int, shouldSubscribe: Bool) async {
         do {
             let request = FollowCommunityRequest(
-                account: account,
+                account: appState.currentActiveAccount,
                 communityId: communityId,
                 follow: shouldSubscribe
             )

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Expanded Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Expanded Post.swift
@@ -22,8 +22,6 @@ struct ExpandedPost: View {
     @StateObject var commentTracker: CommentTracker = .init()
     @StateObject var commentReplyTracker: CommentReplyTracker = .init()
 
-    @State var account: SavedAccount
-
     @EnvironmentObject var postTracker: PostTracker
 
     @State var post: APIPostView
@@ -70,7 +68,7 @@ struct ExpandedPost: View {
         .sheet(isPresented: $isReplyingToComment) {
             if let comment = commentReplyingTo {
                 let replyTo: ReplyToComment = ReplyToComment(comment: comment,
-                                                             account: account,
+                                                             account: appState.currentActiveAccount,
                                                              appState: appState,
                                                              commentTracker: commentTracker)
                 GeneralCommentComposerView(replyTo: replyTo)
@@ -108,7 +106,7 @@ struct ExpandedPost: View {
             }
         }
         .sheet(isPresented: $isComposingReport) {
-            ReportComposerView(account: account, reportedPost: post)
+            ReportComposerView(reportedPost: post)
         }
     }
     // subviews
@@ -134,7 +132,6 @@ struct ExpandedPost: View {
             UserProfileLink(user: post.creator, serverInstanceLocation: .bottom)
             
             PostInteractionBar(postView: post,
-                               account: account,
                                menuFunctions: genMenuFunctions(),
                                voteOnPost: voteOnPost,
                                updatedSavePost: savePost,
@@ -185,7 +182,6 @@ struct ExpandedPost: View {
         LazyVStack(alignment: .leading, spacing: 0) {
             ForEach(commentTracker.comments) { comment in
                 CommentItem(
-                    account: account,
                     hierarchicalComment: comment,
                     postContext: post,
                     depth: 0,

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/ExpandedPostLogic.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/ExpandedPostLogic.swift
@@ -19,7 +19,7 @@ extension ExpandedPost {
             self.post = try await ratePost(
                 postId: post.post.id,
                 operation: operation,
-                account: account,
+                account: appState.currentActiveAccount,
                 postTracker: postTracker,
                 appState: appState
             )
@@ -32,14 +32,24 @@ extension ExpandedPost {
      Sends a save request for the current post
      */
     func savePost(_ save: Bool) async throws {
-        self.post = try await sendSavePostRequest(account: account, postId: post.post.id, save: save, postTracker: postTracker)
+        self.post = try await sendSavePostRequest(
+            account: appState.currentActiveAccount,
+            postId: post.post.id,
+            save: save,
+            postTracker: postTracker
+        )
     }
     
     func deletePost() async {
         do {
             // TODO: renamed this function and/or move `deleteComment` out of the global scope to avoid
             // having to refer to our own module
-            _ = try await Mlem.deletePost(postId: post.post.id, account: account, postTracker: postTracker, appState: appState)
+            _ = try await Mlem.deletePost(
+                postId: post.post.id,
+                account: appState.currentActiveAccount,
+                postTracker: postTracker,
+                appState: appState
+            )
         } catch {
             appState.contextualError = .init(underlyingError: error)
         }
@@ -110,7 +120,7 @@ extension ExpandedPost {
             })
         
         // delete
-        if post.creator.id == account.id {
+        if post.creator.id == appState.currentActiveAccount.id {
             ret.append(MenuFunction(
                 text: "Delete",
                 imageName: "trash",
@@ -142,7 +152,7 @@ extension ExpandedPost {
 
         commentTracker.isLoading = true
         do {
-            let request = GetCommentsRequest(account: account, postId: post.post.id)
+            let request = GetCommentsRequest(account: appState.currentActiveAccount, postId: post.post.id)
             let response = try await APIClient().perform(request: request)
             commentTracker.comments = sortComments(response.comments.hierarchicalRepresentation, by: defaultCommentSorting)
         } catch {

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
@@ -186,7 +186,11 @@ struct FeedPost: View {
     
     func blockUser() async {
         do {
-            let blocked = try await blockPerson(account: account, person: postView.creator, blocked: true)
+            let blocked = try await blockPerson(
+                account: appState.currentActiveAccount,
+                person: postView.creator,
+                blocked: true
+            )
             if blocked {
                 postTracker.removePosts(from: postView.creator.id)
                 

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
@@ -35,7 +35,6 @@ struct FeedPost: View {
     // MARK: Parameters
     
     init(postView: APIPostView,
-         account: SavedAccount,
          showPostCreator: Bool = true,
          showCommunity: Bool = true,
          showInteractionBar: Bool = true,
@@ -43,7 +42,6 @@ struct FeedPost: View {
          isDragging: Binding<Bool>,
          replyToPost: ((APIPostView) -> Void)?) {
         self.postView = postView
-        self.account = account
         self.showPostCreator = showPostCreator
         self.showCommunity = showCommunity
         self.showInteractionBar = showInteractionBar
@@ -53,7 +51,6 @@ struct FeedPost: View {
     }
     
     let postView: APIPostView
-    let account: SavedAccount
     let showPostCreator: Bool
     let showCommunity: Bool
     let showInteractionBar: Bool
@@ -97,7 +94,7 @@ struct FeedPost: View {
             }
         }
         .sheet(isPresented: $isComposingReport) {
-            ReportComposerView(account: account, reportedPost: postView)
+            ReportComposerView(reportedPost: postView)
         }
     }
     
@@ -118,7 +115,6 @@ struct FeedPost: View {
         if postSize == .compact {
             UltraCompactPost(
                 postView: postView,
-                account: account,
                 showCommunity: showCommunity,
                 menuFunctions: genMenuFunctions()
             )
@@ -138,10 +134,7 @@ struct FeedPost: View {
                 }
                 
                 if postSize == .headline {
-                    CompactPost(
-                        postView: postView,
-                        account: account
-                    )
+                    CompactPost(postView: postView)
                 } else {
                     LargePost(
                         postView: postView,
@@ -156,7 +149,6 @@ struct FeedPost: View {
                 
                 if showInteractionBar {
                     PostInteractionBar(postView: postView,
-                                       account: account,
                                        menuFunctions: genMenuFunctions(),
                                        voteOnPost: voteOnPost,
                                        updatedSavePost: { _ in await savePost() },
@@ -181,7 +173,12 @@ struct FeedPost: View {
     
     func deletePost() async {
         do {
-            _ = try await Mlem.deletePost(postId: postView.post.id, account: account, postTracker: postTracker, appState: appState)
+            _ = try await Mlem.deletePost(
+                postId: postView.post.id,
+                account: appState.currentActiveAccount,
+                postTracker: postTracker,
+                appState: appState
+            )
         } catch {
             appState.contextualError = .init(underlyingError: error)
         }
@@ -226,7 +223,7 @@ struct FeedPost: View {
             _ = try await ratePost(
                 postId: postView.post.id,
                 operation: operation,
-                account: account,
+                account: appState.currentActiveAccount,
                 postTracker: postTracker,
                 appState: appState
             )
@@ -237,7 +234,12 @@ struct FeedPost: View {
 
     func savePost() async {
         do {
-            _ = try await sendSavePostRequest(account: account, postId: postView.post.id, save: !postView.saved, postTracker: postTracker)
+            _ = try await sendSavePostRequest(
+                account: appState.currentActiveAccount,
+                postId: postView.post.id,
+                save: !postView.saved,
+                postTracker: postTracker
+            )
         } catch {
             appState.contextualError = .init(underlyingError: error)
         }
@@ -305,7 +307,7 @@ struct FeedPost: View {
         }
         
         // delete
-        if postView.creator.id == account.id {
+        if postView.creator.id == appState.currentActiveAccount.id {
             ret.append(MenuFunction(
                 text: "Delete",
                 imageName: "trash",

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Lazy Load Expanded Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Lazy Load Expanded Post.swift
@@ -15,7 +15,6 @@ struct LazyLoadExpandedPost: View {
     
     @EnvironmentObject var appState: AppState
     
-    @State var account: SavedAccount
     @State var post: APIPost
     
     @State private var loadedPostView: APIPostView?
@@ -25,7 +24,7 @@ struct LazyLoadExpandedPost: View {
     var body: some View {
         Group {
             if let loadedPost = loadedPostView {
-                ExpandedPost(account: account, post: loadedPost)
+                ExpandedPost(post: loadedPost)
                     .environmentObject(postTracker)
             } else {
                 progressView
@@ -38,7 +37,7 @@ struct LazyLoadExpandedPost: View {
             Text("Loading post details…")
         }
         .task(priority: .background) {
-            let request = GetPostRequest(account: account, id: post.id, commentId: nil)
+            let request = GetPostRequest(account: appState.currentActiveAccount, id: post.id, commentId: nil)
             do {
                 let response = try await APIClient().perform(request: request)
                 postTracker.add([response.postView])

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Components/Post Header.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Components/Post Header.swift
@@ -15,7 +15,6 @@ struct PostHeader: View {
     
     // parameters
     var postView: APIPostView
-    var account: SavedAccount
 
     // constants
     private let communityIconSize: CGFloat = 32

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Components/Post Interaction Bar.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Components/Post Interaction Bar.swift
@@ -35,7 +35,6 @@ struct PostInteractionBar: View {
 
     // parameters
     let postView: APIPostView
-    let account: SavedAccount
     let menuFunctions: [MenuFunction]
     let voteOnPost: (ScoringOperation) async -> Void
     let updatedSavePost: (_ save: Bool) async throws -> Void
@@ -44,7 +43,6 @@ struct PostInteractionBar: View {
     
     init(
         postView: APIPostView,
-        account: SavedAccount,
         menuFunctions: [MenuFunction],
         voteOnPost: @escaping (ScoringOperation) async -> Void,
         updatedSavePost: @escaping (_ save: Bool) async throws -> Void,
@@ -52,7 +50,6 @@ struct PostInteractionBar: View {
         replyToPost: (() -> Void)?
     ) {
         self.postView = postView
-        self.account = account
         self.voteOnPost = voteOnPost
         self.menuFunctions = menuFunctions
         self.updatedSavePost = updatedSavePost
@@ -88,7 +85,7 @@ struct PostInteractionBar: View {
     // helper functions
     
     func canDeletePost() -> Bool {
-        if postView.creator.id != account.id {
+        if postView.creator.id != appState.currentActiveAccount.id {
             return false
         }
         

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Compact Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Compact Post.swift
@@ -21,7 +21,6 @@ struct CompactPost: View {
 
     // arguments
     let postView: APIPostView
-    let account: SavedAccount
 
     // computed
     var usernameColor: Color {

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/UltraCompactPost.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/UltraCompactPost.swift
@@ -20,7 +20,6 @@ struct UltraCompactPost: View {
     
     // arguments
     let postView: APIPostView
-    let account: SavedAccount
     let showCommunity: Bool // true to show community name, false to show username
     let menuFunctions: [MenuFunction]
     
@@ -29,9 +28,8 @@ struct UltraCompactPost: View {
     let voteIconName: String
     var showNsfwFilter: Bool { postView.post.nsfw && shouldBlurNsfw }
 
-    init(postView: APIPostView, account: SavedAccount, showCommunity: Bool, menuFunctions: [MenuFunction]) {
+    init(postView: APIPostView, showCommunity: Bool, menuFunctions: [MenuFunction]) {
         self.postView = postView
-        self.account = account
         self.showCommunity = showCommunity
         self.menuFunctions = menuFunctions
         

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Instance and Community List/Accounts Page.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Instance and Community List/Accounts Page.swift
@@ -12,14 +12,13 @@ struct AccountsPage: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var accountsTracker: SavedAccountTracker
 
-    @Binding var isShowingInstanceAdditionSheet: Bool
-
-    @State var selection: Int?
-
+    @State private var isShowingInstanceAdditionSheet: Bool = false
+    @Binding var selectedAccount: SavedAccount?
+    
     var body: some View {
         VStack {
             if !accountsTracker.savedAccounts.isEmpty {
-                List(selection: $appState.currentActiveAccount) {
+                List(selection: $selectedAccount) {
                     ForEach(accountsTracker.savedAccounts, id: \.self) { savedAccount in
                         HStack(alignment: .center) {
                             Text(savedAccount.username)
@@ -42,11 +41,14 @@ struct AccountsPage: View {
                 .foregroundColor(.secondary)
             }
         }
+        .sheet(isPresented: $isShowingInstanceAdditionSheet) {
+            AddSavedInstanceView(isShowingSheet: $isShowingInstanceAdditionSheet)
+        }
         .navigationTitle("Accounts")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    isShowingInstanceAdditionSheet.toggle()
+                    isShowingInstanceAdditionSheet = true
                 } label: {
                     Image(systemName: "plus")
                 }

--- a/Mlem/Views/Tabs/Profile/Profile View.swift
+++ b/Mlem/Views/Tabs/Profile/Profile View.swift
@@ -12,17 +12,16 @@ struct ProfileView: View {
     // appstorage
     @AppStorage("shouldShowUserHeaders") var shouldShowUserHeaders: Bool = true
     
+    let userID: Int
+    
     // environment
     @EnvironmentObject var appState: AppState
-    
-    // parameters
-    @State var account: SavedAccount
 
     @State private var navigationPath = NavigationPath()
     
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            UserView(userID: account.id, account: account)
+            UserView(userID: userID)
                 .handleLemmyViews()
                 .edgesIgnoringSafeArea(.top)
                 .toolbar(.hidden)

--- a/Mlem/Views/Tabs/Profile/User Moderator View.swift
+++ b/Mlem/Views/Tabs/Profile/User Moderator View.swift
@@ -5,7 +5,6 @@
 //  Created by Jake Shirley on 6/30/23.
 //
 
-import CachedAsyncImage
 import SwiftUI
 
 /*
@@ -13,7 +12,6 @@ import SwiftUI
  */
 struct UserModeratorView: View {
     // parameters
-    let account: SavedAccount
     var userDetails: APIPersonView
     var moderatedCommunities: [APICommunityModeratorView]
     

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -14,7 +14,6 @@ import SwiftUI
 /// View for showing user profiles
 /// Accepts the following parameters:
 /// - **userID**: Non-optional ID of the user
-/// - **account**: Authenticated account to make the requests
 struct UserView: View {
     // appstorage
     @AppStorage("shouldShowUserHeaders") var shouldShowUserHeaders: Bool = true
@@ -24,7 +23,6 @@ struct UserView: View {
     
     // parameters
     @State var userID: Int
-    @State var account: SavedAccount
     @State var userDetails: APIPersonView?
 
     @StateObject private var privateCommentReplyTracker: CommentReplyTracker = .init()
@@ -149,7 +147,7 @@ struct UserView: View {
     }
     
     private func isShowingOwnProfile() -> Bool {
-        return userID == account.id
+        return userID == appState.currentActiveAccount.id
     }
     
     @ViewBuilder
@@ -337,8 +335,8 @@ struct UserView: View {
     
     private func loadUser(savedItems: Bool) async throws -> GetPersonDetailsResponse {
         let request = try GetPersonDetailsRequest(
-            accessToken: account.accessToken,
-            instanceURL: account.instanceLink,
+            accessToken: appState.currentActiveAccount.accessToken,
+            instanceURL: appState.currentActiveAccount.instanceLink,
             limit: 20, // TODO: Stream pages
             savedOnly: savedItems,
             personId: userID
@@ -361,7 +359,6 @@ struct UserView: View {
     private func postEntry(for post: APIPostView) -> some View {
         NavigationLink(value: PostLinkWithContext(post: post, postTracker: privatePostTracker)) {
             FeedPost(postView: post,
-                     account: account,
                      showPostCreator: false,
                      showCommunity: true,
                      isDragging: $isDragging,
@@ -376,7 +373,6 @@ struct UserView: View {
      */
     private func commentEntry(for comment: HierarchicalComment) -> some View {
         CommentItem(
-            account: account,
             hierarchicalComment: comment,
             postContext: nil,
             depth: 0,
@@ -557,7 +553,6 @@ struct UserViewPreview: PreviewProvider {
     static var previews: some View {
         UserView(
             userID: 123,
-            account: previewAccount,
             userDetails: APIPersonView(
                 person: generatePreviewUser(name: "actualUsername", displayName: "PreferredUsername", userType: .normal),
                 counts: APIPersonAggregates(id: 123, personId: 123, postCount: 123, postScore: 567, commentCount: 14, commentScore: 974)

--- a/Mlem/Views/Tabs/Search/Search View.swift
+++ b/Mlem/Views/Tabs/Search/Search View.swift
@@ -9,8 +9,6 @@ import Foundation
 import SwiftUI
 
 struct SearchView: View {
-    // paremters
-    let account: SavedAccount
     
     // environment
     @EnvironmentObject var appState: AppState
@@ -159,7 +157,7 @@ struct SearchView: View {
                 print("Searching for '\(searchText)' on page \(searchPage)")
                 
                 let request = SearchRequest(
-                    account: account,
+                    account: appState.currentActiveAccount,
                     query: searchText,
                     searchType: .communities,
                     sortOption: .topAll,

--- a/Mlem/Views/Tabs/Settings/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Settings View.swift
@@ -8,8 +8,13 @@
 import SwiftUI
 
 struct SettingsView: View {
+    
+    @EnvironmentObject var appState: AppState
+    
     @Environment(\.openURL) private var openURL
 
+    @State private var accountToSwitchTo: SavedAccount?
+    
     @State private var specialContributors: [Contributor] = [
         Contributor(
             name: "Seb Jachec",
@@ -87,6 +92,18 @@ struct SettingsView: View {
                             AlternativeIcons.getCurrentIcon()
                                 .foregroundColor(.pink)
                             Text("Alternative Icons")
+                        }
+                    }
+                }
+                
+                Section {
+                    NavigationLink {
+                        AccountsPage(selectedAccount: $accountToSwitchTo)
+                    } label: {
+                        HStack(alignment: .center) {
+                            Image(systemName: "person.fill.questionmark")
+                                .foregroundColor(.mint)
+                            Text("Switch Account")
                         }
                     }
                 }
@@ -190,6 +207,10 @@ struct SettingsView: View {
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
+            .onChange(of: accountToSwitchTo) { account in
+                guard let account else { return }
+                appState.setActiveAccount(account)
+            }
         }
     }
 }

--- a/Mlem/Window.swift
+++ b/Mlem/Window.swift
@@ -8,49 +8,65 @@
 import SwiftUI
 
 struct Window: View {
-    @StateObject var appState: AppState = .init()
     @StateObject var favoriteCommunitiesTracker: FavoriteCommunitiesTracker = .init()
     @StateObject var communitySearchResultsTracker: CommunitySearchResultsTracker = .init()
     @StateObject var filtersTracker: FiltersTracker = .init()
     @StateObject var recentSearchesTracker: RecentSearchesTracker = .init()
-
+    
+    @State var selectedAccount: SavedAccount?
+    
     var body: some View {
+        if let selectedAccount {
+            view(for: selectedAccount)
+        } else {
+            NavigationStack {
+                AccountsPage(selectedAccount: $selectedAccount)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private func view(for account: SavedAccount) -> some View {
         ContentView()
+            .id(account.id)
             .environmentObject(filtersTracker)
-            .environmentObject(appState)
+            .environmentObject(AppState(defaultAccount: account, selectedAccount: $selectedAccount))
             .environmentObject(favoriteCommunitiesTracker)
             .environmentObject(communitySearchResultsTracker)
             .environmentObject(recentSearchesTracker)
-            .onChange(of: filtersTracker.filteredKeywords) { newValue in
-                print("Change detected in filtered keywords: \(newValue)")
-                do {
-                    let encodedFilteredKeywords: Data = try encodeForSaving(object: newValue)
+            .onChange(of: filtersTracker.filteredKeywords) { saveFilteredKeywords($0) }
+            .onChange(of: favoriteCommunitiesTracker.favoriteCommunities) { saveFavouriteCommunities($0) }
+    }
+    
+    private func saveFilteredKeywords(_ newValue: [String]) {
+        print("Change detected in filtered keywords: \(newValue)")
+        do {
+            let encodedFilteredKeywords: Data = try encodeForSaving(object: newValue)
 
-                    print(encodedFilteredKeywords)
-                    do {
-                        try writeDataToFile(data: encodedFilteredKeywords, fileURL: AppConstants.filteredKeywordsFilePath)
-                    } catch let writingError {
-                        print("Failed while saving data to file: \(writingError)")
-                    }
-                } catch let encodingError {
-                    print("Failed while encoding filters to data: \(encodingError)")
-                }
+            print(encodedFilteredKeywords)
+            do {
+                try writeDataToFile(data: encodedFilteredKeywords, fileURL: AppConstants.filteredKeywordsFilePath)
+            } catch let writingError {
+                print("Failed while saving data to file: \(writingError)")
             }
-            .onChange(of: favoriteCommunitiesTracker.favoriteCommunities) { newValue in
-                print("Change detected in favorited communities")
+        } catch let encodingError {
+            print("Failed while encoding filters to data: \(encodingError)")
+        }
+    }
+    
+    private func saveFavouriteCommunities(_ newValue: [FavoriteCommunity]) {
+        print("Change detected in favorited communities")
 
-                do {
-                    let encodedFavoriteCommunities: Data = try encodeForSaving(object: newValue)
+        do {
+            let encodedFavoriteCommunities: Data = try encodeForSaving(object: newValue)
 
-                    do {
-                        try writeDataToFile(data: encodedFavoriteCommunities, fileURL: AppConstants.favoriteCommunitiesFilePath)
-                    } catch let writingError {
-                        print("Failed while saving data to file: \(writingError)")
-                    }
-                } catch let encodingError {
-                    print("Failed while encoding favorited communities to data: \(encodingError)")
-                }
+            do {
+                try writeDataToFile(data: encodedFavoriteCommunities, fileURL: AppConstants.favoriteCommunitiesFilePath)
+            } catch let writingError {
+                print("Failed while saving data to file: \(writingError)")
             }
-
+        } catch let encodingError {
+            print("Failed while encoding favorited communities to data: \(encodingError)")
+        }
     }
 }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - fixes #207 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR started off as _"show a modal, get a new token, carry on"_. Unfortunately showing a modal and getting a token was simples, but then came the issue that the entire application was holding onto copies of a now out of date `SavedAccount` with the old token in it.

The token should be separated from the account (I think), but I've not done that in this PR, when we introduce the _middleware_ between the application and the API we can do that bit 🙏 

Onto the changes;

- The accounts page is no longer the root view of the application 🎉 
- The start-up of the application has been adapted and now does one of the following:
    - If the user has a _default account_ (currently this is just the last used) they will go directly to their feed at launch
    - If the user has no _default account_ or no accounts at all, they'll land on the accounts page
- As we now always have an account before entering the main application, the `.currentActiveAccount` in the `AppState` is now a non-optional property 🎉 
- As the `.currentActiveAccount` is now non-optional, we don't need to pass the account into every view, you just ask the `AppState` for it, it'll always be up-to-date and you don't need any unwrapping 🎉 
- All the account passing around has been removed, now everywhere does as above and reads it from the shared `AppState` 🎉 
- If we encounter an invalid session a modal will be presented asking the user to re-authenticate, once done the `.currentActiveAccount` is updated, that in combination with the above should make future interactions succeed with the refreshed token 🎉 
- Added a new `Switch Account` option in settings where the user can switch between any added accounts. When this is selected the whole application UI will reset to give that account a clean slate to start from 🎉 

## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/5231793/6760eb74-1ac2-445f-aa98-866cfe5ff96a

https://github.com/mlemgroup/mlem/assets/5231793/657d4591-e299-4434-9069-268d6a156100

## Additional Context

A couple of known issues:
- When a user switches account the app state initialises twice very quickly, which causes no _issues_ but we do trigger two `/site` calls as a result, this is more an issue that we should likely be handling that call elsewhere than an issue with switching accounts.
- The modal will not display if we're _already_ inside a modal, this is the age old _you can't present because you're already presenting_ issue, which is easy to get round in `UIKit` but... not so simple in `SwiftUI` unless we want to start manually showing sheets in every modal when we see a token issue 🤮 - I'll continue to look into this and see if we can solve it inside `SwiftUI` 🙏 
- I've kinda borked the iPad navigation (sorry @tht7) we can address that separately since we don't actively support it yet
