### PR TITLE
Thumbnail refinements

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2590,7 +2590,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 76ULHQGAPN;
+				DEVELOPMENT_TEAM = 8B9GNJW88W;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2608,7 +2608,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = local.eric;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -2631,7 +2631,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 76ULHQGAPN;
+				DEVELOPMENT_TEAM = 8B9GNJW88W;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2649,7 +2649,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = local.eric;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2590,7 +2590,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 8B9GNJW88W;
+				DEVELOPMENT_TEAM = 76ULHQGAPN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2608,7 +2608,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = local.eric;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -2631,7 +2631,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 8B9GNJW88W;
+				DEVELOPMENT_TEAM = 76ULHQGAPN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2649,7 +2649,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = local.eric;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -30,8 +30,6 @@ class PostTracker: FeedTracker<APIPostView> {
     ) async throws {
         let currentPage = page
         
-        print("internet speed: \(internetSpeed.label)")
-        
         // retry this until we get some items that pass the filter
         var responsePosts: [APIPostView] = .init()
         let numItems = items.count
@@ -49,7 +47,6 @@ class PostTracker: FeedTracker<APIPostView> {
             )
             
             responsePosts = response.posts
-            print("got \(responsePosts.count) posts, there are \(items.count) total posts")
         } while !responsePosts.isEmpty && numItems > items.count + AppConstants.infiniteLoadThresholdOffset
 
         // so although the API kindly returns `400`/"not_logged_in" for expired

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -118,7 +118,6 @@ struct CachedImage: View {
                         .quickLookPreview($bigPicMode)
                         .onChange(of: bigPicMode) { mode in
                             if mode == nil, let dismissCallback {
-                                print("dismissed")
                                 dismissCallback()
                             }
                         }

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -27,15 +27,22 @@ struct CachedImage: View {
     let maxHeight: CGFloat
     let screenWidth: CGFloat
     
+    /**
+     Optional callback triggered when the quicklook preview is dismissed
+     */
+    let dismissCallback: (() -> Void)?
+    
     init(url: URL?,
          shouldExpand: Bool = true,
          maxHeight: CGFloat = .infinity,
          fixedSize: CGSize? = nil,
-         imageNotFound: @escaping () -> AnyView = imageNotFoundDefault) {
+         imageNotFound: @escaping () -> AnyView = imageNotFoundDefault,
+         dismissCallback: (() -> Void)? = nil) {
         self.url = url
         self.shouldExpand = shouldExpand
         self.maxHeight = maxHeight
         self.imageNotFound = imageNotFound
+        self.dismissCallback = dismissCallback
         
         screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
         
@@ -109,6 +116,12 @@ struct CachedImage: View {
                             }
                         }
                         .quickLookPreview($bigPicMode)
+                        .onChange(of: bigPicMode) { mode in
+                            if mode == nil, let dismissCallback {
+                                print("dismissed")
+                                dismissCallback()
+                            }
+                        }
                 } else {
                     imageView
                 }

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -66,7 +66,7 @@ struct ThumbnailImageView: View {
         Task(priority: .userInitiated) {
             do {
                 let readPost = try await postRepository.markRead(for: postView.post.id, read: true)
-                postTracker.update(with: readPost.postView)
+                postTracker.update(with: readPost)
             } catch {
                 errorHandler.handle(.init(underlyingError: error))
             }

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -14,10 +14,8 @@ struct ThumbnailImageView: View {
     @AppStorage("shouldBlurNsfw") var shouldBlurNsfw: Bool = true
     @EnvironmentObject var postTracker: PostTracker
     
-    @Dependency(\.apiClient) var apiClient
     @Dependency(\.errorHandler) var errorHandler
-    // @Dependency(\.postRepository) var postRepository
-    // TODO: Eric use repository 
+    @Dependency(\.postRepository) var postRepository
     @Environment(\.openURL) private var openURL 
     
     let postView: APIPostView
@@ -66,8 +64,8 @@ struct ThumbnailImageView: View {
     func markPostAsRead() {
         Task(priority: .userInitiated) {
             do {
-                let readPost = try await apiClient.markPostAsRead(for: postView.post.id, read: true)
-                postTracker.update(with: readPost.postView)
+                let readPost = try await postRepository.markRead(for: postView.post.id, read: true)
+                postTracker.update(with: readPost)
             } catch {
                 errorHandler.handle(.init(underlyingError: error))
             }

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -65,7 +65,7 @@ struct ThumbnailImageView: View {
     func markPostAsRead() {
         Task(priority: .userInitiated) {
             do {
-                let readPost = try await postRepository.markPostAsRead(for: postView.post.id, read: true)
+                let readPost = try await postRepository.markRead(for: postView.post.id, read: true)
                 postTracker.update(with: readPost.postView)
             } catch {
                 errorHandler.handle(.init(underlyingError: error))

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -16,6 +16,7 @@ struct ThumbnailImageView: View {
     
     @Dependency(\.apiClient) var apiClient
     @Dependency(\.errorHandler) var errorHandler
+    @Environment(\.openURL) private var openURL
     
     let postView: APIPostView
     
@@ -34,6 +35,12 @@ struct ThumbnailImageView: View {
                     .blur(radius: showNsfwFilter ? 8 : 0)
             case .link(let url):
                 CachedImage(url: url, shouldExpand: false, fixedSize: size)
+                    .onTapGesture {
+                        if let url = postView.post.url {
+                            openURL(url)
+                            markPostAsRead()
+                        }
+                    }
                     .blur(radius: showNsfwFilter ? 8 : 0)
             case .text:
                 Image(systemName: "text.book.closed")

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -16,7 +16,8 @@ struct ThumbnailImageView: View {
     
     @Dependency(\.apiClient) var apiClient
     @Dependency(\.errorHandler) var errorHandler
-    @Environment(\.openURL) private var openURL
+    @Dependency(\.postRepository) var postRepository
+    @Environment(\.openURL) private var openURL 
     
     let postView: APIPostView
     
@@ -64,7 +65,7 @@ struct ThumbnailImageView: View {
     func markPostAsRead() {
         Task(priority: .userInitiated) {
             do {
-                let readPost = try await apiClient.markPostAsRead(for: postView.post.id, read: true)
+                let readPost = try await postRepository.markPostAsRead(for: postView.post.id, read: true)
                 postTracker.update(with: readPost.postView)
             } catch {
                 errorHandler.handle(.init(underlyingError: error))

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -16,7 +16,8 @@ struct ThumbnailImageView: View {
     
     @Dependency(\.apiClient) var apiClient
     @Dependency(\.errorHandler) var errorHandler
-    @Dependency(\.postRepository) var postRepository
+    // @Dependency(\.postRepository) var postRepository
+    // TODO: Eric use repository 
     @Environment(\.openURL) private var openURL 
     
     let postView: APIPostView
@@ -65,8 +66,8 @@ struct ThumbnailImageView: View {
     func markPostAsRead() {
         Task(priority: .userInitiated) {
             do {
-                let readPost = try await postRepository.markRead(for: postView.post.id, read: true)
-                postTracker.update(with: readPost)
+                let readPost = try await apiClient.markPostAsRead(for: postView.post.id, read: true)
+                postTracker.update(with: readPost.postView)
             } catch {
                 errorHandler.handle(.init(underlyingError: error))
             }

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -25,7 +25,6 @@ extension FeedView {
     func loadFeed() async {
         defer { isLoading = false }
         isLoading = true
-        print("called loadFeed")
         do {
             try await postTracker.loadNextPage(
                 account: appState.currentActiveAccount,


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #419 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR makes thumbnails in compact and headline mode behave properly:
- Tapping an image thumbnail opens the image viewer and marks the post as read
- Tapping a link thumbnail opens the link and marks the post as read

Updating post state unfortunately closes the QuickLook viewer, so image posts have to send the read call on dismissal of the viewer. I've added an optional `dismissCallback` parameter to `CachedImage` to achieve this.

**IMAGE POST**
https://github.com/mlemgroup/mlem/assets/44140166/08ac5a0d-a93b-4328-aea2-08719c366d87

**LINK POST**

https://github.com/mlemgroup/mlem/assets/44140166/5077a850-35ef-4fd6-97b3-3850fa01c567


