### PR TITLE
Deemphasize body in feed of large posts

### DIFF
--- a/Mlem/Views/Shared/Markdown View.swift
+++ b/Mlem/Views/Shared/Markdown View.swift
@@ -171,6 +171,11 @@ extension Theme {
                         .stroke(Color(.secondarySystemBackground), lineWidth: 1.5)
                 )
         }
+    
+    static let mlemDeemphasized = mlem
+        .text {
+            ForegroundColor(.secondary)
+        }
 }
 
 private extension Color {
@@ -216,11 +221,13 @@ struct MarkdownView: View {
     @State var text: String
     let isNsfw: Bool
     let replaceImagesWithEmoji: Bool
+    let isDeemphasized: Bool
     
-    init(text: String, isNsfw: Bool, replaceImagesWithEmoji: Bool = false) {
+    init(text: String, isNsfw: Bool, replaceImagesWithEmoji: Bool = false, isDeemphasized: Bool = false) {
         self.text = text
         self.isNsfw = isNsfw
         self.replaceImagesWithEmoji = replaceImagesWithEmoji
+        self.isDeemphasized = isDeemphasized
     }
 
     var body: some View {
@@ -229,18 +236,19 @@ struct MarkdownView: View {
 
     @MainActor func generateView() -> some View {
         let blocks = parseMarkdownForImages(text: text)
+        let theme: Theme = isDeemphasized ? .mlemDeemphasized : .mlem
         
         return VStack {
             ForEach(blocks) { block in
                 if block.isImage {
                     if replaceImagesWithEmoji {
-                        getMarkdown(text: AppConstants.pictureEmoji.randomElement() ?? "🖼️")
+                        getMarkdown(text: AppConstants.pictureEmoji.randomElement() ?? "🖼️", theme: theme)
                     } else {
                         CachedImage(url: URL(string: String(block.text)))
                             .applyNsfwOverlay(isNsfw)
                     }
                 } else {
-                    getMarkdown(text: String(block.text))
+                    getMarkdown(text: String(block.text), theme: theme)
                 }
             }
         }
@@ -295,9 +303,9 @@ struct MarkdownView: View {
         return blocks
     }
 
-    func getMarkdown(text: String) -> some View {
+    func getMarkdown(text: String, theme: Theme = .mlem) -> some View {
         Markdown(text)
             .frame(maxWidth: .infinity, alignment: .topLeading)
-            .markdownTheme(.mlem)
+            .markdownTheme(theme)
     }
 }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -106,6 +106,8 @@ struct LargePost: View {
                              replaceImagesWithEmoji: true)
                     .lineLimit(8)
                     .font(.subheadline)
+                    .opacity(0.5)
+                    .contentShape(Rectangle())
             }
         }
     }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -103,11 +103,10 @@ struct LargePost: View {
             } else {
                 MarkdownView(text: bodyText.components(separatedBy: .newlines).joined(separator: " "),
                              isNsfw: postView.post.nsfw,
-                             replaceImagesWithEmoji: true)
+                             replaceImagesWithEmoji: true,
+                             isDeemphasized: true)
                     .lineLimit(8)
                     .font(.subheadline)
-                    .opacity(0.5)
-                    .contentShape(Rectangle())
             }
         }
     }


### PR DESCRIPTION
Not sure what you'd like the process to be for this one, but since I couldn't find the task in the backlog I'll just ask you here. Let me know if you'd like this to go another way, or if you want to postpone this until later on.

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - #437
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information
This deemphasises the body in large posts by simply making it 50% opaque.

## Screenshots and Videos
![Simulator Screenshot - iPhone 14 Pro - 2023-08-06 at 20 32 45](https://github.com/mlemgroup/mlem/assets/20093825/09a1e253-24a1-4b26-8260-1cb59c669289)

![Simulator Screenshot - iPhone 14 Pro - 2023-08-06 at 20 32 52](https://github.com/mlemgroup/mlem/assets/20093825/0b0375a9-2289-4cde-85fc-aa04527954f1)

## Additional Context
I'm not sure if that's the correct approach, it's certainly a very simple solution. I'm assuming that links should stay clickable, so the alternative approach I can think of is adding a new theme for the `MarkdownView`. That would set all the colors explicitly which is probably better, but would also introduce some more code to maintain. I can give that one a go if you'd prefer it (or any other if you have a suggestion).
