### PR TITLE
"small" lag fix

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -158,7 +158,6 @@
 		63F0C7AD2A05235400A18C5D /* Encode for Saving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F0C7AC2A05235400A18C5D /* Encode for Saving.swift */; };
 		63F0C7AF2A05256C00A18C5D /* Decode Data from File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F0C7AE2A05256C00A18C5D /* Decode Data from File.swift */; };
 		63F0C7B12A0525FB00A18C5D /* Create Empty File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F0C7B02A0525FB00A18C5D /* Create Empty File.swift */; };
-		63F0C7B72A052F5000A18C5D /* CachedAsyncImage in Frameworks */ = {isa = PBXBuildFile; productRef = 63F0C7B62A052F5000A18C5D /* CachedAsyncImage */; };
 		63F0C7B92A0533C700A18C5D /* Add Account View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F0C7B82A0533C700A18C5D /* Add Account View.swift */; };
 		63F0C7BB2A058CB700A18C5D /* URLSessionWebSocketTask - Send Ping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F0C7BA2A058CB700A18C5D /* URLSessionWebSocketTask - Send Ping.swift */; };
 		63F0C7BD2A058CD200A18C5D /* Check if Endpoint Exists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F0C7BC2A058CD200A18C5D /* Check if Endpoint Exists.swift */; };
@@ -619,7 +618,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				63E5D3902A13CE4100EC1FBD /* DebouncedOnChange in Frameworks */,
-				63F0C7B72A052F5000A18C5D /* CachedAsyncImage in Frameworks */,
 				B104A6DA2A59BF3C00B3E725 /* NukeExtensions in Frameworks */,
 				63D24EDC2A169F12005CCA81 /* MarkdownUI in Frameworks */,
 				B104A6D82A59BF3C00B3E725 /* Nuke in Frameworks */,
@@ -1565,7 +1563,6 @@
 			);
 			name = Mlem;
 			packageProductDependencies = (
-				63F0C7B62A052F5000A18C5D /* CachedAsyncImage */,
 				63E5D38F2A13CE4100EC1FBD /* DebouncedOnChange */,
 				63D24EDB2A169F12005CCA81 /* MarkdownUI */,
 				636250DB2A18111400FC59B4 /* KeychainAccess */,
@@ -1648,7 +1645,6 @@
 			);
 			mainGroup = 6363D5B827EE196700E34822;
 			packageReferences = (
-				63F0C7B52A052F5000A18C5D /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */,
 				63E5D38E2A13CE4100EC1FBD /* XCRemoteSwiftPackageReference "DebouncedOnChange" */,
 				63D24EDA2A169F12005CCA81 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 				636250DA2A18111400FC59B4 /* XCRemoteSwiftPackageReference "KeychainAccess" */,
@@ -2367,14 +2363,6 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		63F0C7B52A052F5000A18C5D /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/lorenzofiamingo/swiftui-cached-async-image.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
-			};
-		};
 		B104A6D62A59BF3C00B3E725 /* XCRemoteSwiftPackageReference "Nuke" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kean/Nuke";
@@ -2408,11 +2396,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 63E5D38E2A13CE4100EC1FBD /* XCRemoteSwiftPackageReference "DebouncedOnChange" */;
 			productName = DebouncedOnChange;
-		};
-		63F0C7B62A052F5000A18C5D /* CachedAsyncImage */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 63F0C7B52A052F5000A18C5D /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */;
-			productName = CachedAsyncImage;
 		};
 		B104A6D72A59BF3C00B3E725 /* Nuke */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "f67266f176af4add9f7a7020486826d82d562473",
