### PR TITLE
Eric/fancy tab bar

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 		CD7B53B92A5F263D00006E81 /* APIPrivateMessageReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B53B82A5F263D00006E81 /* APIPrivateMessageReport.swift */; };
 		CD7B53BB2A5F27DB00006E81 /* Report Private Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B53BA2A5F27DB00006E81 /* Report Private Message.swift */; };
 		CD863FBA2A6AEB5900A31ED9 /* TabSafeScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD863FB92A6AEB5900A31ED9 /* TabSafeScrollView.swift */; };
+		CD863FBC2A6B026400A31ED9 /* DocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD863FBB2A6B026400A31ED9 /* DocumentView.swift */; };
 		CD9DD8832A622A6C0044EA8E /* ReportCommentReply.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9DD8822A622A6C0044EA8E /* ReportCommentReply.swift */; };
 		CD9DD8852A62302A0044EA8E /* ConcreteRespondable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9DD8842A62302A0044EA8E /* ConcreteRespondable.swift */; };
 		CDA145ED2A510AC100DDAFC9 /* MarkCommentReplyAsReadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA145EC2A510AC100DDAFC9 /* MarkCommentReplyAsReadRequest.swift */; };
@@ -645,6 +646,7 @@
 		CD7B53B82A5F263D00006E81 /* APIPrivateMessageReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPrivateMessageReport.swift; sourceTree = "<group>"; };
 		CD7B53BA2A5F27DB00006E81 /* Report Private Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Report Private Message.swift"; sourceTree = "<group>"; };
 		CD863FB92A6AEB5900A31ED9 /* TabSafeScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSafeScrollView.swift; sourceTree = "<group>"; };
+		CD863FBB2A6B026400A31ED9 /* DocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentView.swift; sourceTree = "<group>"; };
 		CD9DD8822A622A6C0044EA8E /* ReportCommentReply.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportCommentReply.swift; sourceTree = "<group>"; };
 		CD9DD8842A62302A0044EA8E /* ConcreteRespondable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcreteRespondable.swift; sourceTree = "<group>"; };
 		CDA145EC2A510AC100DDAFC9 /* MarkCommentReplyAsReadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkCommentReplyAsReadRequest.swift; sourceTree = "<group>"; };
@@ -1472,6 +1474,7 @@
 				6374570F2A18CB6600B69C03 /* Custom Text Field.swift */,
 				B11D72822A49FAA7009DC22F /* Cached Image.swift */,
 				50F2851B2A5C5C1500CF8865 /* TokenRefreshView.swift */,
+				CD863FBB2A6B026400A31ED9 /* DocumentView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -2102,6 +2105,7 @@
 				CD04D5D92A3614BE008EF95B /* Large Post.swift in Sources */,
 				CDF8425E2A49E61A00723DA0 /* APIPersonMention.swift in Sources */,
 				CD64832A2A38C69600EE6CA3 /* Vote Complex.swift in Sources */,
+				CD863FBC2A6B026400A31ED9 /* DocumentView.swift in Sources */,
 				63F0C7BB2A058CB700A18C5D /* URLSessionWebSocketTask - Send Ping.swift in Sources */,
 				CDA145EF2A510C3D00DDAFC9 /* MarkCommentReplyAsRead.swift in Sources */,
 				CD3FBCE52A4A89B900B2063F /* Mentions Feed View.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		CD7B53B72A5F258B00006E81 /* APIPrivateMessageReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B53B62A5F258B00006E81 /* APIPrivateMessageReportView.swift */; };
 		CD7B53B92A5F263D00006E81 /* APIPrivateMessageReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B53B82A5F263D00006E81 /* APIPrivateMessageReport.swift */; };
 		CD7B53BB2A5F27DB00006E81 /* Report Private Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B53BA2A5F27DB00006E81 /* Report Private Message.swift */; };
