### PR TITLE
Change link from #mlemapp to #mlemappspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Hello!
 
-If you're reading this, you probably want to contribute to Mlem. Welcome! We're happy to have you on board. You may wish to join our [Matrix room](https://matrix.to/#/#mlemapp:matrix.org) if you haven't already.
+If you're reading this, you probably want to contribute to Mlem. Welcome! We're happy to have you on board. You may wish to join our [Matrix room](https://matrix.to/#/#mlemappspace:matrix.org) if you haven't already.
 
 ## Prerequesites
 

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 struct AboutView: View {
     @EnvironmentObject var appState: AppState
-    
+
     @Binding var navigationPath: NavigationPath
-    
+
     var body: some View {
         Group {
             List {
@@ -19,37 +19,37 @@ struct AboutView: View {
                     appHeaderView
                         .listRowBackground(Color(.systemGroupedBackground))
                 }
-                
+
                 Section {
                     Link(destination: URL(string: "https://mlem.group/")!) {
                         Label("Website", systemImage: "globe").labelStyle(SquircleLabelStyle(color: .blue))
                     }
                     .buttonStyle(SettingsButtonStyle())
-                    
+
                     Link(destination: URL(string: "https://lemmy.world/c/mlemapp@lemmy.ml")!) {
                         Label("Official Community", systemImage: "house.fill").labelStyle(SquircleLabelStyle(color: .green, fontSize: 15))
                     }
                     .buttonStyle(SettingsButtonStyle())
-                    
-                    Link(destination: URL(string: "https://matrix.to/#/%23mlemapp:matrix.org")!) {
+
+                    Link(destination: URL(string: "https://matrix.to/#/%23mlemappspace:matrix.org")!) {
                         Label("Matrix Room", systemImage: "chart.bar.doc.horizontal").labelStyle(SquircleLabelStyle(color: .teal))
                     }
                     .buttonStyle(SettingsButtonStyle())
                 }
-                
+
                 Section {
                     Link(destination: URL(string: "https://github.com/mlemgroup/mlem")!) {
                         Label("Github Repository", image: "logo.github").labelStyle(SquircleLabelStyle(color: .black))
                     }
                     .buttonStyle(SettingsButtonStyle())
-                    
+
                     NavigationLink {
                         ContributorsView()
                     } label: {
                         Label("Contributors", systemImage: "person.2.fill").labelStyle(SquircleLabelStyle(color: .teal))
                     }
                 }
-                
+
                 Section {
                     NavigationLink {
                         DocumentView(text: privacyPolicy.body)
@@ -72,7 +72,7 @@ struct AboutView: View {
         }
         .navigationTitle("About")
     }
-    
+
     var versionString: String {
         var result = "n/a"
 
@@ -86,7 +86,7 @@ struct AboutView: View {
 
         return result
     }
-    
+
     @ViewBuilder
     private var appHeaderView: some View {
         VStack(spacing: AppConstants.postAndCommentSpacing) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mlem - the iOS Lemmy Client
 
-Mlem is a client for [Lemmy](https://join-lemmy.org) - a Reddit-esque, open-source link aggregator. With Mlem, you can effortlessly participate in the conversation across all Lemmy servers. 
+Mlem is a client for [Lemmy](https://join-lemmy.org) - a Reddit-esque, open-source link aggregator. With Mlem, you can effortlessly participate in the conversation across all Lemmy servers.
 
 [You can download Mlem here.](https://apps.apple.com/gb/app/mlem-for-lemmy/id6450543782) Mlem requires iOS 16 or later.
 
@@ -19,7 +19,7 @@ And that's not all; Mlem is also extensively optimized and performant, which mea
 <img src="https://github.com/mlemgroup/mlem/assets/78750526/30478f39-169d-47ea-b983-a453af2b0959" width="30%">
 
 ## Want to chat about Mlem?
-You're welcome to join our [community on lemmy.ml](https://lemmy.ml/c/mlemapp) or [Matrix room](https://matrix.to/#/#mlemapp:matrix.org)!
+You're welcome to join our [community on lemmy.ml](https://lemmy.ml/c/mlemapp) or [Matrix room](https://matrix.to/#/#mlemappspace:matrix.org)!
 
 ## Contributing
 


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Fixes #415
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR changes the default URL to a new one with fresh cache, to allow people to join the right space, if the old one was cached wrongly

I've added an extra local alias to the space so that this one directs the correct way
