### PR TITLE
fix - add missing return in link handling

### DIFF
--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -137,6 +137,9 @@ struct HandleLemmyLinkResolution: ViewModifier {
                             // so I'll skip and let the system open it instead
                             // }
                         }
+                        
+                        // as the link was handled we return, else it would also be passed to the default URL handling below
+                        return
                     } catch {
                         guard case let APIClientError.response(apiError, _) = error,
                               apiError.error == "couldnt_find_object",


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - No issue, just spotted while testing stuff
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
The change added in #418 to ensure we make our changes to the navigation path on the `MainActor` missed adding a `return` below the hop 🙈 - things still work, but for links that are resolved since we don't return we push onto our stack and _also_ open the URL in the native browser.

## Screenshots and Videos
| BEFORE | AFTER |
| --- | --- |
| <video src="https://github.com/mlemgroup/mlem/assets/5231793/721fc5b2-b5e4-4b7e-95f3-f982ca3de58f"> | <video src="https://github.com/mlemgroup/mlem/assets/5231793/8ac4e5b8-dfb2-4e31-9a5e-868a176cd870"> |


