### PR TITLE
Fixed reply modal not appearing for FeedPost

### DIFF
--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
@@ -39,6 +39,7 @@ struct CommunityView: View {
 
     @State private var isComposingPost: Bool = false
     @State private var isPostingPost: Bool = false
+    @State var responseItem: ConcreteRespondable?
 
     @State var isDragging: Bool = false
 
@@ -294,6 +295,9 @@ struct CommunityView: View {
                 PostComposerView(community: community)
             }
         }
+        .sheet(item: $responseItem) { responseItem in
+            ResponseComposerView(concreteRespondable: responseItem)
+        }
         .onAppear {
             if !didLoad {
                 didLoad = true
@@ -352,7 +356,8 @@ struct CommunityView: View {
                         postView: post,
                         showPostCreator: shouldShowPostCreator,
                         showCommunity: !isInSpecificCommunity,
-                        isDragging: $isDragging
+                        isDragging: $isDragging,
+                        responseItem: $responseItem
                     )
                 }
                 Divider()

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
@@ -33,7 +33,7 @@ struct FeedPost: View {
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     
-    @State var responseItem: ConcreteRespondable?
+    @Binding var responseItem: ConcreteRespondable?
     
     // MARK: Parameters
 
@@ -42,13 +42,15 @@ struct FeedPost: View {
          showCommunity: Bool = true,
          showInteractionBar: Bool = true,
          enableSwipeActions: Bool = true,
-         isDragging: Binding<Bool>) {
+         isDragging: Binding<Bool>,
+         responseItem: Binding<ConcreteRespondable?>) {
         self.postView = postView
         self.showPostCreator = showPostCreator
         self.showCommunity = showCommunity
         self.showInteractionBar = showInteractionBar
         self.enableSwipeActions = enableSwipeActions
         self._isDragging = isDragging
+        self._responseItem = responseItem
     }
 
     let postView: APIPostView
@@ -88,9 +90,6 @@ struct FeedPost: View {
                     primaryTrailingAction: enableSwipeActions ? saveSwipeAction : nil,
                     secondaryTrailingAction: enableSwipeActions ? replySwipeAction : nil
                 )
-        }
-        .sheet(item: $responseItem) { responseItem in
-            ResponseComposerView(concreteRespondable: responseItem)
         }
     }
 

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -34,6 +34,7 @@ struct UserView: View {
     
     @State private var selectionSection = UserViewTab.overview
     @State var isDragging: Bool = false
+    @State var responseItem: ConcreteRespondable?
     @FocusState var isReplyFieldFocused
     
     struct FeedItem: Identifiable {
@@ -45,6 +46,9 @@ struct UserView: View {
     
     var body: some View {
         contentView
+            .sheet(item: $responseItem) { responseItem in
+                ResponseComposerView(concreteRespondable: responseItem)
+            }
     }
 
     @ViewBuilder
@@ -362,7 +366,8 @@ struct UserView: View {
                 FeedPost(postView: post,
                          showPostCreator: false,
                          showCommunity: true,
-                         isDragging: $isDragging
+                         isDragging: $isDragging,
+                         responseItem: $responseItem
                 )
                 
                 Divider()


### PR DESCRIPTION
This PR fixes an issue where the reply modal wasn't popping up on FeedPosts.

FeedPost now no longer provides its own reply sheet; rather, it accepts a `@Binding ConcreteRespondable?` which triggers a response sheet in its parent view.