### PR TITLE
fix - non sendable actor boundary warnings

### DIFF
--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -122,19 +122,21 @@ struct HandleLemmyLinkResolution: ViewModifier {
                     do {
                         let resolution = try await APIClient().perform(request: ResolveObjectRequest(account: account, query: lookup))
                         
-                        // this is gonna be a bit of an ugly if switch but oh well for now
-                        if let post = resolution.post {
-                            // wop wop that was a post link!
-                            return navigationPath.wrappedValue.append(post)
-                        } else if let community = resolution.community {
-                            return navigationPath.wrappedValue.append(community)
-                        } else if let user = resolution.person?.person {
-                            return navigationPath.wrappedValue.append(user)
+                        await MainActor.run {
+                            // this is gonna be a bit of an ugly if switch but oh well for now
+                            if let post = resolution.post {
+                                // wop wop that was a post link!
+                                return navigationPath.wrappedValue.append(post)
+                            } else if let community = resolution.community {
+                                return navigationPath.wrappedValue.append(community)
+                            } else if let user = resolution.person?.person {
+                                return navigationPath.wrappedValue.append(user)
+                            }
+                            // else if let d = resolution.comment {
+                            // hmm I don't think we can do that right now!
+                            // so I'll skip and let the system open it instead
+                            // }
                         }
-                        // else if let d = resolution.comment {
-                        // hmm I don't think we can do that right now!
-                        // so I'll skip and let the system open it instead
-                        // }
                     } catch {
                         guard case let APIClientError.response(apiError, _) = error,
                               apiError.error == "couldnt_find_object",


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - no issue, spotted during development
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
While running the build in the latest Xcode 15 (Beta 5) the build system flagged these additional warnings for accessing the navigation path from an actor other than `MainActor`, makes sense as we've just come off a network call above.

They don't flag in the current Xcode (14.3.1) and don't appear to cause any immediate issues in the application but it's best to get them fixed now as if we're pushing on the wrong thread/actor things might go awry without warning 😅 

Fix is just to hop back to the `MainActor` before we attempt to push anything to the navigation stack.

## Screenshots and Videos
| WARNINGS |
| --- |
| <img width="1400" alt="warnings" src="https://github.com/mlemgroup/mlem/assets/5231793/19f9cc24-504f-49e2-945b-629667d662ac"> |

