### PR TITLE
Fixed accessibility on infostack

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2566,7 +2566,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 8B9GNJW88W;
+				DEVELOPMENT_TEAM = 76ULHQGAPN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2584,7 +2584,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = eric.local;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -2607,7 +2607,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 8B9GNJW88W;
+				DEVELOPMENT_TEAM = 76ULHQGAPN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2625,7 +2625,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = eric.local;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2566,7 +2566,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 76ULHQGAPN;
+				DEVELOPMENT_TEAM = 8B9GNJW88W;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2584,7 +2584,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = eric.local;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -2607,7 +2607,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 76ULHQGAPN;
+				DEVELOPMENT_TEAM = 8B9GNJW88W;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2625,7 +2625,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = eric.local;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Mlem/Views/Shared/Components/Buttons/Save.swift
+++ b/Mlem/Views/Shared/Components/Buttons/Save.swift
@@ -40,7 +40,6 @@ struct SaveButton: View {
                 .contentShape(Rectangle())
                 .fontWeight(.medium) // makes it look a little nicer
         }
-        .accessibilityAddTraits(.isButton)
         .accessibilityLabel(saveButtonText)
         .accessibilityAction(.default) { save() }
     }

--- a/Mlem/Views/Shared/Components/Buttons/Vote Complex/Vote Complex.swift
+++ b/Mlem/Views/Shared/Components/Buttons/Vote Complex/Vote Complex.swift
@@ -27,7 +27,6 @@ struct VoteComplex: View {
             }
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityValue("\(score) votes")
         .accessibilityAdjustableAction { direction in
             switch direction {
             case .increment:

--- a/Mlem/Views/Shared/Components/Interaction Bars/InfoStack.swift
+++ b/Mlem/Views/Shared/Components/Interaction Bars/InfoStack.swift
@@ -85,7 +85,7 @@ struct InfoStack: View {
         }
         .accessibilityAddTraits(.isStaticText)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(votes.upvotes) downvotes")
+        .accessibilityLabel("\(votes.downvotes) downvotes")
     }
     
     @ViewBuilder

--- a/Mlem/Views/Shared/Components/Interaction Bars/InfoStack.swift
+++ b/Mlem/Views/Shared/Components/Interaction Bars/InfoStack.swift
@@ -30,41 +30,80 @@ struct InfoStack: View {
         HStack(spacing: 12) {
             if let votes {
                 if votes.showDownvotes {
-                    HStack(spacing: AppConstants.iconToTextSpacing) {
-                        Image(systemName: votes.myVote == .upvote ? AppConstants.fullUpvoteSymbolName : AppConstants.emptyUpvoteSymbolName)
-                        Text(String(votes.upvotes))
-                    }
-                    
-                    HStack(spacing: AppConstants.iconToTextSpacing) {
-                        Image(systemName: votes.myVote == .downvote
-                              ? AppConstants.fullDownvoteSymbolName
-                              : AppConstants.emptyDownvoteSymbolName)
-                        Text(String(votes.downvotes))
-                    }
+                    upvotesView(votes: votes)
+                    downvotesView(votes: votes)
                 } else {
-                    HStack(spacing: AppConstants.iconToTextSpacing) {
-                        Image(systemName: AppConstants.scoringOpToVoteImage[votes.myVote]!)
-                        Text(String(votes.score))
-                    }
+                    netVotesView(votes: votes)
                 }
             }
             
-            if let published = published {
+            if let published {
                 TimestampView(date: published, spacing: AppConstants.iconToTextSpacing)
             }
             
-            if let saved = saved {
-                Image(systemName: saved ? AppConstants.fullSaveSymbolName : AppConstants.emptySaveSymbolName)
+            if let saved {
+                savedView(isSaved: saved)
             }
             
-            if let commentCount = commentCount {
-                HStack(spacing: AppConstants.iconToTextSpacing) {
-                    Image(systemName: "bubble.right")
-                    Text(commentCount.description)
-                }
+            if let commentCount {
+                repliesView(numReplies: commentCount)
             }
         }
         .foregroundColor(.secondary)
         .font(.footnote)
+    }
+    
+    @ViewBuilder
+    func netVotesView(votes: DetailedVotes) -> some View {
+        HStack(spacing: AppConstants.iconToTextSpacing) {
+            Image(systemName: AppConstants.scoringOpToVoteImage[votes.myVote]!)
+            Text(String(votes.score))
+        }
+        .accessibilityAddTraits(.isStaticText)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(votes.score) net votes")
+    }
+    
+    @ViewBuilder
+    func upvotesView(votes: DetailedVotes) -> some View {
+        HStack(spacing: AppConstants.iconToTextSpacing) {
+            Image(systemName: votes.myVote == .upvote ? AppConstants.fullUpvoteSymbolName : AppConstants.emptyUpvoteSymbolName)
+            Text(String(votes.upvotes))
+        }
+        .accessibilityAddTraits(.isStaticText)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(votes.upvotes) upvotes")
+    }
+    
+    @ViewBuilder
+    func downvotesView(votes: DetailedVotes) -> some View {
+        HStack(spacing: AppConstants.iconToTextSpacing) {
+            Image(systemName: votes.myVote == .downvote
+                  ? AppConstants.fullDownvoteSymbolName
+                  : AppConstants.emptyDownvoteSymbolName)
+            Text(String(votes.downvotes))
+        }
+        .accessibilityAddTraits(.isStaticText)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(votes.upvotes) downvotes")
+    }
+    
+    @ViewBuilder
+    func savedView(isSaved: Bool) -> some View {
+        Image(systemName: isSaved ? AppConstants.fullSaveSymbolName : AppConstants.emptySaveSymbolName)
+            .accessibilityAddTraits(.isStaticText)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(isSaved ? "saved" : "")
+    }
+    
+    @ViewBuilder
+    func repliesView(numReplies: Int) -> some View {
+        HStack(spacing: AppConstants.iconToTextSpacing) {
+            Image(systemName: "bubble.right")
+            Text(numReplies.description)
+        }
+        .accessibilityAddTraits(.isStaticText)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(numReplies) comments")
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - *list issue(s) here*
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

Attaches proper accessibility tags to the items in the InfoStack.

Also removed the "votes" label from the vote complex--that item only ever exists in an InfoStack, which by default has the vote count in it, so the total votes were being read twice. This way also respects "show downvotes separately" for free.