### PR TITLE
Improved Smooth Scrolling

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -262,6 +262,7 @@
 		CD18DC712A520A60002C56BC /* MarkPrivateMessageAsRead.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD18DC702A520A60002C56BC /* MarkPrivateMessageAsRead.swift */; };
 		CD18DC732A522A7C002C56BC /* CreatePrivateMessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD18DC722A522A7C002C56BC /* CreatePrivateMessageRequest.swift */; };
 		CD18DC752A522B38002C56BC /* SendPrivateMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD18DC742A522B38002C56BC /* SendPrivateMessage.swift */; };
+		CD2BD6782A79F55800ECFF89 /* ImageSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2BD6772A79F55800ECFF89 /* ImageSize.swift */; };
 		CD2E182B2A3B708500224F8A /* Settings Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2E182A2A3B708500224F8A /* Settings Options.swift */; };
 		CD391F8B2A53371300E213B5 /* ExpandedPostLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD391F8A2A53371300E213B5 /* ExpandedPostLogic.swift */; };
 		CD391F942A533B7700E213B5 /* EditorModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD391F932A533B7700E213B5 /* EditorModelProtocol.swift */; };
@@ -621,6 +622,7 @@
 		CD18DC702A520A60002C56BC /* MarkPrivateMessageAsRead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkPrivateMessageAsRead.swift; sourceTree = "<group>"; };
 		CD18DC722A522A7C002C56BC /* CreatePrivateMessageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePrivateMessageRequest.swift; sourceTree = "<group>"; };
 		CD18DC742A522B38002C56BC /* SendPrivateMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendPrivateMessage.swift; sourceTree = "<group>"; };
+		CD2BD6772A79F55800ECFF89 /* ImageSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSize.swift; sourceTree = "<group>"; };
 		CD2E182A2A3B708500224F8A /* Settings Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Settings Options.swift"; sourceTree = "<group>"; };
 		CD391F8A2A53371300E213B5 /* ExpandedPostLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedPostLogic.swift; sourceTree = "<group>"; };
 		CD391F932A533B7700E213B5 /* EditorModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorModelProtocol.swift; sourceTree = "<group>"; };
@@ -978,6 +980,7 @@
 				63F0C7A52A05225100A18C5D /* Saved Account.swift */,
 				63CE4E722A06F5A100405271 /* Access Token.swift */,
 				63E5D3932A13CF3600EC1FBD /* Favorite Community.swift */,
+				CD2BD6772A79F55800ECFF89 /* ImageSize.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2161,6 +2164,7 @@
 				CDF8426B2A4A2AB600723DA0 /* Inbox Item.swift in Sources */,
 				637218572A3A2AAD008C4816 /* APISiteView.swift in Sources */,
 				B14E93C02A45CA3400D6DA93 /* Post Link.swift in Sources */,
