### PR TITLE
Option for solid coloured navigation bar/tab bar

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -218,7 +218,7 @@
 		6DEB0FFD2A4F891B007CAB99 /* User Moderator Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEB0FFC2A4F891B007CAB99 /* User Moderator Link.swift */; };
 		6DFF50432A48DED3001E648D /* Inbox View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFF50422A48DED3001E648D /* Inbox View.swift */; };
 		6DFF50452A48E373001E648D /* GetPrivateMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFF50442A48E373001E648D /* GetPrivateMessages.swift */; };
-		88B165B62A863357007C9115 /* BarBackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B165B52A863357007C9115 /* BarBackgroundColor.swift */; };
+		88B165B82A8643F4007C9115 /* View - NavigationBar Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B165B72A8643F4007C9115 /* View - NavigationBar Color.swift */; };
 		AD1B0D352A5F63F60006F554 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1B0D342A5F63F60006F554 /* AboutView.swift */; };
 		AD1B0D372A5F7A260006F554 /* Licenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1B0D362A5F7A260006F554 /* Licenses.swift */; };
 		ADDC9E3A2A5CEAA100383D58 /* BlockPerson.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDC9E392A5CEAA100383D58 /* BlockPerson.swift */; };
@@ -609,7 +609,7 @@
 		6DEB0FFC2A4F891B007CAB99 /* User Moderator Link.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User Moderator Link.swift"; sourceTree = "<group>"; };
 		6DFF50422A48DED3001E648D /* Inbox View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox View.swift"; sourceTree = "<group>"; };
 		6DFF50442A48E373001E648D /* GetPrivateMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPrivateMessages.swift; sourceTree = "<group>"; };
-		88B165B52A863357007C9115 /* BarBackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarBackgroundColor.swift; sourceTree = "<group>"; };
+		88B165B72A8643F4007C9115 /* View - NavigationBar Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View - NavigationBar Color.swift"; sourceTree = "<group>"; };
 		AD1B0D342A5F63F60006F554 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		AD1B0D362A5F7A260006F554 /* Licenses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Licenses.swift; sourceTree = "<group>"; };
 		ADDC9E392A5CEAA100383D58 /* BlockPerson.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPerson.swift; sourceTree = "<group>"; };
@@ -1128,40 +1128,41 @@
 		6332FDC127EFCB530009A98A /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				6D8003782A45FD1300363206 /* Bundle.swift */,
-				E4DDB4312A81819300B3A7E0 /* Double.swift */,
-				6332FDC227EFCB5F0009A98A /* Color.swift */,
-				6386E0392A0455BC006B3C1D /* String - Contains Elements From Array.swift */,
-				63F0C7BA2A058CB700A18C5D /* URLSessionWebSocketTask - Send Ping.swift */,
-				63344C552A07D81D001BC616 /* Array - Prepend.swift */,
-				63344C572A07DB9A001BC616 /* Array - Move Elements Around.swift */,
-				63344C612A08460D001BC616 /* View - Border on Specific Sides.swift */,
-				63344C6D2A097FA1001BC616 /* View - Hide View.swift */,
-				63D24ED82A169A5F005CCA81 /* UIApplication.swift */,
-				5016A2B02A67EB8600B257E8 /* UIViewController.swift */,
-				630737882A1CD1E900039852 /* String.swift */,
-				63A200522A2DDD38005CDDE3 /* Dictionary - Append.swift */,
 				6354F3092A2E20040074C08D /* Alert - Multiple Alerts.swift */,
-				503BA26E2A2C94540052516C /* URL+Identifiable.swift */,
-				508845CE2A3641160088E483 /* JSONDecoder+Default.swift */,
 				CD6483332A39F1C100EE6CA3 /* API Post View - Post Type.swift */,
-				CD69F55C2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift */,
-				6D8601ED2A43C0B1002A56FC /* Image.swift */,
-				6D15D74B2A44DC240061B5CB /* Date.swift */,
-				CD69F56E2A41EDF50028D4F7 /* Swipey Actions.swift */,
-				B1A26FE02A44AAB200B91A32 /* Navigation getter.swift */,
-				B1A26FE22A45B11800B91A32 /* View - Handle Lemmy Links.swift */,
+				63344C572A07DB9A001BC616 /* Array - Move Elements Around.swift */,
+				63344C552A07D81D001BC616 /* Array - Prepend.swift */,
 				B1CB6E742A4C729D00DA9675 /* Bundle - Current App Icon.swift */,
-				6DA61F842A568F99001EA633 /* Int.swift */,
-				6DA61F882A575DF1001EA633 /* URL - Lemmy Image Parameters.swift */,
-				507573902A5AD53C00AA7ABD /* Error+Equatable.swift */,
-				B104A6DF2A59C19400B3E725 /* OperationQueue - Easy init.swift */,
-				CDA217F22A63202600BDA173 /* NSFW Overlay.swift */,
+				6D8003782A45FD1300363206 /* Bundle.swift */,
+				6332FDC227EFCB5F0009A98A /* Color.swift */,
+				6D15D74B2A44DC240061B5CB /* Date.swift */,
+				63A200522A2DDD38005CDDE3 /* Dictionary - Append.swift */,
+				E4DDB4312A81819300B3A7E0 /* Double.swift */,
+				503A5D742A78EF3C00488C38 /* Encodable+Export.swift */,
 				B1955A202A6145C00056CF99 /* Environment - EasterFlagSetter.swift */,
 				CDE8F2382A68DA7D00E0AE68 /* Environment - Force Onboard.swift */,
+				507573902A5AD53C00AA7ABD /* Error+Equatable.swift */,
+				6D8601ED2A43C0B1002A56FC /* Image.swift */,
+				6DA61F842A568F99001EA633 /* Int.swift */,
+				508845CE2A3641160088E483 /* JSONDecoder+Default.swift */,
+				B1A26FE02A44AAB200B91A32 /* Navigation getter.swift */,
+				CDA217F22A63202600BDA173 /* NSFW Overlay.swift */,
+				B104A6DF2A59C19400B3E725 /* OperationQueue - Easy init.swift */,
+				6386E0392A0455BC006B3C1D /* String - Contains Elements From Array.swift */,
+				630737882A1CD1E900039852 /* String.swift */,
+				CD69F56E2A41EDF50028D4F7 /* Swipey Actions.swift */,
 				5064D0402A6E63E000B22EE3 /* Task+Notifiable.swift */,
