### PR TITLE
Minor Polishing

### DIFF
--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -77,7 +77,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
         VStack(spacing: 0) {
             Divider()
             
-            HStack(alignment: .top, spacing: 0) {
+            HStack(spacing: 0) {
                 ForEach(tabItemKeys, id: \.hashValue) { key in
                     tabItems[key]?.label()
                         .accessibilityElement(children: .combine)

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -77,7 +77,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
         VStack(spacing: 0) {
             Divider()
             
-            HStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 0) {
                 ForEach(tabItemKeys, id: \.hashValue) { key in
                     tabItems[key]?.label()
                         .accessibilityElement(children: .combine)

--- a/Mlem/Custom Tab Bar/FancyTabBarLabel.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBarLabel.swift
@@ -57,16 +57,16 @@ struct FancyTabBarLabel: View {
     
     var body: some View {
         labelDisplay
-        .accessibilityShowsLargeContentViewer {
-            labelDisplay
-        }
-        .customBadge(badgeCount)
-        .padding(.top, 10)
-        .frame(maxWidth: .infinity)
-        .frame(height: AppConstants.fancyTabBarHeight)
-        .contentShape(Rectangle())
-        .foregroundColor(active ? activeColor : color.opacity(0.4))
-        .animation(.linear(duration: 0.1), value: active)
+            .accessibilityShowsLargeContentViewer {
+                labelDisplay
+            }
+            .customBadge(badgeCount)
+            .padding(.top, 10)
+            .frame(maxWidth: .infinity)
+            .frame(height: AppConstants.fancyTabBarHeight)
+            .contentShape(Rectangle())
+            .foregroundColor(active ? activeColor : color.opacity(0.4))
+            .animation(.linear(duration: 0.1), value: active)
     }
     
     var labelDisplay: some View {

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -26,6 +26,7 @@ struct CachedImage: View {
     
     let maxHeight: CGFloat
     let screenWidth: CGFloat
+    let contentMode: ContentMode
     
     /**
      Optional callback triggered when the quicklook preview is dismissed
@@ -37,11 +38,13 @@ struct CachedImage: View {
          maxHeight: CGFloat = .infinity,
          fixedSize: CGSize? = nil,
          imageNotFound: @escaping () -> AnyView = imageNotFoundDefault,
+         contentMode: ContentMode = .fit,
          dismissCallback: (() -> Void)? = nil) {
         self.url = url
         self.shouldExpand = shouldExpand
         self.maxHeight = maxHeight
         self.imageNotFound = imageNotFound
+        self.contentMode = contentMode
         self.dismissCallback = dismissCallback
         
         screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
@@ -74,7 +77,7 @@ struct CachedImage: View {
             if let imageContainer = state.imageContainer {
                 let imageView = Image(uiImage: imageContainer.image)
                     .resizable()
-                    .scaledToFit()
+                    .aspectRatio(contentMode: contentMode)
                     .frame(width: size.width, height: size.height)
                     .clipped()
                     .allowsHitTesting(false)

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -74,7 +74,7 @@ struct CachedImage: View {
             if let imageContainer = state.imageContainer {
                 let imageView = Image(uiImage: imageContainer.image)
                     .resizable()
-                    .scaledToFill()
+                    .scaledToFit()
                     .frame(width: size.width, height: size.height)
                     .clipped()
                     .allowsHitTesting(false)

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -31,10 +31,14 @@ struct ThumbnailImageView: View {
                 // just blur, no need for the whole filter viewModifier since this is just a thumbnail
                 CachedImage(url: url,
                             fixedSize: size,
+                            contentMode: .fill,
                             dismissCallback: markPostAsRead)
                     .blur(radius: showNsfwFilter ? 8 : 0)
             case .link(let url):
-                CachedImage(url: url, shouldExpand: false, fixedSize: size)
+                CachedImage(url: url,
+                            shouldExpand: false,
+                            fixedSize: size,
+                            contentMode: .fill)
                     .onTapGesture {
                         if let url = postView.post.url {
                             openURL(url)

--- a/Mlem/Views/Shared/Links/Community Link View.swift
+++ b/Mlem/Views/Shared/Links/Community Link View.swift
@@ -155,7 +155,8 @@ struct CommunityLabel: View {
                 CachedImage(url: url.withIcon64Parameters,
                             shouldExpand: false,
                             fixedSize: avatarSize,
-                            imageNotFound: defaultCommunityAvatar)
+                            imageNotFound: defaultCommunityAvatar,
+                            contentMode: .fill)
             } else {
                 defaultCommunityAvatar()
             }

--- a/Mlem/Views/Shared/Links/User Profile Label.swift
+++ b/Mlem/Views/Shared/Links/User Profile Label.swift
@@ -86,7 +86,8 @@ struct UserProfileLabel: View {
                 CachedImage(url: userAvatarLink,
                             shouldExpand: false,
                             fixedSize: avatarSize,
-                            imageNotFound: defaultUserAvatar)
+                            imageNotFound: defaultUserAvatar,
+                            contentMode: .fill)
             } else {
                 defaultUserAvatar()
             }

--- a/Mlem/Views/Shared/Links/User Profile Label.swift
+++ b/Mlem/Views/Shared/Links/User Profile Label.swift
@@ -56,7 +56,7 @@ struct UserProfileLabel: View {
         "lemmy.tespia.org/u/navi",
         "beehaw.org/u/jojo",
         "beehaw.org/u/kronusdark",
-        "vlemmy.net/u/ericbandrews",
+        "lemmy.ml/u/ericbandrews",
         "programming.dev/u/tht7"
     ]
     
@@ -115,6 +115,7 @@ struct UserProfileLabel: View {
         HStack(spacing: 4) {
             if let flairImage = flair.image {
                 flairImage
+                    .font(.footnote)
                     .imageScale(serverInstanceLocation == .bottom ? .large : .small)
                     .foregroundColor(flair.color)
             }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -113,11 +113,12 @@ struct LargePost: View {
                 postContentView
             }
         }
-        .overlay(alignment: .bottomTrailing) {
-            if layoutMode == .minimize {
-                minimizedIcon
-            }
-        }
+        // TEMPORARILY DISABLED so we can play with it on the nightly without the icon
+//        .overlay(alignment: .bottomTrailing) {
+//            if layoutMode == .minimize {
+//                minimizedIcon
+//            }
+//        }
     }
 
     // MARK: - Subviews

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -232,7 +232,7 @@ struct LargePost: View {
     var postBodyView: some View {
         if let bodyText = postView.post.body, !bodyText.isEmpty {
             MarkdownView(
-                text: bodyText,
+                text: postBodyText(bodyText, layoutMode: layoutMode),
                 isNsfw: postView.post.nsfw,
                 replaceImagesWithEmoji: isExpanded ? false : true,
                 isInline: isExpanded ? false : true

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
@@ -18,7 +18,8 @@ struct CommunitySidebarHeaderAvatar: View {
             if let avatarURL = imageUrl {
                 CachedImage(url: avatarURL,
                             shouldExpand: false,
-                            fixedSize: CGSize(width: 120, height: 120))
+                            fixedSize: CGSize(width: 120, height: 120),
+                            contentMode: .fill)
                 .clipShape(Circle())
                 .overlay(Circle()
                     .stroke(.secondary, lineWidth: shouldClipAvatar ? 2 : 0))

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header.swift
@@ -26,7 +26,8 @@ struct CommunitySidebarHeader: View {
                 if let bannerUrl = bannerURL {
                     CachedImage(url: bannerUrl,
                                 shouldExpand: false,
-                                fixedSize: CGSize(width: UIScreen.main.bounds.width, height: 200))
+                                fixedSize: CGSize(width: UIScreen.main.bounds.width, height: 200),
+                                contentMode: .fill)
                 }
             }
             VStack {


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - 🧹 housekeeping
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR makes some minor housekeeping/polishing tweaks:

- CachedImage now accepts a `contentMode` parameter to determine how the image should be resized. By default this is `.fit`, which causes tall images to get shrunk down to fit the maxHeight instead of being clipped; for avatars and such, it has been overridden to `fill`.
- Gave the flair icon the font size of `.footnote` so it's a little less overwhelmingly large
- Used the previously uncalled `postBodyText` function in `LargePost` to re-enable truncating large posts in feed
- Temporarily disabled the "maximize" icon in minimized posts so we can see how it feels without it on the nightly

Simulator doesn't seem to indicate any regression on scrolling performance.

<img width="393" alt="Screenshot 2023-08-13 at 7 47 41 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/c2212844-35e4-49e6-a46a-f7fec234f0a5">
<img width="401" alt="Screenshot 2023-08-13 at 7 48 09 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/8a126824-c68b-4ad6-8e46-5eea9313474d">
<img width="405" alt="Screenshot 2023-08-13 at 7 48 24 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/b2001c5e-659f-4b58-88ce-8a2318f85637">

