### PR TITLE
Read Posts

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -329,6 +329,10 @@
 		CDA2C5262A705D6000649D5A /* PostEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA2C5252A705D6000649D5A /* PostEditor.swift */; };
 		CDB0117D2A6F703800D043EB /* CommentEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB0117C2A6F703800D043EB /* CommentEditor.swift */; };
 		CDB0117F2A6F70A000D043EB /* Editor Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB0117E2A6F70A000D043EB /* Editor Tracker.swift */; };
+		CDC1C93C2A7AA76000072E3D /* InternetSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC1C93B2A7AA76000072E3D /* InternetSpeed.swift */; };
+		CDC1C93F2A7AB8C700072E3D /* AccessibilitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC1C93E2A7AB8C700072E3D /* AccessibilitySettingsView.swift */; };
+		CDC1C9412A7ABA9C00072E3D /* ReadMarkStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC1C9402A7ABA9C00072E3D /* ReadMarkStyle.swift */; };
+		CDC1C9432A7AC24600072E3D /* ReadCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC1C9422A7AC24600072E3D /* ReadCheck.swift */; };
 		CDC6A8CA2A6F1C8D00CC11AC /* AssociatedIconProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC6A8C92A6F1C8D00CC11AC /* AssociatedIconProtocol.swift */; };
 		CDDB08782A5DF1330075BFEE /* CommentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDB08772A5DF1330075BFEE /* CommentSettingsView.swift */; };
 		CDDCF6432A66343D003DA3AC /* FancyTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDCF6422A66343D003DA3AC /* FancyTabBar.swift */; };
@@ -692,6 +696,10 @@
 		CDA2C5252A705D6000649D5A /* PostEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditor.swift; sourceTree = "<group>"; };
 		CDB0117C2A6F703800D043EB /* CommentEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentEditor.swift; sourceTree = "<group>"; };
 		CDB0117E2A6F70A000D043EB /* Editor Tracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Editor Tracker.swift"; sourceTree = "<group>"; };
+		CDC1C93B2A7AA76000072E3D /* InternetSpeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetSpeed.swift; sourceTree = "<group>"; };
+		CDC1C93E2A7AB8C700072E3D /* AccessibilitySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySettingsView.swift; sourceTree = "<group>"; };
+		CDC1C9402A7ABA9C00072E3D /* ReadMarkStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMarkStyle.swift; sourceTree = "<group>"; };
+		CDC1C9422A7AC24600072E3D /* ReadCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadCheck.swift; sourceTree = "<group>"; };
 		CDC6A8C92A6F1C8D00CC11AC /* AssociatedIconProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedIconProtocol.swift; sourceTree = "<group>"; };
 		CDDB08772A5DF1330075BFEE /* CommentSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSettingsView.swift; sourceTree = "<group>"; };
 		CDDCF6422A66343D003DA3AC /* FancyTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyTabBar.swift; sourceTree = "<group>"; };
@@ -1095,6 +1103,7 @@
 			isa = PBXGroup;
 			children = (
 				030AC0432A62F82B00037155 /* General */,
+				CDC1C93D2A7AB8B400072E3D /* Accessibility */,
 				030AC0402A62F7E700037155 /* Appearance */,
 				030AC0442A62F83100037155 /* Filters */,
 				030AC0412A62F80600037155 /* About */,
@@ -1649,6 +1658,7 @@
 				CD1446162A58FC2F00610EF1 /* Interaction Bars */,
 				CDF1EF152A6C3BC2003594B6 /* End Of Feed View.swift */,
 				CD45BCED2A75CA7200A2899C /* Thumbnail Image View.swift */,
+				CDC1C9422A7AC24600072E3D /* ReadCheck.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1702,6 +1712,8 @@
 				CDE6A80A2A43E9F00062D161 /* CommentSortType.swift */,
 				63F0C7A12A0519BA00A18C5D /* PostSortType.swift */,
 				CD05E7782A4E381A0081D102 /* PostSize.swift */,
+				CDC1C93B2A7AA76000072E3D /* InternetSpeed.swift */,
+				CDC1C9402A7ABA9C00072E3D /* ReadMarkStyle.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -1766,6 +1778,14 @@
 				CDB0117C2A6F703800D043EB /* CommentEditor.swift */,
 			);
 			path = Editors;
+			sourceTree = "<group>";
+		};
+		CDC1C93D2A7AB8B400072E3D /* Accessibility */ = {
+			isa = PBXGroup;
+			children = (
+				CDC1C93E2A7AB8C700072E3D /* AccessibilitySettingsView.swift */,
+			);
+			path = Accessibility;
 			sourceTree = "<group>";
 		};
 		CDC6A8C82A6F1C8000CC11AC /* Protocols */ = {
@@ -2041,6 +2061,7 @@
 				CDDCF6472A663849003DA3AC /* FancyTabBarSelectionEnvironmentKey.swift in Sources */,
 				63D24EDE2A169F2A005CCA81 /* Markdown View.swift in Sources */,
 				B104A6E02A59C19400B3E725 /* OperationQueue - Easy init.swift in Sources */,
+				CDC1C9432A7AC24600072E3D /* ReadCheck.swift in Sources */,
 				63F0C7A22A0519BA00A18C5D /* PostSortType.swift in Sources */,
 				CD69F5612A40B6270028D4F7 /* Save Post.swift in Sources */,
 				637218682A3A2AAD008C4816 /* CreateComment.swift in Sources */,
@@ -2235,11 +2256,14 @@
 				CD69F5752A42479A0028D4F7 /* Comment Item Logic.swift in Sources */,
 				6D7782342A48EE8C008AC1BF /* APIPrivateMessageView.swift in Sources */,
 				B11A1A782A4EFF2B00520DB4 /* Feed Root.swift in Sources */,
+				CDC1C93F2A7AB8C700072E3D /* AccessibilitySettingsView.swift in Sources */,
 				50C99B622A629C06005D57DD /* ErrorHandler+Dependency.swift in Sources */,
+				CDC1C93C2A7AA76000072E3D /* InternetSpeed.swift in Sources */,
 				50EC39B22A346DDC00E014C2 /* URLHandler.swift in Sources */,
 				63344C602A080CA1001BC616 /* Outlined Web Complex Style.swift in Sources */,
 				63F0C7BF2A058EDE00A18C5D /* Get Correct URL to Endpoint.swift in Sources */,
 				632E8EE827EE63DB007E8D75 /* Downvote.swift in Sources */,
+				CDC1C9412A7ABA9C00072E3D /* ReadMarkStyle.swift in Sources */,
 				6372186D2A3A2AAD008C4816 /* EditComment.swift in Sources */,
 				6D693A4A2A51B98F009E2D76 /* APICommentReportView.swift in Sources */,
 				637218622A3A2AAD008C4816 /* DeletePost.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -301,6 +301,9 @@
 		CD69F5712A422EDD0028D4F7 /* Comment Interaction Bar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F5702A422EDD0028D4F7 /* Comment Interaction Bar.swift */; };
 		CD69F5732A4239D70028D4F7 /* Comment Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F5722A4239D70028D4F7 /* Comment Item.swift */; };
 		CD69F5752A42479A0028D4F7 /* Comment Item Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F5742A42479A0028D4F7 /* Comment Item Logic.swift */; };
+		CD6F29A82A77FF1700F20B6B /* MarkPostRead.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6F29A72A77FF1700F20B6B /* MarkPostRead.swift */; };
+		CD6F29AA2A78003A00F20B6B /* PostRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6F29A92A78003A00F20B6B /* PostRepository.swift */; };
+		CD6F29AC2A78015200F20B6B /* PostRepository+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6F29AB2A78015200F20B6B /* PostRepository+Dependency.swift */; };
 		CD7B53B52A5F251400006E81 /* CreatePrivateMessageReportRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B53B42A5F251400006E81 /* CreatePrivateMessageReportRequest.swift */; };
 		CD7B53B72A5F258B00006E81 /* APIPrivateMessageReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B53B62A5F258B00006E81 /* APIPrivateMessageReportView.swift */; };
 		CD7B53B92A5F263D00006E81 /* APIPrivateMessageReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B53B82A5F263D00006E81 /* APIPrivateMessageReport.swift */; };