+				63D24ED82A169A5F005CCA81 /* UIApplication.swift */,
+				CD69F55C2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift */,
+				5016A2B02A67EB8600B257E8 /* UIViewController.swift */,
+				6DA61F882A575DF1001EA633 /* URL - Lemmy Image Parameters.swift */,
+				503BA26E2A2C94540052516C /* URL+Identifiable.swift */,
+				63F0C7BA2A058CB700A18C5D /* URLSessionWebSocketTask - Send Ping.swift */,
+				63344C612A08460D001BC616 /* View - Border on Specific Sides.swift */,
 				CD82A24B2A70A26900111034 /* View - CustomBadge.swift */,
-				503A5D742A78EF3C00488C38 /* Encodable+Export.swift */,
+				B1A26FE22A45B11800B91A32 /* View - Handle Lemmy Links.swift */,
+				63344C6D2A097FA1001BC616 /* View - Hide View.swift */,
+				88B165B72A8643F4007C9115 /* View - NavigationBar Color.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1861,7 +1862,6 @@
 				CDDCF6502A677E1B003DA3AC /* FancyTabItemPreferenceKeys.swift */,
 				CDDCF6562A678298003DA3AC /* FancyTabBarSelection.swift */,
 				CD863FB92A6AEB5900A31ED9 /* TabSafeScrollView.swift */,
-				88B165B52A863357007C9115 /* BarBackgroundColor.swift */,
 			);
 			path = "Custom Tab Bar";
 			sourceTree = "<group>";
@@ -2441,7 +2441,6 @@
 				637218602A3A2AAD008C4816 /* EditPost.swift in Sources */,
 				6D693A402A51147E009E2D76 /* APIPostReportView.swift in Sources */,
 				637218562A3A2AAD008C4816 /* APILocalSite.swift in Sources */,
-				88B165B62A863357007C9115 /* BarBackgroundColor.swift in Sources */,
 				CDA217EE2A630F3300BDA173 /* ReportPost.swift in Sources */,
 				6372185B2A3A2AAD008C4816 /* APICommunityView.swift in Sources */,
 				637218552A3A2AAD008C4816 /* APITagline.swift in Sources */,
@@ -2449,6 +2448,7 @@
 				03A1B3F72A84000400AB0DE0 /* APIContentAggregatesProtocol.swift in Sources */,
 				CD4DBC032A6F803C001A1E61 /* ReplyToPost.swift in Sources */,
 				CD6483302A38D31C00EE6CA3 /* UpvoteCounterView.swift in Sources */,
+				88B165B82A8643F4007C9115 /* View - NavigationBar Color.swift in Sources */,
 				030AC0522A64666C00037155 /* UserSettingsView.swift in Sources */,
 				CDA2C5262A705D6000649D5A /* PostEditor.swift in Sources */,
 				6372184A2A3A2AAD008C4816 /* APIPost.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		6DEB0FFD2A4F891B007CAB99 /* User Moderator Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEB0FFC2A4F891B007CAB99 /* User Moderator Link.swift */; };
 		6DFF50432A48DED3001E648D /* Inbox View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFF50422A48DED3001E648D /* Inbox View.swift */; };
 		6DFF50452A48E373001E648D /* GetPrivateMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFF50442A48E373001E648D /* GetPrivateMessages.swift */; };
+		88B165B62A863357007C9115 /* BarBackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B165B52A863357007C9115 /* BarBackgroundColor.swift */; };
 		AD1B0D352A5F63F60006F554 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1B0D342A5F63F60006F554 /* AboutView.swift */; };
 		AD1B0D372A5F7A260006F554 /* Licenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1B0D362A5F7A260006F554 /* Licenses.swift */; };
 		ADDC9E3A2A5CEAA100383D58 /* BlockPerson.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDC9E392A5CEAA100383D58 /* BlockPerson.swift */; };
@@ -608,6 +609,7 @@
 		6DEB0FFC2A4F891B007CAB99 /* User Moderator Link.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User Moderator Link.swift"; sourceTree = "<group>"; };
 		6DFF50422A48DED3001E648D /* Inbox View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox View.swift"; sourceTree = "<group>"; };
 		6DFF50442A48E373001E648D /* GetPrivateMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPrivateMessages.swift; sourceTree = "<group>"; };
+		88B165B52A863357007C9115 /* BarBackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarBackgroundColor.swift; sourceTree = "<group>"; };
 		AD1B0D342A5F63F60006F554 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		AD1B0D362A5F7A260006F554 /* Licenses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Licenses.swift; sourceTree = "<group>"; };
 		ADDC9E392A5CEAA100383D58 /* BlockPerson.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPerson.swift; sourceTree = "<group>"; };
@@ -1859,6 +1861,7 @@
 				CDDCF6502A677E1B003DA3AC /* FancyTabItemPreferenceKeys.swift */,
 				CDDCF6562A678298003DA3AC /* FancyTabBarSelection.swift */,
 				CD863FB92A6AEB5900A31ED9 /* TabSafeScrollView.swift */,
+				88B165B52A863357007C9115 /* BarBackgroundColor.swift */,
 			);
 			path = "Custom Tab Bar";
 			sourceTree = "<group>";
@@ -2438,6 +2441,7 @@
 				637218602A3A2AAD008C4816 /* EditPost.swift in Sources */,
 				6D693A402A51147E009E2D76 /* APIPostReportView.swift in Sources */,
 				637218562A3A2AAD008C4816 /* APILocalSite.swift in Sources */,
+				88B165B62A863357007C9115 /* BarBackgroundColor.swift in Sources */,
 				CDA217EE2A630F3300BDA173 /* ReportPost.swift in Sources */,
 				6372185B2A3A2AAD008C4816 /* APICommunityView.swift in Sources */,
 				637218552A3A2AAD008C4816 /* APITagline.swift in Sources */,
