### PR TITLE
fix - remove interactivity from toasts

### DIFF
--- a/Mlem/Notifications/NotificationDisplayer.swift
+++ b/Mlem/Notifications/NotificationDisplayer.swift
@@ -165,6 +165,7 @@ class NotificationDisplayer {
     }
     
     private static func configureLayout(of toastView: UIView, in controller: UIViewController) {
+        toastView.isUserInteractionEnabled = false
         toastView.translatesAutoresizingMaskIntoConstraints = false
         toastView.backgroundColor = .clear
         toastView.alpha = 0 // start with the toast invisible


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - just something I found which annoyed me 😅 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
A really small tweak that removes interactivity from our toasts so that they do not block taps at the top of the screen (eg back navigation) while visible.
