### PR TITLE
Fixed an issue where all posts in a community showed the poster as OP

### DIFF
--- a/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/UltraCompactPost.swift
@@ -72,8 +72,7 @@ struct UltraCompactPost: View {
                             CommunityLinkView(community: postView.community, serverInstanceLocation: .trailing, overrideShowAvatar: false)
                         } else {
                             UserProfileLink(user: postView.creator,
-                                            serverInstanceLocation: .trailing,
-                                            postContext: postView.post)
+                                            serverInstanceLocation: .trailing)
                         }
                     }
                     


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #468 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

Post context was wrongly being passed to the user label in UltraCompactPost, causing all users to be flaired as OP.

Fixed:

<img width="563" alt="Screenshot 2023-08-09 at 12 27 18 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/60271417-7814-4302-ae84-b9aa2ecb6069">
