### PR TITLE
Edit Post Prep

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -9,8 +9,10 @@
 /* Begin PBXBuildFile section */
 		030AC04F2A6464DA00037155 /* CommunitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030AC04E2A6464DA00037155 /* CommunitySettingsView.swift */; };
 		030AC0522A64666C00037155 /* UserSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030AC0512A64666C00037155 /* UserSettingsView.swift */; };
+		032EAFED2A6DB56D00CC19A6 /* Edit Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032EAFEC2A6DB56D00CC19A6 /* Edit Post.swift */; };
 		03B643572A6864CD00F65700 /* TabBarSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B643562A6864CD00F65700 /* TabBarSettingsView.swift */; };
 		03BAA23A2A57DC1400D48252 /* TimestampView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BAA2392A57DC1400D48252 /* TimestampView.swift */; };
+		03CB329E2A6D8E910021EF27 /* PostDetailEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CB329D2A6D8E910021EF27 /* PostDetailEditorView.swift */; };
 		03E0B9C82A61F0F400FED265 /* AdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9C72A61F0F400FED265 /* AdvancedSettingsView.swift */; };
 		03E0B9CA2A62B4A400FED265 /* ContributorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9C92A62B4A400FED265 /* ContributorsView.swift */; };
 		03E0B9CC2A62CD5800FED265 /* ThemeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9CB2A62CD5800FED265 /* ThemeSettingsView.swift */; };
@@ -356,8 +358,10 @@
 /* Begin PBXFileReference section */
 		030AC04E2A6464DA00037155 /* CommunitySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunitySettingsView.swift; sourceTree = "<group>"; };
 		030AC0512A64666C00037155 /* UserSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsView.swift; sourceTree = "<group>"; };
+		032EAFEC2A6DB56D00CC19A6 /* Edit Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Edit Post.swift"; sourceTree = "<group>"; };
 		03B643562A6864CD00F65700 /* TabBarSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarSettingsView.swift; sourceTree = "<group>"; };
 		03BAA2392A57DC1400D48252 /* TimestampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimestampView.swift; sourceTree = "<group>"; };
+		03CB329D2A6D8E910021EF27 /* PostDetailEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailEditorView.swift; sourceTree = "<group>"; };
 		03E0B9C72A61F0F400FED265 /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
 		03E0B9C92A62B4A400FED265 /* ContributorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorsView.swift; sourceTree = "<group>"; };
 		03E0B9CB2A62CD5800FED265 /* ThemeSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsView.swift; sourceTree = "<group>"; };
@@ -895,6 +899,7 @@
 				63D64E042A1BC20D00FD39C6 /* Post Post.swift */,
 				6307378A2A1CE2B300039852 /* Rate Post or Comment.swift */,
 				6DE1183D2A4A4FF500810C7E /* Delete Post or Comment.swift */,
+				032EAFEC2A6DB56D00CC19A6 /* Edit Post.swift */,
 				CD69F5602A40B6270028D4F7 /* Save Post.swift */,
 				6D693A452A51175E009E2D76 /* Report Post or Comment.swift */,
 				CDA145EE2A510C3D00DDAFC9 /* MarkCommentReplyAsRead.swift */,
@@ -1484,6 +1489,7 @@
 			children = (
 				ADF266942A4E8A1E00EBA648 /* PostComposerView.swift */,
 				CD391F952A535F5400E213B5 /* ResponseComposerView.swift */,
+				03CB329D2A6D8E910021EF27 /* PostDetailEditorView.swift */,
 			);
 			path = Composer;
 			sourceTree = "<group>";
@@ -1978,6 +1984,7 @@
 				CD391F9C2A53980900E213B5 /* ReplyToCommentReply.swift in Sources */,
 				630737892A1CD1E900039852 /* String.swift in Sources */,
 				63A01E542A2B980100C84E04 /* Subscribe Button.swift in Sources */,
+				032EAFED2A6DB56D00CC19A6 /* Edit Post.swift in Sources */,
 				6320BFD12A2F7AF500ECF661 /* Download UIImage from URL.swift in Sources */,
 				03E0B9CC2A62CD5800FED265 /* ThemeSettingsView.swift in Sources */,
 				637218532A3A2AAD008C4816 /* APIMyUserInfo.swift in Sources */,
