### PR TITLE
fix - large images blocking interactions in preceeding posts

### DIFF
--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Post Types/Large Post.swift
@@ -65,7 +65,7 @@ struct LargePost: View {
         case .image(let url):
             VStack(spacing: AppConstants.postAndCommentSpacing) {
                 CachedImage(url: url)
-                    .frame(maxWidth: .infinity, maxHeight: isExpanded ? .infinity : AppConstants.maxFeedPostHeight, alignment: .center)
+                    .frame(maxWidth: .infinity, maxHeight: isExpanded ? .infinity : AppConstants.maxFeedPostHeight, alignment: .top)
                     .applyNsfwOverlay(postView.post.nsfw || postView.community.nsfw)
                     .cornerRadius(AppConstants.largeItemCornerRadius)
                     .clipped()


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - discussion in development channel
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR adjusts the alignment of the images in large posts to avoid an issue where interaction was becoming blocked on preceeding posts.