### PR TITLE
added duplicate avoidance, logic for deleting the last account

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 		CDE6A8162A490AE00062D161 /* Inbox Message View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE6A8152A490AE00062D161 /* Inbox Message View.swift */; };
 		CDE6A8182A490AF20062D161 /* Inbox Mention View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE6A8172A490AF20062D161 /* Inbox Mention View.swift */; };
 		CDE6A81A2A490B970062D161 /* Inbox Reply View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE6A8192A490B970062D161 /* Inbox Reply View.swift */; };
+		CDE8F2392A68DA7D00E0AE68 /* Environment - Force Onboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE8F2382A68DA7D00E0AE68 /* Environment - Force Onboard.swift */; };
 		CDF8425C2A49E4C000723DA0 /* APIPersonMentionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8425B2A49E4C000723DA0 /* APIPersonMentionView.swift */; };
 		CDF8425E2A49E61A00723DA0 /* APIPersonMention.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8425D2A49E61A00723DA0 /* APIPersonMention.swift */; };
 		CDF842612A49EA3900723DA0 /* Mentions Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF842602A49EA3900723DA0 /* Mentions Tracker.swift */; };
@@ -642,6 +643,7 @@
 		CDE6A8152A490AE00062D161 /* Inbox Message View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox Message View.swift"; sourceTree = "<group>"; };
 		CDE6A8172A490AF20062D161 /* Inbox Mention View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox Mention View.swift"; sourceTree = "<group>"; };
 		CDE6A8192A490B970062D161 /* Inbox Reply View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox Reply View.swift"; sourceTree = "<group>"; };
+		CDE8F2382A68DA7D00E0AE68 /* Environment - Force Onboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Environment - Force Onboard.swift"; sourceTree = "<group>"; };
 		CDF8425B2A49E4C000723DA0 /* APIPersonMentionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPersonMentionView.swift; sourceTree = "<group>"; };
 		CDF8425D2A49E61A00723DA0 /* APIPersonMention.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPersonMention.swift; sourceTree = "<group>"; };
 		CDF842602A49EA3900723DA0 /* Mentions Tracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mentions Tracker.swift"; sourceTree = "<group>"; };
@@ -865,6 +867,7 @@
 				B104A6DF2A59C19400B3E725 /* OperationQueue - Easy init.swift */,
 				CDA217F22A63202600BDA173 /* NSFW Overlay.swift */,
 				B1955A202A6145C00056CF99 /* Environment - EasterFlagSetter.swift */,
+				CDE8F2382A68DA7D00E0AE68 /* Environment - Force Onboard.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1878,6 +1881,7 @@
 				6386E02A2A03D0C3006B3C1D /* Post Tracker.swift in Sources */,
 				637218752A3A2AAD008C4816 /* GetCommunity.swift in Sources */,
 				6DFF50432A48DED3001E648D /* Inbox View.swift in Sources */,
+				CDE8F2392A68DA7D00E0AE68 /* Environment - Force Onboard.swift in Sources */,
 				CDF8426F2A4A385A00723DA0 /* Inbox Item Type.swift in Sources */,
 				CD1446232A5B336900610EF1 /* Documents View.swift in Sources */,
 				CDDCF6432A66343D003DA3AC /* FancyTabBar.swift in Sources */,

--- a/Mlem/Extensions/Environment - Force Onboard.swift
+++ b/Mlem/Extensions/Environment - Force Onboard.swift
@@ -1,0 +1,20 @@
+//
+//  Environment - Force Onboard.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-07-19.
+//
+
+import Foundation
+import SwiftUI
+
+private struct ForceOnboardSetter: EnvironmentKey {
+    static let defaultValue: () -> Void = { }
+}
+
+extension EnvironmentValues {
+    var forceOnboard: () -> Void {
+        get { self[ForceOnboardSetter.self] }
+        set { self[ForceOnboardSetter.self] = newValue }
+      }
+}

--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -24,4 +24,10 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
         try container.encode("redacted", forKey: .accessToken)
         try container.encode(self.username, forKey: .username)
     }