@@ -661,6 +664,9 @@
 		CD69F5702A422EDD0028D4F7 /* Comment Interaction Bar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comment Interaction Bar.swift"; sourceTree = "<group>"; };
 		CD69F5722A4239D70028D4F7 /* Comment Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comment Item.swift"; sourceTree = "<group>"; };
 		CD69F5742A42479A0028D4F7 /* Comment Item Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comment Item Logic.swift"; sourceTree = "<group>"; };
+		CD6F29A72A77FF1700F20B6B /* MarkPostRead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkPostRead.swift; sourceTree = "<group>"; };
+		CD6F29A92A78003A00F20B6B /* PostRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRepository.swift; sourceTree = "<group>"; };
+		CD6F29AB2A78015200F20B6B /* PostRepository+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostRepository+Dependency.swift"; sourceTree = "<group>"; };
 		CD7B53B42A5F251400006E81 /* CreatePrivateMessageReportRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePrivateMessageReportRequest.swift; sourceTree = "<group>"; };
 		CD7B53B62A5F258B00006E81 /* APIPrivateMessageReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPrivateMessageReportView.swift; sourceTree = "<group>"; };
 		CD7B53B82A5F263D00006E81 /* APIPrivateMessageReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPrivateMessageReport.swift; sourceTree = "<group>"; };
@@ -894,6 +900,7 @@
 			children = (
 				50C99B5B2A61F5EB005D57DD /* CommentRepository.swift */,
 				CD82A2522A716B8100111034 /* PersonRepository.swift */,
+				CD6F29A92A78003A00F20B6B /* PostRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -1362,6 +1369,7 @@
 				6372182C2A3A2AAD008C4816 /* GetPosts.swift */,
 				6372182D2A3A2AAD008C4816 /* SavePost.swift */,
 				6D693A3D2A5113DF009E2D76 /* CreatePostReport.swift */,
+				CD6F29A72A77FF1700F20B6B /* MarkPostRead.swift */,
 			);
 			path = Post;
 			sourceTree = "<group>";
@@ -1714,6 +1722,7 @@
 			children = (
 				50C99B5D2A61F611005D57DD /* CommentRepository+Dependency.swift */,
 				CD82A2562A716D7C00111034 /* PersonRepository+Dependency.swift */,
+				CD6F29AB2A78015200F20B6B /* PostRepository+Dependency.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -2013,6 +2022,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6DEB0FFB2A4F87BF007CAB99 /* User Moderator View.swift in Sources */,
+				CD6F29AA2A78003A00F20B6B /* PostRepository.swift in Sources */,
 				63D64E052A1BC20D00FD39C6 /* Post Post.swift in Sources */,
 				63F0C7A82A0522FC00A18C5D /* Saved Account Tracker.swift in Sources */,
 				6372186A2A3A2AAD008C4816 /* GetComment.swift in Sources */,
@@ -2060,6 +2070,7 @@
 				6314C9EB2A18D9C500B08405 /* Reply Editor.swift in Sources */,
 				6DFF50452A48E373001E648D /* GetPrivateMessages.swift in Sources */,
 				ADDC9E3A2A5CEAA100383D58 /* BlockPerson.swift in Sources */,
+				CD6F29A82A77FF1700F20B6B /* MarkPostRead.swift in Sources */,
 				6372186B2A3A2AAD008C4816 /* GetComments.swift in Sources */,
 				6307378B2A1CE2B300039852 /* Rate Post or Comment.swift in Sources */,
 				B1DD00BD2A62DDEC002A7B39 /* RecognizedLemmyInstances.swift in Sources */,
@@ -2199,6 +2210,7 @@
 				6DCE71292A53C26600CFEB5E /* ServerInstanceLocation.swift in Sources */,
 				03E0B9CA2A62B4A400FED265 /* ContributorsView.swift in Sources */,
 				637218662A3A2AAD008C4816 /* SavePost.swift in Sources */,
+				CD6F29AC2A78015200F20B6B /* PostRepository+Dependency.swift in Sources */,
 				637218452A3A2AAD008C4816 /* APICommentAggregates.swift in Sources */,
 				6D80037B2A46458800363206 /* Lazy Load Expanded Post.swift in Sources */,
 				CD18DC752A522B38002C56BC /* SendPrivateMessage.swift in Sources */,

--- a/Mlem/API/APIClient.swift
+++ b/Mlem/API/APIClient.swift
@@ -131,6 +131,15 @@ class APIClient {
     }
 }
 
