### PR TITLE
Added per feed sorting preference persistence (fixes #486)

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		6D693A482A51B904009E2D76 /* CreateCommentReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D693A472A51B904009E2D76 /* CreateCommentReport.swift */; };
 		6D693A4A2A51B98F009E2D76 /* APICommentReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D693A492A51B98F009E2D76 /* APICommentReportView.swift */; };
 		6D693A4C2A51B99E009E2D76 /* APICommentReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D693A4B2A51B99E009E2D76 /* APICommentReport.swift */; };
+		6D6B322A2A85B47100A410CD /* Feed Sort Type Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6B32292A85B47100A410CD /* Feed Sort Type Tracker.swift */; };
 		6D7782342A48EE8C008AC1BF /* APIPrivateMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7782332A48EE8C008AC1BF /* APIPrivateMessageView.swift */; };
 		6D7782362A48EED8008AC1BF /* APIPrivateMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7782352A48EED8008AC1BF /* APIPrivateMessage.swift */; };
 		6D8003792A45FD1300363206 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D8003782A45FD1300363206 /* Bundle.swift */; };
@@ -586,6 +587,7 @@
 		6D693A472A51B904009E2D76 /* CreateCommentReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommentReport.swift; sourceTree = "<group>"; };
 		6D693A492A51B98F009E2D76 /* APICommentReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICommentReportView.swift; sourceTree = "<group>"; };
 		6D693A4B2A51B99E009E2D76 /* APICommentReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICommentReport.swift; sourceTree = "<group>"; };
+		6D6B32292A85B47100A410CD /* Feed Sort Type Tracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Feed Sort Type Tracker.swift"; sourceTree = "<group>"; };
 		6D7782332A48EE8C008AC1BF /* APIPrivateMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPrivateMessageView.swift; sourceTree = "<group>"; };
 		6D7782352A48EED8008AC1BF /* APIPrivateMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPrivateMessage.swift; sourceTree = "<group>"; };
 		6D8003782A45FD1300363206 /* Bundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
@@ -1536,6 +1538,7 @@
 				034C724E2A82B61200B8A4B8 /* LayoutWidgetTracker.swift */,
 				B1955A1E2A606F010056CF99 /* EasterFlagsTracker.swift */,
 				CDB0117E2A6F70A000D043EB /* Editor Tracker.swift */,
+				6D6B32292A85B47100A410CD /* Feed Sort Type Tracker.swift */,
 			);
 			path = Trackers;
 			sourceTree = "<group>";
@@ -2261,6 +2264,7 @@
 				CD1446232A5B336900610EF1 /* LicensesView.swift in Sources */,
 				CDDCF6432A66343D003DA3AC /* FancyTabBar.swift in Sources */,
 				6318DE5627FBAE3600CC2AD6 /* Share Sheet.swift in Sources */,
+				6D6B322A2A85B47100A410CD /* Feed Sort Type Tracker.swift in Sources */,
 				CD05E77F2A4F263B0081D102 /* Menu Function.swift in Sources */,
 				CDDB08782A5DF1330075BFEE /* CommentSettingsView.swift in Sources */,
 				6386E02C2A03D1EC006B3C1D /* App State.swift in Sources */,

