### PR TITLE
Removed autocorrect/-capitalisation from search

### DIFF
--- a/Mlem/Views/Tabs/Search/Search View.swift
+++ b/Mlem/Views/Tabs/Search/Search View.swift
@@ -44,6 +44,7 @@ struct SearchView: View {
         .handleLemmyLinkResolution(navigationPath: $navigationPath)
         .searchable(text: getSearchTextBinding(), prompt: "Search for communities")
         .autocorrectionDisabled(true)
+        .textInputAutocapitalization(.never)
         .onSubmit(of: .search) {
             performSearch()
         }

--- a/Mlem/Views/Tabs/Search/Search View.swift
+++ b/Mlem/Views/Tabs/Search/Search View.swift
@@ -43,7 +43,7 @@ struct SearchView: View {
         }
         .handleLemmyLinkResolution(navigationPath: $navigationPath)
         .searchable(text: getSearchTextBinding(), prompt: "Search for communities")
-        .disableAutocorrection(true)
+        .autocorrectionDisabled(true)
         .onSubmit(of: .search) {
             performSearch()
         }

--- a/Mlem/Views/Tabs/Search/Search View.swift
+++ b/Mlem/Views/Tabs/Search/Search View.swift
@@ -43,6 +43,7 @@ struct SearchView: View {
         }
         .handleLemmyLinkResolution(navigationPath: $navigationPath)
         .searchable(text: getSearchTextBinding(), prompt: "Search for communities")
+        .disableAutocorrection(true)
         .onSubmit(of: .search) {
             performSearch()
         }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - *list issue(s) here*
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information
Disables autocorrect for the community search

## Additional Context
I don't think it makes sense to autocorrect text that clearly won't be sentences or words. It happened multiple times that I typed something correctly and it got "corrected" to something entirely different