+// MARK: Post Requests
+extension APIClient {
+    func markPostAsRead(for postId: Int, read: Bool) async throws -> PostResponse {
+        let request = MarkPostReadRequest(session: try session, postId: postId, read: read)
+        print(request)
+        return try await perform(request: request)
+    }
+}
+
 // MARK: Comment Requests
 
 extension APIClient {

--- a/Mlem/API/APIClient.swift
+++ b/Mlem/API/APIClient.swift
@@ -135,7 +135,6 @@ class APIClient {
 extension APIClient {
     func markPostAsRead(for postId: Int, read: Bool) async throws -> PostResponse {
         let request = MarkPostReadRequest(session: try session, postId: postId, read: read)
-        print(request)
         return try await perform(request: request)
     }
 }

--- a/Mlem/API/Requests/Post/MarkPostRead.swift
+++ b/Mlem/API/Requests/Post/MarkPostRead.swift
@@ -1,0 +1,37 @@
+//
+//  MarkPostRead.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-07-31.
+//
+
+import Foundation
+
+struct MarkPostReadRequest: APIPostRequest {
+
+    typealias Response = PostResponse
+
+    let instanceURL: URL
+    let path = "post/mark_as_read"
+    let body: Body
+
+    struct Body: Encodable {
+        let post_id: Int
+        let read: Bool
+        let auth: String
+    }
+
+    init(
+        session: APISession,
+        postId: Int,
+        read: Bool
+    ) {
+        self.instanceURL = session.URL
+
+        self.body = .init(
+            post_id: postId,
+            read: read,
+            auth: session.token
+        )
+    }
+}

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -168,4 +168,5 @@ struct AppConstants {
     
     // MARK: - Other
     static let pictureEmoji: [String] = ["🎆", "🎇", "🌠", "🌅", "🌆", "🌁", "🌃", "🌄", "🌉", "🌌", "🌇", "🖼️", "🎑", "🏞️", "🗾", "🏙️"]
+    static let infiniteLoadThresholdOffset: Int = -10
 }

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -165,6 +165,7 @@ struct AppConstants {
     // misc
     static let switchUserSymbolName: String = "person.crop.circle.badge.plus"
     static let missingSymbolName: String = "questionmark.square.dashed"
+    static let connectionSymbolName: String = "antenna.radiowaves.left.and.right"
     
     // MARK: - Other
     static let pictureEmoji: [String] = ["🎆", "🎇", "🌠", "🌅", "🌆", "🌁", "🌃", "🌄", "🌉", "🌌", "🌇", "🖼️", "🎑", "🏞️", "🗾", "🏙️"]

--- a/Mlem/Dependency/Repositories/PersonRepository+Dependency.swift
+++ b/Mlem/Dependency/Repositories/PersonRepository+Dependency.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-
 import Dependencies
 
 extension PersonRepository: DependencyKey {

--- a/Mlem/Dependency/Repositories/PostRepository+Dependency.swift
+++ b/Mlem/Dependency/Repositories/PostRepository+Dependency.swift
@@ -1,0 +1,20 @@
+//
+//  PostRepository+Dependency.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-07-31.
+//
+
+import Foundation
+import Dependencies
+
+extension PostRepository: DependencyKey {
+  static let liveValue = PostRepository()
+}
+
+extension DependencyValues {
+  var postRepository: PostRepository {
+    get { self[PostRepository.self] }
+    set { self[PostRepository.self] = newValue }
+  }
+}

--- a/Mlem/Enums/Settings/InternetSpeed.swift
+++ b/Mlem/Enums/Settings/InternetSpeed.swift
@@ -1,0 +1,23 @@
+//
+//  InternetSpeed.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-08-02.
+//
+
+import Foundation
+
+enum InternetSpeed: String, SettingsOptions {
+    case slow, fast
+    
+    var label: String { self.rawValue.capitalized }
+    
+    var id: Self { self }
+    
+    var pageSize: Int {
+        switch self {
+        case .slow: return 25
+        case .fast: return 50
+        }
+    }
+}

--- a/Mlem/Enums/Settings/ReadMarkStyle.swift
+++ b/Mlem/Enums/Settings/ReadMarkStyle.swift
@@ -1,0 +1,16 @@
+//
+//  ReadMarkStyle.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-08-02.
+//
+
+import Foundation
+
+enum ReadMarkStyle: String, SettingsOptions {
+    case bar, check
+    
+    var label: String { self.rawValue.capitalized }
+    
+    var id: Self { self }
+}

--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -14,6 +14,8 @@ struct HandleLemmyLinksDisplay: ViewModifier {
     @EnvironmentObject var filtersTracker: FiltersTracker
     @EnvironmentObject var favoriteCommunitiesTracker: FavoriteCommunitiesTracker
     @EnvironmentObject var savedAccounts: SavedAccountTracker
+    
+    @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
 
     // swiftlint:disable function_body_length
     func body(content: Content) -> some View {
@@ -51,7 +53,7 @@ struct HandleLemmyLinksDisplay: ViewModifier {
             .navigationDestination(for: APIPostView.self) { post in
                 ExpandedPost(post: post)
                 .environmentObject(
-                    PostTracker(shouldPerformMergeSorting: false, initialItems: [post])
+                    PostTracker(shouldPerformMergeSorting: false, internetSpeed: internetSpeed, initialItems: [post])
                 )
                 .environmentObject(appState)
             }

--- a/Mlem/Models/Composers/PostEditor.swift
+++ b/Mlem/Models/Composers/PostEditor.swift
@@ -18,7 +18,7 @@ struct PostEditorModel: Identifiable {
     
     init(community: APICommunity,
          appState: AppState,
-         postTracker: PostTracker = PostTracker(shouldPerformMergeSorting: false),
+         postTracker: PostTracker = PostTracker(shouldPerformMergeSorting: false, internetSpeed: .slow),
          editPost: APIPost? = nil,
          responseCallback: ((APIPostView) -> Void)? = nil) {
         self.community = community

--- a/Mlem/Models/Trackers/Feed/FeedTracker.swift
+++ b/Mlem/Models/Trackers/Feed/FeedTracker.swift
@@ -17,7 +17,6 @@ class FeedTracker<Item: FeedTrackerItem>: ObservableObject {
     private(set) var page: Int = 1
 
     private var ids: Set<Item.UniqueIdentifier> = .init(minimumCapacity: 1_000)
-    private var thresholdOffset: Int = -10
     private let shouldPerformMergeSorting: Bool
 
     init(shouldPerformMergeSorting: Bool = true, initialItems: [Item] = .init()) {
@@ -35,7 +34,7 @@ class FeedTracker<Item: FeedTrackerItem>: ObservableObject {
             return false
         }
 
-        let thresholdIndex = items.index(items.endIndex, offsetBy: thresholdOffset)
+        let thresholdIndex = items.index(items.endIndex, offsetBy: AppConstants.infiniteLoadThresholdOffset)
         if thresholdIndex >= 0,
            let itemIndex = items.firstIndex(where: { $0.uniqueIdentifier == item.uniqueIdentifier }),
            itemIndex >= thresholdIndex {
@@ -49,7 +48,7 @@ class FeedTracker<Item: FeedTrackerItem>: ObservableObject {
     @MainActor func shouldLoadContentPrecisely(after item: Item) -> Bool {
         guard !isLoading else { return false }
         
-        let thresholdIndex = max(0, items.index(items.endIndex, offsetBy: thresholdOffset))
+        let thresholdIndex = max(0, items.index(items.endIndex, offsetBy: AppConstants.infiniteLoadThresholdOffset))
   
         if let itemIndex = items.firstIndex(where: { $0.uniqueIdentifier == item.uniqueIdentifier }),
            itemIndex == thresholdIndex {
@@ -61,7 +60,7 @@ class FeedTracker<Item: FeedTrackerItem>: ObservableObject {
 
     /// A method to perform a request to retrieve  tracker items
     /// - Parameter request: An `APIRequest` that conforms to `FeedItemProviding` with an `Item` type that matches this trackers generic type
-    /// - Returns: Newly added items
+    /// - Returns: The `Response` type of the request as a discardable result
     @discardableResult func perform<Request: APIRequest>(
         _ request: Request,
         filtering: @escaping (_: Request.Response.Item) -> Bool = { _ in true}

--- a/Mlem/Models/Trackers/Feed/FeedTracker.swift
+++ b/Mlem/Models/Trackers/Feed/FeedTracker.swift
@@ -93,15 +93,14 @@ class FeedTracker<Item: FeedTrackerItem>: ObservableObject {
 
     /// A method to add new items into the tracker, duplicate items will be rejected
     /// - Parameter newItems: The array of new `Item`'s you wish to add
-    /// - Returns Newly added items
     @MainActor
-    @discardableResult func add(_ newItems: [Item], filtering: @escaping (_: Item) -> Bool = { _ in true}) -> [Item] {
+    func add(_ newItems: [Item], filtering: @escaping (_: Item) -> Bool = { _ in true}) {
         let accepted = dedupedItems(from: newItems.filter(filtering))
         if !shouldPerformMergeSorting {
             RunLoop.main.perform { [self] in
                 items.append(contentsOf: accepted)
             }
-            return accepted
+            return
         }
 
         let merged =  merge(arr1: items, arr2: accepted, compare: { $0.published > $1.published })
@@ -109,7 +108,7 @@ class FeedTracker<Item: FeedTrackerItem>: ObservableObject {
             items = merged
         }
         
-        return accepted
+        return
     }
 
     /// A method to add an item  to the start of the current list of items

--- a/Mlem/Models/Trackers/Feed/FeedTracker.swift
+++ b/Mlem/Models/Trackers/Feed/FeedTracker.swift
@@ -39,7 +39,20 @@ class FeedTracker<Item: FeedTrackerItem>: ObservableObject {
         if thresholdIndex >= 0,
            let itemIndex = items.firstIndex(where: { $0.uniqueIdentifier == item.uniqueIdentifier }),
            itemIndex >= thresholdIndex {
-            print("Should load content after \(itemIndex) (threshold \(thresholdIndex)")
+            return true
+        }
+
+        return false
+    }
+    
+    /// Similar to above, but only returns true if this item *is* the threshold item
+    @MainActor func shouldLoadContentPrecisely(after item: Item) -> Bool {
+        guard !isLoading else { return false }
+        
+        let thresholdIndex = max(0, items.index(items.endIndex, offsetBy: thresholdOffset))
+  
+        if let itemIndex = items.firstIndex(where: { $0.uniqueIdentifier == item.uniqueIdentifier }),
+           itemIndex == thresholdIndex {
             return true
         }
 

--- a/Mlem/Models/Trackers/Feed/FeedTracker.swift
+++ b/Mlem/Models/Trackers/Feed/FeedTracker.swift
@@ -18,9 +18,13 @@ class FeedTracker<Item: FeedTrackerItem>: ObservableObject {
 
     private var ids: Set<Item.UniqueIdentifier> = .init(minimumCapacity: 1_000)
     private let shouldPerformMergeSorting: Bool
+    let internetSpeed: InternetSpeed
 
-    init(shouldPerformMergeSorting: Bool = true, initialItems: [Item] = .init()) {
+    init(shouldPerformMergeSorting: Bool = true,
+         internetSpeed: InternetSpeed,
+         initialItems: [Item] = .init()) {
         self.shouldPerformMergeSorting = shouldPerformMergeSorting
+        self.internetSpeed = internetSpeed
         items = initialItems
     }
 

--- a/Mlem/Models/Trackers/Inbox/Mentions Tracker.swift
+++ b/Mlem/Models/Trackers/Inbox/Mentions Tracker.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 @MainActor
 class MentionsTracker: FeedTracker<APIPersonMentionView>, InboxTracker {
@@ -16,7 +17,7 @@ class MentionsTracker: FeedTracker<APIPersonMentionView>, InboxTracker {
                 account: account,
                 sort: .new,
                 page: page,
-                limit: 50,
+                limit: internetSpeed.pageSize,
                 unreadOnly: unreadOnly
             )
         )
@@ -28,7 +29,7 @@ class MentionsTracker: FeedTracker<APIPersonMentionView>, InboxTracker {
                 account: account,
                 sort: .new,
                 page: 1,
-                limit: 50,
+                limit: internetSpeed.pageSize,
                 unreadOnly: unreadOnly
             )
         )

--- a/Mlem/Models/Trackers/Inbox/Messages Tracker.swift
+++ b/Mlem/Models/Trackers/Inbox/Messages Tracker.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 @MainActor
 class MessagesTracker: FeedTracker<APIPrivateMessageView>, InboxTracker {
@@ -15,7 +16,7 @@ class MessagesTracker: FeedTracker<APIPrivateMessageView>, InboxTracker {
             GetPrivateMessagesRequest(
                 account: account,
                 page: page,
-                limit: 50,
+                limit: internetSpeed.pageSize,
                 unreadOnly: unreadOnly
             )
         )
@@ -26,7 +27,7 @@ class MessagesTracker: FeedTracker<APIPrivateMessageView>, InboxTracker {
             GetPrivateMessagesRequest(
                 account: account,
                 page: 1,
-                limit: 50,
+                limit: internetSpeed.pageSize,
                 unreadOnly: unreadOnly
             )
         )

--- a/Mlem/Models/Trackers/Inbox/Replies Tracker.swift
+++ b/Mlem/Models/Trackers/Inbox/Replies Tracker.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 @MainActor
 class RepliesTracker: FeedTracker<APICommentReplyView>, InboxTracker {
@@ -16,7 +17,7 @@ class RepliesTracker: FeedTracker<APICommentReplyView>, InboxTracker {
                 account: account,
                 sort: .new,
                 page: page,
-                limit: 50,
+                limit: internetSpeed.pageSize,
                 unreadOnly: unreadOnly
             )
         )
@@ -28,7 +29,7 @@ class RepliesTracker: FeedTracker<APICommentReplyView>, InboxTracker {
                 account: account,
                 sort: .new,
                 page: 1,
-                limit: 50,
+                limit: internetSpeed.pageSize,
                 unreadOnly: unreadOnly
             )
         )

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -33,7 +33,6 @@ class PostTracker: FeedTracker<APIPostView> {
         var responsePosts: [APIPostView] = .init()
         let numItems = items.count
         repeat {
-            print("loading more posts")
             let response = try await perform(
                 GetPostsRequest(
                     account: account,

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -9,24 +9,6 @@ import Foundation
 import Nuke
 
 class PostTracker: FeedTracker<APIPostView> {
-    
-    // EXPERIMENTAL
-    
-    @Published var shoudLoad: Bool = false
-    
-    @MainActor
-    func sawItem(item: APIPostView) {
-        if shouldLoadContent(after: item) {
-            self.shoudLoad = true
-        }
-    }
-    
-    @MainActor
-    func loaded() {
-        self.shoudLoad = false
-    }
-    
-    // END EXPERIMENTAL
 
     private let prefetcher = ImagePrefetcher(pipeline: ImagePipeline.shared,
                                              destination: .memoryCache,
@@ -78,8 +60,6 @@ class PostTracker: FeedTracker<APIPostView> {
         if currentPage == 1 && responsePosts.isEmpty {
             try await attemptAuthenticatedCall(with: account)
         }
-        
-        await loaded()
         
         // don't preload filtered images
         preloadImages(responsePosts.filter(filtering))

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -28,17 +28,28 @@ class PostTracker: FeedTracker<APIPostView> {
         filtering: @escaping (_: APIPostView) -> Bool = { _ in true}
     ) async throws {
         let currentPage = page
-        let response = try await perform(
-            GetPostsRequest(
-                account: account,
-                communityId: communityId,
-                page: page,
-                sort: sort,
-                type: type,
-                limit: page == 1 ? 25 : 50
-            ),
-            filtering: filtering
-        )
+        
+        print(currentPage)
+        
+        // retry this until we get some items that pass the filter
+        var responsePosts: [APIPostView] = .init()
+        var numItems = items.count
+        repeat {
+            let response = try await perform(
+                GetPostsRequest(
+                    account: account,
+                    communityId: communityId,
+                    page: page,
+                    sort: sort,
+                    type: type,
+                    limit: page == 1 ? 25 : 50
+                ),
+                filtering: filtering
+            )
+            
+            responsePosts = response.posts
+            numItems = items.count
+        } while !responsePosts.isEmpty && numItems == items.count
 
         // so although the API kindly returns `400`/"not_logged_in" for expired
         // sessions _without_ 2FA enabled, currently once you enable 2FA on an account
@@ -48,11 +59,12 @@ class PostTracker: FeedTracker<APIPostView> {
         // the API doesn't want to tell us - so to avoid the user being confused, we'll fire
         // off an authenticated call in the background and if appropriate show the expired
         // session modal. We should be able to remove this once the API behaves as expected.
-        if currentPage == 1 && response.posts.isEmpty {
+        if currentPage == 1 && responsePosts.isEmpty {
             try await attemptAuthenticatedCall(with: account)
         }
         
-        preloadImages(response.posts)
+        // TODO: should we preload filtered images?
+        preloadImages(responsePosts)
     }
 
     func refresh(

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -31,7 +31,7 @@ class PostTracker: FeedTracker<APIPostView> {
         
         // retry this until we get some items that pass the filter
         var responsePosts: [APIPostView] = .init()
-        var numItems = items.count
+        let numItems = items.count
         repeat {
             print("loading more posts")
             let response = try await perform(

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -46,7 +46,7 @@ class PostTracker: FeedTracker<APIPostView> {
             )
             
             responsePosts = response.posts
-        } while !responsePosts.isEmpty && numItems == items.count
+        } while !responsePosts.isEmpty && numItems > items.count + AppConstants.infiniteLoadThresholdOffset
 
         // so although the API kindly returns `400`/"not_logged_in" for expired
         // sessions _without_ 2FA enabled, currently once you enable 2FA on an account

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Nuke
+import SwiftUI
 
 class PostTracker: FeedTracker<APIPostView> {
 
@@ -29,6 +30,8 @@ class PostTracker: FeedTracker<APIPostView> {
     ) async throws {
         let currentPage = page
         
+        print("internet speed: \(internetSpeed.label)")
+        
         // retry this until we get some items that pass the filter
         var responsePosts: [APIPostView] = .init()
         let numItems = items.count
@@ -40,12 +43,13 @@ class PostTracker: FeedTracker<APIPostView> {
                     page: page,
                     sort: sort,
                     type: type,
-                    limit: page == 1 ? 25 : 50
+                    limit: internetSpeed.pageSize
                 ),
                 filtering: filtering
             )
             
             responsePosts = response.posts
+            print("got \(responsePosts.count) posts, there are \(items.count) total posts")
         } while !responsePosts.isEmpty && numItems > items.count + AppConstants.infiniteLoadThresholdOffset
 
         // so although the API kindly returns `400`/"not_logged_in" for expired
@@ -80,7 +84,7 @@ class PostTracker: FeedTracker<APIPostView> {
                 page: 1,
                 sort: sort,
                 type: type,
-                limit: 25
+                limit: internetSpeed.pageSize
             ),
             clearBeforeFetch: clearBeforeFetch,
             filtering: filtering

--- a/Mlem/Repositories/PostRepository.swift
+++ b/Mlem/Repositories/PostRepository.swift
@@ -1,0 +1,23 @@
+//
+//  PostRepository.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-07-31.
+//
+
+import Foundation
+import Dependencies
+
+class PostRepository {
+    
+    @Dependency(\.apiClient) private var apiClient
+    
+    func markRead(for postId: Int, read: Bool) async throws -> APIPostView {
+        do {
+            let response = try await apiClient.markPostAsRead(for: postId, read: read)
+            return response.postView
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Mlem/Views/Shared/Comments/Components/Embedded Post.swift
+++ b/Mlem/Views/Shared/Comments/Components/Embedded Post.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct EmbeddedPost: View {
-    // used to handle the lazy load embedded post
-    @StateObject var postTracker: PostTracker = .init()
+    // used to handle the lazy load embedded post--speed doesn't matter because it's not a "real" post tracker
+    @StateObject var postTracker: PostTracker = .init(internetSpeed: .slow)
     
     let community: APICommunity
     let post: APIPost

--- a/Mlem/Views/Shared/Components/ReadCheck.swift
+++ b/Mlem/Views/Shared/Components/ReadCheck.swift
@@ -1,0 +1,20 @@
+//
+//  ReadCheck.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-08-02.
+//
+
+import Foundation
+import SwiftUI
+
+struct ReadCheck: View {
+    
+    var body: some View {
+        Image(systemName: "checkmark")
+            .resizable()
+            .scaledToFit()
+            .frame(width: 10, height: 10)
+            .foregroundColor(.secondary)
+    }
+}

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -15,6 +15,7 @@ internal enum PossibleStyling {
 struct ExpandedPost: View {
     
     @Dependency(\.commentRepository) var commentRepository
+    @Dependency(\.postRepository) var postRepository
     @Dependency(\.errorHandler) var errorHandler
     @Dependency(\.notifier) var notifier
     

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -43,6 +43,7 @@ struct ExpandedPost: View {
                 ToolbarItemGroup(placement: .navigationBarTrailing) { toolbarMenu }
             }
             .task { await loadComments() }
+            .task { await markPostAsRead() }
             .refreshable { await refreshComments() }
             .onChange(of: commentSortingType) { newSortingType in
                 withAnimation(.easeIn(duration: 0.4)) {

--- a/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
+++ b/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
@@ -13,8 +13,12 @@ extension ExpandedPost {
     
     // TODO: add flag
     func markPostAsRead() async {
-        // TODO: implement
-        print("marking as read")
+        do {
+            post = try await postRepository.markRead(for: post.post.id, read: true)
+            postTracker.update(with: post)
+        } catch {
+            errorHandler.handle(.init(underlyingError: error))
+        }
     }
     
     /// Votes on a post

--- a/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
+++ b/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
@@ -11,6 +11,12 @@ extension ExpandedPost {
     
     // MARK: Interaction callbacks
     
+    // TODO: add flag
+    func markPostAsRead() async {
+        // TODO: implement
+        print("marking as read")
+    }
+    
     /// Votes on a post
     /// - Parameter inputOp: The voting operation to perform
     func voteOnPost(inputOp: ScoringOperation) async {

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -32,6 +32,9 @@ struct FeedPost: View {
     @AppStorage("shouldShowCommunityIcons") var shouldShowCommunityIcons: Bool = true
     @AppStorage("shouldShowCommunityServerInPost") var shouldShowCommunityServerInPost: Bool = true
     @AppStorage("shouldShowUserServerInPost") var shouldShowUserServerInPost: Bool = true
+    
+    @AppStorage("reakMarkStyle") var readMarkStyle: ReadMarkStyle = .bar
+    @AppStorage("readBarThickness") var readBarThickness: Int = 3
 
     @EnvironmentObject var postTracker: PostTracker
     @EnvironmentObject var editorTracker: EditorTracker
@@ -61,10 +64,16 @@ struct FeedPost: View {
     @State private var isShowingSafari: Bool = false
     @State private var isShowingEnlargedImage: Bool = false
     @State private var isComposingReport: Bool = false
+    
+    // MARK: Computed
+    
+    var barThickness: CGFloat { !postView.read && diffWithoutColor && readMarkStyle == .bar  ? CGFloat(readBarThickness) : .zero }
+    var showCheck: Bool { postView.read && diffWithoutColor && readMarkStyle == .check }
 
     var body: some View {
         VStack(spacing: 0) {
             postItem
+                .border(width: barThickness, edges: [.leading], color: .secondary)
                 .background(Color.systemBackground)
 //                .background(horizontalSizeClass == .regular ? Color.secondarySystemBackground : Color.systemBackground)
 //                .clipShape(RoundedRectangle(cornerRadius: horizontalSizeClass == .regular ? 16 : 0))
@@ -119,15 +128,11 @@ struct FeedPost: View {
                         CommunityLinkView(community: postView.community)
 
                         Spacer()
-                        
-                        if diffWithoutColor && postView.read {
-                            Image(systemName: "checkmark")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 10, height: 10)
-                                .foregroundColor(.secondary)
-                        }
 
+                        if showCheck {
+                            ReadCheck()
+                        }
+                        
                         EllipsisMenu(size: 24, menuFunctions: genMenuFunctions())
                     }
 

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -25,6 +25,8 @@ struct FeedPost: View {
     @Dependency(\.notifier) var notifier
     
     // MARK: Environment
+    @Environment(\.accessibilityDifferentiateWithoutColor) var diffWithoutColor: Bool
+    
     @AppStorage("postSize") var postSize: PostSize = .large
     @AppStorage("shouldShowUserAvatars") var shouldShowUserAvatars: Bool = true
     @AppStorage("shouldShowCommunityIcons") var shouldShowCommunityIcons: Bool = true
@@ -117,6 +119,14 @@ struct FeedPost: View {
                         CommunityLinkView(community: postView.community)
 
                         Spacer()
+                        
+                        if diffWithoutColor && postView.read {
+                            Image(systemName: "checkmark")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 10, height: 10)
+                                .foregroundColor(.secondary)
+                        }
 
                         EllipsisMenu(size: 24, menuFunctions: genMenuFunctions())
                     }

--- a/Mlem/Views/Shared/Posts/Lazy Load Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Lazy Load Expanded Post.swift
@@ -19,7 +19,7 @@ struct LazyLoadExpandedPost: View {
     
     @State private var loadedPostView: APIPostView?
 
-    @StateObject private var postTracker =  PostTracker()
+    @StateObject private var postTracker =  PostTracker(internetSpeed: .slow)
 
     var body: some View {
         Group {

--- a/Mlem/Views/Shared/Posts/Post Sizes/Headline Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Headline Post.swift
@@ -52,6 +52,7 @@ struct HeadlinePost: View {
                         Text(postView.post.name)
                             .font(.headline)
                             .padding(.trailing)
+                            .foregroundColor(postView.read ? .secondary : .primary)
                         
                         Spacer()
                         if postView.post.nsfw {

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -24,6 +24,7 @@ struct LargePost: View {
     
     // computed
     let maxHeight: CGFloat
+    let titleColor: Color
 
     // initializer--used so we can set showNsfwFilterToggle to false when expanded or true when not
     init(
@@ -33,6 +34,7 @@ struct LargePost: View {
         self.postView = postView
         self.isExpanded = isExpanded
         self.maxHeight = isExpanded ? .infinity : AppConstants.maxFeedPostHeight
+        self.titleColor = !isExpanded && postView.read ? Color.secondary : Color.primary
     }
 
     var body: some View {
@@ -49,7 +51,7 @@ struct LargePost: View {
                     .font(.headline)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .italic(postView.post.deleted)
-                    .foregroundColor(postView.read ? .secondary : .primary)
+                    .foregroundColor(titleColor)
                 
                 Spacer()
                 if postView.post.nsfw {

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -49,6 +49,7 @@ struct LargePost: View {
                     .font(.headline)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .italic(postView.post.deleted)
+                    .foregroundColor(postView.read ? .secondary : .primary)
                 
                 Spacer()
                 if postView.post.nsfw {

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -23,8 +23,8 @@ struct LargePost: View {
     let isExpanded: Bool
     
     // computed
-    let maxHeight: CGFloat
-    let titleColor: Color
+    var maxHeight: CGFloat { isExpanded ? .infinity : AppConstants.maxFeedPostHeight }
+    var titleColor: Color { !isExpanded && postView.read ? .secondary : .primary }
 
     // initializer--used so we can set showNsfwFilterToggle to false when expanded or true when not
     init(
@@ -33,8 +33,6 @@ struct LargePost: View {
     ) {
         self.postView = postView
         self.isExpanded = isExpanded
-        self.maxHeight = isExpanded ? .infinity : AppConstants.maxFeedPostHeight
-        self.titleColor = !isExpanded && postView.read ? Color.secondary : Color.primary
     }
 
     var body: some View {

--- a/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
@@ -74,6 +74,7 @@ struct UltraCompactPost: View {
                 
                 Text(postView.post.name)
                     .font(.subheadline)
+                    .foregroundColor(postView.read ? .secondary : .primary)
     
                 compactInfo
             }

--- a/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import Dependencies
 
 struct UltraCompactPost: View {
     // app storage
@@ -15,6 +16,12 @@ struct UltraCompactPost: View {
     @AppStorage("shouldShowPostThumbnails") var shouldShowPostThumbnails: Bool = true
     @AppStorage("thumbnailsOnRight") var thumbnailsOnRight: Bool = false
     @AppStorage("showDownvotesSeparately") var showDownvotesSeparately: Bool = false
+    
+    // environment and dependencies
+    @Dependency(\.postRepository) var postRepository
+    @Dependency(\.errorHandler) var errorHandler
+    
+    @EnvironmentObject var postTracker: PostTracker
 
     // constants
     let thumbnailSize: CGFloat = 60

--- a/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
@@ -17,9 +17,13 @@ struct UltraCompactPost: View {
     @AppStorage("thumbnailsOnRight") var thumbnailsOnRight: Bool = false
     @AppStorage("showDownvotesSeparately") var showDownvotesSeparately: Bool = false
     
+    @AppStorage("reakMarkStyle") var readMarkStyle: ReadMarkStyle = .bar
+    
     // environment and dependencies
     @Dependency(\.postRepository) var postRepository
     @Dependency(\.errorHandler) var errorHandler
+    
+    @Environment(\.accessibilityDifferentiateWithoutColor) var diffWithoutColor: Bool
     
     @EnvironmentObject var postTracker: PostTracker
 
@@ -35,6 +39,7 @@ struct UltraCompactPost: View {
     // computed
     let voteColor: Color
     let voteIconName: String
+    var showReadCheck: Bool { postView.read && diffWithoutColor && readMarkStyle == .check }
 
     init(postView: APIPostView, showCommunity: Bool, menuFunctions: [MenuFunction]) {
         self.postView = postView
@@ -73,6 +78,8 @@ struct UltraCompactPost: View {
                     }
                     
                     Spacer()
+                    
+                    if showReadCheck { ReadCheck() }
                     
                     EllipsisMenu(size: 12, menuFunctions: menuFunctions)
                         .padding(.trailing, 6)

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -278,7 +278,7 @@ extension FeedView {
     }
     
     private func filter(postView: APIPostView) -> Bool {
-        !postView.post.name.contains(filtersTracker.filteredKeywords) &&
+        return !postView.post.name.lowercased().contains(filtersTracker.filteredKeywords) &&
         (showReadPosts || !postView.read)
     }
     

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -56,8 +56,8 @@ extension FeedView {
     /**
      Function to reset the feed, used as a callback to switcher options. Clears the items and displays a loading view.
      */
-    func hardRefreshFeed() {
-        Task(priority: .userInitiated) {
+    func hardRefreshFeed() async {
+        // Task(priority: .userInitiated) {
             defer { isLoading = false }
             isLoading = true
             do {
@@ -71,7 +71,7 @@ extension FeedView {
             } catch {
                 handle(error)
             }
-        }
+        // }
     }
     
     // MARK: Community loading

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -31,9 +31,7 @@ extension FeedView {
                 communityId: community?.id,
                 sort: postSortType,
                 type: feedType,
-                filtering: { postView in
-                    !postView.post.name.contains(filtersTracker.filteredKeywords)
-                }
+                filtering: filter
             )
         } catch {
             handle(error)
@@ -48,9 +46,7 @@ extension FeedView {
                 communityId: community?.id,
                 sort: postSortType,
                 type: feedType,
-                filtering: { postView in
-                    !postView.post.name.contains(filtersTracker.filteredKeywords)
-                }
+                filtering: filter
             )
         } catch {
             handle(error)
@@ -71,9 +67,7 @@ extension FeedView {
                     sort: postSortType,
                     type: feedType,
                     clearBeforeFetch: true,
-                    filtering: { postView in
-                        !postView.post.name.contains(filtersTracker.filteredKeywords)
-                    })
+                    filtering: filter)
             } catch {
                 handle(error)
             }
@@ -139,6 +133,14 @@ extension FeedView {
             enabled: true) {
                 shouldBlurNsfw.toggle()
             })
+        
+        let showReadPostsText = showReadPosts ? "Hide read" : "Show read"
+        ret.append(MenuFunction(text: showReadPostsText,
+                                imageName: "book",
+                                destructiveActionPrompt: nil,
+                                enabled: true) {
+            showReadPosts.toggle()
+        })
         
         return ret
     }
@@ -275,6 +277,11 @@ extension FeedView {
             message: errorMessage,
             underlyingError: error
         )
+    }
+    
+    private func filter(postView: APIPostView) -> Bool {
+        !postView.post.name.contains(filtersTracker.filteredKeywords) &&
+        (showReadPosts || !postView.read)
     }
     
     // MARK: TODO: MOVE TO REPOSITORY MODEL

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -11,14 +11,18 @@ extension FeedView {
     
     // MARK: Feed loading
     
+    // NOTE: using defer { isLoading = false } causes unwanted behavior where isLoading is set to false before loading is complete, triggering an erroneous "end of feed" view--putting it inside both the do and the catch is annoyingly duplicitave, but works
+    
     func initFeed() async {
         defer { isLoading = false }
         isLoading = true
         if postTracker.items.isEmpty {
             print("Post tracker is empty")
             await loadFeed()
+            // isLoading = false
         } else {
             print("Post tracker is not empty")
+            // isLoading = false
         }
     }
     
@@ -33,8 +37,10 @@ extension FeedView {
                 type: feedType,
                 filtering: filter
             )
+            // isLoading = false
         } catch {
             handle(error)
+            // isLoading = false
         }
     }
     

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -278,7 +278,7 @@ extension FeedView {
     }
     
     private func filter(postView: APIPostView) -> Bool {
-        return !postView.post.name.lowercased().contains(filtersTracker.filteredKeywords) &&
+        !postView.post.name.lowercased().contains(filtersTracker.filteredKeywords) &&
         (showReadPosts || !postView.read)
     }
     

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -25,6 +25,7 @@ extension FeedView {
     func loadFeed() async {
         defer { isLoading = false }
         isLoading = true
+        print("called loadFeed")
         do {
             try await postTracker.loadNextPage(
                 account: appState.currentActiveAccount,

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -57,7 +57,6 @@ extension FeedView {
      Function to reset the feed, used as a callback to switcher options. Clears the items and displays a loading view.
      */
     func hardRefreshFeed() async {
-        // Task(priority: .userInitiated) {
             defer { isLoading = false }
             isLoading = true
             do {
@@ -71,7 +70,6 @@ extension FeedView {
             } catch {
                 handle(error)
             }
-        // }
     }
     
     // MARK: Community loading

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -11,18 +11,14 @@ extension FeedView {
     
     // MARK: Feed loading
     
-    // NOTE: using defer { isLoading = false } causes unwanted behavior where isLoading is set to false before loading is complete, triggering an erroneous "end of feed" view--putting it inside both the do and the catch is annoyingly duplicitave, but works
-    
     func initFeed() async {
         defer { isLoading = false }
         isLoading = true
         if postTracker.items.isEmpty {
             print("Post tracker is empty")
             await loadFeed()
-            // isLoading = false
         } else {
             print("Post tracker is not empty")
-            // isLoading = false
         }
     }
     
@@ -37,10 +33,8 @@ extension FeedView {
                 type: feedType,
                 filtering: filter
             )
-            // isLoading = false
         } catch {
             handle(error)
-            // isLoading = false
         }
     }
     

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -85,11 +85,9 @@ struct FeedView: View {
                 }
             }
             .onChange(of: shouldLoad) { value in
-                Task(priority: .medium) {
-                    if value {
-                        await loadFeed()
-                        shouldLoad = false
-                    }
+                if value {
+                    Task(priority: .medium) { await loadFeed() }
+                    shouldLoad = false
                 }
             }
             .refreshable { await refreshFeed() }
@@ -143,9 +141,9 @@ struct FeedView: View {
             Divider()
         }
         .buttonStyle(EmptyButtonStyle()) // Make it so that the link doesn't mess with the styling
-        // .task(priority: .medium) {
         .onAppear {
-            if postTracker.shouldLoadContent(after: postView) {
+            // on appear, flag whether new content should be loaded. Actual loading is attached to the feed view itself so that it doesn't get cancelled by view derenders
+            if postTracker.shouldLoadContentPrecisely(after: postView) {
                 shouldLoad = true
             }
         }

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -45,6 +45,7 @@ struct FeedView: View {
     @State var communityDetails: GetCommunityResponse?
     @State var postSortType: PostSortType = .hot
     @State var isLoading: Bool = false
+    @State var showReadPosts: Bool = true
     
     // MARK: - Main Views
     
@@ -69,6 +70,9 @@ struct FeedView: View {
                 hardRefreshFeed()
             }
             .onChange(of: appState.currentActiveAccount) { _ in
+                hardRefreshFeed()
+            }
+            .onChange(of: showReadPosts) { _ in
                 hardRefreshFeed()
             }
             .refreshable { await refreshFeed() }

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -46,6 +46,7 @@ struct FeedView: View {
     @State var communityDetails: GetCommunityResponse?
     @State var postSortType: PostSortType = .hot
     @State var isLoading: Bool = false
+    @State var shouldLoad: Bool = false
     
     // MARK: - Main Views
     
@@ -75,10 +76,11 @@ struct FeedView: View {
             .onChange(of: showReadPosts) { _ in
                 hardRefreshFeed()
             }
-            .onChange(of: postTracker.shoudLoad) { value in
+            .onChange(of: shouldLoad) { value in
                 Task(priority: .medium) {
                     if value {
                         await loadFeed()
+                        shouldLoad = false
                     }
                 }
             }
@@ -133,11 +135,11 @@ struct FeedView: View {
             Divider()
         }
         .buttonStyle(EmptyButtonStyle()) // Make it so that the link doesn't mess with the styling
-        .task(priority: .medium) {
-            postTracker.sawItem(item: postView)
-//            if postTracker.shouldLoadContent(after: postView) {
-//                await loadFeed()
-//            }
+        // .task(priority: .medium) {
+        .onAppear {
+            if postTracker.shouldLoadContent(after: postView) {
+                shouldLoad = true
+            }
         }
     }
     

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -20,6 +20,7 @@ struct FeedView: View {
     @AppStorage("defaultPostSorting") var defaultPostSorting: PostSortType = .hot
     @AppStorage("shouldShowPostCreator") var shouldShowPostCreator: Bool = true
     @AppStorage("postSize") var postSize: PostSize = .large
+    @AppStorage("showReadPosts") var showReadPosts: Bool = true
     
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var filtersTracker: FiltersTracker
@@ -45,7 +46,6 @@ struct FeedView: View {
     @State var communityDetails: GetCommunityResponse?
     @State var postSortType: PostSortType = .hot
     @State var isLoading: Bool = false
-    @State var showReadPosts: Bool = true
     
     // MARK: - Main Views
     
@@ -74,6 +74,13 @@ struct FeedView: View {
             }
             .onChange(of: showReadPosts) { _ in
                 hardRefreshFeed()
+            }
+            .onChange(of: postTracker.shoudLoad) { value in
+                Task(priority: .medium) {
+                    if value {
+                        await loadFeed()
+                    }
+                }
             }
             .refreshable { await refreshFeed() }
     }
@@ -127,9 +134,10 @@ struct FeedView: View {
         }
         .buttonStyle(EmptyButtonStyle()) // Make it so that the link doesn't mess with the styling
         .task(priority: .medium) {
-            if postTracker.shouldLoadContent(after: postView) {
-                await loadFeed()
-            }
+            postTracker.sawItem(item: postView)
+//            if postTracker.shouldLoadContent(after: postView) {
+//                await loadFeed()
+//            }
         }
     }
     

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -65,16 +65,24 @@ struct FeedView: View {
             .task(priority: .background) { await fetchCommunityDetails() }
         // using hardRefreshFeed() for these three so that the user gets immediate feedback, also kills the ScrollViewReader
             .onChange(of: feedType) { _ in
-                hardRefreshFeed()
+                Task(priority: .userInitiated) {
+                    await hardRefreshFeed()
+                }
             }
             .onChange(of: postSortType) { _ in
-                hardRefreshFeed()
+                Task(priority: .userInitiated) {
+                    await hardRefreshFeed()
+                }
             }
             .onChange(of: appState.currentActiveAccount) { _ in
-                hardRefreshFeed()
+                Task(priority: .userInitiated) {
+                    await hardRefreshFeed()
+                }
             }
             .onChange(of: showReadPosts) { _ in
-                hardRefreshFeed()
+                Task(priority: .userInitiated) {
+                    await hardRefreshFeed()
+                }
             }
             .onChange(of: shouldLoad) { value in
                 Task(priority: .medium) {

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -34,14 +34,18 @@ struct FeedView: View {
     @State var feedType: FeedType
     
     init(community: APICommunity?, feedType: FeedType, showLoading: Bool = false) {
+        @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
+        
         self.community = community
         self.showLoading = showLoading
+        
         self._feedType = State(initialValue: feedType)
+        self._postTracker = StateObject(wrappedValue: .init(shouldPerformMergeSorting: false, internetSpeed: internetSpeed))
     }
     
     // MARK: State
     
-    @StateObject var postTracker: PostTracker = .init(shouldPerformMergeSorting: false)
+    @StateObject var postTracker: PostTracker
     
     @State var communityDetails: GetCommunityResponse?
     @State var postSortType: PostSortType = .hot
@@ -86,6 +90,7 @@ struct FeedView: View {
             }
             .onChange(of: shouldLoad) { value in
                 if value {
+                    print("should load more posts...")
                     Task(priority: .medium) { await loadFeed() }
                     shouldLoad = false
                 }

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -40,6 +40,8 @@ struct InboxView: View {
     @EnvironmentObject var editorTracker: EditorTracker
     @EnvironmentObject var unreadTracker: UnreadTracker
     
+    @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
+    
     // MARK: Internal
     // id of the last account loaded with
     @State var lastKnownAccountId: Int = 0
@@ -54,10 +56,19 @@ struct InboxView: View {
     
     // item feeds
     @State var allItems: [InboxItem] = .init()
-    @StateObject var mentionsTracker: MentionsTracker = .init()
-    @StateObject var messagesTracker: MessagesTracker = .init()
-    @StateObject var repliesTracker: RepliesTracker = .init()
-    @StateObject var dummyPostTracker: PostTracker = .init() // used for nav
+    @StateObject var mentionsTracker: MentionsTracker // = .init(internetSpeed: internetSpeed)
+    @StateObject var messagesTracker: MessagesTracker // = .init(internetSpeed: internetSpeed)
+    @StateObject var repliesTracker: RepliesTracker // = .init(internetSpeed: internetSpeed)
+    @StateObject var dummyPostTracker: PostTracker // = .init(internetSpeed: internetSpeed) // used for nav
+    
+    init() {
+        @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
+        
+        self._mentionsTracker = StateObject(wrappedValue: .init(internetSpeed: internetSpeed))
+        self._messagesTracker = StateObject(wrappedValue: .init(internetSpeed: internetSpeed))
+        self._repliesTracker = StateObject(wrappedValue: .init(internetSpeed: internetSpeed))
+        self._dummyPostTracker = StateObject(wrappedValue: .init(internetSpeed: internetSpeed))
+    }
     
     // input state handling
     // - current view

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -25,13 +25,22 @@ struct UserView: View {
     @State var userID: Int
     @State var userDetails: APIPersonView?
 
-    @StateObject private var privatePostTracker: PostTracker = .init(shouldPerformMergeSorting: false)
+    @StateObject private var privatePostTracker: PostTracker
     @StateObject private var privateCommentTracker: CommentTracker = .init()
     @State private var avatarSubtext: String = ""
     @State private var showingCakeDay = false
     @State private var moderatedCommunities: [APICommunityModeratorView] = []
     
     @State private var selectionSection = UserViewTab.overview
+    
+    init(userID: Int, userDetails: APIPersonView? = nil) {
+        @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
+        
+        self._userID = State(initialValue: userID)
+        self._userDetails = State(initialValue: userDetails)
+        
+        self._privatePostTracker = StateObject(wrappedValue: .init(shouldPerformMergeSorting: false, internetSpeed: internetSpeed))
+    }
     
     // account switching
     var isSelf: Bool { userID == appState.currentActiveAccount.id }

--- a/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
@@ -39,10 +39,11 @@ struct SelectableSettingsItem<T: SettingsOptions>: View {
                 }
             }
         } label: {
-            HStack(alignment: .center) {
+            Label {
+                Text(settingName)
+            } icon: {
                 Image(systemName: settingIconSystemName)
                     .foregroundColor(.pink)
-                Text(settingName)
             }
         }
     }

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -32,6 +32,13 @@ struct SettingsView: View {
                     }
                     
                     NavigationLink {
+                        AccessibilitySettingsView()
+                    } label: {
+                        // apparently the Apple a11y symbol isn't an SFSymbol
+                        Label("Accessibility", systemImage: "hand.point.up.braille.fill").labelStyle(SquircleLabelStyle(color: .blue))
+                    }
+                    
+                    NavigationLink {
                         AppearanceSettingsView()
                     } label: {
                         Label("Appearance", systemImage: "paintbrush.fill").labelStyle(SquircleLabelStyle(color: .pink))

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -61,5 +61,7 @@ struct AccessibilitySettingsView: View {
                 Text("Configure how this app behaves when the system \"differentiate without color\" option is on")
             }
         }
+        .fancyTabScrollCompatible()
+        .navigationTitle("Accessibility")
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -1,0 +1,65 @@
+//
+//  AccessibilitySettingsView.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-08-02.
+//
+
+import Foundation
+import SwiftUI
+
+struct AccessibilitySettingsView: View {
+    
+    @AppStorage("reakMarkStyle") var readMarkStyle: ReadMarkStyle = .bar
+    @AppStorage("readBarThickness") var readBarThickness: Int = 3
+    
+    @State private var readBarThicknessSlider: CGFloat = 3.0
+    
+    var body: some View {
+        List {
+            Section {
+                SelectableSettingsItem(settingIconSystemName: "book",
+                                       settingName: "Read Post Indicator",
+                                       currentValue: $readMarkStyle,
+                                       options: ReadMarkStyle.allCases)
+                
+                VStack(alignment: .leading) {
+                    HStack {
+                        Label {
+                            Text("Bar Thickness")
+                        } icon: {
+                            Image(systemName: "rectangle.leftthird.inset.filled")
+                                .foregroundColor(.pink)
+                                .opacity(readMarkStyle == .bar ? 1 : 0.4)
+                        }
+                        
+                        Spacer()
+                        
+                        Text(String(format: "%.0f", readBarThicknessSlider))
+                    }
+                    .frame(maxWidth: .infinity)
+                    
+                    Slider(value: $readBarThicknessSlider,
+                           in: 1...5,
+                           step: 1) {
+                        Text("Bar Thickness")
+                    } minimumValueLabel: {
+                        Text("1")
+                    } maximumValueLabel: {
+                        Text("5")
+                    } onEditingChanged: { editing in
+                        if !editing {
+                            readBarThickness = Int(readBarThicknessSlider)
+                        }
+                    }
+                    .disabled(readMarkStyle != .bar)
+                }
+                .foregroundColor(readMarkStyle == .bar ? .primary : .secondary)
+            } header: {
+                Text("Differentiate Without Color")
+            } footer: {
+                Text("Configure how this app behaves when the system \"differentiate without color\" option is on")
+            }
+        }
+    }
+}

--- a/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
@@ -157,14 +157,15 @@ struct FiltersSettingsView: View {
 
     func addKeyword(_ newKeyword: String) {
         if !newKeyword.isEmpty {
-            if filtersTracker.filteredKeywords.contains(newKeyword) { /// If the word is already in there, just move it to the top
+            // If the word is already in there, just move it to the top
+            if filtersTracker.filteredKeywords.contains(newKeyword.lowercased()) {
                 let indexOfPreviousOccurence: Int = filtersTracker.filteredKeywords.firstIndex(where: { $0 == newKeyword })!
                 withAnimation {
                     filtersTracker.filteredKeywords.move(from: indexOfPreviousOccurence, to: 0)
                 }
             } else {
                 withAnimation {
-                    filtersTracker.filteredKeywords.prepend(newKeyword)
+                    filtersTracker.filteredKeywords.prepend(newKeyword.lowercased())
                 }
             }
 

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -15,6 +15,8 @@ struct GeneralSettingsView: View {
     
     @AppStorage("shouldBlurNsfw") var shouldBlurNsfw: Bool = true
     
+    @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
+    
     @AppStorage("defaultPostSorting") var defaultPostSorting: PostSortType = .hot
     @AppStorage("defaultCommentSorting") var defaultCommentSorting: CommentSortType = .top
     @AppStorage("defaultFeed") var defaultFeed: FeedType = .subscribed
@@ -80,6 +82,17 @@ struct GeneralSettingsView: View {
                 Text("Default Sorting")
             } footer: {
                 Text("The sort mode that is selected by default when you open the app.")
+            }
+            
+            Section {
+                SelectableSettingsItem(settingIconSystemName: AppConstants.connectionSymbolName,
+                                       settingName: "Internet Speed",
+                                       currentValue: $internetSpeed,
+                                       options: InternetSpeed.allCases)
+            } header: {
+                Text("Connection Type")
+            } footer: {
+                Text("Optimizes performance for your internet speed. You may need to restart the app for all optimizations to take effect.")
             }
 
             Section {


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #400
      - closes #383 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR introduces a visual indication of read posts and the option to hide them.

To support this, makes the following backend changes:
- Added API types to mark a post as read
- Added `PostRepository` and put a function to mark posts as read in there
- Reworked how infinite loading feed operates:
  - Added a `shouldLoad` state bool to the feed view that, when true, indicates that more items should be loaded
  - Added and `onChange` task to the top-level feed view that listens to `shouldLoad` and performs the loading. This prevents loading being cancelled by view derenders.
  - Feed items still check whether more content should load when they appear, but now they simply update `shouldLoad` instead of loading that content themselves.
  - Added `shouldLoadContentPrecisely` to the feed tracker, which is very similar to `shouldLoadContent` but only returns true if the item in question is precisely the threshold item. This prevents `shouldLoad` from being toggled by several items in one batch.
- Tweaked how `PostTracker.loadNextPage` works. With filtering read posts it becomes quite common to fetch an entire page that gets filtered out; this was prompting an "end of feed" state because no new posts were added to the feed, thus no new trigger for "should load more posts" was rendered. Now the function keeps loading pages until it either receives an empty *unfiltered* array *or* it adds the threshold number of items.

This PR also performs some minor filtering changes, so I went ahead and fixed the filters problem too while I was at it. Keyword filtering is now case insensitive.

## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/44140166/30ddeab8-b3d3-43af-b517-153b96004e69

## Additional Context
**Any additional context you'd like to add to help us review this PR**
