### PR TITLE
Fixed navigation tab VO text (partial fix for #440)

### DIFF
--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -46,12 +46,20 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
             }
     }
     
-    private func getAccessibilityLabel(tabIndex: Selection) -> String {
-        if let tabLabel = tabItems[tabIndex]?.tag.labelText {
-            return "\(tabLabel), Tab \(tabIndex.index) of \(tabItems.count.description)"
-        } else {
-            return "Tab \(tabIndex.index) of \(tabItems.count.description)"
+    private func getAccessibilityLabel(tab: Selection) -> String {
+        var label = String()
+        
+        if selection == tab {
+            label += "Selected, "
         }
+        
+        if let tabLabel = tabItems[tab]?.tag.labelText {
+            label += "\(tabLabel), "
+        }
+        
+        label += "Tab \(tab.index) of \(tabItems.count.description)"
+        
+        return label
     }
     
     private var tabBar: some View {
@@ -63,7 +71,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                     tabItems[key]?.label()
                         .accessibilityElement(children: .combine)
                     // IDK how to get the "Tab: 1 of 5" VO working natively so here's a janky solution
-                        .accessibilityLabel(getAccessibilityLabel(tabIndex: key))
+                        .accessibilityLabel(getAccessibilityLabel(tab: key))
                         .frame(maxWidth: .infinity)
                         .contentShape(Rectangle())
                     // high priority to prevent conflict with long press/drag

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -46,6 +46,14 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
             }
     }
     
+    private func getAccessibilityLabel(tabIndex: Selection) -> String {
+        if let tabLabel = tabItems[tabIndex]?.tag.labelText {
+            return "\(tabLabel), Tab \(tabIndex.index) of \(tabItems.count.description)"
+        } else {
+            return "Tab \(tabIndex.index) of \(tabItems.count.description)"
+        }
+    }
+    
     private var tabBar: some View {
         VStack(spacing: 0) {
             Divider()
@@ -55,7 +63,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                     tabItems[key]?.label()
                         .accessibilityElement(children: .combine)
                     // IDK how to get the "Tab: 1 of 5" VO working natively so here's a janky solution
-                        .accessibilityLabel("Tab \(key.index) of \(tabItems.count.description)")
+                        .accessibilityLabel(getAccessibilityLabel(tabIndex: key))
                         .frame(maxWidth: .infinity)
                         .contentShape(Rectangle())
                     // high priority to prevent conflict with long press/drag


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #440
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR does not address the entire bug, but one half of it.  It updates the VO for the navigation tabs to include the label in them.  ("Selected (if selected), Feeds, Tab 1 of 5" instead of just "Tab 1 of 5").

## Screenshots and Videos
n/a

## Additional Context
Perhaps we should split the bug into two separate items.
