### PR TITLE
Post/Reply editors improvements

### DIFF
--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -45,6 +45,7 @@ struct AppConstants {
     static let barIconHitbox: CGFloat = 44 // Apple HIG guidelines
     static let settingsIconSize: CGFloat = 28
     static let fancyTabBarHeight: CGFloat = 48 // total height of the fancy tab bar
+    static let editorOverscroll: CGFloat = 30
     
     // MARK: - SFSymbols
     // votes

--- a/Mlem/Views/Shared/Composer/PostDetailEditorView.swift
+++ b/Mlem/Views/Shared/Composer/PostDetailEditorView.swift
@@ -20,6 +20,10 @@ extension HorizontalAlignment {
 
 struct PostDetailEditorView: View {
     
+    private enum Field: Hashable {
+        case title, url, body
+    }
+    
     @Dependency(\.errorHandler) var errorHandler
     
     @Environment(\.dismiss) var dismiss
@@ -35,6 +39,8 @@ struct PostDetailEditorView: View {
     @State var isSubmitting: Bool = false
     @State var isShowingErrorDialog: Bool = false
     @State var errorDialogMessage: String = ""
+    
+    @FocusState private var focusedField: Field?
     
     init(
         community: APICommunity,
@@ -135,6 +141,10 @@ struct PostDetailEditorView: View {
                                 .alignmentGuide(.labelStart) { $0[HorizontalAlignment.leading] }
                                 .dynamicTypeSize(.small ... .accessibility2)
                                 .accessibilityLabel("Title")
+                                .focused($focusedField, equals: .title)
+                                .onAppear {
+                                    focusedField = .title
+                                }
                         }
                         
                         // URL Row
@@ -151,6 +161,7 @@ struct PostDetailEditorView: View {
                                 .autocorrectionDisabled()
                                 .autocapitalization(.none)
                                 .accessibilityLabel("URL")
+                                .focused($focusedField, equals: .url)
                             
                             // Upload button, temporarily hidden
                             //                        Button(action: uploadImage) {
@@ -168,6 +179,8 @@ struct PostDetailEditorView: View {
                               axis: .vertical)
                     .dynamicTypeSize(.small ... .accessibility2)
                     .accessibilityLabel("Post Body")
+                    .focused($focusedField, equals: .body)
+                    
                     Spacer()
                 }
                 .padding()
@@ -184,7 +197,7 @@ struct PostDetailEditorView: View {
                     .allowsHitTesting(false)
                 }
             }
-
+            .scrollDismissesKeyboard(.automatic)
             .navigationTitle("New Post")
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {

--- a/Mlem/Views/Shared/Composer/ResponseEditorView.swift
+++ b/Mlem/Views/Shared/Composer/ResponseEditorView.swift
@@ -11,6 +11,10 @@ import SwiftUI
 
 struct ResponseEditorView: View {
     
+    private enum Field: Hashable {
+        case editorBody
+    }
+    
     @Dependency(\.errorHandler) var errorHandler
     
     let editorModel: any ResponseEditorModel
@@ -24,6 +28,8 @@ struct ResponseEditorView: View {
 
     @State var editorBody: String
     @State var isSubmitting: Bool = false
+    
+    @FocusState private var focusedField: Field?
 
     private var isReadyToReply: Bool {
         return editorBody.trimmed.isNotEmpty
@@ -48,11 +54,17 @@ struct ResponseEditorView: View {
                               axis: .vertical)
                     .accessibilityLabel("Response Body")
                     .padding(AppConstants.postAndCommentSpacing)
+                    .focused($focusedField, equals: .editorBody)
+                    .scrollDismissesKeyboard(.interactively)
+                    .onAppear {
+                        focusedField = .editorBody
+                    }
                     
                     Divider()
                     
                     editorModel.embeddedView()
                 }
+                .padding(.bottom, AppConstants.editorOverscroll)
             }
             .overlay {
                 // Loading Indicator

--- a/Mlem/Views/Shared/Composer/ResponseEditorView.swift
+++ b/Mlem/Views/Shared/Composer/ResponseEditorView.swift
@@ -55,7 +55,6 @@ struct ResponseEditorView: View {
                     .accessibilityLabel("Response Body")
                     .padding(AppConstants.postAndCommentSpacing)
                     .focused($focusedField, equals: .editorBody)
-                    .scrollDismissesKeyboard(.interactively)
                     .onAppear {
                         focusedField = .editorBody
                     }
@@ -66,6 +65,7 @@ struct ResponseEditorView: View {
                 }
                 .padding(.bottom, AppConstants.editorOverscroll)
             }
+            .scrollDismissesKeyboard(.automatic)
             .overlay {
                 // Loading Indicator
                 if isSubmitting {


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #432 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
- New post, reply to post, reply to comment views now focus on the first field (show the keyboard) available on initial appearance.
- Added a small overscroll padding to editor views so there's breathing room.
- Specify scroll dismisses keyboard value.