### PR TITLE
Fixed expanded post not updating when edited

### DIFF
--- a/Mlem/Logic/Participating/Edit Post.swift
+++ b/Mlem/Logic/Participating/Edit Post.swift
@@ -15,8 +15,8 @@ import SwiftUI
     postURL: String?,
     postIsNSFW: Bool,
     postTracker: PostTracker,
-    
-    account: SavedAccount) async throws -> APIPostView {
+    account: SavedAccount,
+    responseCallback: ((APIPostView) -> Void)? = nil) async throws -> APIPostView {
         let request = EditPostRequest(
             account: account,
             postId: postId,
@@ -32,6 +32,11 @@ import SwiftUI
         
         await MainActor.run {
             postTracker.update(with: response.postView)
+            
+            if let responseCallback {
+                print("responding")
+                responseCallback(response.postView)
+            }
         }
         
         return response.postView

--- a/Mlem/Logic/Participating/Edit Post.swift
+++ b/Mlem/Logic/Participating/Edit Post.swift
@@ -34,7 +34,6 @@ import SwiftUI
             postTracker.update(with: response.postView)
             
             if let responseCallback {
-                print("responding")
                 responseCallback(response.postView)
             }
         }

--- a/Mlem/Models/Composers/PostEditor.swift
+++ b/Mlem/Models/Composers/PostEditor.swift
@@ -14,14 +14,17 @@ struct PostEditorModel: Identifiable {
     let appState: AppState
     let postTracker: PostTracker
     let editPost: APIPost?
+    var responseCallback: ((APIPostView) -> Void)?
     
     init(community: APICommunity,
          appState: AppState,
          postTracker: PostTracker = PostTracker(shouldPerformMergeSorting: false),
-         editPost: APIPost? = nil) {
+         editPost: APIPost? = nil,
+         responseCallback: ((APIPostView) -> Void)? = nil) {
         self.community = community
         self.appState = appState
         self.postTracker = postTracker
         self.editPost = editPost
+        self.responseCallback = responseCallback
     }
 }

--- a/Mlem/Views/Shared/Composer/PostComposerView.swift
+++ b/Mlem/Views/Shared/Composer/PostComposerView.swift
@@ -47,7 +47,9 @@ struct PostComposerView: View {
                                    postURL: postURL,
                                    postIsNSFW: isNSFW,
                                    postTracker: postTracker,
-                                   account: appState.currentActiveAccount)
+                                   account: appState.currentActiveAccount,
+                                   responseCallback: editModel.responseCallback)
+                
                 print("Edit successful")
             } else {
                 try await postPost(to: editModel.community,

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -55,6 +55,7 @@ struct ExpandedPost: View {
         ScrollView {
             VStack(spacing: 0) {
                 postView
+                    .id(post.hashValue)
                 
                 Divider()
                     .background(.black)

--- a/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
+++ b/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
@@ -159,7 +159,11 @@ extension ExpandedPost {
                 imageName: "pencil",
                 destructiveActionPrompt: nil,
                 enabled: true) {
-                    editorTracker.openEditor(with: PostEditorModel(community: post.community, appState: appState, editPost: post.post))
+                    editorTracker.openEditor(with: PostEditorModel(community: post.community,
+                                                                   appState: appState,
+                                                                   postTracker: postTracker,
+                                                                   editPost: post.post,
+                                                                   responseCallback: updatePost))
                 })
             
             // delete
@@ -258,5 +262,9 @@ extension ExpandedPost {
             newComment.children = sortComments(comment.children, by: sort)
             return newComment
         }
+    }
+    
+    func updatePost(newPost: APIPostView) {
+        post = newPost
     }
 }


### PR DESCRIPTION
Expanded posts weren't updating when the body of the post was updated. Since they aren't handled with the post tracker, this required some slight jank--PostEditor now has an optional callback that takes in the updated post. This gets used to update the state back in `ExpandedPost` when the edit call completes.


https://github.com/mlemgroup/mlem/assets/44140166/9fe9a552-33a6-4b7c-96b9-f0d3b9e5ede5

