### PR TITLE
Profile Nicknames

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -287,6 +287,7 @@
 		CD6483342A39F1C100EE6CA3 /* API Post View - Post Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6483332A39F1C100EE6CA3 /* API Post View - Post Type.swift */; };
 		CD6483362A39F20800EE6CA3 /* Post Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6483352A39F20800EE6CA3 /* Post Type.swift */; };
 		CD6483382A3A0F2200EE6CA3 /* NSFW Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6483372A3A0F2200EE6CA3 /* NSFW Tag.swift */; };
+		CD6483A62A82FAF200A5AE84 /* ProfileTabLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6483A52A82FAF200A5AE84 /* ProfileTabLabel.swift */; };
 		CD69F55B2A400D820028D4F7 /* App Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F55A2A400D820028D4F7 /* App Theme.swift */; };
 		CD69F55D2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F55C2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift */; };
 		CD69F55F2A40121D0028D4F7 /* Ellipsis Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F55E2A40121D0028D4F7 /* Ellipsis Menu.swift */; };
@@ -664,6 +665,7 @@
 		CD6483332A39F1C100EE6CA3 /* API Post View - Post Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API Post View - Post Type.swift"; sourceTree = "<group>"; };
 		CD6483352A39F20800EE6CA3 /* Post Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post Type.swift"; sourceTree = "<group>"; };
 		CD6483372A3A0F2200EE6CA3 /* NSFW Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFW Tag.swift"; sourceTree = "<group>"; };
+		CD6483A52A82FAF200A5AE84 /* ProfileTabLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabLabel.swift; sourceTree = "<group>"; };
 		CD69F55A2A400D820028D4F7 /* App Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App Theme.swift"; sourceTree = "<group>"; };
 		CD69F55C2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceStyle - SettingsOption conformant.swift"; sourceTree = "<group>"; };
 		CD69F55E2A40121D0028D4F7 /* Ellipsis Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ellipsis Menu.swift"; sourceTree = "<group>"; };
@@ -1728,6 +1730,7 @@
 				CD05E7782A4E381A0081D102 /* PostSize.swift */,
 				CDC1C93B2A7AA76000072E3D /* InternetSpeed.swift */,
 				CDC1C9402A7ABA9C00072E3D /* ReadMarkStyle.swift */,
+				CD6483A52A82FAF200A5AE84 /* ProfileTabLabel.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -2362,6 +2365,7 @@
 				637218742A3A2AAD008C4816 /* ListCommunities.swift in Sources */,
 				CD1446182A58FC3B00610EF1 /* InfoStack.swift in Sources */,
 				CDE9CE4F2A7B0B1B002B97DD /* Haptic.swift in Sources */,
+				CD6483A62A82FAF200A5AE84 /* ProfileTabLabel.swift in Sources */,
 				6386E0402A045723006B3C1D /* Website Icon Complex.swift in Sources */,
 				5064D0412A6E63E000B22EE3 /* Task+Notifiable.swift in Sources */,
 				63F0C7BD2A058CD200A18C5D /* Check if Endpoint Exists.swift in Sources */,

--- a/Mlem/App State.swift
+++ b/Mlem/App State.swift
@@ -50,6 +50,10 @@ class AppState: ObservableObject {
         accountUpdated()
     }
     
