### PR TITLE
Tap Thumbnails to Expand

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 		CD3FBCE52A4A89B900B2063F /* Mentions Feed View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCE42A4A89B900B2063F /* Mentions Feed View.swift */; };
 		CD3FBCE72A4A8CE300B2063F /* Messages Feed View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCE62A4A8CE300B2063F /* Messages Feed View.swift */; };
 		CD3FBCE92A4B482700B2063F /* Generic Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCE82A4B482700B2063F /* Generic Merge.swift */; };
-		CD45BCEE2A75CA7200A2899C /* ThumbnailImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD45BCED2A75CA7200A2899C /* ThumbnailImage.swift */; };
+		CD45BCEE2A75CA7200A2899C /* Thumbnail Image View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD45BCED2A75CA7200A2899C /* Thumbnail Image View.swift */; };
 		CD4DBC032A6F803C001A1E61 /* ReplyToPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4DBC022A6F803C001A1E61 /* ReplyToPost.swift */; };
 		CD4E98A12A69BE980026C4D9 /* AlternativeIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4E98A02A69BE980026C4D9 /* AlternativeIconCell.swift */; };
 		CD4E98A32A69BEDC0026C4D9 /* IconSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4E98A22A69BEDC0026C4D9 /* IconSettingsView.swift */; };
@@ -638,7 +638,7 @@
 		CD3FBCE42A4A89B900B2063F /* Mentions Feed View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mentions Feed View.swift"; sourceTree = "<group>"; };
 		CD3FBCE62A4A8CE300B2063F /* Messages Feed View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Messages Feed View.swift"; sourceTree = "<group>"; };
 		CD3FBCE82A4B482700B2063F /* Generic Merge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generic Merge.swift"; sourceTree = "<group>"; };
-		CD45BCED2A75CA7200A2899C /* ThumbnailImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailImage.swift; sourceTree = "<group>"; };
+		CD45BCED2A75CA7200A2899C /* Thumbnail Image View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Thumbnail Image View.swift"; sourceTree = "<group>"; };
 		CD4DBC022A6F803C001A1E61 /* ReplyToPost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplyToPost.swift; sourceTree = "<group>"; };
 		CD4E98A02A69BE980026C4D9 /* AlternativeIconCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AlternativeIconCell.swift; path = Mlem/Extensions/AlternativeIconCell.swift; sourceTree = SOURCE_ROOT; };
 		CD4E98A22A69BEDC0026C4D9 /* IconSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconSettingsView.swift; path = Mlem/Extensions/IconSettingsView.swift; sourceTree = SOURCE_ROOT; };
@@ -1637,7 +1637,7 @@
 				632E8EE427EE63BD007E8D75 /* Buttons */,
 				CD1446162A58FC2F00610EF1 /* Interaction Bars */,
 				CDF1EF152A6C3BC2003594B6 /* End Of Feed View.swift */,
-				CD45BCED2A75CA7200A2899C /* ThumbnailImage.swift */,
+				CD45BCED2A75CA7200A2899C /* Thumbnail Image View.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2199,7 +2199,7 @@
 				6D80037B2A46458800363206 /* Lazy Load Expanded Post.swift in Sources */,
 				CD18DC752A522B38002C56BC /* SendPrivateMessage.swift in Sources */,
 				6372184F2A3A2AAD008C4816 /* APIPerson.swift in Sources */,
-				CD45BCEE2A75CA7200A2899C /* ThumbnailImage.swift in Sources */,
+				CD45BCEE2A75CA7200A2899C /* Thumbnail Image View.swift in Sources */,
 				63E5D3962A13DAF200EC1FBD /* Mark Community as Favorite.swift in Sources */,
 				6322A5D027F8629700135D4F /* User Profile Link.swift in Sources */,
 				6372184B2A3A2AAD008C4816 /* APIPostAggregates.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		CD3FBCE52A4A89B900B2063F /* Mentions Feed View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCE42A4A89B900B2063F /* Mentions Feed View.swift */; };
 		CD3FBCE72A4A8CE300B2063F /* Messages Feed View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCE62A4A8CE300B2063F /* Messages Feed View.swift */; };
 		CD3FBCE92A4B482700B2063F /* Generic Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCE82A4B482700B2063F /* Generic Merge.swift */; };
