### PR TITLE
Make instance field more lenient

### DIFF
--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "c3864b8882bc69f5edfe5c70e18786c91d228b28",
-        "version" : "12.1.3"
+        "revision" : "989586f86b683680f7bd5765d6a5683edbea0c1b",
+        "version" : "12.1.4"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "989586f86b683680f7bd5765d6a5683edbea0c1b",
-        "version" : "12.1.4"
+        "revision" : "c3864b8882bc69f5edfe5c70e18786c91d228b28",
+        "version" : "12.1.3"
       }
     },
     {

--- a/Mlem/API/Models/APIErrorResponse.swift
+++ b/Mlem/API/Models/APIErrorResponse.swift
@@ -14,7 +14,8 @@ struct APIErrorResponse: Decodable {
 private let possibleCredentialErrors = [
     "incorrect_password",
     "password_incorrect",
-    "incorrect_login"
+    "incorrect_login",
+    "couldnt_find_that_username_or_email"
 ]
 
 extension APIErrorResponse {

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -253,7 +253,7 @@ struct AddSavedInstanceView: View {
         }
         
         // There should always be a match, but we return if there isn't just to be safe
-        guard let match = instance.firstMatch(of: /^(?:https?:\/\/)?(?:www\.)?([^\/\?]+?)(?:\.*$|\/)/) else {
+        guard let match = instance.firstMatch(of: /^(?:https?:\/\/)?(?:www\.)?(?:[\.\s]*)([^\/\?]+?)(?:[\.\s]*$|\/)/) else {
             return
         }
         let sanitizedLink = String(match.1)

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -253,7 +253,7 @@ struct AddSavedInstanceView: View {
         }
         
         // There should always be a match, but we return if there isn't just to be safe
-        guard let match = instance.firstMatch(of: /^(?:https?:\/\/)?(?:www\.)?([^\/.?]+\.[^\/.?]+)/) else {
+        guard let match = instance.firstMatch(of: /^(?:https?:\/\/)?(?:www\.)?([^\/\?]+?)(?:\.*$|\/)/) else {
             return
         }
         let sanitizedLink = String(match.1)

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -252,11 +252,11 @@ struct AddSavedInstanceView: View {
             viewState = .loading
         }
         
-        let sanitizedLink = instance
-            .replacingOccurrences(of: "https://", with: "")
-            .replacingOccurrences(of: "http://", with: "")
-            .replacingOccurrences(of: "www.", with: "")
-            .lowercased()
+        // There should always be a match, but we return if there isn't just to be safe
+        guard let match = instance.firstMatch(of: /^(?:https?:\/\/)?(?:www\.)?([^\/.?]+\.[^\/.?]+)/) else {
+            return
+        }
+        let sanitizedLink = String(match.1)
         
         print("Sanitized link: \(sanitizedLink)")
         


### PR DESCRIPTION
Closes #83

Currently, when adding a new account, the user much enter an instance url in the form `lemmy.world`. This PR makes the instance field accept other forms of URL too.

Test cases:

```
lemmy.world
www.lemmy.world
https://lemmy.world/
https://www.lemmy.world/
lemmy.world.
lemmy.world/
lemmy.world/post
https://lemmy.world/post
```