@@ -2666,7 +2670,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 76ULHQGAPN;
+				DEVELOPMENT_TEAM = 47UE8GR842;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2684,7 +2688,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fer0n.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -2707,7 +2711,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 76ULHQGAPN;
+				DEVELOPMENT_TEAM = 47UE8GR842;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2725,7 +2729,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fer0n.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2670,7 +2670,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 47UE8GR842;
+				DEVELOPMENT_TEAM = 76ULHQGAPN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2688,7 +2688,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.fer0n.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -2711,7 +2711,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 47UE8GR842;
+				DEVELOPMENT_TEAM = 76ULHQGAPN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2729,7 +2729,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.fer0n.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -138,6 +138,7 @@ struct AppConstants {
     static let switchUserSymbolName: String = "person.crop.circle.badge.plus"
     static let missingSymbolName: String = "questionmark.square.dashed"
     static let connectionSymbolName: String = "antenna.radiowaves.left.and.right"
+    static let transparencySymbolName: String = "square.on.square.intersection.dashed"
     
     // MARK: - Other
     static let pictureEmoji: [String] = ["🎆", "🎇", "🌠", "🌅", "🌆", "🌁", "🌃", "🌄", "🌉", "🌌", "🌇", "🖼️", "🎑", "🏞️", "🗾", "🏙️"]

--- a/Mlem/Custom Tab Bar/BarBackgroundColor.swift
+++ b/Mlem/Custom Tab Bar/BarBackgroundColor.swift
@@ -14,6 +14,7 @@ struct BarBackgroundColorModifier: ViewModifier {
         if showSolidBarColor {
             content
                 .toolbarBackground(Color.systemBackground, for: .navigationBar)
+                .toolbarBackground(.visible, for: .navigationBar)
         } else {
             content
         }

--- a/Mlem/Custom Tab Bar/BarBackgroundColor.swift
+++ b/Mlem/Custom Tab Bar/BarBackgroundColor.swift
@@ -1,0 +1,27 @@
+//
+//  BarBackgroundColor.swift
+//  Mlem
+//
+//  Created by fer0n on 11.08.23.
+//
+
+import SwiftUI
+
+struct BarBackgroundColorModifier: ViewModifier {
+    @AppStorage("showSolidBarColor") var showSolidBarColor: Bool = false
+
+    func body(content: Content) -> some View {
+        if showSolidBarColor {
+            content
+                .toolbarBackground(Color.systemBackground, for: .navigationBar)
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    func barBackgroundColor() -> some View {
+        self.modifier(BarBackgroundColorModifier())
+    }
+}

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -13,7 +13,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
     typealias NavigationSelection = any FancyTabBarSelection
 
     @AppStorage("homeButtonExists") var homeButtonExists: Bool = false
-    @AppStorage("showSolidBarColor") var showSolidBarColor: Bool = false
+    @AppStorage("isTranslucentBar") var isTranslucentBar: Bool = true
     
     @Binding private var selection: Selection
     @Binding private var navigationSelection: NavigationSelection
@@ -111,7 +111,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                     }
             )
             .padding(.bottom, homeButtonExists ? 2.5 : 0)
-            .background(showSolidBarColor ? Color.systemBackground.ignoresSafeArea(.all) : nil)
+            .background(isTranslucentBar ? nil : Color.systemBackground.ignoresSafeArea(.all))
             .background(.thinMaterial)
         }
         .accessibilityElement(children: .contain)

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -13,7 +13,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
     typealias NavigationSelection = any FancyTabBarSelection
 
     @AppStorage("homeButtonExists") var homeButtonExists: Bool = false
-    @AppStorage("isTranslucentBar") var isTranslucentBar: Bool = true
+    @AppStorage("hasTranslucentInsets") var hasTranslucentInsets: Bool = true
     
     @Binding private var selection: Selection
     @Binding private var navigationSelection: NavigationSelection
@@ -111,7 +111,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                     }
             )
             .padding(.bottom, homeButtonExists ? 2.5 : 0)
-            .background(isTranslucentBar ? nil : Color.systemBackground.ignoresSafeArea(.all))
+            .background(hasTranslucentInsets ? nil : Color.systemBackground.ignoresSafeArea(.all))
             .background(.thinMaterial)
         }
         .accessibilityElement(children: .contain)

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -13,6 +13,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
     typealias NavigationSelection = any FancyTabBarSelection
 
     @AppStorage("homeButtonExists") var homeButtonExists: Bool = false
+    @AppStorage("showSolidBarColor") var showSolidBarColor: Bool = false
     
     @Binding private var selection: Selection
     @Binding private var navigationSelection: NavigationSelection
@@ -110,6 +111,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                     }
             )
             .padding(.bottom, homeButtonExists ? 2.5 : 0)
+            .background(showSolidBarColor ? Color.systemBackground.ignoresSafeArea(.all) : nil)
             .background(.thinMaterial)
         }
         .accessibilityElement(children: .contain)

--- a/Mlem/Extensions/View - NavigationBar Color.swift
+++ b/Mlem/Extensions/View - NavigationBar Color.swift
@@ -1,5 +1,5 @@
 //
-//  BarBackgroundColor.swift
+//  View - View - NavigationBar Color.swift
 //  Mlem
 //
 //  Created by fer0n on 11.08.23.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct BarBackgroundColorModifier: ViewModifier {
