### PR TITLE
Fixed show instance toggles for posts and comments (fixes #442)

### DIFF
--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -19,7 +19,6 @@ struct CommentItem: View {
     @Dependency(\.notifier) var notifier
     
     // appstorage
-    @AppStorage("shouldShowUserServerInComment") var shouldShowUserServerInComment: Bool = false
     @AppStorage("compactComments") var compactComments: Bool = false
 
     // MARK: Temporary

--- a/Mlem/Views/Shared/Comments/Components/CommentBodyView.swift
+++ b/Mlem/Views/Shared/Comments/Components/CommentBodyView.swift
@@ -24,7 +24,7 @@ struct CommentBodyView: View {
     var myVote: ScoringOperation { commentView.myVote ?? .resetVote }
     
     var serverInstanceLocation: ServerInstanceLocation {
-        if shouldShowUserServerInComment {
+        if !shouldShowUserServerInComment {
             return .disabled
         } else if compactComments {
             return .trailing

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -22,7 +22,8 @@ struct ExpandedPost: View {
     
     // appstorage
     @AppStorage("defaultCommentSorting") var defaultCommentSorting: CommentSortType = .top
-    @AppStorage("shouldShowUserServerInComment") var shouldShowUserServerInComment: Bool = false
+    @AppStorage("shouldShowUserServerInPost") var shouldShowUserServerInPost: Bool = false
+    @AppStorage("shouldShowCommunityServerInPost") var shouldShowCommunityServerInPost: Bool = false
     @AppStorage("shouldShowUserAvatars") var shouldShowUserAvatars: Bool = false
 
     @EnvironmentObject var appState: AppState
@@ -74,6 +75,22 @@ struct ExpandedPost: View {
         .fancyTabScrollCompatible()
     }
     
+    var userServerInstanceLocation: ServerInstanceLocation {
+        if !shouldShowUserServerInPost {
+            return .disabled
+        } else {
+            return .bottom
+        }
+    }
+    
+    var communityServerInstanceLocation: ServerInstanceLocation {
+        if !shouldShowCommunityServerInPost {
+            return .disabled
+        } else {
+            return .bottom
+        }
+    }
+    
     // MARK: Subviews
 
     /**
@@ -83,7 +100,9 @@ struct ExpandedPost: View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: AppConstants.postAndCommentSpacing) {
                 HStack {
-                    CommunityLinkView(community: post.community)
+                    CommunityLinkView(
+                        community: post.community,
+                        serverInstanceLocation: communityServerInstanceLocation)
                     
                     Spacer()
                     
@@ -96,8 +115,7 @@ struct ExpandedPost: View {
                 )
                 
                 UserProfileLink(user: post.creator,
-                                serverInstanceLocation: .bottom,
-                                postContext: post.post)
+                                serverInstanceLocation: userServerInstanceLocation)
             }
             .padding(.top, AppConstants.postAndCommentSpacing)
             .padding(.horizontal, AppConstants.postAndCommentSpacing)

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -97,12 +97,17 @@ struct FeedPost: View {
         }
     }
 
-    private func calculateServerInstanceLocation() -> ServerInstanceLocation {
-        guard shouldShowUserServerInPost else {
+    var userServerInstanceLocation: ServerInstanceLocation {
+        if !shouldShowUserServerInPost {
             return .disabled
+        } else {
+            return .bottom
         }
-        if postSize == .compact {
-            return .trailing
+    }
+    
+    var communityServerInstanceLocation: ServerInstanceLocation {
+        if !shouldShowCommunityServerInPost {
+            return .disabled
         } else {
             return .bottom
         }
@@ -126,7 +131,9 @@ struct FeedPost: View {
                     //    CommunityLinkView(community: postView.community)
                     // }
                     HStack {
-                        CommunityLinkView(community: postView.community)
+                        CommunityLinkView(
+                            community: postView.community,
+                            serverInstanceLocation: communityServerInstanceLocation)
 
                         Spacer()
 
@@ -149,8 +156,7 @@ struct FeedPost: View {
                     // posting user
                     if showPostCreator {
                         UserProfileLink(user: postView.creator,
-                                        serverInstanceLocation: .bottom,
-                                        postContext: postView.post)
+                                        serverInstanceLocation: userServerInstanceLocation)
                     }
                 }
                 .padding(.top, AppConstants.postAndCommentSpacing)


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #442
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR fixes the "Show instance" toggles for users and communities in posts and comments.  Comments were inverted (off showed the instance, on hid the instance) and posts always would show the instance regardless of setting.

This PR also fixes a bug where every post author in the feed was being rendered as OP (orange). This was because we were including the post context when rendering the label when we shouldn't've been.

## Screenshots and Videos
n/a

## Additional Context
n/a
