### PR TITLE
Fix Text Line Break in CommuntiyFeedRowView

### DIFF
--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Components/CommunityListRowViews.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Components/CommunityListRowViews.swift
@@ -41,12 +41,8 @@ struct CommuntiyFeedRowView: View {
         NavigationLink(value: CommunityLinkWithContext(community: community, feedType: .subscribed)) {
             HStack {
                 // NavigationLink with invisible array
-                HStack(alignment: .bottom, spacing: 0) {
-                    Text(community.name)
-                    if let website = community.actorId.host(percentEncoded: false) {
-                        Text("@\(website)").font(.footnote).foregroundColor(.gray).opacity(0.5)
-                    }
-                }
+                communityNameLabel
+
                 Spacer()
                 Button("Favorite Community") {
                     // Nice little haptics
@@ -78,6 +74,22 @@ struct CommuntiyFeedRowView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(communityLabel)
+    }
+
+	private var communityNameText: Text {
+		Text(community.name)
+	}
+
+    @ViewBuilder
+    private var communityNameLabel: some View {
+        if let website = community.actorId.host(percentEncoded: false) {
+            communityNameText +
+            Text("@\(website)")
+                .font(.footnote)
+                .foregroundColor(.gray.opacity(0.5))
+        } else {
+            communityNameText
+        }
     }
 
     private var communityLabel: String {


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR fixes some line breaking issues with Text elements in `CommuntiyFeedRowView`. Previously the Text views were concatenated using an `HStack`. I changed that to use native `Text` concatenation using the + operator.

## Screenshots and Videos
Note: The Operating Systems community row.

Before:
![Simulator Screenshot - iPad mini (6th generation) - 2023-07-17 at 16 40 11](https://github.com/mlemgroup/mlem/assets/5980743/febf86d6-e3f9-4e29-b248-bb84f0e2b516)

After:
![Simulator Screenshot - iPad mini (6th generation) - 2023-07-17 at 16 38 40](https://github.com/mlemgroup/mlem/assets/5980743/7b871674-71f6-4d02-9a53-0ac7e35d6759)


## Additional Context
N/A