+    func setNickname(nickname: String) {
+        currentActiveAccount.storedNickname = nickname
+    }
+    
     private func accountUpdated() {
         // ensure our client session is updated
         apiClient.configure(for: currentActiveAccount)

--- a/Mlem/App State.swift
+++ b/Mlem/App State.swift
@@ -16,6 +16,7 @@ class AppState: ObservableObject {
     @AppStorage("defaultAccountId") var defaultAccountId: Int?
     @Binding private var selectedAccount: SavedAccount?
     @Published private(set) var currentActiveAccount: SavedAccount
+    @Published private(set) var currentNickname: String
     
     @Published var contextualError: ContextualError?
     
@@ -28,6 +29,7 @@ class AppState: ObservableObject {
     init(defaultAccount: SavedAccount, selectedAccount: Binding<SavedAccount?>) {
         _selectedAccount = selectedAccount
         self.currentActiveAccount = defaultAccount
+        self.currentNickname = defaultAccount.nickname
         defaultAccountId = currentActiveAccount.id
         accountUpdated()
     }
@@ -50,8 +52,12 @@ class AppState: ObservableObject {
         accountUpdated()
     }
     
-    func setNickname(nickname: String) {
-        currentActiveAccount.storedNickname = nickname
+    /**
+     Update the nickname. This is needed to quickly propagate changes from settings over to the tab bar, since nickname doesn't affect account identity and so changing it doesn't always prompt redraws
+     */
+    func changeDisplayedNickname(to nickname: String) {
+        print("changing to \(nickname)")
+        currentNickname = nickname
     }
     
     private func accountUpdated() {

--- a/Mlem/App State.swift
+++ b/Mlem/App State.swift
@@ -56,7 +56,6 @@ class AppState: ObservableObject {
      Update the nickname. This is needed to quickly propagate changes from settings over to the tab bar, since nickname doesn't affect account identity and so changing it doesn't always prompt redraws
      */
     func changeDisplayedNickname(to nickname: String) {
-        print("changing to \(nickname)")
         currentNickname = nickname
     }
     

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -130,7 +130,8 @@ struct ContentView: View {
     }
     
     func computeUsername(account: SavedAccount) -> String {
-        return showUsernameInNavigationBar ? account.username : "Profile"
+        // return showUsernameInNavigationBar ? account.username : "Profile"
+        account.nickname
     }
     
     func showAccountSwitcherDragCallback() {

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -29,9 +29,9 @@ struct ContentView: View {
     
     @State private var isPresentingAccountSwitcher: Bool = false
     
-    @AppStorage("showUsernameInNavigationBar") var showUsernameInNavigationBar: Bool = true
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true
     @AppStorage("homeButtonExists") var homeButtonExists: Bool = false
+    @AppStorage("profileTabLabel") var profileTabLabel: ProfileTabLabel = .username
     
     var accessibilityFont: Bool { UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory }
     
@@ -130,8 +130,12 @@ struct ContentView: View {
     }
     
     func computeUsername(account: SavedAccount) -> String {
-        // return showUsernameInNavigationBar ? account.username : "Profile"
-        account.nickname
+        switch profileTabLabel {
+        case .username: return account.username
+        case .instance: return account.hostName ?? account.username
+        case .nickname: return appState.currentNickname
+        case .anonymous: return "Profile"
+        }
     }
     
     func showAccountSwitcherDragCallback() {

--- a/Mlem/Enums/Settings/ProfileTabLabel.swift
+++ b/Mlem/Enums/Settings/ProfileTabLabel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum ProfileTabLabel: String {
-    case username, instance, nickname
+    case username, instance, nickname, anonymous
 }
 
 extension ProfileTabLabel: SettingsOptions {

--- a/Mlem/Enums/Settings/ProfileTabLabel.swift
+++ b/Mlem/Enums/Settings/ProfileTabLabel.swift
@@ -1,0 +1,24 @@
+//
+//  ProfileTabLabel.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-08-08.
+//
+
+import Foundation
+
+enum ProfileTabLabel: String {
+    case username, instance, nickname
+}
+
+extension ProfileTabLabel: SettingsOptions {
+    var label: String { self.rawValue.capitalized }
+    
+    var id: Self { self }
+}
+
+extension ProfileTabLabel: AssociatedIcon {
+    var iconName: String { "person.text.rectangle" }
+    
+    var iconNameFill: String { "person.text.rectangle.fill"}
+}

--- a/Mlem/Haptics/Haptic Manager.swift
+++ b/Mlem/Haptics/Haptic Manager.swift
@@ -23,7 +23,7 @@ class HapticManager {
     
     init() {
         // create and start the engine if this device supports haptics
-        print("initialized haptic engine")
+        print("Initialized haptic engine")
         hapticEngine = initEngine()
         
         // if the engine stops, tell us why

--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -12,7 +12,7 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
     let instanceLink: URL
     let accessToken: String
     let username: String
-    var storedNickname: String?
+    let storedNickname: String?
     
     init(id: Int,
          instanceLink: URL,
@@ -24,6 +24,19 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
         self.accessToken = accessToken
         self.username = username
         self.storedNickname = storedNickname
+    }
+    
+    /**
+     Convenience initializer to create an equal copy with different non-identifying properties.
+     */
+    init(from account: SavedAccount,
+         accessToken: String? = nil,
+         storedNickname: String? = nil) {
+        self.id = account.id
+        self.instanceLink = account.instanceLink
+        self.accessToken = accessToken ?? account.accessToken
+        self.username = account.username
+        self.storedNickname = storedNickname ?? account.storedNickname
     }
   
     // convenience
@@ -41,6 +54,7 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
         try container.encode(self.instanceLink, forKey: .instanceLink)
         try container.encode("redacted", forKey: .accessToken)
         try container.encode(self.username, forKey: .username)
+        try container.encode(self.storedNickname, forKey: .storedNickname)
     }
     
     static func == (lhs: SavedAccount, rhs: SavedAccount) -> Bool {

--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -12,9 +12,27 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
     let instanceLink: URL
     let accessToken: String
     let username: String
+    var storedNickname: String?
+    
+    init(id: Int,
+         instanceLink: URL,
+         accessToken: String,
+         username: String,
+         storedNickname: String? = nil) {
+        self.id = id
+        self.instanceLink = instanceLink
+        self.accessToken = accessToken
+        self.username = username
+        self.storedNickname = storedNickname
+    }
   
     // convenience
     var hostName: String? { instanceLink.host?.description }
+    
+    /**
+     If there is a nickname stored, returns that; otherwise returns the username
+     */
+    var nickname: String { storedNickname ?? username }
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)

--- a/Mlem/Repositories/PersistenceRepository.swift
+++ b/Mlem/Repositories/PersistenceRepository.swift
@@ -69,13 +69,8 @@ class PersistenceRepository {
             guard let token = keychainAccess("\(account.id)_accessToken") else {
                 return nil
             }
-
-            return SavedAccount(
-                id: account.id,
-                instanceLink: account.instanceLink,
-                accessToken: token,
-                username: account.username
-            )
+            
+            return SavedAccount(from: account, accessToken: token)
         }
     }
     

--- a/Mlem/Views/Shared/TokenRefreshView.swift
+++ b/Mlem/Views/Shared/TokenRefreshView.swift
@@ -246,14 +246,7 @@ struct TokenRefreshView: View {
         try? await Task.sleep(for: .seconds(0.5))
         
         await MainActor.run {
-            refreshedAccount(
-                .init(
-                    id: account.id,
-                    instanceLink: account.instanceLink,
-                    accessToken: newToken,
-                    username: account.username
-                )
-            )
+            refreshedAccount(.init(from: account, accessToken: newToken))
             dismiss()
         }
     }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct TabBarSettingsView: View {
-    @AppStorage("showUsernameInNavigationBar") var showUsernameInNavigationBar: Bool = true
     @AppStorage("profileTabLabel") var profileTabLabel: ProfileTabLabel = .username
     @AppStorage("showTabNames") var showTabNames: Bool = true
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -9,27 +9,49 @@ import SwiftUI
 
 struct TabBarSettingsView: View {
     @AppStorage("showUsernameInNavigationBar") var showUsernameInNavigationBar: Bool = true
+    @AppStorage("profileTabLabel") var profileTabLabel: ProfileTabLabel = .username
     @AppStorage("showTabNames") var showTabNames: Bool = true
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true
         
+    @EnvironmentObject var appState: AppState
+    
+    @State var textFieldEntry: String = ""
+    
     var body: some View {
         Form {
             SwitchableSettingsItem(settingPictureSystemName: "tag",
                                    settingName: "Show Tab Labels",
                                    isTicked: $showTabNames)
             
-            Section {
-                SwitchableSettingsItem(settingPictureSystemName: "person.text.rectangle",
-                                       settingName: "Show Username",
-                                       isTicked: $showUsernameInNavigationBar)
-            } footer: {
-                Text("Displays your username as the label for the \"Profile\" tab.")
-            }
+//            Section {
+//                SwitchableSettingsItem(settingPictureSystemName: "person.text.rectangle",
+//                                       settingName: "Show Username",
+//                                       isTicked: $showUsernameInNavigationBar)
+//            } footer: {
+//                Text("Displays your username as the label for the \"Profile\" tab.")
+//            }
             
             SwitchableSettingsItem(settingPictureSystemName: "envelope.badge",
                                    settingName: "Show Unread Count",
                                    isTicked: $showInboxUnreadBadge)
+            
+            VStack {
+                SelectableSettingsItem(settingIconSystemName: "person.text.rectangle",
+                                       settingName: "Profile Tab Label",
+                                       currentValue: $profileTabLabel,
+                                       options: ProfileTabLabel.allCases)
+                
+                TextField(text: $textFieldEntry, prompt: Text(appState.currentActiveAccount.username)) {
+                    Text("Nickname")
+                }
+                .onSubmit {
+                    appState.setNickname(nickname: textFieldEntry)
+                }
+            }
         }
         .fancyTabScrollCompatible()
+        .onChange(of: appState.currentActiveAccount.nickname) { _ in
+            textFieldEntry = appState.currentActiveAccount.nickname
+        }
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #289 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR adds the ability to create and save profile nicknames, and use those nicknames in the profile tab.

It also removes the old `showUsernameInNavigationBar` toggle in favor of a new 4-way selector: username, instance, nickname, or anonymous.

## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/44140166/255c64ce-d195-4823-8cf5-6cf677bcaaf9


