### PR TITLE
fix #306 - display large post instead of expanded post in reply preview

### DIFF
--- a/Mlem/Models/Respondables/ReplyToExpandedPost.swift
+++ b/Mlem/Models/Respondables/ReplyToExpandedPost.swift
@@ -18,7 +18,7 @@ struct ReplyToExpandedPost: Respondable {
     let commentTracker: CommentTracker
     
     func embeddedView() -> AnyView {
-        return AnyView(ExpandedPost(post: post)
+        return AnyView(LargePost(postView: post, isExpanded: true)
             .padding(.horizontal))
     }
     


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Fixes #306
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR addresses the issue raised in #306 by replacing the `ExpandedPost` view with the `FeedPost` view for the preview when replying to a post.

## Screenshots and Videos
| BEFORE | AFTER |
| --- | --- |
| ![before](https://github.com/mlemgroup/mlem/assets/5231793/23de81eb-a510-41bb-9d86-7c37e6565513) | ![after](https://github.com/mlemgroup/mlem/assets/5231793/87855d32-29e6-4366-bb62-c8efae76c630) |