+		CD863FBA2A6AEB5900A31ED9 /* TabSafeScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD863FB92A6AEB5900A31ED9 /* TabSafeScrollView.swift */; };
 		CD9DD8832A622A6C0044EA8E /* ReportCommentReply.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9DD8822A622A6C0044EA8E /* ReportCommentReply.swift */; };
 		CD9DD8852A62302A0044EA8E /* ConcreteRespondable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9DD8842A62302A0044EA8E /* ConcreteRespondable.swift */; };
 		CDA145ED2A510AC100DDAFC9 /* MarkCommentReplyAsReadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA145EC2A510AC100DDAFC9 /* MarkCommentReplyAsReadRequest.swift */; };
@@ -643,6 +644,7 @@
 		CD7B53B62A5F258B00006E81 /* APIPrivateMessageReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPrivateMessageReportView.swift; sourceTree = "<group>"; };
 		CD7B53B82A5F263D00006E81 /* APIPrivateMessageReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPrivateMessageReport.swift; sourceTree = "<group>"; };
 		CD7B53BA2A5F27DB00006E81 /* Report Private Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Report Private Message.swift"; sourceTree = "<group>"; };
+		CD863FB92A6AEB5900A31ED9 /* TabSafeScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSafeScrollView.swift; sourceTree = "<group>"; };
 		CD9DD8822A622A6C0044EA8E /* ReportCommentReply.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportCommentReply.swift; sourceTree = "<group>"; };
 		CD9DD8842A62302A0044EA8E /* ConcreteRespondable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcreteRespondable.swift; sourceTree = "<group>"; };
 		CDA145EC2A510AC100DDAFC9 /* MarkCommentReplyAsReadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkCommentReplyAsReadRequest.swift; sourceTree = "<group>"; };
@@ -1707,6 +1709,7 @@
 				CDDCF64E2A672C0A003DA3AC /* FancyTabBarLabel.swift */,
 				CDDCF6502A677E1B003DA3AC /* FancyTabItemPreferenceKeys.swift */,
 				CDDCF6562A678298003DA3AC /* FancyTabBarSelection.swift */,
+				CD863FB92A6AEB5900A31ED9 /* TabSafeScrollView.swift */,
 			);
 			path = "Custom Tab Bar";
 			sourceTree = "<group>";
@@ -1977,6 +1980,7 @@
 				CD525F652A4B6D8F00BCA794 /* Community Link View.swift in Sources */,
 				637218592A3A2AAD008C4816 /* APISiteAggregates.swift in Sources */,
 				6DA7E9A22A50764E0095AB68 /* UserViewTab.swift in Sources */,
