### PR TITLE
Fixed Sort order of Communities to include instance

### DIFF
--- a/Mlem/API/Models/Community/APICommunity.swift
+++ b/Mlem/API/Models/Community/APICommunity.swift
@@ -36,3 +36,11 @@ extension APICommunity: Equatable, Hashable {
         hasher.combine(self.id)
     }
 }
+
+extension APICommunity: Comparable {
+    static func < (lhs: APICommunity, rhs: APICommunity) -> Bool {
+        let lhsFullCommunity = lhs.name + (lhs.actorId.host ?? "")
+        let rhsFullCommunity = rhs.name + (rhs.actorId.host ?? "")
+        return lhsFullCommunity < rhsFullCommunity
+    }
+}

--- a/Mlem/Enums/FeedType.swift
+++ b/Mlem/Enums/FeedType.swift
@@ -13,7 +13,7 @@ enum FeedType: String, Encodable, SettingsOptions {
 
     var label: String {
         switch self {
-        case .all: return "All Known"
+        case .all: return self.rawValue
         case .local: return self.rawValue
         case .subscribed: return self.rawValue
         }

--- a/Mlem/Logic/File Management/Decode Data from File.swift
+++ b/Mlem/Logic/File Management/Decode Data from File.swift
@@ -26,7 +26,7 @@ func decodeFromFile(fromURL: URL, whatToDecode: WhatToDecode) throws -> any Coda
             case .recentSearches:
                 return try JSONDecoder().decode([String].self, from: rawData)
             case .easterFlags:
-                return try JSONDecoder().decode(Set<String>.self, from: rawData)
+                return try JSONDecoder().decode(Set<EasterFlag>.self, from: rawData)
             }
         } catch let decodingError {
             throw decodingError

--- a/Mlem/Logic/Get Favorited Communities.swift
+++ b/Mlem/Logic/Get Favorited Communities.swift
@@ -11,5 +11,5 @@ func getFavoritedCommunities(account: SavedAccount, favoritedCommunitiesTracker:
     return favoritedCommunitiesTracker.favoriteCommunities
         .filter { $0.forAccountID == account.id }
         .map { $0.community }
-        .sorted(by: { $0.name < $1.name })
+        .sorted()
 }

--- a/Mlem/Models/Favorite Community.swift
+++ b/Mlem/Models/Favorite Community.swift
@@ -17,8 +17,6 @@ struct FavoriteCommunity: Identifiable, Codable, Equatable {
 
 extension FavoriteCommunity: Comparable {
     static func < (lhs: FavoriteCommunity, rhs: FavoriteCommunity) -> Bool {
-        let lhsFullCommunity = lhs.community.name + (lhs.community.actorId.host ?? "")
-        let rhsFullCommunity = rhs.community.name + (rhs.community.actorId.host ?? "")
-        return lhsFullCommunity < rhsFullCommunity
+        return lhs.community < rhs.community
     }
 }

--- a/Mlem/Models/Favorite Community.swift
+++ b/Mlem/Models/Favorite Community.swift
@@ -14,3 +14,11 @@ struct FavoriteCommunity: Identifiable, Codable, Equatable {
 
     let community: APICommunity
 }
+
+extension FavoriteCommunity: Comparable {
+    static func < (lhs: FavoriteCommunity, rhs: FavoriteCommunity) -> Bool {
+        let lhsFullCommunity = lhs.community.name + (lhs.community.actorId.host ?? "")
+        let rhsFullCommunity = rhs.community.name + (rhs.community.actorId.host ?? "")
+        return lhsFullCommunity < rhsFullCommunity
+    }
+}

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
@@ -52,22 +52,22 @@ struct CommunityListView: View {
                     List(selection: $selectedCommunity) {
                         HomepageFeedRowView(
                             feedType: .subscribed,
-                            iconName: "house.circle.fill",
+                            iconName: "newspaper.circle.fill",
                             iconColor: .red,
                             description: "Subscribed communities from all servers"
                         )
                             .id("top") // For "scroll to top" sidebar item
                         HomepageFeedRowView(
                             feedType: .local,
-                            iconName: "building.2.crop.circle.fill",
+                            iconName: "house.circle.fill",
                             iconColor: .green,
                             description: "Local communities from your server"
                         )
                         HomepageFeedRowView(
                             feedType: .all,
-                            iconName: "cloud.circle.fill",
+                            iconName: "repeat.circle.fill",
                             iconColor: .blue,
-                            description: "All known communities that federate with your server"
+                            description: "All communities that federate with your server"
                         )
 
                         ForEach(calculateVisibleCommunitySections()) { communitySection in
@@ -176,8 +176,6 @@ struct CommunityListView: View {
 
                 let newSubscribedCommunities = response.communities.map({
                     return $0.community
-                }).sorted(by: {
-                    $0.name < $1.name
                 })
 
                 refreshedCommunities.append(contentsOf: newSubscribedCommunities)
@@ -188,7 +186,7 @@ struct CommunityListView: View {
                 moreCommunities = response.communities.count == communitiesRequestCount
             } while (moreCommunities)
 
-            subscribedCommunities = refreshedCommunities.sorted(by: { $0.name < $1.name })
+            subscribedCommunities = refreshedCommunities.sorted()
         } catch {
             appState.contextualError = .init(underlyingError: error)
         }
@@ -221,7 +219,7 @@ struct CommunityListView: View {
         // Add or remove subscribed sub locally
         if isSubscribed {
             subscribedCommunities.append(community)
-            subscribedCommunities = subscribedCommunities.sorted(by: { $0.name < $1.name })
+            subscribedCommunities = subscribedCommunities.sorted()
         } else {
             if let index = subscribedCommunities.firstIndex(where: { $0 == community }) {
                 subscribedCommunities.remove(at: index)
@@ -236,7 +234,7 @@ struct CommunityListView: View {
         result.append(contentsOf: favoritedCommunitiesTracker.favoriteCommunities.map({ $0.community }))
 
         // Remove duplicates and sort by name
-        result = Array(Set(result)).sorted(by: { $0.name < $1.name })
+        result = Array(Set(result)).sorted()
 
         return result
     }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
Made APICommunity and FavoriteCommunity Comparable, this should fix lots of sorting issues
Changed Feed Icons
Renamed All Known back to All. This matches Lemmy Web

## Screenshots and Videos
<img width="345" alt="image" src="https://github.com/mlemgroup/mlem/assets/864259/0a7cfaa7-5ae9-4b7d-a2cd-63f78e16d700">