+struct NavigationBarColorModifier: ViewModifier {
     @AppStorage("showSolidBarColor") var showSolidBarColor: Bool = false
 
     func body(content: Content) -> some View {
@@ -22,7 +22,7 @@ struct BarBackgroundColorModifier: ViewModifier {
 }
 
 extension View {
-    func barBackgroundColor() -> some View {
-        self.modifier(BarBackgroundColorModifier())
+    func navigationBarColor() -> some View {
+        self.modifier(NavigationBarColorModifier())
     }
 }

--- a/Mlem/Extensions/View - NavigationBar Color.swift
+++ b/Mlem/Extensions/View - NavigationBar Color.swift
@@ -8,15 +8,15 @@
 import SwiftUI
 
 struct NavigationBarColorModifier: ViewModifier {
-    @AppStorage("showSolidBarColor") var showSolidBarColor: Bool = false
+    @AppStorage("isTranslucentBar") var isTranslucentBar: Bool = true
 
     func body(content: Content) -> some View {
-        if showSolidBarColor {
+        if isTranslucentBar {
+            content
+        } else {
             content
                 .toolbarBackground(Color.systemBackground, for: .navigationBar)
                 .toolbarBackground(.visible, for: .navigationBar)
-        } else {
-            content
         }
     }
 }

--- a/Mlem/Extensions/View - NavigationBar Color.swift
+++ b/Mlem/Extensions/View - NavigationBar Color.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct NavigationBarColorModifier: ViewModifier {
-    @AppStorage("isTranslucentBar") var isTranslucentBar: Bool = true
+    @AppStorage("hasTranslucentInsets") var hasTranslucentInsets: Bool = true
 
     func body(content: Content) -> some View {
-        if isTranslucentBar {
+        if hasTranslucentInsets {
             content
         } else {
             content

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -69,7 +69,7 @@ struct AddSavedInstanceView: View {
                 }.disabled(viewState == .loading)
                 footerView
             }
-            .barBackgroundColor()
+            .navigationBarColor()
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("Sign In")
             .toolbar {

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -69,7 +69,6 @@ struct AddSavedInstanceView: View {
                 }.disabled(viewState == .loading)
                 footerView
             }
-            .barBackgroundColor()
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("Sign In")
             .toolbar {

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -69,6 +69,7 @@ struct AddSavedInstanceView: View {
                 }.disabled(viewState == .loading)
                 footerView
             }
+            .barBackgroundColor()
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("Sign In")
             .toolbar {

--- a/Mlem/Views/Shared/Composer/PostDetailEditorView.swift
+++ b/Mlem/Views/Shared/Composer/PostDetailEditorView.swift
@@ -223,6 +223,7 @@ struct PostDetailEditorView: View {
             } message: {
                 Text(errorDialogMessage)
             }
+            .barBackgroundColor()
             .navigationBarTitleDisplayMode(.inline)
         }
     }

--- a/Mlem/Views/Shared/Composer/PostDetailEditorView.swift
+++ b/Mlem/Views/Shared/Composer/PostDetailEditorView.swift
@@ -223,7 +223,7 @@ struct PostDetailEditorView: View {
             } message: {
                 Text(errorDialogMessage)
             }
-            .barBackgroundColor()
+            .navigationBarColor()
             .navigationBarTitleDisplayMode(.inline)
         }
     }

--- a/Mlem/Views/Shared/Composer/PostDetailEditorView.swift
+++ b/Mlem/Views/Shared/Composer/PostDetailEditorView.swift
@@ -223,7 +223,6 @@ struct PostDetailEditorView: View {
             } message: {
                 Text(errorDialogMessage)
             }
-            .barBackgroundColor()
             .navigationBarTitleDisplayMode(.inline)
         }
     }

--- a/Mlem/Views/Shared/Composer/ResponseEditorView.swift
+++ b/Mlem/Views/Shared/Composer/ResponseEditorView.swift
@@ -97,7 +97,7 @@ struct ResponseEditorView: View {
                     }.disabled(isSubmitting || !isReadyToReply)
                 }
             }
-            .barBackgroundColor()
+            .navigationBarColor()
             .navigationTitle(editorModel.modalName)
             .navigationBarTitleDisplayMode(.inline)
         }

--- a/Mlem/Views/Shared/Composer/ResponseEditorView.swift
+++ b/Mlem/Views/Shared/Composer/ResponseEditorView.swift
@@ -97,7 +97,6 @@ struct ResponseEditorView: View {
                     }.disabled(isSubmitting || !isReadyToReply)
                 }
             }
-            .barBackgroundColor()
             .navigationTitle(editorModel.modalName)
             .navigationBarTitleDisplayMode(.inline)
         }

--- a/Mlem/Views/Shared/Composer/ResponseEditorView.swift
+++ b/Mlem/Views/Shared/Composer/ResponseEditorView.swift
@@ -97,6 +97,7 @@ struct ResponseEditorView: View {
                     }.disabled(isSubmitting || !isReadyToReply)
                 }
             }
+            .barBackgroundColor()
             .navigationTitle(editorModel.modalName)
             .navigationBarTitleDisplayMode(.inline)
         }

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -89,6 +89,7 @@ struct ExpandedPost: View {
         }
         .listStyle(PlainListStyle())
         .fancyTabScrollCompatible()