@@ -2097,6 +2104,7 @@
 				6DA61F872A5720EA001EA633 /* RecentSearchesTracker.swift in Sources */,
 				CD3FBCD32A4A4B8B00B2063F /* Messages Tracker.swift in Sources */,
 				637218762A3A2AAD008C4816 /* BlockCommunity.swift in Sources */,
+				03CB329E2A6D8E910021EF27 /* PostDetailEditorView.swift in Sources */,
 				CD69F5752A42479A0028D4F7 /* Comment Item Logic.swift in Sources */,
 				6D7782342A48EE8C008AC1BF /* APIPrivateMessageView.swift in Sources */,
 				B11A1A782A4EFF2B00520DB4 /* Feed Root.swift in Sources */,
@@ -2374,7 +2382,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 76ULHQGAPN;
+				DEVELOPMENT_TEAM = V4747CQLU2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2392,7 +2400,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sjmarf.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -2415,7 +2423,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 76ULHQGAPN;
+				DEVELOPMENT_TEAM = V4747CQLU2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2433,7 +2441,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sjmarf.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "f67266f176af4add9f7a7020486826d82d562473",
-        "version" : "12.1.2"
+        "revision" : "c3864b8882bc69f5edfe5c70e18786c91d228b28",
+        "version" : "12.1.3"
       }
     },
     {

--- a/Mlem/API/Requests/Post/EditPost.swift
+++ b/Mlem/API/Requests/Post/EditPost.swift
@@ -32,7 +32,7 @@ struct EditPostRequest: APIPutRequest {
 
         postId: Int,
         name: String?,
-        url: URL?,
+        url: String?,
         body: String?,
         nsfw: Bool?,
         languageId: Int?
@@ -42,7 +42,7 @@ struct EditPostRequest: APIPutRequest {
         self.body = .init(
             post_id: postId,
             name: name,
-            url: url,
+            url: URL(string: url ?? ""),
             body: body,
             nsfw: nsfw,
             language_id: languageId,

--- a/Mlem/Logic/Participating/Edit Post.swift
+++ b/Mlem/Logic/Participating/Edit Post.swift
@@ -21,7 +21,7 @@ import SwiftUI
             account: account,
             postId: postId,
             name: postTitle,
-            url: URL(string: postURL!),
+            url: postURL,
             body: postBody,
             nsfw: postIsNSFW,
             languageId: nil

--- a/Mlem/Logic/Participating/Edit Post.swift
+++ b/Mlem/Logic/Participating/Edit Post.swift
@@ -1,0 +1,39 @@
+//
+//  Edit Post.swift
+//  Mlem
+//
+//  Created by Sjmarf on 23/07/2023.
+//
+
+import SwiftUI
+
+// swiftlint:disable function_parameter_count
+@discardableResult func editPost(
+    postId: Int,
+    postTitle: String,
+    postBody: String,
+    postURL: String?,
+    postIsNSFW: Bool,
+    postTracker: PostTracker,
+    
+    account: SavedAccount) async throws -> APIPostView {
+        let request = EditPostRequest(
+            account: account,
+            postId: postId,
+            name: postTitle,
+            url: URL(string: postURL!),
+            body: postBody,
+            nsfw: postIsNSFW,
+            languageId: nil
+        )
+        
+        let response = try await APIClient().perform(request: request)
+        HapticManager.shared.success()
+        
+        await MainActor.run {
+            postTracker.update(with: response.postView)
+        }
+        
+        return response.postView
+    }
+// swiftlint:enable function_parameter_count

--- a/Mlem/Views/Shared/Composer/PostComposerView.swift
+++ b/Mlem/Views/Shared/Composer/PostComposerView.swift
@@ -8,19 +8,7 @@
 import Dependencies
 import SwiftUI
 
-extension HorizontalAlignment {
-    enum LabelStart: AlignmentID {
-        static func defaultValue(in context: ViewDimensions) -> CGFloat {
-            context[HorizontalAlignment.leading]
-        }
-    }
-    
-    static let labelStart = HorizontalAlignment(LabelStart.self)
-}
-
 struct PostComposerView: View {
-    
-    @Dependency(\.errorHandler) var errorHandler
     
     init(community: APICommunity) {
         self.community = community
@@ -36,45 +24,15 @@ struct PostComposerView: View {
     @State var postURL: String = ""
     @State var postBody: String = ""
     @State var isNSFW: Bool = false
-    
-    @State var isSubmitting: Bool = false
-    @State var isShowingErrorDialog: Bool = false
-    @State var errorDialogMessage: String = ""
 
-    private var isReadyToPost: Bool {
-        // This only requirement to post is a title
-        return postTitle.trimmed.isNotEmpty
-    }
-    
-    private var isValidURL: Bool {
-        guard postURL.lowercased().hasPrefix("http://") ||
-                postURL.lowercased().hasPrefix("https://") else {
-            return false // URL protocol is missing
-        }
-
-        guard URL(string: postURL) != nil else {
-            return false // Not Parsable
-        }
-        
-        return true
-    }
-    
-    func submitPost() async {
-        do {
-            guard postTitle.trimmed.isNotEmpty else {
-                errorDialogMessage = "You need to enter a title for your post."
-                isShowingErrorDialog = true
-                return
-            }
-            
-            guard postURL.lowercased().isEmpty || isValidURL else {
-                errorDialogMessage = "You seem to have entered an invalid URL, please check it again."
-                isShowingErrorDialog = true
-                return
-            }
-            
-            isSubmitting = true
-            
+    var body: some View {
+        PostDetailEditorView(
+            community: community,
+            postTitle: $postTitle,
+            postURL: $postURL,
+            postBody: $postBody,
+            isNSFW: $isNSFW
+        ) {
             try await postPost(to: community,
                                postTitle: postTitle.trimmed,
                                postBody: postBody.trimmed,
@@ -86,130 +44,6 @@ struct PostComposerView: View {
             print("Post Successful")
             
             dismiss()
-            
-        } catch {
-            isSubmitting = false
-            errorHandler.handle(
-                .init(underlyingError: error)
-            )
-        }
-    }
-    
-    func uploadImage() {
-        print("Uploading")
-    }
-    
-    var body: some View {
-        NavigationStack {
-            ZStack {
-                VStack(spacing: 15) {
-                    
-                    // Community Row
-                    HStack {
-                        CommunityLabel(community: community,
-                                       serverInstanceLocation: .bottom,
-                                       overrideShowAvatar: true
-                        )
-                        Spacer()
-                        // NSFW Toggle
-                        Toggle(isOn: $isNSFW) {
-                            Text("NSFW")
-                                .foregroundStyle(.secondary)
-                                .bold()
-                                .frame(maxWidth: .infinity, alignment: .trailing)
-                        }
-                        .toggleStyle(.switch)
-                        .controlSize(.mini)
-                        .tint(.red)
-                    }
-                    
-                    VStack(alignment: .labelStart) {
-                        // Title Row
-                        HStack {
-                            Text("Title")
-                                .foregroundColor(.secondary)
-                                .dynamicTypeSize(.small ... .accessibility2)
-                                .accessibilityHidden(true)
-                            TextField("Your post title", text: $postTitle)
-                                .alignmentGuide(.labelStart) { $0[HorizontalAlignment.leading] }
-                                .dynamicTypeSize(.small ... .accessibility2)
-                                .accessibilityLabel("Title")
-                        }
-                        
-                        // URL Row
-                        HStack {
-                            Text("URL")
-                                .foregroundColor(.secondary)
-                                .dynamicTypeSize(.small ... .accessibility2)
-                                .accessibilityHidden(true)
-                            
-                            TextField("Your post link (Optional)", text: $postURL)
-                                .alignmentGuide(.labelStart) { $0[HorizontalAlignment.leading] }
-                                .dynamicTypeSize(.small ... .accessibility2)
-                                .keyboardType(.URL)
-                                .autocorrectionDisabled()
-                                .autocapitalization(.none)
-                                .accessibilityLabel("URL")
-                            
-                            // Upload button, temporarily hidden
-                            //                        Button(action: uploadImage) {
-                            //                            Image(systemName: "paperclip")
-                            //                                .font(.title3)
-                            //                                .dynamicTypeSize(.medium)
-                            //                        }
-                            //                        .accessibilityLabel("Upload Image")
-                        }
-                    }
-
-                    // Post Text
-                    TextField("What do you want to say? (Optional)",
-                              text: $postBody,
-                              axis: .vertical)
-                    .dynamicTypeSize(.small ... .accessibility2)
-                    .accessibilityLabel("Post Body")
-                    Spacer()
-                }
-                .padding()
-                
-                // Loading Indicator
-                if isSubmitting {
-                    ZStack {
-                        Color.gray.opacity(0.3)
-                        ProgressView()
-                    }
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityLabel("Submitting Post")
-                    .edgesIgnoringSafeArea(.all)
-                    .allowsHitTesting(false)
-                }
-            }
-
-            .navigationTitle("New Post")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Cancel", role: .destructive) {
-                        dismiss()
-                    }
-                    .tint(.red)
-                }
-                
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    // Submit Button
-                    Button {
-                        Task(priority: .userInitiated) {
-                            await submitPost()
-                        }
-                    } label: {
-                        Image(systemName: "paperplane")
-                    }.disabled(isSubmitting || !isReadyToPost)
-                }
-            }
-            .alert("Submit Failed", isPresented: $isShowingErrorDialog) {
-                Button("OK", role: .cancel) { }
-            } message: {
-                Text(errorDialogMessage)
-            }
-            .navigationBarTitleDisplayMode(.inline)
         }
     }
 }

--- a/Mlem/Views/Shared/Composer/PostDetailEditorView.swift
+++ b/Mlem/Views/Shared/Composer/PostDetailEditorView.swift
@@ -1,0 +1,216 @@
+//
+//  PostComposerView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 23/07/23
+//
+
+import Dependencies
+import SwiftUI
+
+extension HorizontalAlignment {
+    enum LabelStart: AlignmentID {
+        static func defaultValue(in context: ViewDimensions) -> CGFloat {
+            context[HorizontalAlignment.leading]
+        }
+    }
+    
+    static let labelStart = HorizontalAlignment(LabelStart.self)
+}
+
+struct PostDetailEditorView: View {
+    
+    @Dependency(\.errorHandler) var errorHandler
+    
+    @Environment(\.dismiss) var dismiss
+        
+    var community: APICommunity
+    var onSubmit: () async throws -> Void
+    
+    @Binding var postTitle: String
+    @Binding var postURL: String
+    @Binding var postBody: String
+    @Binding var isNSFW: Bool
+    
+    @State var isSubmitting: Bool = false
+    @State var isShowingErrorDialog: Bool = false
+    @State var errorDialogMessage: String = ""
+    
+    init(
+        community: APICommunity,
+        postTitle: Binding<String>,
+        postURL: Binding<String>,
+        postBody: Binding<String>,
+        isNSFW: Binding<Bool>,
+        onSubmit: @escaping () async throws -> Void
+    ) {
+        self.community = community
+        _postTitle = postTitle
+        _postURL = postURL
+        _postBody = postBody
+        _isNSFW = isNSFW
+        self.onSubmit = onSubmit
+    }
+
+    private var isReadyToPost: Bool {
+        // This only requirement to post is a title
+        return postTitle.trimmed.isNotEmpty
+    }
+    
+    private var isValidURL: Bool {
+        guard postURL.lowercased().hasPrefix("http://") ||
+                postURL.lowercased().hasPrefix("https://") else {
+            return false // URL protocol is missing
+        }
+
+        guard URL(string: postURL) != nil else {
+            return false // Not Parsable
+        }
+        
+        return true
+    }
+    
+    func submitPost() async {
+        do {
+            guard postTitle.trimmed.isNotEmpty else {
+                errorDialogMessage = "You need to enter a title for your post."
+                isShowingErrorDialog = true
+                return
+            }
+            
+            guard postURL.lowercased().isEmpty || isValidURL else {
+                errorDialogMessage = "You seem to have entered an invalid URL, please check it again."
+                isShowingErrorDialog = true
+                return
+            }
+            
+            isSubmitting = true
+            
+            try await onSubmit()
+            
+        } catch {
+            isSubmitting = false
+            errorHandler.handle(
+                .init(underlyingError: error)
+            )
+        }
+    }
+    
+    func uploadImage() {
+        print("Uploading")
+    }
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                VStack(spacing: 15) {
+                    
+                    // Community Row
+                    HStack {
+                        CommunityLabel(community: community,
+                                       serverInstanceLocation: .bottom,
+                                       overrideShowAvatar: true
+                        )
+                        Spacer()
+                        // NSFW Toggle
+                        Toggle(isOn: $isNSFW) {
+                            Text("NSFW")
+                                .foregroundStyle(.secondary)
+                                .bold()
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                        }
+                        .toggleStyle(.switch)
+                        .controlSize(.mini)
+                        .tint(.red)
+                    }
+                    
+                    VStack(alignment: .labelStart) {
+                        // Title Row
+                        HStack {
+                            Text("Title")
+                                .foregroundColor(.secondary)
+                                .dynamicTypeSize(.small ... .accessibility2)
+                                .accessibilityHidden(true)
+                            TextField("Your post title", text: $postTitle)
+                                .alignmentGuide(.labelStart) { $0[HorizontalAlignment.leading] }
+                                .dynamicTypeSize(.small ... .accessibility2)
+                                .accessibilityLabel("Title")
+                        }
+                        
+                        // URL Row
+                        HStack {
+                            Text("URL")
+                                .foregroundColor(.secondary)
+                                .dynamicTypeSize(.small ... .accessibility2)
+                                .accessibilityHidden(true)
+                            
+                            TextField("Your post link (Optional)", text: $postURL)
+                                .alignmentGuide(.labelStart) { $0[HorizontalAlignment.leading] }
+                                .dynamicTypeSize(.small ... .accessibility2)
+                                .keyboardType(.URL)
+                                .autocorrectionDisabled()
+                                .autocapitalization(.none)
+                                .accessibilityLabel("URL")
+                            
+                            // Upload button, temporarily hidden
+                            //                        Button(action: uploadImage) {
+                            //                            Image(systemName: "paperclip")
+                            //                                .font(.title3)
+                            //                                .dynamicTypeSize(.medium)
+                            //                        }
+                            //                        .accessibilityLabel("Upload Image")
+                        }
+                    }
+
+                    // Post Text
+                    TextField("What do you want to say? (Optional)",
+                              text: $postBody,
+                              axis: .vertical)
+                    .dynamicTypeSize(.small ... .accessibility2)
+                    .accessibilityLabel("Post Body")
+                    Spacer()
+                }
+                .padding()
+                
+                // Loading Indicator
+                if isSubmitting {
+                    ZStack {
+                        Color.gray.opacity(0.3)
+                        ProgressView()
+                    }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("Submitting Post")
+                    .edgesIgnoringSafeArea(.all)
+                    .allowsHitTesting(false)
+                }
+            }
+
+            .navigationTitle("New Post")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel", role: .destructive) {
+                        dismiss()
+                    }
+                    .tint(.red)
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    // Submit Button
+                    Button {
+                        Task(priority: .userInitiated) {
+                            await submitPost()
+                        }
+                    } label: {
+                        Image(systemName: "paperplane")
+                    }.disabled(isSubmitting || !isReadyToPost)
+                }
+            }
+            .alert("Submit Failed", isPresented: $isShowingErrorDialog) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(errorDialogMessage)
+            }
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}


### PR DESCRIPTION
Backend prep for the editing posts feature. No functionality is changed in this PR. I would have done more, but I'll be going away for a week so I thought I'd submit what I've done so far - if someone else wants to finish this feature, have at it.

I've separated the editing interface from `PostComposerView` into a separate `PostDetailEditorView`. I imagine this new `PostDetailEditorView` could be used in a `PostEditorView` sheet similar to `PostComposerView` but for editing the post. I've also implemented the `editPost` function to perform the post edit. 

Related: #36, #134