### PR TITLE
fix - initial state of token refresh modal

### DIFF
--- a/Mlem/Views/Shared/TokenRefreshView.swift
+++ b/Mlem/Views/Shared/TokenRefreshView.swift
@@ -31,7 +31,7 @@ struct TokenRefreshView: View {
     
     @State private var password = ""
     @State private var twoFactorCode = ""
-    @State private var viewState: ViewState = .success
+    @State private var viewState: ViewState = .initial
     @State private var showing2FAAlert = false
     
     @FocusState private var selectedField: FocusedField?


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - no issue raised, just spotted it while doing some testing on error handling
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
The recent changes to the token refresh modal have left the initial state set to `.success` instead of `.initial`, this means when the modal is presented it is displaying that login was successful and the field/controls are disabled leaving the user stuck inside the modal and unable to continue.