+        .barBackgroundColor()
     }
     
     var userServerInstanceLocation: ServerInstanceLocation {

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -89,7 +89,7 @@ struct ExpandedPost: View {
         }
         .listStyle(PlainListStyle())
         .fancyTabScrollCompatible()
-        .barBackgroundColor()
+        .navigationBarColor()
     }
     
     var userServerInstanceLocation: ServerInstanceLocation {

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -89,7 +89,6 @@ struct ExpandedPost: View {
         }
         .listStyle(PlainListStyle())
         .fancyTabScrollCompatible()
-        .barBackgroundColor()
     }
     
     var userServerInstanceLocation: ServerInstanceLocation {

--- a/Mlem/Views/Shared/TokenRefreshView.swift
+++ b/Mlem/Views/Shared/TokenRefreshView.swift
@@ -59,7 +59,7 @@ struct TokenRefreshView: View {
             .edgesIgnoringSafeArea(.horizontal)
             .navigationBarTitleDisplayMode(.inline)
             .interactiveDismissDisabled()
-            .barBackgroundColor()
+            .navigationBarColor()
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     cancelButton

--- a/Mlem/Views/Shared/TokenRefreshView.swift
+++ b/Mlem/Views/Shared/TokenRefreshView.swift
@@ -59,6 +59,7 @@ struct TokenRefreshView: View {
             .edgesIgnoringSafeArea(.horizontal)
             .navigationBarTitleDisplayMode(.inline)
             .interactiveDismissDisabled()
+            .barBackgroundColor()
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     cancelButton

--- a/Mlem/Views/Shared/TokenRefreshView.swift
+++ b/Mlem/Views/Shared/TokenRefreshView.swift
@@ -59,7 +59,6 @@ struct TokenRefreshView: View {
             .edgesIgnoringSafeArea(.horizontal)
             .navigationBarTitleDisplayMode(.inline)
             .interactiveDismissDisabled()
-            .barBackgroundColor()
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     cancelButton

--- a/Mlem/Views/Tabs/Feeds/Community List/Community List View.swift
+++ b/Mlem/Views/Tabs/Feeds/Community List/Community List View.swift
@@ -92,6 +92,7 @@ struct CommunityListView: View {
                     }
                     .fancyTabScrollCompatible()
                     .navigationTitle("Communities")
+                    .barBackgroundColor()
                     .listStyle(PlainListStyle())
                     .scrollIndicators(.hidden)
 

--- a/Mlem/Views/Tabs/Feeds/Community List/Community List View.swift
+++ b/Mlem/Views/Tabs/Feeds/Community List/Community List View.swift
@@ -92,7 +92,7 @@ struct CommunityListView: View {
                     }
                     .fancyTabScrollCompatible()
                     .navigationTitle("Communities")
-                    .barBackgroundColor()
+                    .navigationBarColor()
                     .listStyle(PlainListStyle())
                     .scrollIndicators(.hidden)
 

--- a/Mlem/Views/Tabs/Feeds/Community List/Community List View.swift
+++ b/Mlem/Views/Tabs/Feeds/Community List/Community List View.swift
@@ -92,7 +92,6 @@ struct CommunityListView: View {
                     }
                     .fancyTabScrollCompatible()
                     .navigationTitle("Communities")
-                    .barBackgroundColor()
                     .listStyle(PlainListStyle())
                     .scrollIndicators(.hidden)
 

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -53,14 +53,14 @@ struct FeedView: View {
     @State var isLoading: Bool = false
     @State var shouldLoad: Bool = false
     
-    @AppStorage("isTranslucentBar") var isTranslucentBar: Bool = true
+    @AppStorage("hasTranslucentInsets") var hasTranslucentInsets: Bool = true
     
     // MARK: - Main Views
     
     var body: some View {
         contentView
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(isTranslucentBar ? Color.secondarySystemBackground : Color.systemBackground)
+            .background(hasTranslucentInsets ? Color.secondarySystemBackground : Color.systemBackground)
             .toolbar {
                 ToolbarItem(placement: .principal) { toolbarHeader }
                 ToolbarItem(placement: .navigationBarTrailing) { sortMenu }

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -67,6 +67,7 @@ struct FeedView: View {
                 ToolbarItemGroup(placement: .navigationBarTrailing) { ellipsisMenu }
             }
             .navigationBarTitleDisplayMode(.inline)
+            .barBackgroundColor()
             .environmentObject(postTracker)
             .task(priority: .userInitiated) { await initFeed() }
             .task(priority: .background) { await fetchCommunityDetails() }

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -67,7 +67,6 @@ struct FeedView: View {
                 ToolbarItemGroup(placement: .navigationBarTrailing) { ellipsisMenu }
             }
             .navigationBarTitleDisplayMode(.inline)
-            .barBackgroundColor()
             .environmentObject(postTracker)
             .task(priority: .userInitiated) { await initFeed() }
             .task(priority: .background) { await fetchCommunityDetails() }

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -53,18 +53,21 @@ struct FeedView: View {
     @State var isLoading: Bool = false
     @State var shouldLoad: Bool = false
     
+    @AppStorage("showSolidBarColor") var showSolidBarColor: Bool = false
+    
     // MARK: - Main Views
     
     var body: some View {
         contentView
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.secondarySystemBackground)
+            .background(showSolidBarColor ? Color.systemBackground : Color.secondarySystemBackground)
             .toolbar {
                 ToolbarItem(placement: .principal) { toolbarHeader }
                 ToolbarItem(placement: .navigationBarTrailing) { sortMenu }
                 ToolbarItemGroup(placement: .navigationBarTrailing) { ellipsisMenu }
             }
             .navigationBarTitleDisplayMode(.inline)
+            .barBackgroundColor()
             .environmentObject(postTracker)
             .task(priority: .userInitiated) { await initFeed() }
             .task(priority: .background) { await fetchCommunityDetails() }

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -53,14 +53,14 @@ struct FeedView: View {
     @State var isLoading: Bool = false
     @State var shouldLoad: Bool = false
     
-    @AppStorage("showSolidBarColor") var showSolidBarColor: Bool = false
+    @AppStorage("isTranslucentBar") var isTranslucentBar: Bool = true
     
     // MARK: - Main Views
     
     var body: some View {
         contentView
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(showSolidBarColor ? Color.systemBackground : Color.secondarySystemBackground)
+            .background(isTranslucentBar ? Color.secondarySystemBackground : Color.systemBackground)
             .toolbar {
                 ToolbarItem(placement: .principal) { toolbarHeader }
                 ToolbarItem(placement: .navigationBarTrailing) { sortMenu }

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -67,7 +67,7 @@ struct FeedView: View {
                 ToolbarItemGroup(placement: .navigationBarTrailing) { ellipsisMenu }
             }
             .navigationBarTitleDisplayMode(.inline)
-            .barBackgroundColor()
+            .navigationBarColor()
             .environmentObject(postTracker)
             .task(priority: .userInitiated) { await initFeed() }
             .task(priority: .background) { await fetchCommunityDetails() }

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -86,7 +86,7 @@ struct InboxView: View {
             contentView
                 .navigationTitle("Inbox")
                 .navigationBarTitleDisplayMode(.inline)
-                .barBackgroundColor()
+                .navigationBarColor()
                 .toolbar {
                     ToolbarItemGroup(placement: .navigationBarTrailing) { ellipsisMenu }
                 }

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -86,7 +86,6 @@ struct InboxView: View {
             contentView
                 .navigationTitle("Inbox")
                 .navigationBarTitleDisplayMode(.inline)
-                .barBackgroundColor()
                 .toolbar {
                     ToolbarItemGroup(placement: .navigationBarTrailing) { ellipsisMenu }
                 }

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -86,6 +86,7 @@ struct InboxView: View {
             contentView
                 .navigationTitle("Inbox")
                 .navigationBarTitleDisplayMode(.inline)
+                .barBackgroundColor()
                 .toolbar {
                     ToolbarItemGroup(placement: .navigationBarTrailing) { ellipsisMenu }
                 }

--- a/Mlem/Views/Tabs/Profile/User Moderator View.swift
+++ b/Mlem/Views/Tabs/Profile/User Moderator View.swift
@@ -23,7 +23,6 @@ struct UserModeratorView: View {
             }
         }
         .navigationTitle("Moderator Details")
-        .barBackgroundColor()
         .navigationBarTitleDisplayMode(.inline)
         .headerProminence(.standard)
         .listStyle(.plain)

--- a/Mlem/Views/Tabs/Profile/User Moderator View.swift
+++ b/Mlem/Views/Tabs/Profile/User Moderator View.swift
@@ -23,6 +23,7 @@ struct UserModeratorView: View {
             }
         }
         .navigationTitle("Moderator Details")
+        .barBackgroundColor()
         .navigationBarTitleDisplayMode(.inline)
         .headerProminence(.standard)
         .listStyle(.plain)

--- a/Mlem/Views/Tabs/Profile/User Moderator View.swift
+++ b/Mlem/Views/Tabs/Profile/User Moderator View.swift
@@ -23,7 +23,7 @@ struct UserModeratorView: View {
             }
         }
         .navigationTitle("Moderator Details")
-        .barBackgroundColor()
+        .navigationBarColor()
         .navigationBarTitleDisplayMode(.inline)
         .headerProminence(.standard)
         .listStyle(.plain)

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -139,6 +139,7 @@ struct UserView: View {
         .environmentObject(privateCommentTracker)
         .navigationTitle(userDetails.person.displayName ?? userDetails.person.name)
         .navigationBarTitleDisplayMode(.inline)
+        .barBackgroundColor()
         .headerProminence(.standard)
         .refreshable {
             await tryLoadUser()

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -139,7 +139,7 @@ struct UserView: View {
         .environmentObject(privateCommentTracker)
         .navigationTitle(userDetails.person.displayName ?? userDetails.person.name)
         .navigationBarTitleDisplayMode(.inline)
-        .barBackgroundColor()
+        .navigationBarColor()
         .headerProminence(.standard)
         .refreshable {
             await tryLoadUser()

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -139,7 +139,6 @@ struct UserView: View {
         .environmentObject(privateCommentTracker)
         .navigationTitle(userDetails.person.displayName ?? userDetails.person.name)
         .navigationBarTitleDisplayMode(.inline)
-        .barBackgroundColor()
         .headerProminence(.standard)
         .refreshable {
             await tryLoadUser()

--- a/Mlem/Views/Tabs/Search/Search View.swift
+++ b/Mlem/Views/Tabs/Search/Search View.swift
@@ -38,7 +38,7 @@ struct SearchView: View {
             content
                 .handleLemmyViews()
                 .navigationBarTitleDisplayMode(.inline)
-                .barBackgroundColor()
+                .navigationBarColor()
                 .navigationTitle("Search")
         }
         .handleLemmyLinkResolution(navigationPath: $navigationPath)

--- a/Mlem/Views/Tabs/Search/Search View.swift
+++ b/Mlem/Views/Tabs/Search/Search View.swift
@@ -38,7 +38,6 @@ struct SearchView: View {
             content
                 .handleLemmyViews()
                 .navigationBarTitleDisplayMode(.inline)
-                .barBackgroundColor()
                 .navigationTitle("Search")
         }
         .handleLemmyLinkResolution(navigationPath: $navigationPath)

--- a/Mlem/Views/Tabs/Search/Search View.swift
+++ b/Mlem/Views/Tabs/Search/Search View.swift
@@ -38,6 +38,7 @@ struct SearchView: View {
             content
                 .handleLemmyViews()
                 .navigationBarTitleDisplayMode(.inline)
+                .barBackgroundColor()
                 .navigationTitle("Search")
         }
         .handleLemmyLinkResolution(navigationPath: $navigationPath)

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -72,6 +72,7 @@ struct SettingsView: View {
             .fancyTabScrollCompatible()
             .handleLemmyViews()
             .navigationTitle("Settings")
+            .barBackgroundColor()
             .navigationBarTitleDisplayMode(.inline)
 
         }

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -72,7 +72,6 @@ struct SettingsView: View {
             .fancyTabScrollCompatible()
             .handleLemmyViews()
             .navigationTitle("Settings")
-            .barBackgroundColor()
             .navigationBarTitleDisplayMode(.inline)
 
         }

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -72,7 +72,7 @@ struct SettingsView: View {
             .fancyTabScrollCompatible()
             .handleLemmyViews()
             .navigationTitle("Settings")
-            .barBackgroundColor()
+            .navigationBarColor()
             .navigationBarTitleDisplayMode(.inline)
 
         }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
@@ -71,7 +71,7 @@ struct AboutView: View {
             .fancyTabScrollCompatible()
         }
         .navigationTitle("About")
-        .barBackgroundColor()
+        .navigationBarColor()
     }
 
     var versionString: String {

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
@@ -71,6 +71,7 @@ struct AboutView: View {
             .fancyTabScrollCompatible()
         }
         .navigationTitle("About")
+        .barBackgroundColor()
     }
 
     var versionString: String {

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
@@ -71,7 +71,6 @@ struct AboutView: View {
             .fancyTabScrollCompatible()
         }
         .navigationTitle("About")
-        .barBackgroundColor()
     }
 
     var versionString: String {

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/ContributorsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/ContributorsView.swift
@@ -59,6 +59,6 @@ struct ContributorsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Contributors")
-        .barBackgroundColor()
+        .navigationBarColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/ContributorsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/ContributorsView.swift
@@ -59,5 +59,6 @@ struct ContributorsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Contributors")
+        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/ContributorsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/ContributorsView.swift
@@ -59,6 +59,5 @@ struct ContributorsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Contributors")
-        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
@@ -50,6 +50,5 @@ struct LicensesView: View {
             .fancyTabScrollCompatible()
         }
         .navigationTitle("Licenses")
-        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
@@ -50,5 +50,6 @@ struct LicensesView: View {
             .fancyTabScrollCompatible()
         }
         .navigationTitle("Licenses")
+        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
@@ -50,6 +50,6 @@ struct LicensesView: View {
             .fancyTabScrollCompatible()
         }
         .navigationTitle("Licenses")
-        .barBackgroundColor()
+        .navigationBarColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -64,6 +64,6 @@ struct AccessibilitySettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Accessibility")
-        .barBackgroundColor()
+        .navigationBarColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -12,6 +12,7 @@ struct AccessibilitySettingsView: View {
     
     @AppStorage("reakMarkStyle") var readMarkStyle: ReadMarkStyle = .bar
     @AppStorage("readBarThickness") var readBarThickness: Int = 3
+    @AppStorage("hasTranslucentInsets") var hasTranslucentInsets: Bool = true
     
     @State private var readBarThicknessSlider: CGFloat = 3.0
     
@@ -60,6 +61,14 @@ struct AccessibilitySettingsView: View {
                 Text("Differentiate Without Color")
             } footer: {
                 Text("Configure how this app behaves when the system \"differentiate without color\" option is on.")
+            }
+            
+            Section {
+                SwitchableSettingsItem(settingPictureSystemName: AppConstants.transparencySymbolName,
+                                       settingName: "Translucent Insets",
+                                       isTicked: $hasTranslucentInsets)
+            } header: {
+                Text("Transparency")
             }
         }
         .fancyTabScrollCompatible()

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -64,6 +64,5 @@ struct AccessibilitySettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Accessibility")
-        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -64,5 +64,6 @@ struct AccessibilitySettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Accessibility")
+        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Advanced/AdvancedSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Advanced/AdvancedSettingsView.swift
@@ -43,6 +43,5 @@ struct AdvancedSettingsView: View {
             diskUsage = Int64(URLCache.shared.currentDiskUsage)
         }
         .navigationTitle("Advanced")
-        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Advanced/AdvancedSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Advanced/AdvancedSettingsView.swift
@@ -43,5 +43,6 @@ struct AdvancedSettingsView: View {
             diskUsage = Int64(URLCache.shared.currentDiskUsage)
         }
         .navigationTitle("Advanced")
+        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Advanced/AdvancedSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Advanced/AdvancedSettingsView.swift
@@ -43,6 +43,6 @@ struct AdvancedSettingsView: View {
             diskUsage = Int64(URLCache.shared.currentDiskUsage)
         }
         .navigationTitle("Advanced")
-        .barBackgroundColor()
+        .navigationBarColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
@@ -80,7 +80,7 @@ struct AppearanceSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Appearance")
-        .barBackgroundColor()
+        .navigationBarColor()
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
@@ -80,7 +80,6 @@ struct AppearanceSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Appearance")
-        .barBackgroundColor()
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
@@ -80,6 +80,7 @@ struct AppearanceSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Appearance")
+        .barBackgroundColor()
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -67,6 +67,7 @@ struct CommentSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Comments")
+        .barBackgroundColor()
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -67,7 +67,6 @@ struct CommentSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Comments")
-        .barBackgroundColor()
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -67,7 +67,7 @@ struct CommentSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Comments")
-        .barBackgroundColor()
+        .navigationBarColor()
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
@@ -28,6 +28,6 @@ struct CommunitySettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Communities")
-        .barBackgroundColor()
+        .navigationBarColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
@@ -28,5 +28,6 @@ struct CommunitySettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Communities")
+        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
@@ -28,6 +28,5 @@ struct CommunitySettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Communities")
-        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -159,6 +159,7 @@ struct PostSettingsView: View {
         
         .fancyTabScrollCompatible()
         .navigationTitle("Posts")
+        .barBackgroundColor()
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -159,7 +159,7 @@ struct PostSettingsView: View {
         
         .fancyTabScrollCompatible()
         .navigationTitle("Posts")
-        .barBackgroundColor()
+        .navigationBarColor()
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -159,7 +159,6 @@ struct PostSettingsView: View {
         
         .fancyTabScrollCompatible()
         .navigationTitle("Posts")
-        .barBackgroundColor()
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Shared/LayoutWidgetEditView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Shared/LayoutWidgetEditView.swift
@@ -115,6 +115,7 @@ struct LayoutWidgetEditView: View {
             }
         }
         .navigationTitle("Widgets")
+        .barBackgroundColor()
     }
     
     var infoText: some View {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Shared/LayoutWidgetEditView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Shared/LayoutWidgetEditView.swift
@@ -115,7 +115,7 @@ struct LayoutWidgetEditView: View {
             }
         }
         .navigationTitle("Widgets")
-        .barBackgroundColor()
+        .navigationBarColor()
     }
     
     var infoText: some View {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Shared/LayoutWidgetEditView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Shared/LayoutWidgetEditView.swift
@@ -115,7 +115,6 @@ struct LayoutWidgetEditView: View {
             }
         }
         .navigationTitle("Widgets")
-        .barBackgroundColor()
     }
     
     var infoText: some View {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -63,6 +63,7 @@ struct TabBarSettingsView: View {
             }
         }
         .fancyTabScrollCompatible()
+        .navigationTitle("Tab Bar")
         .navigationBarColor()
         .animation(.easeIn, value: profileTabLabel)
         .onChange(of: appState.currentActiveAccount.nickname) { nickname in

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -11,7 +11,7 @@ struct TabBarSettingsView: View {
     @AppStorage("profileTabLabel") var profileTabLabel: ProfileTabLabel = .username
     @AppStorage("showTabNames") var showTabNames: Bool = true
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true
-    @AppStorage("showSolidBarColor") var showSolidBarColor: Bool = false
+    @AppStorage("isTranslucentBar") var isTranslucentBar: Bool = true
         
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var savedAccountTracker: SavedAccountTracker
@@ -58,8 +58,8 @@ struct TabBarSettingsView: View {
             
             Section {
                 SwitchableSettingsItem(settingPictureSystemName: "paintpalette",
-                                       settingName: "Solid Color",
-                                       isTicked: $showSolidBarColor)
+                                       settingName: "Translucent",
+                                       isTicked: $isTranslucentBar)
             }
         }
         .fancyTabScrollCompatible()

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -11,6 +11,7 @@ struct TabBarSettingsView: View {
     @AppStorage("profileTabLabel") var profileTabLabel: ProfileTabLabel = .username
     @AppStorage("showTabNames") var showTabNames: Bool = true
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true
+    @AppStorage("showSolidBarColor") var showSolidBarColor: Bool = false
         
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var savedAccountTracker: SavedAccountTracker
@@ -54,8 +55,15 @@ struct TabBarSettingsView: View {
                                        settingName: "Show Unread Count",
                                        isTicked: $showInboxUnreadBadge)
             }
+            
+            Section {
+                SwitchableSettingsItem(settingPictureSystemName: "paintpalette",
+                                       settingName: "Solid Color",
+                                       isTicked: $showSolidBarColor)
+            }
         }
         .fancyTabScrollCompatible()
+        .barBackgroundColor()
         .animation(.easeIn, value: profileTabLabel)
         .onChange(of: appState.currentActiveAccount.nickname) { nickname in
             print("new nickname: \(nickname)")

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -63,6 +63,7 @@ struct TabBarSettingsView: View {
             }
         }
         .fancyTabScrollCompatible()
+        .barBackgroundColor()
         .animation(.easeIn, value: profileTabLabel)
         .onChange(of: appState.currentActiveAccount.nickname) { nickname in
             print("new nickname: \(nickname)")

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -11,7 +11,6 @@ struct TabBarSettingsView: View {
     @AppStorage("profileTabLabel") var profileTabLabel: ProfileTabLabel = .username
     @AppStorage("showTabNames") var showTabNames: Bool = true
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true
-    @AppStorage("isTranslucentBar") var isTranslucentBar: Bool = true
         
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var savedAccountTracker: SavedAccountTracker
@@ -54,12 +53,6 @@ struct TabBarSettingsView: View {
                 SwitchableSettingsItem(settingPictureSystemName: "envelope.badge",
                                        settingName: "Show Unread Count",
                                        isTicked: $showInboxUnreadBadge)
-            }
-            
-            Section {
-                SwitchableSettingsItem(settingPictureSystemName: "paintpalette",
-                                       settingName: "Translucent",
-                                       isTicked: $isTranslucentBar)
             }
         }
         .fancyTabScrollCompatible()

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -63,7 +63,6 @@ struct TabBarSettingsView: View {
             }
         }
         .fancyTabScrollCompatible()
-        .barBackgroundColor()
         .animation(.easeIn, value: profileTabLabel)
         .onChange(of: appState.currentActiveAccount.nickname) { nickname in
             print("new nickname: \(nickname)")

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -63,7 +63,7 @@ struct TabBarSettingsView: View {
             }
         }
         .fancyTabScrollCompatible()
-        .barBackgroundColor()
+        .navigationBarColor()
         .animation(.easeIn, value: profileTabLabel)
         .onChange(of: appState.currentActiveAccount.nickname) { nickname in
             print("new nickname: \(nickname)")

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Theme/ThemeSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Theme/ThemeSettingsView.swift
@@ -71,5 +71,6 @@ struct ThemeSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Theme")
+        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Theme/ThemeSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Theme/ThemeSettingsView.swift
@@ -71,6 +71,6 @@ struct ThemeSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Theme")
-        .barBackgroundColor()
+        .navigationBarColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Theme/ThemeSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Theme/ThemeSettingsView.swift
@@ -71,6 +71,5 @@ struct ThemeSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Theme")
-        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
@@ -30,6 +30,6 @@ struct UserSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Users")
-        .barBackgroundColor()
+        .navigationBarColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
@@ -30,5 +30,6 @@ struct UserSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Users")
+        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
@@ -30,6 +30,5 @@ struct UserSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Users")
-        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
@@ -153,6 +153,7 @@ struct FiltersSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Filters")
+        .barBackgroundColor()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .automatic) {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
@@ -153,7 +153,6 @@ struct FiltersSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Filters")
-        .barBackgroundColor()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .automatic) {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
@@ -153,7 +153,7 @@ struct FiltersSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Filters")
-        .barBackgroundColor()
+        .navigationBarColor()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .automatic) {

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -107,6 +107,6 @@ struct GeneralSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("General")
-        .barBackgroundColor()
+        .navigationBarColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -107,6 +107,5 @@ struct GeneralSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("General")
-        .barBackgroundColor()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -107,5 +107,6 @@ struct GeneralSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("General")
+        .barBackgroundColor()
     }
 }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - #435
- [x] If this PR alters the UI, I have attached pictures/videos


## About this Pull Request
- New option under Settings → Appearance → Tab bar → Translucent (on by default)
- New `.navigationBarColor()` view extension that sets the color/translucency according to the setting
- Added `.navigationBarColor()` modifier to contents of multiple `NavigationStack`


## Screenshots and Videos
**New Tab Bar Setting:**
<img src="https://github.com/mlemgroup/mlem/assets/20093825/1f89870b-b70d-4493-a7bc-1724397e449f" alt="New Tab Bar Setting" width="400px">

Translucent (unchanged)             |  Non-translucent (new)
:-------------------------:|:-------------------------:
![Translucent Tab/Navigation bar](https://github.com/mlemgroup/mlem/assets/20093825/4368e2d1-352a-495e-8933-55643c4f6276)  |  ![Non-translucent Tab/Navigation bar](https://github.com/mlemgroup/mlem/assets/20093825/f97e748f-5791-46b7-ad28-f5d5642d9258)


## Discussion
- Not sure if "Tab bar" is the correct place, since it's also affecting the navigation bar. I could rename it to "Tab Bar/Navigation Bar", or move it to theme as "Translucent Bars" or something else.
- I could't find a way to globally set the navigation bar color without using the modifier under every `NavigationStack`, maybe there's a better way to do this?