+				CD863FBA2A6AEB5900A31ED9 /* TabSafeScrollView.swift in Sources */,
 				637218772A3A2AAD008C4816 /* APIRequest.swift in Sources */,
 				63A09B69285F53E9004F0032 /* Error View.swift in Sources */,
 				CD3FBCE72A4A8CE300B2063F /* Messages Feed View.swift in Sources */,

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "245d527002f29c5a616c5b7131f6a50ac7f41cbf",
-        "version" : "0.8.6"
+        "revision" : "50843cbb8551db836adec2290bb4bc6bac5c1865",
+        "version" : "0.9.0"
       }
     }
   ],

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -75,6 +75,7 @@ struct AppConstants {
     static let barIconHitbox: CGFloat = 44 // Apple HIG guidelines
     static let settingsIconSize: CGFloat = 28
     static let settingsIconCornerRadius: CGFloat = 7
+    static let fancyTabBarHeight: CGFloat = 48 // total height of the fancy tab bar
     
     // MARK: - SFSymbols
     // votes

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -46,7 +46,7 @@ struct ContentView: View {
                     .fancyTabItem(tag: TabSelection.profile) {
                         FancyTabBarLabel(tag: TabSelection.profile,
                                          customText: computeUsername(account: appState.currentActiveAccount),
-                                         symbolName: "person.circle",
+                                         symbolName: "folder.fill",
                                          activeSymbolName: "person.circle.fill")
                         .simultaneousGesture(accountSwitchLongPress)
                     }

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -46,7 +46,7 @@ struct ContentView: View {
                     .fancyTabItem(tag: TabSelection.profile) {
                         FancyTabBarLabel(tag: TabSelection.profile,
                                          customText: computeUsername(account: appState.currentActiveAccount),
-                                         symbolName: "folder.fill",
+                                         symbolName: "person.circle",
                                          activeSymbolName: "person.circle.fill")
                         .simultaneousGesture(accountSwitchLongPress)
                     }

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -27,23 +27,23 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
     }
     
     var body: some View {
-            ZStack(content: content)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .safeAreaInset(edge: .bottom, alignment: .center) {
-                    // this VStack/Spacer()/ignoresSafeArea thing prevents the keyboard from pushing the bar up
-                    VStack {
-                        Spacer()
-                        tabBar
-                    }
-                    .ignoresSafeArea(.keyboard, edges: .bottom)
+        ZStack(content: content)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .safeAreaInset(edge: .bottom, alignment: .center) {
+                // this VStack/Spacer()/ignoresSafeArea thing prevents the keyboard from pushing the bar up
+                VStack {
+                    Spacer()
+                    tabBar
                 }
-                .onPreferenceChange(FancyTabItemPreferenceKey<Selection>.self) {
-                    self.tabItemKeys = $0
-                }
-                .onPreferenceChange(FancyTabItemLabelBuilderPreferenceKey<Selection>.self) {
-                    self.tabItems = $0
-                }
-                .environment(\.tabSelectionHashValue, selection.hashValue)
+                .ignoresSafeArea(.keyboard, edges: .bottom)
+            }
+            .onPreferenceChange(FancyTabItemPreferenceKey<Selection>.self) {
+                self.tabItemKeys = $0
+            }
+            .onPreferenceChange(FancyTabItemLabelBuilderPreferenceKey<Selection>.self) {
+                self.tabItems = $0
+            }
+            .environment(\.tabSelectionHashValue, selection.hashValue)
     }
     
     private var tabBar: some View {
@@ -62,9 +62,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                         .highPriorityGesture(
                             TapGesture()
                                 .onEnded {
-                                    withAnimation(.spring(response: 0.25)) {
-                                        selection = key
-                                    }
+                                    selection = key
                                 }
                         )
                 }
@@ -77,7 +75,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                         }
                     }
             )
-            .background(.regularMaterial)
+            .background(.thinMaterial)
         }
         .accessibilityElement(children: .contain)    }
 }

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -37,13 +37,13 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                 }
                 .ignoresSafeArea(.keyboard, edges: .bottom)
             }
+            .environment(\.tabSelectionHashValue, selection.hashValue)
             .onPreferenceChange(FancyTabItemPreferenceKey<Selection>.self) {
                 self.tabItemKeys = $0
             }
             .onPreferenceChange(FancyTabItemLabelBuilderPreferenceKey<Selection>.self) {
                 self.tabItems = $0
             }
