### PR TITLE
Tab bar 2: accessible boogaloo (now with bonus scope creep!)

### DIFF
--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -61,9 +61,7 @@ struct ContentView: View {
                                          symbolName: "gear")
                     }
             }
-            // .simultaneousGesture(accountSwitchDrag)
         }
-        // .simultaneousGesture(accountSwitchDrag)
         .onChange(of: appState.contextualError) { handle($0) }
         .alert(using: $errorAlert) { content in
             Alert(

--- a/Mlem/Custom Tab Bar/FancyTabBarLabel.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBarLabel.swift
@@ -52,6 +52,17 @@ struct FancyTabBarLabel: View {
     }
     
     var body: some View {
+        labelDisplay
+        .accessibilityShowsLargeContentViewer {
+            labelDisplay
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 10)
+        .contentShape(Rectangle())
+        .foregroundColor(active ? activeColor : color)
+    }
+    
+    var labelDisplay: some View {
         VStack(spacing: 4) {
             if let symbolName = symbolName {
                 Image(systemName: active ? activeSymbolName ?? symbolName : symbolName)
@@ -62,12 +73,8 @@ struct FancyTabBarLabel: View {
             
             if showTabNames, let text = labelText {
                 Text(text)
-                    .font(.caption2)
+                    .font(.system(size: 10))
             }
         }
-        .frame(maxWidth: .infinity)
-        .padding(.top, 10)
-        .contentShape(Rectangle())
-        .foregroundColor(active ? activeColor : color)
     }
 }

--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -12,14 +12,9 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
     let instanceLink: URL
     let accessToken: String
     let username: String
-    
-    func fullName() -> String {
-        var ret = username
-        if let host = instanceLink.host() {
-            ret.append("@" + host.description)
-        }
-        return ret
-    }
+  
+    // convenience
+    var hostName: String? { instanceLink.host?.description }
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)

--- a/Mlem/Models/Trackers/Saved Account Tracker.swift
+++ b/Mlem/Models/Trackers/Saved Account Tracker.swift
@@ -13,6 +13,7 @@ class SavedAccountTracker: ObservableObject {
     @AppStorage("defaultAccountId") var defaultAccountId: Int?
     
     @Published var savedAccounts: [SavedAccount]
+    @Published var accountsByInstance: [String: [SavedAccount]]
 
     var defaultAccount: SavedAccount? {
         savedAccounts.first(where: { $0.id == defaultAccountId })
@@ -20,6 +21,38 @@ class SavedAccountTracker: ObservableObject {
     
     init() {
         _savedAccounts = .init(wrappedValue: SavedAccountTracker.loadAccounts())
+        
+        accountsByInstance = [:]
+        savedAccounts.forEach { account in
+            addAccountToInstanceMap(account: account)
+        }
+    }
+    
+    func addAccount(account: SavedAccount) {
+        savedAccounts.append(account)
+        addAccountToInstanceMap(account: account)
+    }
+    
+    func removeAccount(account: SavedAccount) {
+        // remove from array--do this second to force update
+        savedAccounts = savedAccounts.filter { savedAccount in
+            savedAccount != account
+        }
+        
+        // remove from map
+        let hostName = account.hostName ?? "Other"
+        if let instance = accountsByInstance[hostName] {
+            let filteredAccounts = instance.filter { savedAccount in
+                savedAccount != account
+            }
+            
+            // delete key if no accounts associated, otherwise just remove accounts
+            if filteredAccounts.isEmpty {
+                accountsByInstance.removeValue(forKey: hostName)
+            } else {
+                accountsByInstance[hostName] = filteredAccounts
+            }
+        }
     }
 
     static func loadAccounts() -> [SavedAccount] {
@@ -78,5 +111,23 @@ class SavedAccountTracker: ObservableObject {
         } catch let encodingError {
             print("Failed while encoding accounts to data: \(encodingError)")
         }
+    }
+    
+    // MARK: Helpers
+    
+    func addAccountToInstanceMap(account: SavedAccount) {
+        let hostName = account.hostName ?? "Other"
+        print("adding \(account.username) to \(hostName)")
+        
+        let instance = accountsByInstance[hostName] ?? []
+        accountsByInstance[hostName] = instance + [account]
+        
+//        if var instance = accountsByInstance[hostName] {
+//            // do it this way to force the update to publish
+//            accountsByInstance[hostName] = instance + [account]
+//        } else {
+//            // this shouldn't really happen but instanceLink.host is optional so here we are
+//            accountsByInstance[hostName] = [account]
+//        }
     }
 }

--- a/Mlem/Models/Trackers/Saved Account Tracker.swift
+++ b/Mlem/Models/Trackers/Saved Account Tracker.swift
@@ -121,13 +121,5 @@ class SavedAccountTracker: ObservableObject {
         
         let instance = accountsByInstance[hostName] ?? []
         accountsByInstance[hostName] = instance + [account]
-        
-//        if var instance = accountsByInstance[hostName] {
-//            // do it this way to force the update to publish
-//            accountsByInstance[hostName] = instance + [account]
-//        } else {
-//            // this shouldn't really happen but instanceLink.host is optional so here we are
-//            accountsByInstance[hostName] = [account]
-//        }
     }
 }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Instance and Community List/Accounts Page.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Instance and Community List/Accounts Page.swift
@@ -11,61 +11,58 @@ import AlertToast
 struct AccountsPage: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var accountsTracker: SavedAccountTracker
-
+    
     @State private var isShowingInstanceAdditionSheet: Bool = false
     @Binding var selectedAccount: SavedAccount?
     
+    let onboarding: Bool
+    
+    init(selectedAccount: Binding<SavedAccount?> = Binding.constant(nil),
+         onboarding: Bool = false) {
+        self._selectedAccount = selectedAccount
+        self.onboarding = onboarding
+    }
+    
+    @Environment(\.dismiss) var dismiss
+    
     var body: some View {
-        VStack {
-            if !accountsTracker.savedAccounts.isEmpty {
-                List(selection: $selectedAccount) {
-                    ForEach(accountsTracker.savedAccounts, id: \.self) { savedAccount in
-                        HStack(alignment: .center) {
-                            Text(savedAccount.username)
-                            Spacer()
-                            Text(savedAccount.instanceLink.host!)
-                                .foregroundColor(.secondary)
+        let instances = Array(accountsTracker.accountsByInstance.keys)
+        
+        if onboarding || instances.isEmpty || isShowingInstanceAdditionSheet {
+            AddSavedInstanceView(isShowingSheet: $isShowingInstanceAdditionSheet,
+                                 onboarding: onboarding,
+                                 currentAccount: $selectedAccount)
+        } else {
+            List {
+                ForEach(instances, id: \.self) { instance in
+                    Section(header: Text(instance)) {
+                        ForEach(accountsTracker.accountsByInstance[instance] ?? []) { account in
+                            Button(account.username) {
+                                dismiss()
+                                
+                                // this tiny delay prevents the modal dismiss animation from being cancelled
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                                    appState.setActiveAccount(account)
+                                }
+                            }
+                            .swipeActions {
+                                Button("Delete", role: .destructive) {
+                                    accountsTracker.removeAccount(account: account)
+                                }
+                            }
+                            .foregroundColor(appState.currentActiveAccount == account ? .secondary : .primary)
+                            .disabled(appState.currentActiveAccount == account)
                         }
-                        .accessibilityAddTraits(.isButton)
-                        .accessibilityElement(children: .combine)
-                        .id(savedAccount)
-                        .minimumScaleFactor(0.01)
-                        .lineLimit(1)
                     }
-                    .onDelete(perform: deleteAccount)
                 }
-            } else {
-                VStack(alignment: .center, spacing: 15) {
-                    Text("You have no accounts added")
-                }
-                .foregroundColor(.secondary)
-            }
-        }
-        .sheet(isPresented: $isShowingInstanceAdditionSheet) {
-            AddSavedInstanceView(isShowingSheet: $isShowingInstanceAdditionSheet)
-        }
-        .navigationTitle("Accounts")
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
+                
                 Button {
                     isShowingInstanceAdditionSheet = true
                 } label: {
-                    Image(systemName: "plus")
+                    Text("Add Account")
                 }
                 .accessibilityLabel("Add a new account.")
             }
-        }
-    }
-
-    internal func deleteAccount(at offsets: IndexSet) {
-        for index in offsets {
-            let savedAccountToRemove: SavedAccount = accountsTracker.savedAccounts[index]
-
-            accountsTracker.savedAccounts.remove(at: index)
-
-            // MARK: - Purge the account information from the Keychain
-
-            AppConstants.keychain["\(savedAccountToRemove.id)_accessToken"] = nil
         }
     }
 }

--- a/Mlem/Views/Tabs/Profile/Profile View.swift
+++ b/Mlem/Views/Tabs/Profile/Profile View.swift
@@ -23,8 +23,6 @@ struct ProfileView: View {
         NavigationStack(path: $navigationPath) {
             UserView(userID: userID)
                 .handleLemmyViews()
-                .edgesIgnoringSafeArea(.top)
-                .toolbar(.hidden)
         }
         .handleLemmyLinkResolution(navigationPath: $navigationPath)
     }

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -37,17 +37,24 @@ struct UserView: View {
     @State var responseItem: ConcreteRespondable?
     @FocusState var isReplyFieldFocused
     
+    // account switching
+    var isSelf: Bool { userID == appState.currentActiveAccount.id }
+    @State private var isPresentingAccountSwitcher: Bool = false
+    
     struct FeedItem: Identifiable {
         let id = UUID()
         let published: Date
         let comment: HierarchicalComment?
         let post: APIPostView?
     }
-    
+
     var body: some View {
         contentView
             .sheet(item: $responseItem) { responseItem in
                 ResponseComposerView(concreteRespondable: responseItem)
+            }
+            .sheet(isPresented: $isPresentingAccountSwitcher) {
+                AccountsPage()
             }
     }
 
@@ -65,6 +72,17 @@ struct UserView: View {
         if let user = userDetails, !moderatedCommunities.isEmpty {
             NavigationLink(value: UserModeratorLink(user: user, moderatedCommunities: moderatedCommunities)) {
                 Image(systemName: "shield")
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var accountSwitcher: some View {
+        if isSelf {
+            Button {
+                isPresentingAccountSwitcher = true
+            } label: {
+                Image(systemName: "repeat")
             }
         }
     }
@@ -125,6 +143,7 @@ struct UserView: View {
             await tryLoadUser()
         }.toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
+                accountSwitcher
                 moderatorButton
             }
         }

--- a/Mlem/Views/Tabs/Settings/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Settings View.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     @Environment(\.openURL) private var openURL
 
     @State private var accountToSwitchTo: SavedAccount?
+    @State private var isPresentingAccountSheet: Bool = false
 
     var body: some View {
         NavigationView {
@@ -63,17 +64,17 @@ struct SettingsView: View {
                 }
                 #endif
 
-                Section {
-                    NavigationLink {
-                        AccountsPage(selectedAccount: $accountToSwitchTo)
-                    } label: {
-                        HStack(alignment: .center) {
-                            Image(systemName: "person.fill.questionmark")
-                                .foregroundColor(.mint)
-                            Text("Switch Account")
-                        }
-                    }
-                }
+//                 Section {
+//                    NavigationLink {
+//                        AccountsPage(selectedAccount: $accountToSwitchTo)
+//                    } label: {
+//                        HStack(alignment: .center) {
+//                            Image(systemName: "person.fill.questionmark")
+//                                .foregroundColor(.mint)
+//                            Text("Switch Account")
+//                        }
+//                    }
+//                 }
 
                 Section {
                     NavigationLink {

--- a/Mlem/Views/Tabs/Settings/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Settings View.swift
@@ -64,18 +64,6 @@ struct SettingsView: View {
                 }
                 #endif
 
-//                 Section {
-//                    NavigationLink {
-//                        AccountsPage(selectedAccount: $accountToSwitchTo)
-//                    } label: {
-//                        HStack(alignment: .center) {
-//                            Image(systemName: "person.fill.questionmark")
-//                                .foregroundColor(.mint)
-//                            Text("Switch Account")
-//                        }
-//                    }
-//                 }
-
                 Section {
                     NavigationLink {
                         About()

--- a/Mlem/Window.swift
+++ b/Mlem/Window.swift
@@ -27,7 +27,7 @@ struct Window: View {
                 view(for: selectedAccount)
             } else {
                 NavigationStack {
-                    AccountsPage(selectedAccount: $selectedAccount)
+                    AccountsPage(selectedAccount: $selectedAccount, onboarding: true)
                 }
             }
 


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Ongoing accessibility improvements
      - Sets up #32 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR reworks the account switching/account adding interface and improves accessibility on the tab bar:

- Popup is now a modal, not a ContextMenu on the Profile tab. It can be accessed either by swiping up on the tab bar or by long pressing the Profile tab
- When accessibility font sizes are detected, the long press on Profile tab gesture is disabled to allow the tab HUD to properly function; the swipe up remains active
- Login and account switching are now part of the same sheet
- Accounts are now grouped by instance
- "Switch account" has been moved from Settings to the Profile tab
- The nav bar now displays normally in the Profile tab

## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/44140166/fa340200-6e9f-4438-92b0-e32779e956e4


https://github.com/mlemgroup/mlem/assets/44140166/26350207-77eb-4f2c-9c76-15f3e38fc527



## Additional Context
**Any additional context you'd like to add to help us review this PR**