+    
+    static func == (lhs: SavedAccount, rhs: SavedAccount) -> Bool {
+        return lhs.id == rhs.id &&
+        lhs.instanceLink == rhs.instanceLink &&
+        lhs.username == rhs.username
+    }
 }

--- a/Mlem/Models/Trackers/Saved Account Tracker.swift
+++ b/Mlem/Models/Trackers/Saved Account Tracker.swift
@@ -40,13 +40,8 @@ class SavedAccountTracker: ObservableObject {
     
     // TODO: pass in AppState using a dependency or something nice like that
     func removeAccount(account: SavedAccount, appState: AppState, forceOnboard: () -> Void) {
-        // force onboarding if this will remove the last account
-//        if appState.currentActiveAccount == account, savedAccounts.count == 1 {
-//            forceOnboard()
-//        }
-        
         // remove from array
-        let filteredAccounts = savedAccounts.filter { savedAccount in
+        savedAccounts = savedAccounts.filter { savedAccount in
             savedAccount != account
         }
         
@@ -66,13 +61,11 @@ class SavedAccountTracker: ObservableObject {
         }
         
         // if another account exists, swap to it; otherwise force onboarding
-        if let firstAccount: SavedAccount = filteredAccounts.first {
+        if let firstAccount: SavedAccount = savedAccounts.first {
             appState.setActiveAccount(firstAccount)
         } else {
             forceOnboard()
         }
-        
-        savedAccounts = filteredAccounts
     }
 
     static func loadAccounts() -> [SavedAccount] {

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Instance and Community List/Accounts Page.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Instance and Community List/Accounts Page.swift
@@ -11,6 +11,7 @@ import AlertToast
 struct AccountsPage: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var accountsTracker: SavedAccountTracker
+    @Environment(\.forceOnboard) var forceOnboard
     
     @State private var isShowingInstanceAdditionSheet: Bool = false
     @Binding var selectedAccount: SavedAccount?
@@ -47,11 +48,10 @@ struct AccountsPage: View {
                             }
                             .swipeActions {
                                 Button("Delete", role: .destructive) {
-                                    accountsTracker.removeAccount(account: account)
+                                    accountsTracker.removeAccount(account: account, appState: appState, forceOnboard: forceOnboard)
                                 }
                             }
                             .foregroundColor(appState.currentActiveAccount == account ? .secondary : .primary)
-                            .disabled(appState.currentActiveAccount == account)
                         }
                     }
                 }

--- a/Mlem/Window.swift
+++ b/Mlem/Window.swift
@@ -16,6 +16,7 @@ struct Window: View {
     @StateObject var recentSearchesTracker: RecentSearchesTracker = .init()
 
     @State var selectedAccount: SavedAccount?
+    // @State var onboarding: Bool = true
     
     @State var easterRewardsToastsQueue: [AlertToast] = .init()
     @State var easterRewardsToastDisplay: AlertToast?
@@ -44,6 +45,7 @@ struct Window: View {
         }
         .onChange(of: selectedAccount) { _ in onLogin() }
         .onAppear(perform: onLogin)
+        .environment(\.forceOnboard, forceOnboard)
         .environment(\.setEasterFlag, setEasterFlag)
         .environmentObject(easterFlagsTracker)
     }
@@ -126,5 +128,9 @@ struct Window: View {
                 easterRewardShouldShow = true
             }
         }
+    }
+    
+    func forceOnboard() {
+        selectedAccount = nil
     }
 }

--- a/Mlem/Window.swift
+++ b/Mlem/Window.swift
@@ -16,7 +16,6 @@ struct Window: View {
     @StateObject var recentSearchesTracker: RecentSearchesTracker = .init()
 
     @State var selectedAccount: SavedAccount?
-    // @State var onboarding: Bool = true
     
     @State var easterRewardsToastsQueue: [AlertToast] = .init()
     @State var easterRewardsToastDisplay: AlertToast?


### PR DESCRIPTION
Little PR to fix up some logic around the account switcher. Deleting the active account is now possible; if another account is available it swaps you to it, otherwise it chucks you out to the onboarding flow.

Added an environment function to force into the onboarding flow.