-            .environment(\.tabSelectionHashValue, selection.hashValue)
     }
     
     private var tabBar: some View {
@@ -54,8 +54,8 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                 ForEach(tabItemKeys, id: \.hashValue) { key in
                     tabItems[key]?.label()
                         .accessibilityElement(children: .combine)
-                    // IDK how to get the "Tab: 1 of 5" VO working--hopefully there's a nice clean way, if not we can add an 'index: Int' field to the FancyTabBarSelection protocol and use that 🙃
-                        .accessibilityLabel("Tab of \(tabItems.count.description)")
+                    // IDK how to get the "Tab: 1 of 5" VO working natively so here's a janky solution
+                        .accessibilityLabel("Tab \(key.index) of \(tabItems.count.description)")
                         .frame(maxWidth: .infinity)
                         .contentShape(Rectangle())
                     // high priority to prevent conflict with long press/drag

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -70,7 +70,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
             .gesture(
                 DragGesture()
                     .onChanged { gesture in
-                        if let callback = dragUpGestureCallback, gesture.translation.height < -100 {
+                        if let callback = dragUpGestureCallback, gesture.translation.height < -50 {
                             callback()
                         }
                     }

--- a/Mlem/Custom Tab Bar/FancyTabBarLabel.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBarLabel.swift
@@ -60,6 +60,7 @@ struct FancyTabBarLabel: View {
         .padding(.top, 10)
         .contentShape(Rectangle())
         .foregroundColor(active ? activeColor : color)
+        .animation(.spring(response: 0.25), value: active)
     }
     
     var labelDisplay: some View {

--- a/Mlem/Custom Tab Bar/FancyTabBarLabel.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBarLabel.swift
@@ -56,8 +56,9 @@ struct FancyTabBarLabel: View {
         .accessibilityShowsLargeContentViewer {
             labelDisplay
         }
-        .frame(maxWidth: .infinity)
         .padding(.top, 10)
+        .frame(maxWidth: .infinity)
+        .frame(height: AppConstants.fancyTabBarHeight)
         .contentShape(Rectangle())
         .foregroundColor(active ? activeColor : color)
         .animation(.spring(response: 0.25), value: active)

--- a/Mlem/Custom Tab Bar/FancyTabBarLabel.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBarLabel.swift
@@ -41,7 +41,7 @@ struct FancyTabBarLabel: View {
          customText: String? = nil,
          symbolName: String? = nil,
          activeSymbolName: String? = nil,
-         customColor: Color = Color(uiColor: .darkGray),
+         customColor: Color = Color.primary,
          activeColor: Color = .accentColor) {
         self.tagHash = tag.hashValue
         self.symbolName = symbolName
@@ -60,7 +60,7 @@ struct FancyTabBarLabel: View {
         .frame(maxWidth: .infinity)
         .frame(height: AppConstants.fancyTabBarHeight)
         .contentShape(Rectangle())
-        .foregroundColor(active ? activeColor : color)
+        .foregroundColor(active ? activeColor : color.opacity(0.4))
         .animation(.spring(response: 0.25), value: active)
     }
     

--- a/Mlem/Custom Tab Bar/FancyTabBarSelection.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBarSelection.swift
@@ -12,6 +12,7 @@ import Foundation
  
  If needed, this can be used to jank up a "tab x of y" accessibility label by adding an index Int to the protocol
  */
-protocol FancyTabBarSelection: Hashable {
+protocol FancyTabBarSelection: Hashable, Comparable {
     var labelText: String? { get }
+    var index: Int { get }
 }

--- a/Mlem/Custom Tab Bar/FancyTabItemPreferenceKeys.swift
+++ b/Mlem/Custom Tab Bar/FancyTabItemPreferenceKeys.swift
@@ -21,10 +21,11 @@ struct FancyTabItemLabelBuilderPreferenceKey<Selection: FancyTabBarSelection>: P
 }
 
 // preference key--this lets each view add itself to the list of keys
-struct FancyTabItemPreferenceKey<FancyTabBarSelection: Hashable>: PreferenceKey {
-    static var defaultValue: [FancyTabBarSelection] { [] }
+struct FancyTabItemPreferenceKey<Selection: FancyTabBarSelection>: PreferenceKey {
+    static var defaultValue: [Selection] { [] }
 
-    static func reduce(value: inout [FancyTabBarSelection], nextValue: () -> [FancyTabBarSelection]) {
+    static func reduce(value: inout [Selection], nextValue: () -> [Selection]) {
         value.append(contentsOf: nextValue())
+        value.sort() // preserve stability of view order
     }
 }

--- a/Mlem/Custom Tab Bar/FancyTabItemViewModifier.swift
+++ b/Mlem/Custom Tab Bar/FancyTabItemViewModifier.swift
@@ -22,19 +22,14 @@ struct FancyTabItem<Selection: FancyTabBarSelection, V: View>: ViewModifier {
     }
     
     func body(content: Content) -> some View {
-        Group {
-            if selectedTagHashValue == tagHashValue {
-                content
-            } else {
-                Color.clear
-            }
-        }
+        content
+            .zIndex(selectedTagHashValue == tagHashValue ? 1 : 0)
         // this little preference tells the parent bar that this tab item exists
-        .preference(key: FancyTabItemPreferenceKey<Selection>.self, value: [tag])
+            .preference(key: FancyTabItemPreferenceKey<Selection>.self, value: [tag])
         // and this big ugly one adds its label builder to the dictionary
-        .preference(key: FancyTabItemLabelBuilderPreferenceKey<Selection>.self,
-                    value: [tag: FancyTabItemLabelBuilder(tag: tag,
-                                                          label: { AnyView(label()) })])
+            .preference(key: FancyTabItemLabelBuilderPreferenceKey<Selection>.self,
+                        value: [tag: FancyTabItemLabelBuilder(tag: tag,
+                                                              label: { AnyView(label()) })])
     }
 }
 

--- a/Mlem/Custom Tab Bar/TabSafeScrollView.swift
+++ b/Mlem/Custom Tab Bar/TabSafeScrollView.swift
@@ -1,0 +1,29 @@
+//
+//  TabSafeScrollView.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-07-21.
+//
+
+import Foundation
+import SwiftUI
+
+struct TabSafeScrollView: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .safeAreaInset(edge: .bottom) {
+                Spacer()
+                    .frame(height: AppConstants.fancyTabBarHeight)
+            }
+    }
+}
+
+extension View {
+    /**
+     Attach this modifier to a ScrollView to prevent it from not respecting the FancyTabBar's safeAreaInset
+     */
+    @ViewBuilder
+    func fancyTabScrollCompatible() -> some View {
+        modifier(TabSafeScrollView())
+    }
+}

--- a/Mlem/Enums/TabSelection.swift
+++ b/Mlem/Enums/TabSelection.swift
@@ -8,7 +8,21 @@
 import Foundation
 
 enum TabSelection: String, FancyTabBarSelection {
+    static func < (lhs: TabSelection, rhs: TabSelection) -> Bool {
+        return lhs.index < rhs.index
+    }
+    
     case feeds, inbox, profile, search, settings
     
     var labelText: String? { return self.rawValue.capitalized }
+    
+    var index: Int {
+        switch self {
+        case .feeds: return 1
+        case .inbox: return 2
+        case .profile: return 3
+        case .search: return 4
+        case .settings: return 5
+        }
+    }
 }

--- a/Mlem/Extensions/IconSettingsView.swift
+++ b/Mlem/Extensions/IconSettingsView.swift
@@ -33,6 +33,7 @@ struct IconSettingsView: View {
                 AlternativeIconCell(icon: icon, setAppIcon: setAppIcon)
             }
         }
+        .fancyTabScrollCompatible()
     }
 
     func getAllIcons() -> [AlternativeIcon] {

--- a/Mlem/Views/Shared/DocumentView.swift
+++ b/Mlem/Views/Shared/DocumentView.swift
@@ -1,0 +1,24 @@
+//
+//  DocumentView.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-07-21.
+//
+
+import Foundation
+import SwiftUI
+
+/**
+ Displays a document
+ */
+struct DocumentView: View {
+    let text: String
+    
+    var body: some View {
+        ScrollView {
+            MarkdownView(text: text, isNsfw: false)
+                .padding()
+        }
+        .fancyTabScrollCompatible()
+    }
+}

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -106,6 +106,7 @@ struct InboxView: View {
                     }
                 }
             }
+            .fancyTabScrollCompatible()
             .refreshable {
                 Task(priority: .userInitiated) {
                     await refreshFeed()

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
@@ -46,7 +46,6 @@ struct CommunityListView: View {
     }
 
     var body: some View {
-        VStack {
             ScrollViewReader { scrollProxy in
                 HStack {
                     List(selection: $selectedCommunity) {
@@ -90,6 +89,7 @@ struct CommunityListView: View {
                         }
 
                     }
+                    .fancyTabScrollCompatible()
                     .navigationTitle("Communities")
                     .listStyle(PlainListStyle())
                     .scrollIndicators(.hidden)
@@ -97,7 +97,6 @@ struct CommunityListView: View {
                     SectionIndexTitles(proxy: scrollProxy, communitySections: communitySections)
                 }
             }
-        }
         .refreshable {
             await refreshCommunitiesList()
         }

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -133,6 +133,7 @@ struct UserView: View {
                 savedFeed
             }
         }
+        .fancyTabScrollCompatible()
         .environmentObject(privateCommentReplyTracker)
         .environmentObject(privatePostTracker)
         .environmentObject(privateCommentTracker)

--- a/Mlem/Views/Tabs/Search/Search View.swift
+++ b/Mlem/Views/Tabs/Search/Search View.swift
@@ -109,6 +109,7 @@ struct SearchView: View {
                         }
                 }
             }
+            .fancyTabScrollCompatible()
         }
     }
     

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -60,6 +60,7 @@ struct SettingsView: View {
                     }
                 }
             }
