### PR TITLE
applied nsfw filter to community avatar

### DIFF
--- a/Mlem/Views/Shared/Links/Community Link View.swift
+++ b/Mlem/Views/Shared/Links/Community Link View.swift
@@ -63,11 +63,15 @@ struct CommunityLinkView: View {
 struct CommunityLabel: View {
     // settings
     @AppStorage("shouldShowCommunityIcons") var shouldShowCommunityIcons: Bool = true
+    @AppStorage("shouldBlurNsfw") var shouldBlurNsfw: Bool = true
     
     // parameters
     let community: APICommunity
     let serverInstanceLocation: ServerInstanceLocation
     let overrideShowAvatar: Bool? // if present, shows or hides the avatar according to value; otherwise uses system setting
+    
+    // computed
+    var blurAvatar: Bool { shouldBlurNsfw && community.nsfw }
 
     var showAvatar: Bool {
         if let overrideShowAvatar = overrideShowAvatar {
@@ -89,14 +93,12 @@ struct CommunityLabel: View {
         Group {
             HStack(alignment: .bottom, spacing: AppConstants.largeAvatarSpacing) {
                 if showAvatar {
-                    if shouldClipAvatar(community: community) {
-                        communityAvatar
-                            .clipShape(Circle())
-                            .overlay(Circle()
-                                .stroke(Color(UIColor.secondarySystemBackground), lineWidth: 1))
-                    } else {
-                        communityAvatar
-                    }
+                    communityAvatar
+                        .blur(radius: blurAvatar ? 4 : 0)
+                        .clipShape(Circle())
+                        .overlay(Circle()
+                            .stroke(Color(UIColor.secondarySystemBackground),
+                                    lineWidth: shouldClipAvatar(community: community) ? 1 : 0))
                 }
                 
                 switch serverInstanceLocation {
@@ -137,6 +139,7 @@ struct CommunityLabel: View {
                 .lineLimit(1)
                 .opacity(0.6)
                 .font(.caption)
+                .allowsHitTesting(false)
         } else {
             EmptyView()
         }

--- a/Mlem/Views/Shared/Links/User Profile Label.swift
+++ b/Mlem/Views/Shared/Links/User Profile Label.swift
@@ -10,6 +10,7 @@ import CachedAsyncImage
 
 struct UserProfileLabel: View {
     @AppStorage("shouldShowUserAvatars") var shouldShowUserAvatars: Bool = true
+    @AppStorage("shouldBlurNsfw") var shouldBlurNsfw: Bool = true
     
     var user: APIPerson
     let serverInstanceLocation: ServerInstanceLocation
@@ -20,6 +21,9 @@ struct UserProfileLabel: View {
     @State var postContext: APIPost?
     @State var commentContext: APIComment?
     @State var communityContext: GetCommunityResponse?
+
+    var blurAvatar: Bool { shouldBlurNsfw && (postContext?.nsfw ?? false ||
+                                             communityContext?.communityView.community.nsfw ?? false) }
     
     init(user: APIPerson,
          serverInstanceLocation: ServerInstanceLocation,
@@ -90,6 +94,7 @@ struct UserProfileLabel: View {
             }
         }
         .frame(width: avatarSize(), height: avatarSize())
+        .blur(radius: blurAvatar ? 4 : 0)
         .clipShape(Circle())
         .overlay(Circle()
             .stroke(Color(UIColor.secondarySystemBackground), lineWidth: 1))

--- a/Mlem/Views/Shared/Links/User Profile Label.swift
+++ b/Mlem/Views/Shared/Links/User Profile Label.swift
@@ -156,6 +156,7 @@ struct UserProfileLabel: View {
                 .lineLimit(1)
                 .opacity(0.6)
                 .font(.caption)
+                .allowsHitTesting(false)
         } else {
             EmptyView()
         }

--- a/Mlem/Views/Shared/Posts/Components/Post Header.swift
+++ b/Mlem/Views/Shared/Posts/Components/Post Header.swift
@@ -50,7 +50,8 @@ struct PostHeader: View {
                 }
                 Text("by")
                 UserProfileLink(user: postView.creator,
-                                serverInstanceLocation: shouldShowUserServerInPost ? .bottom : .disabled)
+                                serverInstanceLocation: shouldShowUserServerInPost ? .bottom : .disabled,
+                                postContext: postView.post)
             }
 
             Spacer()

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -91,7 +91,9 @@ struct ExpandedPost: View {
                     isExpanded: true
                 )
                 
-                UserProfileLink(user: post.creator, serverInstanceLocation: .bottom)
+                UserProfileLink(user: post.creator,
+                                serverInstanceLocation: .bottom,
+                                postContext: post.post)
             }
             .padding(.top, AppConstants.postAndCommentSpacing)
             .padding(.horizontal, AppConstants.postAndCommentSpacing)

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -131,7 +131,9 @@ struct FeedPost: View {
 
                     // posting user
                     if showPostCreator {
-                        UserProfileLink(user: postView.creator, serverInstanceLocation: .bottom)
+                        UserProfileLink(user: postView.creator,
+                                        serverInstanceLocation: .bottom,
+                                        postContext: postView.post)
                     }
                 }
                 .padding(.top, AppConstants.postAndCommentSpacing)

--- a/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
@@ -59,7 +59,9 @@ struct UltraCompactPost: View {
                         if showCommunity {
                             CommunityLinkView(community: postView.community, serverInstanceLocation: .trailing, overrideShowAvatar: false)
                         } else {
-                            UserProfileLink(user: postView.creator, serverInstanceLocation: .trailing)
+                            UserProfileLink(user: postView.creator,
+                                            serverInstanceLocation: .trailing,
+                                            postContext: postView.post)
                         }
                     }
                     


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #373 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR adds the NSFW blur to the community and user avatars, plus adds post context to a lot of the user avatar labels so they can accurately detect NSFW posts.

The NSFW filter will not be appropriately applied to the user avatar if the community is NSFW but the post is not; this should be fixed implicitly when we migrate to a middleware post model that will be automatically flagged NSFW if its community is.

This PR also makes the instance text not tappable, as per Slack discussion

## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/44140166/982b5336-48ce-4acd-95aa-66a0068b3e1f

