### PR TITLE
Persisting inbox read/unread filter (#445)

### DIFF
--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -55,7 +55,7 @@ struct InboxView: View {
     
     // loading handling
     @State var isLoading: Bool = true
-    @State var shouldFilterRead: Bool = false
+    @AppStorage("shouldFilterRead") var shouldFilterRead: Bool = false
     
     // item feeds
     @State var allItems: [InboxItem] = .init()


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - #445 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information
Using user defaults to persist the `shouldFilterRead` toggle for the inbox