+            .fancyTabScrollCompatible()
             .handleLemmyViews()
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
@@ -52,18 +52,12 @@ struct AboutView: View {
                 
                 Section {
                     NavigationLink {
-                        ScrollView {
-                            MarkdownView(text: privacyPolicy.body, isNsfw: false)
-                                .padding()
-                        }
+                        DocumentView(text: privacyPolicy.body)
                     } label: {
                         Label("Privacy Policy", systemImage: "hand.raised.fill").labelStyle(SquircleLabelStyle(color: .blue))
                     }
                     NavigationLink {
-                        ScrollView {
-                            MarkdownView(text: eula.body, isNsfw: false)
-                                .padding()
-                        }
+                        DocumentView(text: eula.body)
                     } label: {
                         Label("EULA", systemImage: "doc.plaintext.fill").labelStyle(SquircleLabelStyle(color: .purple))
                     }
@@ -74,6 +68,7 @@ struct AboutView: View {
                     }
                 }
             }
+            .fancyTabScrollCompatible()
         }
         .navigationTitle("About")
     }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/ContributorsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/ContributorsView.swift
@@ -57,6 +57,7 @@ struct ContributorsView: View {
                               color: .cyan)
             }
         }
+        .fancyTabScrollCompatible()
         .navigationTitle("Contributors")
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
@@ -29,49 +29,32 @@ struct LicensesView: View {
                 
                 Section("Open Source Licenses") {
                     NavigationLink("Alert Toast") {
-                        ScrollView {
-                            MarkdownView(text: alertToastLicense.body, isNsfw: false)
-                                .padding()
-                        }
+                        DocumentView(text: alertToastLicense.body)
                     }
                     
                     NavigationLink("Debounced OnChange") {
-                        ScrollView {
-                            MarkdownView(text: debouncedOnChangeLicense.body, isNsfw: false)
-                                .padding()
-                        }
+                        DocumentView(text: debouncedOnChangeLicense.body)
                     }
                     
                     NavigationLink("KeychainAccess") {
-                        ScrollView {
-                            MarkdownView(text: keychainAccessLicense.body, isNsfw: false)
-                                .padding()
-                        }
+                        DocumentView(text: keychainAccessLicense.body)
                     }
                     
                     NavigationLink("Nuke") {
-                        ScrollView {
-                            MarkdownView(text: nukeLicense.body, isNsfw: false)
-                                .padding()
-                        }
+                        DocumentView(text: nukeLicense.body)
                     }
                     
                     NavigationLink("Swift Markdown UI") {
-                        ScrollView {
-                            MarkdownView(text: swiftMarkdownUILIcense.body, isNsfw: false)
-                                .padding()
-                        }
+                        DocumentView(text: swiftMarkdownUILIcense.body)
                     }
                     
                     NavigationLink("SwiftUI Cached Async Image") {
-                        ScrollView {
-                            MarkdownView(text: swiftUICachedAsyncImageLicense.body, isNsfw: false)
-                                .padding()
-                        }
+                        DocumentView(text: swiftUICachedAsyncImageLicense.body)
                     }
                     
                 }
             }