--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -14,29 +14,37 @@ struct HandleLemmyLinksDisplay: ViewModifier {
     @EnvironmentObject var filtersTracker: FiltersTracker
     @EnvironmentObject var favoriteCommunitiesTracker: FavoriteCommunitiesTracker
     @EnvironmentObject var savedAccounts: SavedAccountTracker
+    @EnvironmentObject var feedSortTypeTracker: FeedSortTypeTracker
     
     @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
-    @AppStorage("defaultPostSorting") var defaultPostSorting: PostSortType = .hot
     
     // swiftlint:disable function_body_length
     func body(content: Content) -> some View {
         content
             .navigationDestination(for: APICommunityView.self) { context in
-                FeedView(community: context.community, feedType: .all, sortType: defaultPostSorting)
+                FeedView(
+                    community: context.community,
+                    feedType: .all,
+                    sortType: feedSortTypeTracker.getSortType(for: context.community))
                     .environmentObject(appState)
                     .environmentObject(filtersTracker)
                     .environmentObject(CommunitySearchResultsTracker())
                     .environmentObject(favoriteCommunitiesTracker)
             }
             .navigationDestination(for: APICommunity.self) { community in
-                FeedView(community: community, feedType: .all, sortType: defaultPostSorting)
+                FeedView(community: community, feedType: .all, sortType: feedSortTypeTracker.getSortType(for: community))
                     .environmentObject(appState)
                     .environmentObject(filtersTracker)
                     .environmentObject(CommunitySearchResultsTracker())
                     .environmentObject(favoriteCommunitiesTracker)
             }
             .navigationDestination(for: CommunityLinkWithContext.self) { context in
-                FeedView(community: context.community, feedType: context.feedType, sortType: defaultPostSorting)
+                FeedView(
+                    community: context.community,
+                    feedType: context.feedType,
+                    sortType: context.community != nil
+                    ? feedSortTypeTracker.getSortType(for: context.community!)
+                    : feedSortTypeTracker.getSortType(for: context.feedType))
                     .environmentObject(appState)
                     .environmentObject(filtersTracker)
                     .environmentObject(CommunitySearchResultsTracker())

--- a/Mlem/Models/Trackers/Feed Sort Type Tracker.swift
+++ b/Mlem/Models/Trackers/Feed Sort Type Tracker.swift
@@ -1,0 +1,91 @@
+//
+//  Community Sort Type Tracker.swift
+//  Mlem
+//
+//  Created by Jake Shirley on 8/10/23.
+//
+
+import Foundation
+import Dependencies
+import SwiftUI
+
+// Tracks, stores, and saves the post sort type
+// for feeds
+@MainActor
+class FeedSortTypeTracker: ObservableObject {
+    
+    @AppStorage("defaultPostSorting") var defaultPostSorting: PostSortType = .hot
+    
+    @Dependency(\.persistenceRepository) var persistenceRepository
+    
+    @Published private var sortTypes: [String: PostSortType] = .init()
+    
+    init() {
+        sortTypes = persistenceRepository.loadFeedSortingPreferences()
+    }
+    
+    var isEmpty: Bool {
+        return sortTypes.isEmpty
+    }
+    
+    var count: Int {
+        return sortTypes.count
+    }
+    
+    func clear() {
+        sortTypes.removeAll()
+        saveSortTypes()
+    }
+    
+    func saveSortTypes() {
+        Task {
+            try await persistenceRepository.saveFeedSortingPreferences(sortTypes)
+        }
+    }
+    
+    func getSortType(for community: APICommunity) -> PostSortType {
+        if let communityKey = getKey(for: community) {
+            if let configuredSortType = sortTypes[communityKey] {
+                return configuredSortType
+            }
+        }
+        return defaultPostSorting
+    }
+    
+    // Returns the default if the value has not been set
+    // explicitly by the user
+    func getSortType(for feedType: FeedType) -> PostSortType {
+        if let configuredSortType = sortTypes[getKey(for: feedType)] {
+            return configuredSortType
+        }
+        return defaultPostSorting
+    }
+    
+    func setSortType(for community: APICommunity, sortType: PostSortType) {
+        if let communityKey = getKey(for: community) {
+            print("Setting sort type for '\(communityKey)' to '\(sortType.description)'")
+            sortTypes[communityKey] = sortType
+            
+            saveSortTypes()
+        }
+    }
+    
+    func setSortType(for feedType: FeedType, sortType: PostSortType) {
+        let dictKey = getKey(for: feedType)
+        print("Setting sort type for '\(dictKey)' to '\(sortType.description)'")
+        sortTypes[dictKey] = sortType
+        
+        saveSortTypes()
+    }
+    
+    private func getKey(for community: APICommunity) -> String? {
+        if let serverHost = community.actorId.host() {
+            return "\(community.name.lowercased())@\(serverHost.lowercased())"
+        }
+        return nil
+    }
+    
+    private func getKey(for feedType: FeedType) -> String {
+        return "feed \(feedType.rawValue.lowercased())"
+    }
+}

--- a/Mlem/Repositories/PersistenceRepository.swift
+++ b/Mlem/Repositories/PersistenceRepository.swift
@@ -29,6 +29,7 @@ private enum Path {
     static var recentSearches = { root.appendingPathComponent("Recent Searches", conformingTo: .json) }()
     static var easterFlags = { root.appendingPathComponent("Easter eggs flags", conformingTo: .json) }()
     static var layoutWidgets = { root.appendingPathComponent("Layout Widgets", conformingTo: .json) }()
+    static var feedSortTypes = { root.appendingPathComponent("Feed Sorting Preferences", conformingTo: .json) }()
 }
 
 private struct DiskAccess {
@@ -117,6 +118,14 @@ class PersistenceRepository {
     
     func saveLayoutWidgets(_ value: LayoutWidgetGroups) async throws {
         try await save(value, to: Path.layoutWidgets)
+    }
+    
+    func loadFeedSortingPreferences() -> [String: PostSortType] {
+        load([String: PostSortType].self, from: Path.feedSortTypes) ?? .init()
+    }
+    
+    func saveFeedSortingPreferences(_ value: [String: PostSortType]) async throws {
+        try await save(value, to: Path.feedSortTypes)
     }
     
     // MARK: Private methods

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -10,12 +10,12 @@ import SwiftUI
 struct FeedRoot: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var accountsTracker: SavedAccountTracker
+    @EnvironmentObject var feedSortTypeTracker: FeedSortTypeTracker
     @Environment(\.scenePhase) var phase
     @Environment(\.tabSelectionHashValue) private var selectedTagHashValue
     @Environment(\.tabNavigationSelectionHashValue) private var selectedNavigationTabHashValue
     
     @AppStorage("defaultFeed") var defaultFeed: FeedType = .subscribed
-    @AppStorage("defaultPostSorting") var defaultPostSorting: PostSortType = .hot
 
     @State var navigationPath = NavigationPath()
 
@@ -34,7 +34,9 @@ struct FeedRoot: View {
                     FeedView(
                         community: rootDetails.community,
                         feedType: rootDetails.feedType,
-                        sortType: defaultPostSorting,
+                        sortType: rootDetails.community != nil
+                        ? feedSortTypeTracker.getSortType(for: rootDetails.community!)
+                        : feedSortTypeTracker.getSortType(for: rootDetails.feedType),
                         showLoading: showLoading
                     )
                     .environmentObject(appState)

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -26,6 +26,7 @@ struct FeedView: View {
     @EnvironmentObject var filtersTracker: FiltersTracker
     @EnvironmentObject var favoriteCommunitiesTracker: FavoriteCommunitiesTracker
     @EnvironmentObject var editorTracker: EditorTracker
+    @EnvironmentObject var feedSortTypeTracker: FeedSortTypeTracker
     
     // MARK: Parameters and init
     
@@ -76,6 +77,11 @@ struct FeedView: View {
             }
             .onChange(of: postSortType) { _ in
                 Task(priority: .userInitiated) {
+                    if let community {
+                        feedSortTypeTracker.setSortType(for: community, sortType: postSortType)
+                    } else {
+                        feedSortTypeTracker.setSortType(for: feedType, sortType: postSortType)
+                    }
                     await hardRefreshFeed()
                 }
             }

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -19,8 +19,10 @@ struct GeneralSettingsView: View {
 
     @EnvironmentObject var favoritesTracker: FavoriteCommunitiesTracker
     @EnvironmentObject var appState: AppState
+    @EnvironmentObject var feedSortTypeTracker: FeedSortTypeTracker
 
     @State private var isShowingFavoritesDeletionConfirmation: Bool = false
+    @State private var isShowingSortTypesDeletionConfirmation: Bool = false
 
     var body: some View {
         List {
@@ -99,11 +101,38 @@ struct GeneralSettingsView: View {
                 } message: {
                     Text("You cannot undo this action.")
                 }
+                
+                Button(role: .destructive) {
+                    isShowingSortTypesDeletionConfirmation.toggle()
+                } label: {
+                    Label("Delete Community Sort Preferences", systemImage: "trash")
+                        .foregroundColor(.red)
+                        .opacity(feedSortTypeTracker.isEmpty ? 0.6 : 1)
+                }
+                .disabled(feedSortTypeTracker.isEmpty)
+                .confirmationDialog(
+                    "Delete sort preferences for \(feedSortTypeTracker.count) communities?",
+                    isPresented: $isShowingSortTypesDeletionConfirmation,
+                    titleVisibility: .visible) {
+                        Button(role: .destructive) {
+                            feedSortTypeTracker.clear()
+                        } label: {
+                            Text("Delete all sort prefernces")
+                        }
+                        
+                        Button(role: .cancel) {
+                            isShowingSortTypesDeletionConfirmation.toggle()
+                        } label: {
+                            Text("Cancel")
+                        }
+
+                } message: {
+                    Text("You cannot undo this action.")
+                }
 
             } footer: {
-                Text("Community favorites are stored on-device and are not tied to your Lemmy account.")
+                Text("Community preferences are stored on-device and are not tied to your Lemmy account.")
             }
-
         }
         .fancyTabScrollCompatible()
         .navigationTitle("General")

--- a/Mlem/Window.swift
+++ b/Mlem/Window.swift
@@ -19,6 +19,7 @@ struct Window: View {
     @StateObject var filtersTracker: FiltersTracker = .init()
     @StateObject var recentSearchesTracker: RecentSearchesTracker = .init()
     @StateObject var layoutWidgetTracker: LayoutWidgetTracker = .init()
+    @StateObject var feedSortTypeTracker: FeedSortTypeTracker = .init()
 
     @State var selectedAccount: SavedAccount?
 
@@ -60,6 +61,7 @@ struct Window: View {
             .environmentObject(recentSearchesTracker)
             .environmentObject(easterFlagsTracker)
             .environmentObject(layoutWidgetTracker)
+            .environmentObject(feedSortTypeTracker)
     }
     
     func forceOnboard() {


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #486
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR introduces persistence of per-feed/community post sorting options.  It saves it in a simple dictionary file.

It also adds a way to clear this file in settings.

## Screenshots and Videos
![IMG_5416](https://github.com/mlemgroup/mlem/assets/1000311/78602b72-2a70-46a8-82bd-10a148a73a88)
![IMG_5415](https://github.com/mlemgroup/mlem/assets/1000311/4ca31fe4-fbc5-4605-9bf8-c87d13864911)
![IMG_5414](https://github.com/mlemgroup/mlem/assets/1000311/b78fff1b-5c07-45ef-9252-f74e27ab29bd)

Example file contents for persistence (formatted):
```
{
  "soundersfc@lemmy.world": "New",
  "feed subscribed": "TopTwelveHour",
  "spacex@sh.itjust.works": "New",
  "mls@lemmy.world": "New"
}
```

## Additional Context
n/a
