### PR TITLE
Profile Nicknames

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -287,6 +287,7 @@
 		CD6483342A39F1C100EE6CA3 /* API Post View - Post Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6483332A39F1C100EE6CA3 /* API Post View - Post Type.swift */; };
 		CD6483362A39F20800EE6CA3 /* Post Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6483352A39F20800EE6CA3 /* Post Type.swift */; };
 		CD6483382A3A0F2200EE6CA3 /* NSFW Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6483372A3A0F2200EE6CA3 /* NSFW Tag.swift */; };
+		CD6483A62A82FAF200A5AE84 /* ProfileTabLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6483A52A82FAF200A5AE84 /* ProfileTabLabel.swift */; };
 		CD69F55B2A400D820028D4F7 /* App Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F55A2A400D820028D4F7 /* App Theme.swift */; };
 		CD69F55D2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F55C2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift */; };
 		CD69F55F2A40121D0028D4F7 /* Ellipsis Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F55E2A40121D0028D4F7 /* Ellipsis Menu.swift */; };
@@ -662,6 +663,7 @@
 		CD6483332A39F1C100EE6CA3 /* API Post View - Post Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API Post View - Post Type.swift"; sourceTree = "<group>"; };
 		CD6483352A39F20800EE6CA3 /* Post Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post Type.swift"; sourceTree = "<group>"; };
 		CD6483372A3A0F2200EE6CA3 /* NSFW Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFW Tag.swift"; sourceTree = "<group>"; };
+		CD6483A52A82FAF200A5AE84 /* ProfileTabLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabLabel.swift; sourceTree = "<group>"; };
 		CD69F55A2A400D820028D4F7 /* App Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App Theme.swift"; sourceTree = "<group>"; };
 		CD69F55C2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceStyle - SettingsOption conformant.swift"; sourceTree = "<group>"; };
 		CD69F55E2A40121D0028D4F7 /* Ellipsis Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ellipsis Menu.swift"; sourceTree = "<group>"; };
@@ -1723,6 +1725,7 @@
 				CD05E7782A4E381A0081D102 /* PostSize.swift */,
 				CDC1C93B2A7AA76000072E3D /* InternetSpeed.swift */,
 				CDC1C9402A7ABA9C00072E3D /* ReadMarkStyle.swift */,
+				CD6483A52A82FAF200A5AE84 /* ProfileTabLabel.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -2346,6 +2349,7 @@
 				637218742A3A2AAD008C4816 /* ListCommunities.swift in Sources */,
 				CD1446182A58FC3B00610EF1 /* InfoStack.swift in Sources */,
 				CDE9CE4F2A7B0B1B002B97DD /* Haptic.swift in Sources */,
+				CD6483A62A82FAF200A5AE84 /* ProfileTabLabel.swift in Sources */,
 				6386E0402A045723006B3C1D /* Website Icon Complex.swift in Sources */,
 				5064D0412A6E63E000B22EE3 /* Task+Notifiable.swift in Sources */,
 				63F0C7BD2A058CD200A18C5D /* Check if Endpoint Exists.swift in Sources */,

--- a/Mlem/App State.swift
+++ b/Mlem/App State.swift
@@ -50,6 +50,10 @@ class AppState: ObservableObject {
         accountUpdated()
     }
     