+		CD45BCEE2A75CA7200A2899C /* ThumbnailImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD45BCED2A75CA7200A2899C /* ThumbnailImage.swift */; };
 		CD4DBC032A6F803C001A1E61 /* ReplyToPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4DBC022A6F803C001A1E61 /* ReplyToPost.swift */; };
 		CD4E98A12A69BE980026C4D9 /* AlternativeIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4E98A02A69BE980026C4D9 /* AlternativeIconCell.swift */; };
 		CD4E98A32A69BEDC0026C4D9 /* IconSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4E98A22A69BEDC0026C4D9 /* IconSettingsView.swift */; };
@@ -637,6 +638,7 @@
 		CD3FBCE42A4A89B900B2063F /* Mentions Feed View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mentions Feed View.swift"; sourceTree = "<group>"; };
 		CD3FBCE62A4A8CE300B2063F /* Messages Feed View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Messages Feed View.swift"; sourceTree = "<group>"; };
 		CD3FBCE82A4B482700B2063F /* Generic Merge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generic Merge.swift"; sourceTree = "<group>"; };
+		CD45BCED2A75CA7200A2899C /* ThumbnailImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailImage.swift; sourceTree = "<group>"; };
 		CD4DBC022A6F803C001A1E61 /* ReplyToPost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplyToPost.swift; sourceTree = "<group>"; };
 		CD4E98A02A69BE980026C4D9 /* AlternativeIconCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AlternativeIconCell.swift; path = Mlem/Extensions/AlternativeIconCell.swift; sourceTree = SOURCE_ROOT; };
 		CD4E98A22A69BEDC0026C4D9 /* IconSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconSettingsView.swift; path = Mlem/Extensions/IconSettingsView.swift; sourceTree = SOURCE_ROOT; };
@@ -1635,6 +1637,7 @@
 				632E8EE427EE63BD007E8D75 /* Buttons */,
 				CD1446162A58FC2F00610EF1 /* Interaction Bars */,
 				CDF1EF152A6C3BC2003594B6 /* End Of Feed View.swift */,
+				CD45BCED2A75CA7200A2899C /* ThumbnailImage.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2196,6 +2199,7 @@
 				6D80037B2A46458800363206 /* Lazy Load Expanded Post.swift in Sources */,
 				CD18DC752A522B38002C56BC /* SendPrivateMessage.swift in Sources */,
 				6372184F2A3A2AAD008C4816 /* APIPerson.swift in Sources */,
+				CD45BCEE2A75CA7200A2899C /* ThumbnailImage.swift in Sources */,
 				63E5D3962A13DAF200EC1FBD /* Mark Community as Favorite.swift in Sources */,
 				6322A5D027F8629700135D4F /* User Profile Link.swift in Sources */,
 				6372184B2A3A2AAD008C4816 /* APIPostAggregates.swift in Sources */,

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -61,6 +61,7 @@ struct AppConstants {
     
     // MARK: - Sizes
     static let maxFeedPostHeight: CGFloat = 400
+    static let thumbnailSize: CGFloat = 60
     static let largeAvatarSize: CGFloat = 32
     static let smallAvatarSize: CGFloat = 16
     static let defaultAvatarSize: CGFloat = 24

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -33,6 +33,7 @@ struct CachedImage: View {
                 let imageView = image
                     .resizable()
                     .scaledToFill()
+                    .frame(maxHeight: maxHeight)
                     .clipped()
                     .allowsHitTesting(false)
                     .overlay(alignment: .top) {

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -69,20 +69,14 @@ struct CachedImage: View {
                 }
             } else if state.error != nil {
                 // Indicates an error
-                Color.red
-                    .frame(minWidth: 300, minHeight: 300)
-                    .blur(radius: 30)
-                    .overlay(VStack {
-                        Image(systemName: "exclamationmark.triangle")
-                            .font(.largeTitle)
-                        Text("Error")
-                            .fontWeight(.black)
-                    }
-                    .foregroundColor(.white)
-                    .padding(8))
+                Image(systemName: "questionmark.square.dashed")
+                    .background(Color(uiColor: .systemGray4))
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .cornerRadius(AppConstants.smallItemCornerRadius)
             } else {
                 ProgressView() // Acts as a placeholder
-                    .frame(minWidth: 300, minHeight: 300)
+                    .frame(maxWidth: .infinity, maxHeight: maxHeight)
             }
         }
     }

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -69,15 +69,23 @@ struct CachedImage: View {
                 }
             } else if state.error != nil {
                 // Indicates an error
-                Image(systemName: "questionmark.square.dashed")
+                imageNotFound()
+                    .frame(maxWidth: .infinity, maxHeight: min(300, maxHeight))
                     .background(Color(uiColor: .systemGray4))
                     .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .cornerRadius(AppConstants.smallItemCornerRadius)
             } else {
                 ProgressView() // Acts as a placeholder
                     .frame(maxWidth: .infinity, maxHeight: maxHeight)
             }
         }