-        "version" : "12.1.2"
+        "revision" : "c3864b8882bc69f5edfe5c70e18786c91d228b28",
+        "version" : "12.1.3"
       }
     },
     {
@@ -43,15 +43,6 @@
       "state" : {
         "revision" : "12b351a75201a8124c2f2e1f9fc6ef5cd812c0b9",
         "version" : "2.1.0"
-      }
-    },
-    {
-      "identity" : "swiftui-cached-async-image",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lorenzofiamingo/swiftui-cached-async-image.git",
-      "state" : {
-        "revision" : "467a3d17479887943ab917a379e62bbaff60ac8a",
-        "version" : "2.1.1"
       }
     }
   ],

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -17,6 +17,7 @@ struct AppConstants {
 
     // MARK: - Date parsing
     static let dateComponentsFormatter: DateComponentsFormatter = DateComponentsFormatter()
+    static let relativeDateFormatter: RelativeDateTimeFormatter = RelativeDateTimeFormatter()
 
     // MARK: - Keychain
     static let keychain: Keychain = Keychain(service: "com.hanners.Mlem-keychain")
@@ -59,7 +60,8 @@ struct AppConstants {
     static let shortSwipeDragMin: CGFloat = 60
     
     // MARK: - Sizes
-    static let maxFeedPostHeight: CGFloat = 400
+    static let maxFeedPostHeight: CGFloat = 500
+    static let minFeedPostHeight: CGFloat = 200
     static let largeAvatarSize: CGFloat = 32
     static let smallAvatarSize: CGFloat = 16
     static let defaultAvatarSize: CGFloat = 24

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -17,7 +17,6 @@ struct AppConstants {
 
     // MARK: - Date parsing
     static let dateComponentsFormatter: DateComponentsFormatter = DateComponentsFormatter()
-    static let relativeDateFormatter: RelativeDateTimeFormatter = RelativeDateTimeFormatter()
 
     // MARK: - Keychain
     static let keychain: Keychain = Keychain(service: "com.hanners.Mlem-keychain")
@@ -60,8 +59,7 @@ struct AppConstants {
     static let shortSwipeDragMin: CGFloat = 60
     
     // MARK: - Sizes
-    static let maxFeedPostHeight: CGFloat = 500
-    static let minFeedPostHeight: CGFloat = 200
+    static let maxFeedPostHeight: CGFloat = 400
     static let largeAvatarSize: CGFloat = 32
     static let smallAvatarSize: CGFloat = 16
     static let defaultAvatarSize: CGFloat = 24

--- a/Mlem/Logic/Time Parser.swift
+++ b/Mlem/Logic/Time Parser.swift
@@ -7,15 +7,7 @@
 
 import Foundation
 
-func getTimeIntervalFromNow(date: Date, unitsStyle: DateComponentsFormatter.UnitsStyle = .abbreviated) -> String {
-    AppConstants.dateComponentsFormatter.unitsStyle = unitsStyle
-    AppConstants.dateComponentsFormatter.maximumUnitCount = 1
-    
-    let interval = date.timeIntervalSinceNow
-    if interval > -1 {
-        return "Now"
-    }
-    
-    let value = AppConstants.dateComponentsFormatter.string(from: abs(interval))
-    return value ?? "Unknown"
+func getTimeIntervalFromNow(date: Date, unitsStyle: RelativeDateTimeFormatter.UnitsStyle = .abbreviated) -> String {
+    AppConstants.relativeDateFormatter.unitsStyle = unitsStyle
+    return AppConstants.relativeDateFormatter.localizedString(for: date, relativeTo: Date())
 }

--- a/Mlem/Logic/Time Parser.swift
+++ b/Mlem/Logic/Time Parser.swift
@@ -7,7 +7,15 @@
 
 import Foundation
 
-func getTimeIntervalFromNow(date: Date, unitsStyle: RelativeDateTimeFormatter.UnitsStyle = .abbreviated) -> String {
-    AppConstants.relativeDateFormatter.unitsStyle = unitsStyle
-    return AppConstants.relativeDateFormatter.localizedString(for: date, relativeTo: Date())
+func getTimeIntervalFromNow(date: Date, unitsStyle: DateComponentsFormatter.UnitsStyle = .abbreviated) -> String {
+    AppConstants.dateComponentsFormatter.unitsStyle = unitsStyle
+    AppConstants.dateComponentsFormatter.maximumUnitCount = 1
+    
+    let interval = date.timeIntervalSinceNow
+    if interval > -1 {
+        return "Now"
+    }
+    
+    let value = AppConstants.dateComponentsFormatter.string(from: abs(interval))
+    return value ?? "Unknown"
 }

--- a/Mlem/Views/Shared/Cached Image With Nsfw Filter.swift
+++ b/Mlem/Views/Shared/Cached Image With Nsfw Filter.swift
@@ -10,8 +10,11 @@ import SwiftUI
 import MarkdownUI
 import NukeUI
 
-struct CachedImageWithNsfwFilter: View {
-
+struct CachedImageWithNsfwFilter: View, Equatable {
+    static func == (lhs: CachedImageWithNsfwFilter, rhs: CachedImageWithNsfwFilter) -> Bool {
+        lhs.url == rhs.url && lhs.isNsfw == rhs.isNsfw
+    }
+    
     let isNsfw: Bool
     let url: URL?
 

--- a/Mlem/Views/Shared/Links/Community Link View.swift
+++ b/Mlem/Views/Shared/Links/Community Link View.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import SwiftUI
-import CachedAsyncImage
+import NukeUI
 
 private let clipOptOut = ["beehaw.org"]
 
@@ -149,11 +149,12 @@ struct CommunityLabel: View {
         serverInstanceLocation == .bottom ? from.withIcon64Parameters : from.withIcon32Parameters
     }
     
+    @MainActor
     @ViewBuilder
     private var communityAvatar: some View {
         Group {
             if let communityAvatarLink = community.icon {
-                CachedAsyncImage(url: avatarUrl(from: communityAvatarLink), urlCache: AppConstants.urlCache) { image in
+                LazyImage(url: avatarUrl(from: communityAvatarLink)) { image in
                     if let avatar = image.image {
                         avatar
                             .resizable()

--- a/Mlem/Views/Shared/Links/User Profile Label.swift
+++ b/Mlem/Views/Shared/Links/User Profile Label.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import CachedAsyncImage
+import NukeUI
 
 struct UserProfileLabel: View {
     @AppStorage("shouldShowUserAvatars") var shouldShowUserAvatars: Bool = true
@@ -70,12 +70,12 @@ struct UserProfileLabel: View {
             userName
         }
     }
-    
+    @MainActor
     @ViewBuilder
     private var userAvatar: some View {
         Group {
             if let userAvatarLink = user.avatar {
-                CachedAsyncImage(url: avatarUrl(from: userAvatarLink), urlCache: AppConstants.urlCache) { image in
+                LazyImage(url: avatarUrl(from: userAvatarLink)) { image in
                     if let avatar = image.image {
                         avatar
                             .resizable()

--- a/Mlem/Views/Shared/Markdown View.swift
+++ b/Mlem/Views/Shared/Markdown View.swift
@@ -232,7 +232,6 @@ struct MarkdownView: View, Equatable {
 
     @MainActor func generateView() -> some View {
         let blocks = parseMarkdownForImages(text: text)
-//        verbatim
         return VStack {
             ForEach(blocks) { block in
                 if block.isImage {
@@ -244,11 +243,7 @@ struct MarkdownView: View, Equatable {
                                       )
                     }
                 } else {
-                    if replaceImagesWithEmoji {
-                        Text(verbatim: String(block.text))
-                    } else {
-                        getMarkdown(text: String(block.text))
-                    }
+                    getMarkdown(text: String(block.text))
                 }
             }
         }

--- a/Mlem/Views/Shared/Markdown View.swift
+++ b/Mlem/Views/Shared/Markdown View.swift
@@ -211,7 +211,10 @@ struct MarkdownBlock: Identifiable {
     let id: Int
 }
 
-struct MarkdownView: View {
+struct MarkdownView: View, Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.text == rhs.text && lhs.isNsfw == rhs.isNsfw
+    }
 
     @State var text: String
     let isNsfw: Bool
@@ -236,7 +239,9 @@ struct MarkdownView: View {
                     if replaceImagesWithEmoji {
                         getMarkdown(text: AppConstants.pictureEmoji.randomElement() ?? "🖼️")
                     } else {
-                        CachedImageWithNsfwFilter(isNsfw: isNsfw, url: URL(string: String(block.text)))
+                        EquatableView(content:
+                                        CachedImageWithNsfwFilter(isNsfw: isNsfw, url: URL(string: String(block.text)))
+                                      )
                     }
                 } else {
                     if replaceImagesWithEmoji {

--- a/Mlem/Views/Shared/Markdown View.swift
+++ b/Mlem/Views/Shared/Markdown View.swift
@@ -229,7 +229,7 @@ struct MarkdownView: View {
 
     @MainActor func generateView() -> some View {
         let blocks = parseMarkdownForImages(text: text)
-        
+//        verbatim
         return VStack {
             ForEach(blocks) { block in
                 if block.isImage {
@@ -239,7 +239,11 @@ struct MarkdownView: View {
                         CachedImageWithNsfwFilter(isNsfw: isNsfw, url: URL(string: String(block.text)))
                     }
                 } else {
-                    getMarkdown(text: String(block.text))
+                    if replaceImagesWithEmoji {
+                        Text(verbatim: String(block.text))
+                    } else {
+                        getMarkdown(text: String(block.text))
+                    }
                 }
             }
         }

--- a/Mlem/Views/Shared/Markdown View.swift
+++ b/Mlem/Views/Shared/Markdown View.swift
@@ -232,6 +232,7 @@ struct MarkdownView: View, Equatable {
 
     @MainActor func generateView() -> some View {
         let blocks = parseMarkdownForImages(text: text)
+//        verbatim
         return VStack {
             ForEach(blocks) { block in
                 if block.isImage {
@@ -243,7 +244,11 @@ struct MarkdownView: View, Equatable {
                                       )
                     }
                 } else {
-                    getMarkdown(text: String(block.text))
+                    if replaceImagesWithEmoji {
+                        Text(verbatim: String(block.text))
+                    } else {
+                        getMarkdown(text: String(block.text))
+                    }
                 }
             }
         }

--- a/Mlem/Views/Shared/Website Icon Complex.swift
+++ b/Mlem/Views/Shared/Website Icon Complex.swift
@@ -51,9 +51,11 @@ struct WebsiteIconComplex: View {
     var body: some View {
         VStack(spacing: 0) {
             if shouldShowWebsitePreviews, let thumbnailURL = post.thumbnailUrl {
-                CachedImageWithNsfwFilter(isNsfw: post.nsfw, url: thumbnailURL)
-                    .frame(maxHeight: 400)
-                    .clipped()
+                EquatableView(content:
+                    CachedImageWithNsfwFilter(isNsfw: post.nsfw, url: thumbnailURL)
+                )
+                .frame(maxHeight: 400)
+                .clipped()
             }
             
             VStack(alignment: .leading, spacing: AppConstants.postAndCommentSpacing) {

--- a/Mlem/Views/Shared/Website Icon Complex.swift
+++ b/Mlem/Views/Shared/Website Icon Complex.swift
@@ -5,7 +5,7 @@
 //  Created by David Bureš on 04.05.2023.
 //
 
-import CachedAsyncImage
+import NukeUI
 import Foundation
 import SwiftUI
 
@@ -60,12 +60,14 @@ struct WebsiteIconComplex: View {
                 if shouldShowWebsiteHost {
                     HStack {
                         if shouldShowWebsiteIcon {
-                            CachedAsyncImage(url: faviconURL, urlCache: AppConstants.urlCache) { image in
-                                image
-                                    .resizable()
-                                    .scaledToFit()
-                            } placeholder: {
-                                Image(systemName: "globe")
+                            LazyImage(url: faviconURL) { state in
+                                if let image = state.image {
+                                    image
+                                        .resizable()
+                                        .scaledToFit()
+                                } else {
+                                    Image(systemName: "globe")
+                                }
                             }
                             .frame(width: AppConstants.smallAvatarSize, height: AppConstants.smallAvatarSize)
                         }

--- a/Mlem/Views/Tabs/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feed Root.swift
@@ -23,8 +23,10 @@ struct FeedRoot: View {
     var body: some View {
 
         NavigationSplitView {
-            CommunityListView(selectedCommunity: $rootDetails)
-                .id(appState.currentActiveAccount.id)
+            EquatableView(
+                content: CommunityListView(selectedCommunity: $rootDetails)
+            )
+            .id(appState.currentActiveAccount.id)
         } detail: {
             if let rootDetails {
                 NavigationStack(path: $navigationPath) {

--- a/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Mention View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Mention View.swift
@@ -52,7 +52,7 @@ struct InboxMentionView: View {
                     .foregroundColor(.accentColor)
                     .frame(width: userAvatarWidth)
                 
-                MarkdownView(text: mention.comment.content, isNsfw: false)
+                EquatableView(content: MarkdownView(text: mention.comment.content, isNsfw: false))
                     .font(.subheadline)
             }
             

--- a/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Message View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Message View.swift
@@ -32,7 +32,7 @@ struct InboxMessageView: View {
                     .foregroundColor(.accentColor)
                     .frame(height: userAvatarWidth)
                 
-                MarkdownView(text: message.privateMessage.content, isNsfw: false)
+                EquatableView(content: MarkdownView(text: message.privateMessage.content, isNsfw: false))
                     .font(.subheadline)
             }
             

--- a/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Reply View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Item Types/Inbox Reply View.swift
@@ -52,7 +52,7 @@ struct InboxReplyView: View {
                     .foregroundColor(.accentColor)
                     .frame(width: userAvatarWidth)
                 
-                MarkdownView(text: reply.comment.content, isNsfw: false)
+                EquatableView(content: MarkdownView(text: reply.comment.content, isNsfw: false))
                     .font(.subheadline)
             }
             

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-import CachedAsyncImage
 
 enum InboxTab: String, CaseIterable, Identifiable {
     case all, replies, mentions, messages

--- a/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
@@ -176,7 +176,12 @@ struct CommentItem: View {
                     .italic()
                     .foregroundColor(.secondary)
             } else if !isCollapsed {
-                MarkdownView(text: hierarchicalComment.commentView.comment.content, isNsfw: hierarchicalComment.commentView.post.nsfw)
+                EquatableView(content:
+                                MarkdownView(
+                                    text: hierarchicalComment.commentView.comment.content,
+                                    isNsfw: hierarchicalComment.commentView.post.nsfw
+                                )
+                              )
                     .frame(maxWidth: .infinity, alignment: .topLeading)
             }
 

--- a/Mlem/Views/Tabs/Posts/Components/Comment/Components/CommentBodyView.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Comment/Components/CommentBodyView.swift
@@ -65,7 +65,9 @@ struct CommentBodyView: View {
                     .italic()
                     .foregroundColor(.secondary)
             } else if !isCollapsed {
-                MarkdownView(text: commentView.comment.content, isNsfw: commentView.post.nsfw)
+                EquatableView(content:
+                                MarkdownView(text: commentView.comment.content, isNsfw: commentView.post.nsfw)
+                )
                     .frame(maxWidth: .infinity, alignment: .topLeading)
             }
 

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
@@ -7,7 +7,11 @@
 
 import SwiftUI
 
-struct CommunitySection: Identifiable {
+struct CommunitySection: Identifiable, Equatable {
+    static func == (lhs: CommunitySection, rhs: CommunitySection) -> Bool {
+        lhs.viewId == rhs.viewId
+    }
+    
     let id = UUID()
     let viewId: String
     let sidebarEntry: any SidebarEntry
@@ -15,11 +19,14 @@ struct CommunitySection: Identifiable {
     let accessibilityLabel: String
 }
 
-struct CommunityListView: View {
+struct CommunityListView: View, Equatable {
+    static func == (lhs: CommunityListView, rhs: CommunityListView) -> Bool {
+        lhs.communitySections == rhs.communitySections
+        && lhs.selectedCommunity == rhs.selectedCommunity
+    }
+    
     @EnvironmentObject var favoritedCommunitiesTracker: FavoriteCommunitiesTracker
     @EnvironmentObject var appState: AppState
-    @Environment(\.openURL) var openURL
-    @Environment(\.navigationPath) var navigationPath
     @AppStorage("defaultFeed") var defaultFeed: FeedType = .subscribed
 
     @State var subscribedCommunities = [APICommunity]()

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar Header Avatar.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar Header Avatar.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 import SwiftUI
-import CachedAsyncImage
+import NukeUI
 
 struct CommunitySidebarHeaderAvatar: View {
     @State var shouldClipAvatar: Bool = false
@@ -17,22 +17,26 @@ struct CommunitySidebarHeaderAvatar: View {
     var body: some View {
         ZStack {
             if let avatarURL = imageUrl {
-                CachedAsyncImage(url: avatarURL) { image in
-                    if shouldClipAvatar {
-                        image
-                            .resizable()
-                            .scaledToFill()
-                            .clipShape(Circle())
-                            .overlay(Circle()
-                            .stroke(.secondary, lineWidth: 2))
+                LazyImage(url: avatarURL) { state in
+                    if let image = state.image {
+                        if shouldClipAvatar {
+                            image
+                                .resizable()
+                                .scaledToFill()
+                                .clipShape(Circle())
+                                .overlay(Circle()
+                                    .stroke(.secondary, lineWidth: 2))
+                        } else {
+                            image
+                                .resizable()
+                                .scaledToFill()
+                        }
+                    } else if state.error != nil {
+                        Circle().strokeBorder(.background, lineWidth: 2)
+                            .background(Circle().fill(.secondary))
                     } else {
-                        image
-                            .resizable()
-                            .scaledToFill()
+                        ProgressView()
                     }
-
-                } placeholder: {
-                    ProgressView()
                 }
             } else {
                 // TODO: Default avatar?

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar Header.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar Header.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import CachedAsyncImage
+import NukeUI
 
 struct CommunitySidebarHeader: View {
     var title: String
@@ -25,11 +25,16 @@ struct CommunitySidebarHeader: View {
             // Banner
             VStack {
                 if let bannerUrl = bannerURL {
-                    CachedAsyncImage(url: bannerUrl) { image in
-                        image.centerCropped()
-                    } placeholder: {
-                        ProgressView()
-                    }.frame(height: 200)
+                    LazyImage(url: bannerUrl) { state in
+                        if let image = state.image {
+                            image.centerCropped()
+                        } else if state.error != nil {
+                            EmptyView()
+                        } else {
+                            ProgressView()
+                        }
+                    }
+                    .frame(height: 200)
                 }
             }
             VStack {

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar View.swift
@@ -58,10 +58,7 @@ struct CommunitySidebarView: View {
     }
     
     private func getRelativeTime(date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .full
-        
-        return formatter.localizedString(for: date, relativeTo: Date.now)
+        AppConstants.relativeDateFormatter.localizedString(for: date, relativeTo: Date.now)
     }
     
     @ViewBuilder

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar View.swift
@@ -58,7 +58,10 @@ struct CommunitySidebarView: View {
     }
     
     private func getRelativeTime(date: Date) -> String {
-        AppConstants.relativeDateFormatter.localizedString(for: date, relativeTo: Date.now)
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        
+        return formatter.localizedString(for: date, relativeTo: Date.now)
     }
     
     @ViewBuilder

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar View.swift
@@ -87,7 +87,9 @@ struct CommunitySidebarView: View {
                     .communityView
                     .community
                     .description {
-                    MarkdownView(text: description, isNsfw: false).padding()
+                    EquatableView(content:
+                                    MarkdownView(text: description, isNsfw: false)
+                        ).padding()
                 }
             } else if selectionSection == 1 {
                 VStack {

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
@@ -12,7 +12,6 @@
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
 
-import CachedAsyncImage
 import QuickLook
 import SwiftUI
 import AlertToast

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Components/Post Header.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Components/Post Header.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import SwiftUI
-import CachedAsyncImage
+import NukeUI
 
 struct PostHeader: View {
     // appstorage
@@ -72,11 +72,12 @@ struct PostHeader: View {
         .foregroundColor(.secondary)
     }
 
+    @MainActor
     @ViewBuilder
     private var communityAvatar: some View {
         Group {
             if let communityAvatarLink = postView.community.icon {
-                CachedAsyncImage(url: communityAvatarLink, urlCache: AppConstants.urlCache) { image in
+                LazyImage(url: communityAvatarLink) { image in
                     if let avatar = image.image {
                         avatar
                             .resizable()

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Headline Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Headline Post.swift
@@ -52,7 +52,7 @@ struct HeadlinePost: View {
                             StickiedTag(tagType: .community)
                         }
                         
-                        Text(verbatim: postView.post.name)
+                        Text(postView.post.name)
                             .font(.headline)
                             .padding(.trailing)
                         

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Headline Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Headline Post.swift
@@ -5,7 +5,7 @@
 //  Created by Eric Andrews on 2023-06-11.
 //
 
-import CachedAsyncImage
+import NukeUI
 import Foundation
 import SwiftUI
 
@@ -71,27 +71,34 @@ struct HeadlinePost: View {
         }
     }
 
+    @MainActor
     @ViewBuilder
     private var thumbnailImage: some View {
         Group {
             switch postView.postType {
             case .image(let url):
-                CachedAsyncImage(url: url, urlCache: AppConstants.urlCache) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
-                } placeholder: {
-                    ProgressView()
+                LazyImage(url: url) { state in
+                    if let image = state.image {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
+                    } else if state.error != nil {
+                        Image(systemName: "safari")
+                    } else {
+                        ProgressView()
+                    }
                 }
             case .link(let url):
-                CachedAsyncImage(url: url, urlCache: AppConstants.urlCache) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
-                } placeholder: {
-                    Image(systemName: "safari")
+                LazyImage(url: url) { state in
+                    if let image = state.image {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
+                    } else {
+                        Image(systemName: "safari")
+                    }
                 }
             case .text:
                 Image(systemName: "text.book.closed")

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Headline Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Headline Post.swift
@@ -52,7 +52,7 @@ struct HeadlinePost: View {
                             StickiedTag(tagType: .community)
                         }
                         
-                        Text(postView.post.name)
+                        Text(verbatim: postView.post.name)
                             .font(.headline)
                             .padding(.trailing)
                         

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
@@ -41,7 +41,7 @@ struct LargePost: View {
                     StickiedTag(tagType: .community)
                 }
                 
-                Text(verbatim: "\(postView.post.name)\(postView.post.deleted ? " (Deleted)" : "")")
+                Text("\(postView.post.name)\(postView.post.deleted ? " (Deleted)" : "")")
                     .font(.headline)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .italic(postView.post.deleted)
@@ -63,12 +63,11 @@ struct LargePost: View {
         switch postView.postType {
         case .image(let url):
             VStack(spacing: AppConstants.postAndCommentSpacing) {
-                EquatableView(content:
-                                CachedImageWithNsfwFilter(isNsfw: postView.post.nsfw, url: url)
-                              )
-                    .frame(maxWidth: .infinity, maxHeight: isExpanded ? .infinity : AppConstants.maxFeedPostHeight, alignment: .center)
-                    .cornerRadius(AppConstants.largeItemCornerRadius)
+                CachedImageWithNsfwFilter(isNsfw: postView.post.nsfw, url: url)
+                    .aspectRatio(contentMode: .fill)
+                    .frame(height: AppConstants.maxFeedPostHeight)
                     .clipped()
+                    .cornerRadius(AppConstants.largeItemCornerRadius)
                 postBodyView
             }
         case .link:
@@ -89,18 +88,15 @@ struct LargePost: View {
     var postBodyView: some View {
         if let bodyText = postView.post.body, !bodyText.isEmpty {
             if isExpanded {
-                EquatableView(content:
-                                MarkdownView(text: bodyText, isNsfw: postView.post.nsfw)
-                              )
+                EquatableView(content: MarkdownView(text: bodyText, isNsfw: postView.post.nsfw))
                     .font(.subheadline)
             } else {
-                EquatableView(content:
-                                MarkdownView(text: bodyText.components(separatedBy: .newlines).joined(separator: " "),
-                                             isNsfw: postView.post.nsfw,
-                                             replaceImagesWithEmoji: true)
-                              )
-                    .lineLimit(8)
-                    .font(.subheadline)
+                EquatableView(content: MarkdownView(text: bodyText.components(separatedBy: .newlines).joined(separator: " "),
+                                                    isNsfw: postView.post.nsfw,
+                                                    replaceImagesWithEmoji: true)
+                )
+                .lineLimit(8)
+                .font(.subheadline)
             }
         }
     }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
@@ -5,7 +5,6 @@
 //  Created by Eric Andrews on 2023-06-10.
 //
 
-import CachedAsyncImage
 import SwiftUI
 
 import Foundation

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
@@ -41,7 +41,7 @@ struct LargePost: View {
                     StickiedTag(tagType: .community)
                 }
                 
-                Text("\(postView.post.name)\(postView.post.deleted ? " (Deleted)" : "")")
+                Text(verbatim: "\(postView.post.name)\(postView.post.deleted ? " (Deleted)" : "")")
                     .font(.headline)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .italic(postView.post.deleted)

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
@@ -63,7 +63,9 @@ struct LargePost: View {
         switch postView.postType {
         case .image(let url):
             VStack(spacing: AppConstants.postAndCommentSpacing) {
-                CachedImageWithNsfwFilter(isNsfw: postView.post.nsfw, url: url)
+                EquatableView(content:
+                                CachedImageWithNsfwFilter(isNsfw: postView.post.nsfw, url: url)
+                              )
                     .frame(maxWidth: .infinity, maxHeight: isExpanded ? .infinity : AppConstants.maxFeedPostHeight, alignment: .center)
                     .cornerRadius(AppConstants.largeItemCornerRadius)
                     .clipped()
@@ -87,12 +89,16 @@ struct LargePost: View {
     var postBodyView: some View {
         if let bodyText = postView.post.body, !bodyText.isEmpty {
             if isExpanded {
-                MarkdownView(text: bodyText, isNsfw: postView.post.nsfw)
+                EquatableView(content:
+                                MarkdownView(text: bodyText, isNsfw: postView.post.nsfw)
+                              )
                     .font(.subheadline)
             } else {
-                MarkdownView(text: bodyText.components(separatedBy: .newlines).joined(separator: " "),
-                             isNsfw: postView.post.nsfw,
-                             replaceImagesWithEmoji: true)
+                EquatableView(content:
+                                MarkdownView(text: bodyText.components(separatedBy: .newlines).joined(separator: " "),
+                                             isNsfw: postView.post.nsfw,
+                                             replaceImagesWithEmoji: true)
+                              )
                     .lineLimit(8)
                     .font(.subheadline)
             }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
@@ -41,7 +41,7 @@ struct LargePost: View {
                     StickiedTag(tagType: .community)
                 }
                 
-                Text("\(postView.post.name)\(postView.post.deleted ? " (Deleted)" : "")")
+                Text(verbatim: "\(postView.post.name)\(postView.post.deleted ? " (Deleted)" : "")")
                     .font(.headline)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .italic(postView.post.deleted)
@@ -63,11 +63,12 @@ struct LargePost: View {
         switch postView.postType {
         case .image(let url):
             VStack(spacing: AppConstants.postAndCommentSpacing) {
-                CachedImageWithNsfwFilter(isNsfw: postView.post.nsfw, url: url)
-                    .aspectRatio(contentMode: .fill)
-                    .frame(height: AppConstants.maxFeedPostHeight)
-                    .clipped()
+                EquatableView(content:
+                                CachedImageWithNsfwFilter(isNsfw: postView.post.nsfw, url: url)
+                              )
+                    .frame(maxWidth: .infinity, maxHeight: isExpanded ? .infinity : AppConstants.maxFeedPostHeight, alignment: .center)
                     .cornerRadius(AppConstants.largeItemCornerRadius)
+                    .clipped()
                 postBodyView
             }
         case .link:
@@ -88,15 +89,18 @@ struct LargePost: View {
     var postBodyView: some View {
         if let bodyText = postView.post.body, !bodyText.isEmpty {
             if isExpanded {
-                EquatableView(content: MarkdownView(text: bodyText, isNsfw: postView.post.nsfw))
+                EquatableView(content:
+                                MarkdownView(text: bodyText, isNsfw: postView.post.nsfw)
+                              )
                     .font(.subheadline)
             } else {
-                EquatableView(content: MarkdownView(text: bodyText.components(separatedBy: .newlines).joined(separator: " "),
-                                                    isNsfw: postView.post.nsfw,
-                                                    replaceImagesWithEmoji: true)
-                )
-                .lineLimit(8)
-                .font(.subheadline)
+                EquatableView(content:
+                                MarkdownView(text: bodyText.components(separatedBy: .newlines).joined(separator: " "),
+                                             isNsfw: postView.post.nsfw,
+                                             replaceImagesWithEmoji: true)
+                              )
+                    .lineLimit(8)
+                    .font(.subheadline)
             }
         }
     }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/UltraCompactPost.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/UltraCompactPost.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import SwiftUI
-import CachedAsyncImage
+import NukeUI
 
 struct UltraCompactPost: View {
     // app storage
@@ -85,27 +85,34 @@ struct UltraCompactPost: View {
         .padding(AppConstants.postAndCommentSpacing)
     }
     
+    @MainActor
     @ViewBuilder
     private var thumbnailImage: some View {
         Group {
             switch postView.postType {
             case .image(let url):
-                CachedAsyncImage(url: url, urlCache: AppConstants.urlCache) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
-                } placeholder: {
-                    ProgressView()
+                LazyImage(url: url) { state in
+                    if let image = state.image {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
+                    } else if state.error != nil {
+                        Image(systemName: "safari")
+                    } else {
+                        ProgressView()
+                    }
                 }
             case .link(let url):
-                CachedAsyncImage(url: url, urlCache: AppConstants.urlCache) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
-                } placeholder: {
-                    Image(systemName: "safari")
+                LazyImage(url: url) { state in
+                    if let image = state.image {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
+                    } else {
+                        Image(systemName: "safari")
+                    }
                 }
             case .text:
                 Image(systemName: "text.book.closed")

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/UltraCompactPost.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/UltraCompactPost.swift
@@ -71,7 +71,7 @@ struct UltraCompactPost: View {
                 }
                 .padding(.bottom, -2)
                 
-                Text(postView.post.name)
+                Text(verbatim: postView.post.name)
                     .font(.subheadline)
     
                 compactInfo

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/UltraCompactPost.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/UltraCompactPost.swift
@@ -71,7 +71,7 @@ struct UltraCompactPost: View {
                 }
                 .padding(.bottom, -2)
                 
-                Text(verbatim: postView.post.name)
+                Text(postView.post.name)
                     .font(.subheadline)
     
                 compactInfo

--- a/Mlem/Views/Tabs/Posts/Components/Shared/Avatar View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Shared/Avatar View.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import CachedAsyncImage
+import NukeUI
 
 struct AvatarView: View {
 
@@ -14,7 +14,7 @@ struct AvatarView: View {
     var overridenSize: CGFloat = 15
 
     var body: some View {
-        CachedAsyncImage(url: avatarLink, urlCache: AppConstants.urlCache) { phase in
+        LazyImage(url: avatarLink) { phase in
             if let avatar = phase.image { /// Success
                 avatar
                     .resizable()

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -5,7 +5,6 @@
 //  Created by David Bureš on 02.04.2022.
 //
 
-import CachedAsyncImage
 import SwiftUI
 
 // swiftlint:disable file_length

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -81,7 +81,10 @@ struct UserView: View {
             header(for: userDetails)
             
             if let bio = userDetails.person.bio {
-                MarkdownView(text: bio, isNsfw: false).padding()
+                EquatableView(content:
+                                MarkdownView(text: bio, isNsfw: false)
+                )
+                .padding()
             }
             
             Picker(selection: $selectionSection, label: Text("Profile Section")) {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Documents View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Documents View.swift
@@ -48,7 +48,7 @@ struct DocumentsView: View {
     
     func documentView(doc: Document) -> some View {
         ScrollView {
-            MarkdownView(text: doc.body, isNsfw: false)
+            EquatableView(content: MarkdownView(text: doc.body, isNsfw: false))
         }
         .padding()
     }

--- a/Mlem/Views/Tabs/Settings/Contributors/Contributors View.swift
+++ b/Mlem/Views/Tabs/Settings/Contributors/Contributors View.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import CachedAsyncImage
+import NukeUI
 
 struct ContributorsView: View {
 
@@ -14,14 +14,22 @@ struct ContributorsView: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: 10) {
-            CachedAsyncImage(url: contributor.avatarLink, urlCache: AppConstants.urlCache) { image in
-                image
-                    .resizable()
-                    .frame(width: 100, height: 100)
-                    .clipShape(Circle())
-            } placeholder: {
-                ProgressView()
-                    .frame(width: 100, height: 100)
+            LazyImage(url: contributor.avatarLink) { state in
+                if let image = state.image {
+                    image
+                        .resizable()
+                        .frame(width: 100, height: 100)
+                        .clipShape(Circle())
+                } else if state.error != nil {
+                    Color.red
+                        .frame(width: 100, height: 100)
+                        .blur(radius: 30)
+                        .overlay { Image(systemName: "exclamationmark.triangle") }
+                        .clipShape(Circle())
+                } else {
+                    ProgressView()
+                        .frame(width: 100, height: 100)
+                }
             }
 
             VStack(alignment: .center, spacing: 5) {


### PR DESCRIPTION
Lets race down to 120hz
Main changes:
- there was a tiny lag that was the result of SwiftUI re-rendering the Community List View in the background many many time, and since that view does a bunch of filters own the main thread that caused a lag (especially during navigation):
 this was solved by using EquatableView to let SwiftUI know when to explicitly redraw that view
- A lot of images that are drawn constantly still used the old CachedAsyncImage that does image decoding on the main thread! ,soo all those images were replaced to use the Nuke LazyImage