+    func setNickname(nickname: String) {
+        currentActiveAccount.storedNickname = nickname
+    }
+    
     private func accountUpdated() {
         // ensure our client session is updated
         apiClient.configure(for: currentActiveAccount)

--- a/Mlem/App State.swift
+++ b/Mlem/App State.swift
@@ -16,6 +16,7 @@ class AppState: ObservableObject {
     @AppStorage("defaultAccountId") var defaultAccountId: Int?
     @Binding private var selectedAccount: SavedAccount?
     @Published private(set) var currentActiveAccount: SavedAccount
+    @Published private(set) var currentNickname: String
     
     @Published var contextualError: ContextualError?
     
@@ -28,6 +29,7 @@ class AppState: ObservableObject {
     init(defaultAccount: SavedAccount, selectedAccount: Binding<SavedAccount?>) {
         _selectedAccount = selectedAccount
         self.currentActiveAccount = defaultAccount
+        self.currentNickname = defaultAccount.nickname
         defaultAccountId = currentActiveAccount.id
         accountUpdated()
     }
@@ -50,8 +52,12 @@ class AppState: ObservableObject {
         accountUpdated()
     }
     
-    func setNickname(nickname: String) {
-        currentActiveAccount.storedNickname = nickname
+    /**
+     Update the nickname. This is needed to quickly propagate changes from settings over to the tab bar, since nickname doesn't affect account identity and so changing it doesn't always prompt redraws
+     */
+    func changeDisplayedNickname(to nickname: String) {
+        print("changing to \(nickname)")
+        currentNickname = nickname
     }
     
     private func accountUpdated() {

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -130,7 +130,8 @@ struct ContentView: View {
     }
     
     func computeUsername(account: SavedAccount) -> String {
-        return showUsernameInNavigationBar ? account.username : "Profile"
+        // return showUsernameInNavigationBar ? account.username : "Profile"
+        account.nickname
     }
     
     func showAccountSwitcherDragCallback() {

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -29,9 +29,9 @@ struct ContentView: View {
     
     @State private var isPresentingAccountSwitcher: Bool = false
     
-    @AppStorage("showUsernameInNavigationBar") var showUsernameInNavigationBar: Bool = true
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true
     @AppStorage("homeButtonExists") var homeButtonExists: Bool = false
+    @AppStorage("profileTabLabel") var profileTabLabel: ProfileTabLabel = .username
     
     var accessibilityFont: Bool { UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory }
     
@@ -130,8 +130,12 @@ struct ContentView: View {
     }
     
     func computeUsername(account: SavedAccount) -> String {
-        // return showUsernameInNavigationBar ? account.username : "Profile"
-        account.nickname
+        switch profileTabLabel {
+        case .username: return account.username
+        case .instance: return account.hostName ?? account.username
+        case .nickname: return appState.currentNickname
+        case .anonymous: return "Profile"
+        }
     }
     
     func showAccountSwitcherDragCallback() {

--- a/Mlem/Enums/FeedType.swift
+++ b/Mlem/Enums/FeedType.swift
@@ -29,7 +29,7 @@ extension FeedType: AssociatedIcon {
         switch self {
         case .all: return AppConstants.federatedFeedSymbolName
         case .local: return AppConstants.localFeedSymbolName
-        case .subscribed: return AppConstants.subscribeSymbolName
+        case .subscribed: return AppConstants.subscribedFeedSymbolName
         }
     }
     
@@ -38,6 +38,17 @@ extension FeedType: AssociatedIcon {
         case .all: return AppConstants.federatedFeedSymbolName
         case .local: return AppConstants.localFeedSymbolNameFill
         case .subscribed: return AppConstants.subscribedFeedSymbolNameFill
+        }
+    }
+    
+    /**
+     Icon to use in system settings. This should be removed when the "unified symbol handling" is closed
+     */
+    var settingsIconName: String {
+        switch self {
+        case .all: return "circle.hexagongrid"
+        case .local: return "house"
+        case .subscribed: return "newspaper"
         }
     }
 }

--- a/Mlem/Enums/Settings/CommentSortType.swift
+++ b/Mlem/Enums/Settings/CommentSortType.swift
@@ -27,7 +27,7 @@ enum CommentSortType: String, Codable, CaseIterable, Identifiable {
         }
     }
     
-    var imageName: String {
+    var iconName: String {
         switch self {
         case .new:
             return "sun.max"
@@ -38,5 +38,11 @@ enum CommentSortType: String, Codable, CaseIterable, Identifiable {
         case .old:
             return "books.vertical"
         }
+    }
+}
+
+extension CommentSortType: SettingsOptions {
+    var label: String {
+        self.rawValue.capitalized
     }
 }

--- a/Mlem/Enums/Settings/PostSortType.swift
+++ b/Mlem/Enums/Settings/PostSortType.swift
@@ -79,6 +79,12 @@ enum PostSortType: String, Codable, CaseIterable, Identifiable {
     }
 }
 
+extension PostSortType: SettingsOptions {
+    var label: String {
+        self.shortDescription
+    }
+}
+
 extension PostSortType: AssociatedIcon {
     var iconName: String {
         switch self {

--- a/Mlem/Enums/Settings/PostSortType.swift
+++ b/Mlem/Enums/Settings/PostSortType.swift
@@ -27,8 +27,33 @@ enum PostSortType: String, Codable, CaseIterable, Identifiable {
     
     static var outerTypes: [PostSortType] {[.hot, .active, .new, .old, .newComments, .mostComments]}
     static var topTypes: [PostSortType] {[.topHour, .topSixHour, .topTwelveHour, .topDay, .topWeek, .topMonth, .topYear, .topAll]}
+    
+    var description: String {
+        switch self {
+        case .topHour:
+            return "Top of the last hour"
+        case .topSixHour:
+            return "Top of the last six hours"
+        case .topTwelveHour:
+            return "Top of the last twelve hours"
+        case .topDay:
+            return "Top of today"
+        case .topWeek:
+            return "Top of the week"
+        case .topMonth:
+            return "Top of the month"
+        case .topYear:
+            return "Top of the year"
+        case .topAll:
+            return "Top of all time"
+        default:
+            return self.label
+        }
+    }
+}
 
-    var shortDescription: String {
+extension PostSortType: SettingsOptions {
+    var label: String {
         switch self {
         case .newComments:
             return "New comments"
@@ -53,35 +78,6 @@ enum PostSortType: String, Codable, CaseIterable, Identifiable {
         default:
             return self.rawValue
         }
-    }
-    
-    var description: String {
-        switch self {
-        case .topHour:
-            return "Top of the last hour"
-        case .topSixHour:
-            return "Top of the last six hours"
-        case .topTwelveHour:
-            return "Top of the last twelve hours"
-        case .topDay:
-            return "Top of today"
-        case .topWeek:
-            return "Top of the week"
-        case .topMonth:
-            return "Top of the month"
-        case .topYear:
-            return "Top of the year"
-        case .topAll:
-            return "Top of all time"
-        default:
-            return self.shortDescription
-        }
-    }
-}
-
-extension PostSortType: SettingsOptions {
-    var label: String {
-        self.shortDescription
     }
 }
 

--- a/Mlem/Enums/Settings/ProfileTabLabel.swift
+++ b/Mlem/Enums/Settings/ProfileTabLabel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum ProfileTabLabel: String {
-    case username, instance, nickname
+    case username, instance, nickname, anonymous
 }
 
 extension ProfileTabLabel: SettingsOptions {

--- a/Mlem/Enums/Settings/ProfileTabLabel.swift
+++ b/Mlem/Enums/Settings/ProfileTabLabel.swift
@@ -1,0 +1,24 @@
+//
+//  ProfileTabLabel.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-08-08.
+//
+
+import Foundation
+
+enum ProfileTabLabel: String {
+    case username, instance, nickname
+}
+
+extension ProfileTabLabel: SettingsOptions {
+    var label: String { self.rawValue.capitalized }
+    
+    var id: Self { self }
+}
+
+extension ProfileTabLabel: AssociatedIcon {
+    var iconName: String { "person.text.rectangle" }
+    
+    var iconNameFill: String { "person.text.rectangle.fill"}
+}

--- a/Mlem/Enums/Settings/Vote Complex Style.swift
+++ b/Mlem/Enums/Settings/Vote Complex Style.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum VoteComplexStyle: String, CaseIterable, Identifiable, SettingsOptions {
-    case standard, symmetric, plain
+    case plain, classic, symmetric
 
     var id: Self { self }
 

--- a/Mlem/Haptics/Haptic Manager.swift
+++ b/Mlem/Haptics/Haptic Manager.swift
@@ -23,7 +23,7 @@ class HapticManager {
     
     init() {
         // create and start the engine if this device supports haptics
-        print("initialized haptic engine")
+        print("Initialized haptic engine")
         hapticEngine = initEngine()
         
         // if the engine stops, tell us why

--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -12,7 +12,7 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
     let instanceLink: URL
     let accessToken: String
     let username: String
-    var storedNickname: String?
+    let storedNickname: String?
     
     init(id: Int,
          instanceLink: URL,
@@ -24,6 +24,19 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
         self.accessToken = accessToken
         self.username = username
         self.storedNickname = storedNickname
+    }
+    
+    /**
+     Convenience initializer to create an equal copy with different non-identifying properties.
+     */
+    init(from account: SavedAccount,
+         accessToken: String? = nil,
+         storedNickname: String? = nil) {
+        self.id = account.id
+        self.instanceLink = account.instanceLink
+        self.accessToken = accessToken ?? account.accessToken
+        self.username = account.username
+        self.storedNickname = storedNickname ?? account.storedNickname
     }
   
     // convenience
@@ -41,6 +54,7 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
         try container.encode(self.instanceLink, forKey: .instanceLink)
         try container.encode("redacted", forKey: .accessToken)
         try container.encode(self.username, forKey: .username)
+        try container.encode(self.storedNickname, forKey: .storedNickname)
     }
     
     static func == (lhs: SavedAccount, rhs: SavedAccount) -> Bool {

--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -12,9 +12,27 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
     let instanceLink: URL
     let accessToken: String
     let username: String
+    var storedNickname: String?
+    
+    init(id: Int,
+         instanceLink: URL,
+         accessToken: String,
+         username: String,
+         storedNickname: String? = nil) {
+        self.id = id
+        self.instanceLink = instanceLink
+        self.accessToken = accessToken
+        self.username = username
+        self.storedNickname = storedNickname
+    }
   
     // convenience
     var hostName: String? { instanceLink.host?.description }
+    
+    /**
+     If there is a nickname stored, returns that; otherwise returns the username
+     */
+    var nickname: String { storedNickname ?? username }
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)

--- a/Mlem/Repositories/PersistenceRepository.swift
+++ b/Mlem/Repositories/PersistenceRepository.swift
@@ -69,13 +69,8 @@ class PersistenceRepository {
             guard let token = keychainAccess("\(account.id)_accessToken") else {
                 return nil
             }
-
-            return SavedAccount(
-                id: account.id,
-                instanceLink: account.instanceLink,
-                accessToken: token,
-                username: account.username
-            )
+            
+            return SavedAccount(from: account, accessToken: token)
         }
     }
     

--- a/Mlem/Views/Shared/Components/Buttons/Vote Complex/Standard Vote Complex.swift
+++ b/Mlem/Views/Shared/Components/Buttons/Vote Complex/Standard Vote Complex.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-struct StandardVoteComplex: View {
+struct ClassicVoteComplex: View {
     
     @EnvironmentObject var appState: AppState
     

--- a/Mlem/Views/Shared/Components/Buttons/Vote Complex/Vote Complex.swift
+++ b/Mlem/Views/Shared/Components/Buttons/Vote Complex/Vote Complex.swift
@@ -18,12 +18,12 @@ struct VoteComplex: View {
     var body: some View {
         Group {
             switch style {
-            case .standard:
-                StandardVoteComplex(vote: vote, score: score, upvote: upvote, downvote: downvote)
-            case .symmetric:
-                SymmetricVoteComplex(vote: vote, score: score, upvote: upvote, downvote: downvote)
             case .plain:
                 PlainVoteComplex(vote: vote, score: score, upvote: upvote, downvote: downvote)
+            case .classic:
+                ClassicVoteComplex(vote: vote, score: score, upvote: upvote, downvote: downvote)
+            case .symmetric:
+                SymmetricVoteComplex(vote: vote, score: score, upvote: upvote, downvote: downvote)
             }
         }
         .accessibilityElement(children: .ignore)

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -172,13 +172,13 @@ struct ExpandedPost: View {
                 Button {
                     commentSortingType = type
                 } label: {
-                    Label(type.description, systemImage: type.imageName)
+                    Label(type.description, systemImage: type.iconName)
                 }
                 .disabled(type == commentSortingType)
             }
 
         } label: {
-            Label(commentSortingType.description, systemImage: commentSortingType.imageName)
+            Label(commentSortingType.description, systemImage: commentSortingType.iconName)
         }
     }
 }

--- a/Mlem/Views/Shared/TokenRefreshView.swift
+++ b/Mlem/Views/Shared/TokenRefreshView.swift
@@ -246,14 +246,7 @@ struct TokenRefreshView: View {
         try? await Task.sleep(for: .seconds(0.5))
         
         await MainActor.run {
-            refreshedAccount(
-                .init(
-                    id: account.id,
-                    instanceLink: account.instanceLink,
-                    accessToken: newToken,
-                    username: account.username
-                )
-            )
+            refreshedAccount(.init(from: account, accessToken: newToken))
             dismiss()
         }
     }

--- a/Mlem/Views/Tabs/Feeds/Components/PostSortMenu.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/PostSortMenu.swift
@@ -17,7 +17,7 @@ struct PostSortMenu: View {
         Menu {
             ForEach(PostSortType.outerTypes, id: \.self) { type in
                 OptionButton(
-                    title: type.shortDescription,
+                    title: type.label,
                     imageName: type.iconName,
                     option: type,
                     selectedOption: $selectedSortingOption
@@ -27,7 +27,7 @@ struct PostSortMenu: View {
             Menu {
                 ForEach(PostSortType.topTypes, id: \.self) { type in
                     OptionButton(
-                        title: type.shortDescription,
+                        title: type.label,
                         imageName: type.iconName,
                         option: type,
                         selectedOption: $selectedSortingOption
@@ -43,7 +43,7 @@ struct PostSortMenu: View {
                     Spacer()
                     Image(systemName: selectedSortingOption.iconName)
                         .tint(.pink)
-                    Text(selectedSortingOption.shortDescription)
+                    Text(selectedSortingOption.label)
                         .tint(.pink)
                 }
                 .frame(maxWidth: .infinity)

--- a/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
@@ -8,12 +8,22 @@
 import SwiftUI
 
 struct SwitchableSettingsItem: View {
-    @State var settingPictureSystemName: String
-    @State var settingPictureColor: Color
-
-    @State var settingName: String
+    let settingPictureSystemName: String
+    let settingPictureColor: Color
+    let settingName: String
 
     @Binding var isTicked: Bool
+    
+    init(settingPictureSystemName: String,
+         settingPictureColor: Color = .pink,
+         settingName: String,
+         isTicked: Binding<Bool>) {
+        self.settingPictureSystemName = settingPictureSystemName
+        self.settingPictureColor = settingPictureColor
+        self.settingName = settingName
+        
+        self._isTicked = isTicked
+    }
 
     var body: some View {
         Toggle(isOn: $isTicked) {

--- a/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
@@ -16,11 +16,13 @@ struct SwitchableSettingsItem: View {
     @Binding var isTicked: Bool
 
     var body: some View {
-        HStack {
-            Image(systemName: settingPictureSystemName)
-                .foregroundColor(settingPictureColor)
-
-            Toggle(settingName, isOn: $isTicked)
+        Toggle(isOn: $isTicked) {
+            Label {
+                Text(settingName)
+            } icon: {
+                Image(systemName: settingPictureSystemName)
+                    .foregroundColor(settingPictureColor)
+            }
         }
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -59,7 +59,7 @@ struct AccessibilitySettingsView: View {
             } header: {
                 Text("Differentiate Without Color")
             } footer: {
-                Text("Configure how this app behaves when the system \"differentiate without color\" option is on")
+                Text("Configure how this app behaves when the system \"differentiate without color\" option is on.")
             }
         }
         .fancyTabScrollCompatible()

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -36,6 +36,7 @@ struct AccessibilitySettingsView: View {
                         Spacer()
                         
                         Text(String(format: "%.0f", readBarThicknessSlider))
+                            .foregroundColor(.secondary)
                     }
                     .frame(maxWidth: .infinity)
                     

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -26,47 +26,47 @@ struct CommentSettingsView: View {
             Section("Comment Size") {
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.compactSymbolName,
                                        settingPictureColor: .pink,
-                                       settingName: "Compact comments",
+                                       settingName: "Compact Comments",
                                        isTicked: $compactComments)
             }
             
             Section("Display Sides") {
                 SwitchableSettingsItem(settingPictureSystemName: "arrow.up.arrow.down",
                                        settingPictureColor: .pink,
-                                       settingName: "Show vote buttons on right",
+                                       settingName: "Vote Buttons On Right",
                                        isTicked: $shouldShowVoteComplexOnRight)
             }
 
             Section("Interactions and Info") {
                 SelectableSettingsItem(
                     settingIconSystemName: "arrow.up.arrow.down.square",
-                    settingName: "Vote buttons",
+                    settingName: "Vote Buttons",
                     currentValue: $commentVoteComplexStyle,
                     options: VoteComplexStyle.allCases
                 )
                 SwitchableSettingsItem(settingPictureSystemName: "server.rack",
                                                            settingPictureColor: .pink,
-                                                           settingName: "Show user server instance",
+                                                           settingName: "Show User Server Instance",
                                                            isTicked: $shouldShowUserServerInComment)
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.emptyUpvoteSymbolName,
                                        settingPictureColor: .pink,
-                                       settingName: "Show score in info",
+                                       settingName: "Show Score In Info",
                                        isTicked: $shouldShowScoreInCommentBar)
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.generalVoteSymbolName,
                                        settingPictureColor: .pink,
-                                       settingName: "Show downvotes separately",
+                                       settingName: "Show Downvotes Separately",
                                        isTicked: $showCommentDownvotesSeparately)
                 SwitchableSettingsItem(settingPictureSystemName: "clock",
                                        settingPictureColor: .pink,
-                                       settingName: "Show time posted in info",
+                                       settingName: "Show Time Posted In Info",
                                        isTicked: $shouldShowTimeInCommentBar)
                 SwitchableSettingsItem(settingPictureSystemName: "bookmark",
                                        settingPictureColor: .pink,
-                                       settingName: "Show saved status in info",
+                                       settingName: "Show Saved Status In Info",
                                        isTicked: $shouldShowSavedInCommentBar)
                 SwitchableSettingsItem(settingPictureSystemName: "bubble.right",
                                        settingPictureColor: .pink,
-                                       settingName: "Show replies in info",
+                                       settingName: "Show Replies In Info",
                                        isTicked: $shouldShowRepliesInCommentBar)
             }
         }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -40,7 +40,7 @@ struct CommentSettingsView: View {
             Section("Interactions and Info") {
                 SelectableSettingsItem(
                     settingIconSystemName: "arrow.up.arrow.down.square",
-                    settingName: "Vote complex style",
+                    settingName: "Vote buttons",
                     currentValue: $commentVoteComplexStyle,
                     options: VoteComplexStyle.allCases
                 )

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -25,14 +25,12 @@ struct CommentSettingsView: View {
         List {
             Section("Comment Size") {
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.compactSymbolName,
-                                       settingPictureColor: .pink,
                                        settingName: "Compact Comments",
                                        isTicked: $compactComments)
             }
             
             Section("Display Sides") {
                 SwitchableSettingsItem(settingPictureSystemName: "arrow.up.arrow.down",
-                                       settingPictureColor: .pink,
                                        settingName: "Vote Buttons On Right",
                                        isTicked: $shouldShowVoteComplexOnRight)
             }
@@ -45,27 +43,21 @@ struct CommentSettingsView: View {
                     options: VoteComplexStyle.allCases
                 )
                 SwitchableSettingsItem(settingPictureSystemName: "server.rack",
-                                                           settingPictureColor: .pink,
-                                                           settingName: "Show User Server Instance",
-                                                           isTicked: $shouldShowUserServerInComment)
+                                       settingName: "Show User Server Instance",
+                                       isTicked: $shouldShowUserServerInComment)
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.emptyUpvoteSymbolName,
-                                       settingPictureColor: .pink,
                                        settingName: "Show Score In Info",
                                        isTicked: $shouldShowScoreInCommentBar)
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.generalVoteSymbolName,
-                                       settingPictureColor: .pink,
                                        settingName: "Show Downvotes Separately",
                                        isTicked: $showCommentDownvotesSeparately)
                 SwitchableSettingsItem(settingPictureSystemName: "clock",
-                                       settingPictureColor: .pink,
                                        settingName: "Show Time Posted In Info",
                                        isTicked: $shouldShowTimeInCommentBar)
                 SwitchableSettingsItem(settingPictureSystemName: "bookmark",
-                                       settingPictureColor: .pink,
                                        settingName: "Show Saved Status In Info",
                                        isTicked: $shouldShowSavedInCommentBar)
                 SwitchableSettingsItem(settingPictureSystemName: "bubble.right",
-                                       settingPictureColor: .pink,
                                        settingName: "Show Replies In Info",
                                        isTicked: $shouldShowRepliesInCommentBar)
             }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
@@ -16,14 +16,12 @@ struct CommunitySettingsView: View {
         Form {
             SwitchableSettingsItem(
                 settingPictureSystemName: "person.2.circle.fill",
-                settingPictureColor: .pink,
                 settingName: "Show Community Avatars",
                 isTicked: $shouldShowCommunityIcons
             )
 
             SwitchableSettingsItem(
                 settingPictureSystemName: "rectangle.grid.1x2",
-                settingPictureColor: .pink,
                 settingName: "Show Community Banners",
                 isTicked: $shouldShowCommunityHeaders
             )

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
@@ -17,14 +17,14 @@ struct CommunitySettingsView: View {
             SwitchableSettingsItem(
                 settingPictureSystemName: "person.2.circle.fill",
                 settingPictureColor: .pink,
-                settingName: "Show community avatars",
+                settingName: "Show Community Avatars",
                 isTicked: $shouldShowCommunityIcons
             )
 
             SwitchableSettingsItem(
                 settingPictureSystemName: "rectangle.grid.1x2",
                 settingPictureColor: .pink,
-                settingName: "Show community banners",
+                settingName: "Show Community Banners",
                 isTicked: $shouldShowCommunityHeaders
             )
         }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -87,7 +87,7 @@ struct PostSettingsView: View {
             Section("Interactions and Info") {
                 SelectableSettingsItem(
                     settingIconSystemName: "arrow.up.arrow.down.square",
-                    settingName: "Vote complex style",
+                    settingName: "Vote buttons",
                     currentValue: $postVoteComplexStyle,
                     options: VoteComplexStyle.allCases
                 )

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -44,7 +44,7 @@ struct PostSettingsView: View {
             Section("Post Size") {
                 SelectableSettingsItem(
                     settingIconSystemName: "rectangle.compress.vertical",
-                    settingName: "Post size",
+                    settingName: "Post Size",
                     currentValue: $postSize,
                     options: PostSize.allCases
                 )
@@ -53,63 +53,63 @@ struct PostSettingsView: View {
             Section("Display Sides") {
                 SwitchableSettingsItem(settingPictureSystemName: "arrow.up.arrow.down",
                                        settingPictureColor: .pink,
-                                       settingName: "Show vote buttons on right",
+                                       settingName: "Vote Buttons On Right",
                                        isTicked: $shouldShowVoteComplexOnRight)
                 
                 SwitchableSettingsItem(settingPictureSystemName: "photo",
                                        settingPictureColor: .pink,
-                                       settingName: "Show thumbnails on right",
+                                       settingName: "Thumbnails On Right",
                                        isTicked: $shouldShowThumbnailsOnRight)
             }
             
             Section("Body") {
                 SwitchableSettingsItem(settingPictureSystemName: "server.rack",
                                        settingPictureColor: .pink,
-                                       settingName: "Show user server instance",
+                                       settingName: "Show User Server Instance",
                                        isTicked: $shouldShowUserServerInPost)
                 
                 SwitchableSettingsItem(settingPictureSystemName: "server.rack",
                                        settingPictureColor: .pink,
-                                       settingName: "Show community server instance",
+                                       settingName: "Show Community Server Instance",
                                        isTicked: $shouldShowCommunityServerInPost)
                 
                 SwitchableSettingsItem(settingPictureSystemName: "signature",
                                        settingPictureColor: .pink,
-                                       settingName: "Show post creator",
+                                       settingName: "Show Post Creator",
                                        isTicked: $shouldShowPostCreator)
                 
                 SwitchableSettingsItem(settingPictureSystemName: "photo",
                                        settingPictureColor: .pink,
-                                       settingName: "Show post thumbnails",
+                                       settingName: "Show Post Thumbnails",
                                        isTicked: $shouldShowPostThumbnails)
             }
             
             Section("Interactions and Info") {
                 SelectableSettingsItem(
                     settingIconSystemName: "arrow.up.arrow.down.square",
-                    settingName: "Vote buttons",
+                    settingName: "Vote Buttons",
                     currentValue: $postVoteComplexStyle,
                     options: VoteComplexStyle.allCases
                 )
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.emptyUpvoteSymbolName,
                                        settingPictureColor: .pink,
-                                       settingName: "Show score in info",
+                                       settingName: "Show Score In Info",
                                        isTicked: $shouldShowScoreInPostBar)
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.generalVoteSymbolName,
                                        settingPictureColor: .pink,
-                                       settingName: "Show downvotes separately",
+                                       settingName: "Show Downvotes Separately",
                                        isTicked: $showDownvotesSeparately)
                 SwitchableSettingsItem(settingPictureSystemName: "clock",
                                        settingPictureColor: .pink,
-                                       settingName: "Show time posted in info",
+                                       settingName: "Show Time Posted In Info",
                                        isTicked: $shouldShowTimeInPostBar)
                 SwitchableSettingsItem(settingPictureSystemName: "bookmark",
                                        settingPictureColor: .pink,
-                                       settingName: "Show saved status in info",
+                                       settingName: "Show Saved Status In Info",
                                        isTicked: $shouldShowSavedInPostBar)
                 SwitchableSettingsItem(settingPictureSystemName: "bubble.right",
                                        settingPictureColor: .pink,
-                                       settingName: "Show replies in info",
+                                       settingName: "Show Replies In Info",
                                        isTicked: $shouldShowRepliesInPostBar)
             }
             
@@ -142,20 +142,20 @@ struct PostSettingsView: View {
                 SwitchableSettingsItem(
                     settingPictureSystemName: "network",
                     settingPictureColor: .pink,
-                    settingName: "Show website address",
+                    settingName: "Show Website Address",
                     isTicked: $shouldShowWebsiteHost
                 )
                 SwitchableSettingsItem(
                     settingPictureSystemName: "globe",
                     settingPictureColor: .pink,
-                    settingName: "Show website icon",
+                    settingName: "Show Website Icon",
                     isTicked: $shouldShowWebsiteIcon
                 )
                 .disabled(!shouldShowWebsiteHost)
                 SwitchableSettingsItem(
                     settingPictureSystemName: "photo.circle.fill",
                     settingPictureColor: .pink,
-                    settingName: "Show website preview",
+                    settingName: "Show Website Preview",
                     isTicked: $shouldShowWebsitePreviews
                 )
             }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -52,34 +52,28 @@ struct PostSettingsView: View {
             
             Section("Display Sides") {
                 SwitchableSettingsItem(settingPictureSystemName: "arrow.up.arrow.down",
-                                       settingPictureColor: .pink,
                                        settingName: "Vote Buttons On Right",
                                        isTicked: $shouldShowVoteComplexOnRight)
                 
                 SwitchableSettingsItem(settingPictureSystemName: "photo",
-                                       settingPictureColor: .pink,
                                        settingName: "Thumbnails On Right",
                                        isTicked: $shouldShowThumbnailsOnRight)
             }
             
             Section("Body") {
                 SwitchableSettingsItem(settingPictureSystemName: "server.rack",
-                                       settingPictureColor: .pink,
                                        settingName: "Show User Server Instance",
                                        isTicked: $shouldShowUserServerInPost)
                 
                 SwitchableSettingsItem(settingPictureSystemName: "server.rack",
-                                       settingPictureColor: .pink,
                                        settingName: "Show Community Server Instance",
                                        isTicked: $shouldShowCommunityServerInPost)
                 
                 SwitchableSettingsItem(settingPictureSystemName: "signature",
-                                       settingPictureColor: .pink,
                                        settingName: "Show Post Creator",
                                        isTicked: $shouldShowPostCreator)
                 
                 SwitchableSettingsItem(settingPictureSystemName: "photo",
-                                       settingPictureColor: .pink,
                                        settingName: "Show Post Thumbnails",
                                        isTicked: $shouldShowPostThumbnails)
             }
@@ -92,23 +86,18 @@ struct PostSettingsView: View {
                     options: VoteComplexStyle.allCases
                 )
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.emptyUpvoteSymbolName,
-                                       settingPictureColor: .pink,
                                        settingName: "Show Score In Info",
                                        isTicked: $shouldShowScoreInPostBar)
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.generalVoteSymbolName,
-                                       settingPictureColor: .pink,
                                        settingName: "Show Downvotes Separately",
                                        isTicked: $showDownvotesSeparately)
                 SwitchableSettingsItem(settingPictureSystemName: "clock",
-                                       settingPictureColor: .pink,
                                        settingName: "Show Time Posted In Info",
                                        isTicked: $shouldShowTimeInPostBar)
                 SwitchableSettingsItem(settingPictureSystemName: "bookmark",
-                                       settingPictureColor: .pink,
                                        settingName: "Show Saved Status In Info",
                                        isTicked: $shouldShowSavedInPostBar)
                 SwitchableSettingsItem(settingPictureSystemName: "bubble.right",
-                                       settingPictureColor: .pink,
                                        settingName: "Show Replies In Info",
                                        isTicked: $shouldShowRepliesInPostBar)
             }
@@ -141,20 +130,17 @@ struct PostSettingsView: View {
                 
                 SwitchableSettingsItem(
                     settingPictureSystemName: "network",
-                    settingPictureColor: .pink,
                     settingName: "Show Website Address",
                     isTicked: $shouldShowWebsiteHost
                 )
                 SwitchableSettingsItem(
                     settingPictureSystemName: "globe",
-                    settingPictureColor: .pink,
                     settingName: "Show Website Icon",
                     isTicked: $shouldShowWebsiteIcon
                 )
                 .disabled(!shouldShowWebsiteHost)
                 SwitchableSettingsItem(
                     settingPictureSystemName: "photo.circle.fill",
-                    settingPictureColor: .pink,
                     settingName: "Show Website Preview",
                     isTicked: $shouldShowWebsitePreviews
                 )

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct TabBarSettingsView: View {
-    @AppStorage("showUsernameInNavigationBar") var showUsernameInNavigationBar: Bool = true
     @AppStorage("profileTabLabel") var profileTabLabel: ProfileTabLabel = .username
     @AppStorage("showTabNames") var showTabNames: Bool = true
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -16,13 +16,13 @@ struct TabBarSettingsView: View {
         Form {
             SwitchableSettingsItem(settingPictureSystemName: "tag",
                                    settingPictureColor: .pink,
-                                   settingName: "Show tab labels",
+                                   settingName: "Show Tab Labels",
                                    isTicked: $showTabNames)
             
             Section {
                 SwitchableSettingsItem(settingPictureSystemName: "person.text.rectangle",
                                        settingPictureColor: .pink,
-                                       settingName: "Show username",
+                                       settingName: "Show Username",
                                        isTicked: $showUsernameInNavigationBar)
             } footer: {
                 // swiftlint:disable line_length
@@ -32,7 +32,7 @@ struct TabBarSettingsView: View {
             
             SwitchableSettingsItem(settingPictureSystemName: "envelope.badge",
                                    settingPictureColor: .pink,
-                                   settingName: "Show unread count",
+                                   settingName: "Show Unread Count",
                                    isTicked: $showInboxUnreadBadge)
         }
         .fancyTabScrollCompatible()

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -14,17 +14,26 @@ struct TabBarSettingsView: View {
         
     var body: some View {
         Form {
-            Toggle("Show Labels", isOn: $showTabNames)
+            SwitchableSettingsItem(settingPictureSystemName: "tag",
+                                   settingPictureColor: .pink,
+                                   settingName: "Show tab labels",
+                                   isTicked: $showTabNames)
             
             Section {
-                Toggle("Show Username", isOn: $showUsernameInNavigationBar)
+                SwitchableSettingsItem(settingPictureSystemName: "person.text.rectangle",
+                                       settingPictureColor: .pink,
+                                       settingName: "Show username",
+                                       isTicked: $showUsernameInNavigationBar)
             } footer: {
                 // swiftlint:disable line_length
                 Text("When enabled, your username will be displayed as the label for the Profile tab. You may wish to turn this off for privacy reasons.")
                 // swiftlint:enable line_length
             }
             
-            Toggle("Show Unread Count", isOn: $showInboxUnreadBadge)
+            SwitchableSettingsItem(settingPictureSystemName: "envelope.badge",
+                                   settingPictureColor: .pink,
+                                   settingName: "Show unread count",
+                                   isTicked: $showInboxUnreadBadge)
         }
         .fancyTabScrollCompatible()
     }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -15,13 +15,11 @@ struct TabBarSettingsView: View {
     var body: some View {
         Form {
             SwitchableSettingsItem(settingPictureSystemName: "tag",
-                                   settingPictureColor: .pink,
                                    settingName: "Show Tab Labels",
                                    isTicked: $showTabNames)
             
             Section {
                 SwitchableSettingsItem(settingPictureSystemName: "person.text.rectangle",
-                                       settingPictureColor: .pink,
                                        settingName: "Show Username",
                                        isTicked: $showUsernameInNavigationBar)
             } footer: {
@@ -31,7 +29,6 @@ struct TabBarSettingsView: View {
             }
             
             SwitchableSettingsItem(settingPictureSystemName: "envelope.badge",
-                                   settingPictureColor: .pink,
                                    settingName: "Show Unread Count",
                                    isTicked: $showInboxUnreadBadge)
         }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -23,9 +23,7 @@ struct TabBarSettingsView: View {
                                        settingName: "Show Username",
                                        isTicked: $showUsernameInNavigationBar)
             } footer: {
-                // swiftlint:disable line_length
-                Text("When enabled, your username will be displayed as the label for the Profile tab. You may wish to turn this off for privacy reasons.")
-                // swiftlint:enable line_length
+                Text("Displays your username as the label for the \"Profile\" tab.")
             }
             
             SwitchableSettingsItem(settingPictureSystemName: "envelope.badge",

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -9,27 +9,49 @@ import SwiftUI
 
 struct TabBarSettingsView: View {
     @AppStorage("showUsernameInNavigationBar") var showUsernameInNavigationBar: Bool = true
+    @AppStorage("profileTabLabel") var profileTabLabel: ProfileTabLabel = .username
     @AppStorage("showTabNames") var showTabNames: Bool = true
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true
         
+    @EnvironmentObject var appState: AppState
+    
+    @State var textFieldEntry: String = ""
+    
     var body: some View {
         Form {
             SwitchableSettingsItem(settingPictureSystemName: "tag",
                                    settingName: "Show Tab Labels",
                                    isTicked: $showTabNames)
             
-            Section {
-                SwitchableSettingsItem(settingPictureSystemName: "person.text.rectangle",
-                                       settingName: "Show Username",
-                                       isTicked: $showUsernameInNavigationBar)
-            } footer: {
-                Text("Displays your username as the label for the \"Profile\" tab.")
-            }
+//            Section {
+//                SwitchableSettingsItem(settingPictureSystemName: "person.text.rectangle",
+//                                       settingName: "Show Username",
+//                                       isTicked: $showUsernameInNavigationBar)
+//            } footer: {
+//                Text("Displays your username as the label for the \"Profile\" tab.")
+//            }
             
             SwitchableSettingsItem(settingPictureSystemName: "envelope.badge",
                                    settingName: "Show Unread Count",
                                    isTicked: $showInboxUnreadBadge)
+            
+            VStack {
+                SelectableSettingsItem(settingIconSystemName: "person.text.rectangle",
+                                       settingName: "Profile Tab Label",
+                                       currentValue: $profileTabLabel,
+                                       options: ProfileTabLabel.allCases)
+                
+                TextField(text: $textFieldEntry, prompt: Text(appState.currentActiveAccount.username)) {
+                    Text("Nickname")
+                }
+                .onSubmit {
+                    appState.setNickname(nickname: textFieldEntry)
+                }
+            }
         }
         .fancyTabScrollCompatible()
+        .onChange(of: appState.currentActiveAccount.nickname) { _ in
+            textFieldEntry = appState.currentActiveAccount.nickname
+        }
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
@@ -17,14 +17,12 @@ struct UserSettingsView: View {
             Section {
                 SwitchableSettingsItem(
                     settingPictureSystemName: "person.circle.fill",
-                    settingPictureColor: .pink,
                     settingName: "Show User Avatars",
                     isTicked: $shouldShowUserAvatars
                 )
 
                 SwitchableSettingsItem(
                     settingPictureSystemName: "rectangle.grid.1x2",
-                    settingPictureColor: .pink,
                     settingName: "Show User Banners",
                     isTicked: $shouldShowUserHeaders
                 )

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
@@ -18,14 +18,14 @@ struct UserSettingsView: View {
                 SwitchableSettingsItem(
                     settingPictureSystemName: "person.circle.fill",
                     settingPictureColor: .pink,
-                    settingName: "Show user avatars",
+                    settingName: "Show User Avatars",
                     isTicked: $shouldShowUserAvatars
                 )
 
                 SwitchableSettingsItem(
                     settingPictureSystemName: "rectangle.grid.1x2",
                     settingPictureColor: .pink,
-                    settingName: "Show user banners",
+                    settingName: "Show User Banners",
                     isTicked: $shouldShowUserHeaders
                 )
             }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
@@ -63,7 +63,7 @@ struct FiltersSettingsView: View {
                     
                 } label: {
                     Label {
-                        Text("Export filters")
+                        Text("Export Filters")
                     } icon: {
                         Image(systemName: "square.and.arrow.up")
                             .opacity(filtersTracker.filteredKeywords.isEmpty ? 0.6 : 1)

--- a/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
@@ -62,7 +62,12 @@ struct FiltersSettingsView: View {
                     }
                     
                 } label: {
-                    Label("Export Filters", systemImage: "square.and.arrow.up")
+                    Label {
+                        Text("Export filters")
+                    } icon: {
+                        Image(systemName: "square.and.arrow.up")
+                            .opacity(filtersTracker.filteredKeywords.isEmpty ? 0.6 : 1)
+                    }
                 }
                 .disabled(filtersTracker.filteredKeywords.isEmpty)
 

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -26,7 +26,9 @@ struct GeneralSettingsView: View {
         List {
             
             Section {
-                Toggle("Blur NSFW Content", isOn: $shouldBlurNsfw)
+                SwitchableSettingsItem(settingPictureSystemName: AppConstants.blurNsfwSymbolName,
+                                       settingName: "Blur NSFW content",
+                                       isTicked: $shouldBlurNsfw)
             } footer: {
                 // swiftlint:disable line_length
                 Text("When enabled, Not Safe For Work content will be blurred until you click on it. If you want to disable NSFW content from appearing entirely, you can do so from Account Settings on \(appState.currentActiveAccount.instanceLink.host ?? "your instance's webpage").")
@@ -34,46 +36,24 @@ struct GeneralSettingsView: View {
             }
             
             Section {
-                Picker("Default Feed", selection: $defaultFeed) {
-                    ForEach(FeedType.allCases, id: \.self) {
-                        Text($0.label)
-                    }
-                }
+                SelectableSettingsItem(settingIconSystemName: defaultFeed.settingsIconName,
+                                       settingName: "Default feed",
+                                       currentValue: $defaultFeed,
+                                       options: FeedType.allCases)
             } footer: {
                 Text("The feed to show by default when you open the app.")
             }
             
             Section {
-                HStack {
-                    Text("Posts")
-                    Spacer()
-                    PostSortMenu(selectedSortingOption: $defaultPostSorting, shortLabel: true)
-                }
+                SelectableSettingsItem(settingIconSystemName: defaultPostSorting.iconName,
+                                       settingName: "Posts",
+                                       currentValue: $defaultPostSorting,
+                                       options: PostSortType.allCases)
                 
-                HStack {
-                    Text("Comments")
-                    Spacer()
-                    Menu {
-                        ForEach(CommentSortType.allCases, id: \.self) { type in
-                            Button {
-                                defaultCommentSorting = type
-                            } label: {
-                                Label(type.description, systemImage: type.imageName)
-                            }
-                            .disabled(type == defaultCommentSorting)
-                        }
-
-                    } label: {
-                        HStack {
-                            Spacer()
-                            Image(systemName: defaultCommentSorting.imageName)
-                                .tint(.pink)
-                            Text(defaultCommentSorting.description)
-                                .tint(.pink)
-                        }
-                        .frame(maxWidth: .infinity)
-                    }
-                }
+                SelectableSettingsItem(settingIconSystemName: defaultCommentSorting.iconName,
+                                       settingName: "Comments",
+                                       currentValue: $defaultCommentSorting,
+                                       options: CommentSortType.allCases)
             } header: {
                 Text("Default Sorting")
             } footer: {
@@ -97,6 +77,7 @@ struct GeneralSettingsView: View {
                 } label: {
                     Label("Delete Community Favorites", systemImage: "trash")
                         .foregroundColor(.red)
+                        .opacity(favoritesTracker.favoriteCommunities.isEmpty ? 0.6 : 1)
                 }
                 .disabled(favoritesTracker.favoriteCommunities.isEmpty)
                 .confirmationDialog(

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -31,7 +31,7 @@ struct GeneralSettingsView: View {
                                        isTicked: $shouldBlurNsfw)
             } footer: {
                 // swiftlint:disable line_length
-                Text("When enabled, Not Safe For Work content will be blurred until you click on it. If you want to disable NSFW content from appearing entirely, you can do so from Account Settings on \(appState.currentActiveAccount.instanceLink.host ?? "your instance's webpage").")
+                Text("Blurs content flagged as Not Safe For Work until you click on it. If you want to disable NSFW content from appearing entirely, you can do so from Account Settings on \(appState.currentActiveAccount.instanceLink.host ?? "your instance's webpage").")
                 // swiftlint:enable line_length
             }
             

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -27,7 +27,7 @@ struct GeneralSettingsView: View {
             
             Section {
                 SwitchableSettingsItem(settingPictureSystemName: AppConstants.blurNsfwSymbolName,
-                                       settingName: "Blur NSFW content",
+                                       settingName: "Blur NSFW Content",
                                        isTicked: $shouldBlurNsfw)
             } footer: {
                 // swiftlint:disable line_length
@@ -37,7 +37,7 @@ struct GeneralSettingsView: View {
             
             Section {
                 SelectableSettingsItem(settingIconSystemName: defaultFeed.settingsIconName,
-                                       settingName: "Default feed",
+                                       settingName: "Default Feed",
                                        currentValue: $defaultFeed,
                                        options: FeedType.allCases)
             } footer: {


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# DRAFT PR BASED ON #463 

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #289 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR adds the ability to create and save profile nicknames, and use those nicknames in the profile tab.

It also removes the old `showUsernameInNavigationBar` toggle in favor of a new 4-way selector: username, instance, nickname, or anonymous.

## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/44140166/255c64ce-d195-4823-8cf5-6cf677bcaaf9