+    }
+    
+    func imageNotFound() -> some View {
+        Image(systemName: "questionmark.square.dashed")
+            .resizable()
+            .scaledToFit()
+            .frame(maxWidth: AppConstants.thumbnailSize, maxHeight: AppConstants.thumbnailSize)
+            .padding(AppConstants.postAndCommentSpacing)
     }
 }

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -1,5 +1,5 @@
 //
-//  ThumbnailImage.swift
+//  ThumbnailImageView.swift
 //  Mlem
 //
 //  Created by Eric Andrews on 2023-07-29.
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-struct ThumbnailImage: View {
+struct ThumbnailImageView: View {
     
     @AppStorage("shouldBlurNsfw") var shouldBlurNsfw: Bool = true
     

--- a/Mlem/Views/Shared/Components/ThumbnailImage.swift
+++ b/Mlem/Views/Shared/Components/ThumbnailImage.swift
@@ -1,0 +1,44 @@
+//
+//  ThumbnailImage.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-07-29.
+//
+
+import Foundation
+import SwiftUI
+import CachedAsyncImage
+
+struct ThumbnailImage: View {
+    
+    @AppStorage("shouldBlurNsfw") var shouldBlurNsfw: Bool = true
+    
+    let postView: APIPostView
+    
+    var showNsfwFilter: Bool { (postView.post.nsfw || postView.community.nsfw) && shouldBlurNsfw }
+    
+    var body: some View {
+        Group {
+            switch postView.postType {
+            case .image(let url):
+                // just blur, no need for the whole filter viewModifier since this is just a thumbnail
+                CachedImage(url: url)
+                    .blur(radius: showNsfwFilter ? 8 : 0)
+            case .link(let url):
+                CachedImage(url: url)
+                    .blur(radius: showNsfwFilter ? 8 : 0)
+            case .text:
+                Image(systemName: "text.book.closed")
+            case .titleOnly:
+                Image(systemName: "character.bubble")
+            }
+        }
+        .foregroundColor(.secondary)
+        .font(.title)
+        .frame(width: AppConstants.thumbnailSize, height: AppConstants.thumbnailSize)
+        .background(Color(UIColor.systemGray4))
+        .clipShape(RoundedRectangle(cornerRadius: AppConstants.smallItemCornerRadius))
+        .overlay(RoundedRectangle(cornerRadius: AppConstants.smallItemCornerRadius)
+            .stroke(Color(UIColor.secondarySystemBackground), lineWidth: 1))
+    }
+}

--- a/Mlem/Views/Shared/Components/ThumbnailImage.swift
+++ b/Mlem/Views/Shared/Components/ThumbnailImage.swift
@@ -21,10 +21,10 @@ struct ThumbnailImage: View {
             switch postView.postType {
             case .image(let url):
                 // just blur, no need for the whole filter viewModifier since this is just a thumbnail
-                CachedImage(url: url)
+                CachedImage(url: url, maxHeight: AppConstants.thumbnailSize)
                     .blur(radius: showNsfwFilter ? 8 : 0)
             case .link(let url):
-                CachedImage(url: url)
+                CachedImage(url: url, maxHeight: AppConstants.thumbnailSize)
                     .blur(radius: showNsfwFilter ? 8 : 0)
             case .text:
                 Image(systemName: "text.book.closed")
@@ -36,6 +36,7 @@ struct ThumbnailImage: View {
         .font(.title)
         .frame(width: AppConstants.thumbnailSize, height: AppConstants.thumbnailSize)
         .background(Color(UIColor.systemGray4))
+        .contentShape(Rectangle())
         .clipShape(RoundedRectangle(cornerRadius: AppConstants.smallItemCornerRadius))
         .overlay(RoundedRectangle(cornerRadius: AppConstants.smallItemCornerRadius)
             .stroke(Color(UIColor.secondarySystemBackground), lineWidth: 1))

--- a/Mlem/Views/Shared/Components/ThumbnailImage.swift
+++ b/Mlem/Views/Shared/Components/ThumbnailImage.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-import CachedAsyncImage
 
 struct ThumbnailImage: View {
     

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -12,7 +12,6 @@
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
 
-import CachedAsyncImage
 import Dependencies
 import SwiftUI
 import QuickLook

--- a/Mlem/Views/Shared/Posts/Post Sizes/Headline Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Headline Post.swift
@@ -5,7 +5,6 @@
 //  Created by Eric Andrews on 2023-06-11.
 //
 
-import CachedAsyncImage
 import Foundation
 import SwiftUI
 

--- a/Mlem/Views/Shared/Posts/Post Sizes/Headline Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Headline Post.swift
@@ -41,7 +41,7 @@ struct HeadlinePost: View {
         VStack(alignment: .leading, spacing: AppConstants.postAndCommentSpacing) {
             HStack(alignment: .top, spacing: spacing) {
                 if shouldShowPostThumbnails && !thumbnailsOnRight {
-                    thumbnailImage
+                    ThumbnailImage(postView: postView)
                 }
 
                 VStack(spacing: 2) {
@@ -65,46 +65,9 @@ struct HeadlinePost: View {
                 }
                 
                 if shouldShowPostThumbnails && thumbnailsOnRight {
-                    thumbnailImage
+                    ThumbnailImage(postView: postView)
                 }
             }
         }
-    }
-
-    @ViewBuilder
-    private var thumbnailImage: some View {
-        Group {
-            switch postView.postType {
-            case .image(let url):
-                CachedAsyncImage(url: url, urlCache: AppConstants.urlCache) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
-                } placeholder: {
-                    ProgressView()
-                }
-            case .link(let url):
-                CachedAsyncImage(url: url, urlCache: AppConstants.urlCache) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
-                } placeholder: {
-                    Image(systemName: "safari")
-                }
-            case .text:
-                Image(systemName: "text.book.closed")
-            case .titleOnly:
-                Image(systemName: "character.bubble")
-            }
-        }
-        .foregroundColor(.secondary)
-        .font(.title)
-        .frame(width: thumbnailSize, height: thumbnailSize)
-        .background(Color(UIColor.systemGray4))
-        .clipShape(RoundedRectangle(cornerRadius: AppConstants.smallItemCornerRadius))
-        .overlay(RoundedRectangle(cornerRadius: AppConstants.smallItemCornerRadius)
-            .stroke(Color(UIColor.secondarySystemBackground), lineWidth: 1))
     }
 }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Headline Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Headline Post.swift
@@ -34,13 +34,11 @@ struct HeadlinePost: View {
         return .secondary
     }
 
-    var showNsfwFilter: Bool { (postView.post.nsfw || postView.community.nsfw) && shouldBlurNsfw }
-
     var body: some View {
         VStack(alignment: .leading, spacing: AppConstants.postAndCommentSpacing) {
             HStack(alignment: .top, spacing: spacing) {
                 if shouldShowPostThumbnails && !thumbnailsOnRight {
-                    ThumbnailImage(postView: postView)
+                    ThumbnailImageView(postView: postView)
                 }
 
                 VStack(spacing: 2) {
@@ -64,7 +62,7 @@ struct HeadlinePost: View {
                 }
                 
                 if shouldShowPostThumbnails && thumbnailsOnRight {
-                    ThumbnailImage(postView: postView)
+                    ThumbnailImageView(postView: postView)
                 }
             }
         }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -5,7 +5,6 @@
 //  Created by Eric Andrews on 2023-06-10.
 //
 
-import CachedAsyncImage
 import SwiftUI
 
 import Foundation

--- a/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
@@ -52,7 +52,7 @@ struct UltraCompactPost: View {
     var body: some View {
         HStack(alignment: .top, spacing: AppConstants.postAndCommentSpacing) {
             if shouldShowPostThumbnails && !thumbnailsOnRight {
-                thumbnailImage
+                ThumbnailImage(postView: postView)
             }
             
             VStack(alignment: .leading, spacing: AppConstants.compactSpacing) {
@@ -79,48 +79,11 @@ struct UltraCompactPost: View {
             }
             
             if shouldShowPostThumbnails && thumbnailsOnRight {
-                thumbnailImage
+                ThumbnailImage(postView: postView)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(AppConstants.postAndCommentSpacing)
-    }
-    
-    @ViewBuilder
-    private var thumbnailImage: some View {
-        Group {
-            switch postView.postType {
-            case .image(let url):
-                CachedAsyncImage(url: url, urlCache: AppConstants.urlCache) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
-                } placeholder: {
-                    ProgressView()
-                }
-            case .link(let url):
-                CachedAsyncImage(url: url, urlCache: AppConstants.urlCache) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .blur(radius: showNsfwFilter ? 8 : 0) // blur nsfw
-                } placeholder: {
-                    Image(systemName: "safari")
-                }
-            case .text:
-                Image(systemName: "text.book.closed")
-            case .titleOnly:
-                Image(systemName: "character.bubble")
-            }
-        }
-        .foregroundColor(.secondary)
-        .font(.title)
-        .frame(width: thumbnailSize, height: thumbnailSize)
-        .background(Color(UIColor.systemGray4))
-        .clipShape(RoundedRectangle(cornerRadius: AppConstants.smallItemCornerRadius))
-        .overlay(RoundedRectangle(cornerRadius: AppConstants.smallItemCornerRadius)
-            .stroke(Color(UIColor.secondarySystemBackground), lineWidth: 1))
     }
     
     @ViewBuilder

--- a/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
@@ -28,7 +28,6 @@ struct UltraCompactPost: View {
     // computed
     let voteColor: Color
     let voteIconName: String
-    var showNsfwFilter: Bool { (postView.post.nsfw || postView.community.nsfw) && shouldBlurNsfw }
 
     init(postView: APIPostView, showCommunity: Bool, menuFunctions: [MenuFunction]) {
         self.postView = postView
@@ -51,7 +50,7 @@ struct UltraCompactPost: View {
     var body: some View {
         HStack(alignment: .top, spacing: AppConstants.postAndCommentSpacing) {
             if shouldShowPostThumbnails && !thumbnailsOnRight {
-                ThumbnailImage(postView: postView)
+                ThumbnailImageView(postView: postView)
             }
             
             VStack(alignment: .leading, spacing: AppConstants.compactSpacing) {
@@ -78,7 +77,7 @@ struct UltraCompactPost: View {
             }
             
             if shouldShowPostThumbnails && thumbnailsOnRight {
-                ThumbnailImage(postView: postView)
+                ThumbnailImageView(postView: postView)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-import CachedAsyncImage
 
 struct UltraCompactPost: View {
     // app storage


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #279 
      - closes #281 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR allows tapping thumbnails in feed to open the post content. It moves the duplicated thumbnail code from `HeadlinePost` and `UltraCompactPost` into a common `ThumbnailImage`, which now uses `CachedImage` in place of `CachedAsyncImage`, which enables tapping thumbnails to open QuickLook

The "error loading image" graphic has also been replaced with a much gentler one.

## Screenshots and Videos
https://github.com/mlemgroup/mlem/assets/44140166/5d140747-86d0-4962-93f9-f45fe888d536
<img width="632" alt="Screenshot 2023-07-29 at 10 14 56 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/fbd934ad-7951-43eb-8599-07634dee6eae">