+            .fancyTabScrollCompatible()
         }
         .navigationTitle("Licenses")
     }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
@@ -12,74 +12,73 @@ struct AppearanceSettingsView: View {
     @AppStorage("lightOrDarkMode") var lightOrDarkMode: UIUserInterfaceStyle = .unspecified
     
     var body: some View {
-        VStack {
-            List {
-                Section {
-                    NavigationLink {
-                        ThemeSettingsView()
-                    } label: {
-                        switch lightOrDarkMode {
-                        case .unspecified:
-                            ThemeLabel(title: "Theme", color1: .white, color2: .black)
-                        case .light:
-                            ThemeLabel(title: "Theme", color1: .white)
-                        case .dark:
-                            ThemeLabel(title: "Theme", color1: .black)
-                        default:
-                            ThemeLabel(title: "Theme", color1: .clear)
-                        }
+        List {
+            Section {
+                NavigationLink {
+                    ThemeSettingsView()
+                } label: {
+                    switch lightOrDarkMode {
+                    case .unspecified:
+                        ThemeLabel(title: "Theme", color1: .white, color2: .black)
+                    case .light:
+                        ThemeLabel(title: "Theme", color1: .white)
+                    case .dark:
+                        ThemeLabel(title: "Theme", color1: .black)
+                    default:
+                        ThemeLabel(title: "Theme", color1: .clear)
                     }
-                    #if !os(macOS) && !targetEnvironment(macCatalyst)
-                    NavigationLink {
-                        IconSettingsView()
-                    } label: {
-                        Label {
-                           Text("App Icon")
-                        } icon: {
-                            IconSettingsView.getCurrentIcon()
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: AppConstants.settingsIconSize, height: AppConstants.settingsIconSize)
-                                .cornerRadius(AppConstants.settingsIconCornerRadius)
-                        }
+                }
+#if !os(macOS) && !targetEnvironment(macCatalyst)
+                NavigationLink {
+                    IconSettingsView()
+                } label: {
+                    Label {
+                        Text("App Icon")
+                    } icon: {
+                        IconSettingsView.getCurrentIcon()
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: AppConstants.settingsIconSize, height: AppConstants.settingsIconSize)
+                            .cornerRadius(AppConstants.settingsIconCornerRadius)
                     }
-                    #endif
+                }
+#endif
+            }
+            
+            Section {
+                NavigationLink {
+                    PostSettingsView()
+                } label: {
+                    Label("Posts", systemImage: "doc.plaintext.fill").labelStyle(SquircleLabelStyle(color: .pink))
                 }
                 
-                Section {
-                    NavigationLink {
-                        PostSettingsView()
-                    } label: {
-                        Label("Posts", systemImage: "doc.plaintext.fill").labelStyle(SquircleLabelStyle(color: .pink))
-                    }
-                    
-                    NavigationLink {
-                        CommentSettingsView()
-                    } label: {
-                        Label("Comments", systemImage: "bubble.left.fill").labelStyle(SquircleLabelStyle(color: .orange))
-                    }
-                    
-                    NavigationLink {
-                        CommunitySettingsView()
-                    } label: {
-                        Label("Communities", systemImage: "house.fill").labelStyle(SquircleLabelStyle(color: .green, fontSize: 15))
-                    }
-                    
-                    NavigationLink {
-                        UserSettingsView()
-                    } label: {
-                        Label("Users", systemImage: "person.fill").labelStyle(SquircleLabelStyle(color: .blue))
-                    }
+                NavigationLink {
+                    CommentSettingsView()
+                } label: {
+                    Label("Comments", systemImage: "bubble.left.fill").labelStyle(SquircleLabelStyle(color: .orange))
                 }
-                Section {
-                    NavigationLink {
-                        TabBarSettingsView()
-                    } label: {
-                        Label("Tab Bar", systemImage: "square").labelStyle(SquircleLabelStyle(color: .purple))
-                    }
+                
+                NavigationLink {
+                    CommunitySettingsView()
+                } label: {
+                    Label("Communities", systemImage: "house.fill").labelStyle(SquircleLabelStyle(color: .green, fontSize: 15))
+                }
+                
+                NavigationLink {
+                    UserSettingsView()
+                } label: {
+                    Label("Users", systemImage: "person.fill").labelStyle(SquircleLabelStyle(color: .blue))
+                }
+            }
+            Section {
+                NavigationLink {
+                    TabBarSettingsView()
+                } label: {
+                    Label("Tab Bar", systemImage: "square").labelStyle(SquircleLabelStyle(color: .purple))
                 }
             }
         }
+        .fancyTabScrollCompatible()
         .navigationTitle("Appearance")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -57,5 +57,6 @@ struct CommentSettingsView: View {
                                        isTicked: $shouldShowRepliesInCommentBar)
             }
         }
+        .fancyTabScrollCompatible()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
@@ -28,6 +28,7 @@ struct CommunitySettingsView: View {
                 isTicked: $shouldShowCommunityHeaders
             )
         }
+        .fancyTabScrollCompatible()
         .navigationTitle("Communities")
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -159,6 +159,7 @@ struct PostSettingsView: View {
             }
 
         }
+        .fancyTabScrollCompatible()
         .navigationTitle("Posts")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -22,5 +22,6 @@ struct TabBarSettingsView: View {
                 // swiftlint:enable line_length
             }
         }
+        .fancyTabScrollCompatible()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Theme/ThemeSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Theme/ThemeSettingsView.swift
@@ -69,6 +69,7 @@ struct ThemeSettingsView: View {
             .labelsHidden()
             .pickerStyle(.inline)
         }
+        .fancyTabScrollCompatible()
         .navigationTitle("Theme")
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
@@ -29,6 +29,8 @@ struct UserSettingsView: View {
                     isTicked: $shouldShowUserHeaders
                 )
             }
-        }.navigationTitle("Users")
+        }
+        .fancyTabScrollCompatible()
+        .navigationTitle("Users")
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
@@ -144,6 +144,7 @@ struct FiltersSettingsView: View {
 
             }
         }
