### PR TITLE
fixed LazyImage clipping

### DIFF
--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "c3864b8882bc69f5edfe5c70e18786c91d228b28",
-        "version" : "12.1.3"
+        "revision" : "989586f86b683680f7bd5765d6a5683edbea0c1b",
+        "version" : "12.1.4"
       }
     },
     {

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -17,10 +17,14 @@ struct CachedImage: View {
     let url: URL?
     let shouldExpand: Bool
     @State var bigPicMode: URL?
+    let maxHeight: CGFloat
 
-    init(url: URL?, shouldExpand: Bool = true) {
+    init(url: URL?,
+         shouldExpand: Bool = true,
+         maxHeight: CGFloat = .infinity) {
         self.url = url
         self.shouldExpand = shouldExpand
+        self.maxHeight = maxHeight
     }
     
     var body: some View {
@@ -29,6 +33,14 @@ struct CachedImage: View {
                 let imageView = image
                     .resizable()
                     .scaledToFill()
+                    .clipped()
+                    .allowsHitTesting(false)
+                    .overlay(alignment: .top) {
+                        // weeps in janky hack but this lets us tap the image only in the area we want
+                        Rectangle()
+                            .frame(maxHeight: maxHeight)
+                            .opacity(0.00000000001)
+                    }
                 if shouldExpand {
                     imageView
                         .onTapGesture {

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -22,6 +22,9 @@ struct LargePost: View {
     // parameters
     let postView: APIPostView
     let isExpanded: Bool
+    
+    // computed
+    let maxHeight: CGFloat
 
     // initializer--used so we can set showNsfwFilterToggle to false when expanded or true when not
     init(
@@ -30,6 +33,7 @@ struct LargePost: View {
     ) {
         self.postView = postView
         self.isExpanded = isExpanded
+        self.maxHeight = isExpanded ? .infinity : AppConstants.maxFeedPostHeight
     }
 
     var body: some View {
@@ -64,8 +68,8 @@ struct LargePost: View {
         switch postView.postType {
         case .image(let url):
             VStack(spacing: AppConstants.postAndCommentSpacing) {
-                CachedImage(url: url)
-                    .frame(maxWidth: .infinity, maxHeight: isExpanded ? .infinity : AppConstants.maxFeedPostHeight, alignment: .top)
+                CachedImage(url: url, maxHeight: maxHeight)
+                    .frame(maxWidth: .infinity, maxHeight: maxHeight, alignment: .top)
                     .applyNsfwOverlay(postView.post.nsfw || postView.community.nsfw)
                     .cornerRadius(AppConstants.largeItemCornerRadius)
                     .clipped()


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      -
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR fixes an issue where images were tappable outside of their frame. Nuke images apparently refuse to respect frame, so I've disabled hit testing on the image itself and added an overlay to register hits which can be bounded to an optional `maxHeight` parameter.