+				CD2BD6782A79F55800ECFF89 /* ImageSize.swift in Sources */,
 				6DEB0FFD2A4F891B007CAB99 /* User Moderator Link.swift in Sources */,
 				6D405AFF2A43E66600C65F9C /* User Profile Label.swift in Sources */,
 				CD391F9A2A537EF900E213B5 /* CommentBodyView.swift in Sources */,

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -12,6 +12,7 @@ import UIKit
 struct AppConstants {
     static let cacheSize = 500_000_000 // 500MB in bytes
     static let urlCache: URLCache = URLCache(memoryCapacity: cacheSize, diskCapacity: cacheSize)
+    static let imageSizeCache: NSCache<NSString, ImageSize> = .init()
     static let webSocketSession: URLSession = URLSession(configuration: .default)
     static let urlSession: URLSession = URLSession(configuration: .default)
 

--- a/Mlem/Models/ImageSize.swift
+++ b/Mlem/Models/ImageSize.swift
@@ -1,0 +1,16 @@
+//
+//  ImageSize.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-08-01.
+//
+
+import Foundation
+
+class ImageSize {
+    let size: CGSize
+    
+    init(size: CGSize) {
+        self.size = size
+    }
+}

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -41,18 +41,18 @@ struct CachedImage: View {
             self._size = State(initialValue: fixedSize)
             self._shouldRecomputeSize = State(initialValue: false)
         } else if let url, let cachedSize = AppConstants.imageSizeCache.object(forKey: NSString(string: url.description)) {
-            // found a size in the cache, just use that--don't care if we have the image or not
+            // if we find a size in the size cache, use it
             self._size = State(initialValue: cachedSize.size)
             self._shouldRecomputeSize = State(initialValue: false)
         } else if let url, let testImage = ImagePipeline.shared.cache[url] {
-            // found an image that isn't cached--compute its size, cache the size, and set our state
+            // if we have nothing in the size cache but the image is ready, compute its size, use it, and cache it
             let ratio = screenWidth / testImage.image.size.width
             self._size = State(initialValue: CGSize(width: screenWidth,
                                                     height: min(maxHeight, testImage.image.size.height * ratio)))
             self._shouldRecomputeSize = State(initialValue: false)
             cacheImageSize()
         } else {
-            // nothing in the cache *and* no image! default to square
+            // if there's nothing in the cache *and* no image, default to square :(
             self._size = State(initialValue: CGSize(width: screenWidth, height: screenWidth))
             self._shouldRecomputeSize = State(initialValue: true)
         }

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -41,7 +41,7 @@ struct CachedImage: View {
             self._size = State(initialValue: fixedSize)
             self._shouldRecomputeSize = State(initialValue: false)
         } else if let url, let cachedSize = AppConstants.imageSizeCache.object(forKey: NSString(string: url.description)) {
-            // found a size in the size, just use that--don't care if we have the image or not
+            // found a size in the cache, just use that--don't care if we have the image or not
             self._size = State(initialValue: cachedSize.size)
             self._shouldRecomputeSize = State(initialValue: false)
         } else if let url, let testImage = ImagePipeline.shared.cache[url] {

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -47,9 +47,8 @@ struct CachedImage: View {
         } else if let url, let testImage = ImagePipeline.shared.cache[url] {
             // found an image that isn't cached--compute its size, cache the size, and set our state
             let ratio = screenWidth / testImage.image.size.width
-            let newSize = CGSize(width: screenWidth,
-                                 height: min(maxHeight, testImage.image.size.height * ratio))
-            self._size = State(initialValue: newSize)
+            self._size = State(initialValue: CGSize(width: screenWidth,
+                                                    height: min(maxHeight, testImage.image.size.height * ratio)))
             self._shouldRecomputeSize = State(initialValue: false)
             cacheImageSize()
         } else {

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -17,31 +17,52 @@ struct CachedImage: View {
     let url: URL?
     let shouldExpand: Bool
     @State var bigPicMode: URL?
-    let size: CGSize
     
-    // TODO: Right now images that don't load in time get shoved into a square, which is good enough for now, but in the futured the image should be able to resize itself once the image loads and save that size for the future--perhaps look into a size cache that doesn't get as aggressively evicted
+    // state vars to track the current image size and whether that size needs to be recomputed when the image actually loads. Combined with the image size cache, this produces good scrolling behavior except in the case where we scroll past an image and it derenders before it ever gets a chance to load, in which case that image will cause a slight hiccup on the way back up. That's kind of an unsolvable problem, since we can't know the size before we load the image at all, but that's fine because it shouldn't really happen during normal use. If we really want to guarantee smooth feed scrolling we can squish any image with no cached size into a square, but that feels like squishing a lot of images for the sake of a fringe case.
+    @State var size: CGSize
+    @State var shouldRecomputeSize: Bool
+    
+    let maxHeight: CGFloat
+    let screenWidth: CGFloat
     
     init(url: URL?,
          shouldExpand: Bool = true,
-         maxHeight: CGFloat = .infinity) {
+         maxHeight: CGFloat = .infinity,
+         fixedSize: CGSize? = nil) {
         self.url = url
         self.shouldExpand = shouldExpand
+        self.maxHeight = maxHeight
         
-        let screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
+        screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
         
-        if let url, let testImage = ImagePipeline.shared.cache[url] {
+        // determine the size of the image
+        if let fixedSize {
+            // if we're given a size, just use it and to hell with the cache
+            self._size = State(initialValue: fixedSize)
+            self._shouldRecomputeSize = State(initialValue: false)
+        } else if let url, let cachedSize = AppConstants.imageSizeCache.object(forKey: NSString(string: url.description)) {
+            // found a size in the size, just use that--don't care if we have the image or not
+            self._size = State(initialValue: cachedSize.size)
+            self._shouldRecomputeSize = State(initialValue: false)
+        } else if let url, let testImage = ImagePipeline.shared.cache[url] {
+            // found an image that isn't cached--compute its size, cache the size, and set our state
             let ratio = screenWidth / testImage.image.size.width
-            size = CGSize(width: screenWidth,
-                          height: min(maxHeight, testImage.image.size.height * ratio))
+            let newSize = CGSize(width: screenWidth,
+                                 height: min(maxHeight, testImage.image.size.height * ratio))
+            self._size = State(initialValue: newSize)
+            self._shouldRecomputeSize = State(initialValue: false)
+            cacheImageSize()
         } else {
-            size = CGSize(width: screenWidth, height: screenWidth)
+            // nothing in the cache *and* no image! default to square
+            self._size = State(initialValue: CGSize(width: screenWidth, height: screenWidth))
+            self._shouldRecomputeSize = State(initialValue: true)
         }
     }
     
     var body: some View {
         LazyImage(url: url) { state in
-            if let image = state.imageContainer {
-                let imageView = Image(uiImage: image.image)
+            if let imageContainer = state.imageContainer {
+                let imageView = Image(uiImage: imageContainer.image)
                     .resizable()
                     .scaledToFill()
                     .frame(width: size.width, height: size.height)
@@ -52,6 +73,16 @@ struct CachedImage: View {
                         Rectangle()
                             .frame(maxHeight: size.height)
                             .opacity(0.00000000001)
+                    }
+                    .onAppear {
+                        // if the image appears and its size isn't cached, compute its size and cache it
+                        if shouldRecomputeSize {
+                            let ratio = screenWidth / imageContainer.image.size.width
+                            size = CGSize(width: screenWidth,
+                                          height: min(maxHeight, imageContainer.image.size.height * ratio))
+                            shouldRecomputeSize = false
+                            cacheImageSize()
+                        }
                     }
                 if shouldExpand {
                     imageView
@@ -100,5 +131,14 @@ struct CachedImage: View {
             .scaledToFit()
             .frame(maxWidth: AppConstants.thumbnailSize, maxHeight: AppConstants.thumbnailSize)
             .padding(AppConstants.postAndCommentSpacing)
+    }
+    
+    /**
+     Caches the current value of size
+     */
+    private func cacheImageSize() {
+        if let url {
+            AppConstants.imageSizeCache.setObject(ImageSize(size: size), forKey: NSString(string: url.description))
+        }
     }
 }

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -16,15 +16,17 @@ struct ThumbnailImageView: View {
     
     var showNsfwFilter: Bool { (postView.post.nsfw || postView.community.nsfw) && shouldBlurNsfw }
     
+    let size = CGSize(width: AppConstants.thumbnailSize, height: AppConstants.thumbnailSize)
+    
     var body: some View {
         Group {
             switch postView.postType {
             case .image(let url):
                 // just blur, no need for the whole filter viewModifier since this is just a thumbnail
-                CachedImage(url: url, maxHeight: AppConstants.thumbnailSize)
+                CachedImage(url: url, fixedSize: size)
                     .blur(radius: showNsfwFilter ? 8 : 0)
             case .link(let url):
-                CachedImage(url: url, maxHeight: AppConstants.thumbnailSize)
+                CachedImage(url: url, fixedSize: size)// maxHeight: AppConstants.thumbnailSize)
                     .blur(radius: showNsfwFilter ? 8 : 0)
             case .text:
                 Image(systemName: "text.book.closed")

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -26,7 +26,7 @@ struct ThumbnailImageView: View {
                 CachedImage(url: url, fixedSize: size)
                     .blur(radius: showNsfwFilter ? 8 : 0)
             case .link(let url):
-                CachedImage(url: url, fixedSize: size)// maxHeight: AppConstants.thumbnailSize)
+                CachedImage(url: url, fixedSize: size)
                     .blur(radius: showNsfwFilter ? 8 : 0)
             case .text:
                 Image(systemName: "text.book.closed")


### PR DESCRIPTION
Follow-up PR to #408 

This PR introduces an image size cache that exists independently of the Nuke cache--it can hold way more items because it only cares about the URL and the size of the image associated with it. This avoids unnecessarily squishing images into squares because they didn't happen to get prefetched in time.