+        .fancyTabScrollCompatible()
         .navigationTitle("Filters")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -139,6 +139,7 @@ struct GeneralSettingsView: View {
             }
 
         }
+        .fancyTabScrollCompatible()
         .navigationTitle("General")
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - fixes #348 
      - fixes #350
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR brings some minor enhancement to the tab bar:
- The tab bar no longer interacts poorly with scroll views\*
- Tabs no longer fully refresh when being swapped to. The bar now holds its child views in a ZStack, with the inactive views hidden behind the active one.
- The material of the tab bar has also been updated to `.thinMaterial` to align with the native tab bar.
- The color of the labels has been updated to .primary with an opacity of 0.4--I have determined that to be the exact configuration that Apple uses natively

\*Scrolling behavior is fixed with a slight hack--I've added a viewModifier that can be tacked onto a ScrollView to force it to respect the safeAreaInset. #352 is open to clean it up later, this turns out to be one of *those* problems--the ZStack needed for tab state breaks the safeAreaInset

<img width="563" alt="Screenshot 2023-07-21 at 3 35 26 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/dfcfd7ec-2f1a-4502-8368-2eb2f66887c3">
<img width="563" alt="Screenshot 2023-07-21 at 3 35 36 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/3308adc0-a84a-468c-b5f9-cb062450e2ba">
