### PR TITLE
Expand images in feed (large post size)

### DIFF
--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -105,7 +105,7 @@ struct AppConstants {
     static let localFeedSymbolNameFill: String = "house.circle.fill"
     static let subscribedFeedSymbolName: String = "newspaper.circle"
     static let subscribedFeedSymbolNameFill: String = "newspaper.circle.fill"
-    static let limitImageHeightInFeedSymbolName: String = "rectangle.expand.vertical"
+    static let limitImageHeightInFeedSymbolName: String = "rectangle.compress.vertical"
     
     // sort types
     static let activeSortSymbolName: String = "popcorn" // not married to this idea 

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -28,6 +28,7 @@ struct AppConstants {
     
     // MARK: - Sizes
     static let maxFeedPostHeight: CGFloat = 400
+    static let maxFeedPostHeightExpanded: CGFloat = 3000
     static let thumbnailSize: CGFloat = 60
     static let largeAvatarSize: CGFloat = 32
     static let smallAvatarSize: CGFloat = 16

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -105,6 +105,7 @@ struct AppConstants {
     static let localFeedSymbolNameFill: String = "house.circle.fill"
     static let subscribedFeedSymbolName: String = "newspaper.circle"
     static let subscribedFeedSymbolNameFill: String = "newspaper.circle.fill"
+    static let limitImageHeightInFeedSymbolName: String = "rectangle.expand.vertical"
     
     // sort types
     static let activeSortSymbolName: String = "popcorn" // not married to this idea 

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -51,7 +51,6 @@ struct CachedImage: View {
         self.cornerRadius = cornerRadius ?? 0
         
         screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
-        // Problem: Size doesn't update properly when parent size changes
         
         // determine the size of the image
         if let fixedSize {
@@ -164,7 +163,6 @@ struct CachedImage: View {
      */
     private func cacheImageSize() {
         if let url {
-            print("updating size cache")
             AppConstants.imageSizeCache.setObject(ImageSize(size: size), forKey: NSString(string: url.description))
         }
     }

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -52,6 +52,7 @@ struct CachedImage: View {
         self.cornerRadius = cornerRadius ?? 0
         
         screenWidth = UIScreen.main.bounds.width - ((padding ?? AppConstants.postAndCommentSpacing) * 2)
+        // Problem: Size doesn't update properly when parent size changes
         
         // determine the size of the image
         if let fixedSize {
@@ -164,6 +165,7 @@ struct CachedImage: View {
      */
     private func cacheImageSize() {
         if let url {
+            print("updating size cache")
             AppConstants.imageSizeCache.setObject(ImageSize(size: size), forKey: NSString(string: url.description))
         }
     }

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -37,14 +37,15 @@ struct CachedImage: View {
          maxHeight: CGFloat = .infinity,
          fixedSize: CGSize? = nil,
          imageNotFound: @escaping () -> AnyView = imageNotFoundDefault,
-         dismissCallback: (() -> Void)? = nil) {
+         dismissCallback: (() -> Void)? = nil,
+         padding: CGFloat = AppConstants.postAndCommentSpacing) {
         self.url = url
         self.shouldExpand = shouldExpand
         self.maxHeight = maxHeight
         self.imageNotFound = imageNotFound
         self.dismissCallback = dismissCallback
         
-        screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
+        screenWidth = UIScreen.main.bounds.width - (padding * 2)
         
         // determine the size of the image
         if let fixedSize {

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -37,14 +37,15 @@ struct CachedImage: View {
          maxHeight: CGFloat = .infinity,
          fixedSize: CGSize? = nil,
          imageNotFound: @escaping () -> AnyView = imageNotFoundDefault,
-         dismissCallback: (() -> Void)? = nil) {
+         dismissCallback: (() -> Void)? = nil,
+         fullWidth: Bool = false) {
         self.url = url
         self.shouldExpand = shouldExpand
         self.maxHeight = maxHeight
         self.imageNotFound = imageNotFound
         self.dismissCallback = dismissCallback
         
-        screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
+        screenWidth = UIScreen.main.bounds.width - (fullWidth ? 0 : (AppConstants.postAndCommentSpacing * 2))
         
         // determine the size of the image
         if let fixedSize {

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -27,6 +27,7 @@ struct CachedImage: View {
     let maxHeight: CGFloat
     let screenWidth: CGFloat
     let contentMode: ContentMode
+    let cornerRadius: CGFloat
     
     /**
      Optional callback triggered when the quicklook preview is dismissed
@@ -40,6 +41,7 @@ struct CachedImage: View {
          imageNotFound: @escaping () -> AnyView = imageNotFoundDefault,
          contentMode: ContentMode = .fit,
          dismissCallback: (() -> Void)? = nil,
+         cornerRadius: CGFloat? = nil,
          padding: CGFloat? = nil) {
         self.url = url
         self.shouldExpand = shouldExpand
@@ -47,6 +49,7 @@ struct CachedImage: View {
         self.imageNotFound = imageNotFound
         self.contentMode = contentMode
         self.dismissCallback = dismissCallback
+        self.cornerRadius = cornerRadius ?? 0
         
         screenWidth = UIScreen.main.bounds.width - ((padding ?? AppConstants.postAndCommentSpacing) * 2)
         
@@ -79,6 +82,7 @@ struct CachedImage: View {
                 let imageView = Image(uiImage: imageContainer.image)
                     .resizable()
                     .aspectRatio(contentMode: contentMode)
+                    .cornerRadius(cornerRadius)
                     .frame(width: size.width, height: size.height)
                     .clipped()
                     .allowsHitTesting(false)

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -40,7 +40,7 @@ struct CachedImage: View {
          imageNotFound: @escaping () -> AnyView = imageNotFoundDefault,
          contentMode: ContentMode = .fit,
          dismissCallback: (() -> Void)? = nil,
-         padding: CGFloat = AppConstants.postAndCommentSpacing) {
+         padding: CGFloat? = nil) {
         self.url = url
         self.shouldExpand = shouldExpand
         self.maxHeight = maxHeight
@@ -48,7 +48,7 @@ struct CachedImage: View {
         self.contentMode = contentMode
         self.dismissCallback = dismissCallback
         
-        screenWidth = UIScreen.main.bounds.width - (padding * 2)
+        screenWidth = UIScreen.main.bounds.width - ((padding ?? AppConstants.postAndCommentSpacing) * 2)
         
         // determine the size of the image
         if let fixedSize {

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -41,8 +41,7 @@ struct CachedImage: View {
          imageNotFound: @escaping () -> AnyView = imageNotFoundDefault,
          contentMode: ContentMode = .fit,
          dismissCallback: (() -> Void)? = nil,
-         cornerRadius: CGFloat? = nil,
-         padding: CGFloat? = nil) {
+         cornerRadius: CGFloat? = nil) {
         self.url = url
         self.shouldExpand = shouldExpand
         self.maxHeight = maxHeight
@@ -51,7 +50,7 @@ struct CachedImage: View {
         self.dismissCallback = dismissCallback
         self.cornerRadius = cornerRadius ?? 0
         
-        screenWidth = UIScreen.main.bounds.width - ((padding ?? AppConstants.postAndCommentSpacing) * 2)
+        screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
         // Problem: Size doesn't update properly when parent size changes
         
         // determine the size of the image

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -37,15 +37,14 @@ struct CachedImage: View {
          maxHeight: CGFloat = .infinity,
          fixedSize: CGSize? = nil,
          imageNotFound: @escaping () -> AnyView = imageNotFoundDefault,
-         dismissCallback: (() -> Void)? = nil,
-         fullWidth: Bool = false) {
+         dismissCallback: (() -> Void)? = nil) {
         self.url = url
         self.shouldExpand = shouldExpand
         self.maxHeight = maxHeight
         self.imageNotFound = imageNotFound
         self.dismissCallback = dismissCallback
         
-        screenWidth = UIScreen.main.bounds.width - (fullWidth ? 0 : (AppConstants.postAndCommentSpacing * 2))
+        screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
         
         // determine the size of the image
         if let fixedSize {

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -207,8 +207,8 @@ struct LargePost: View {
                     CachedImage(url: url,
                                 maxHeight: limitImageHeightInFeed ? layoutMode.maxHeight : .infinity,
                                 dismissCallback: markPostAsRead,
+                                cornerRadius: AppConstants.largeItemCornerRadius,
                                 padding: limitImageHeightInFeed ? nil : AppConstants.compactSpacing)
-                    .cornerRadius(AppConstants.largeItemCornerRadius)
                     .padding(.horizontal, limitImageHeightInFeed ? 0 : -AppConstants.compactSpacing)
                     .frame(maxWidth: .infinity,
                            maxHeight: limitImageHeightInFeed ? layoutMode.maxHeight : .infinity,

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -204,11 +204,11 @@ struct LargePost: View {
                 if layoutMode != .minimize {
                     CachedImage(url: url,
                                 maxHeight: .infinity,
-                                dismissCallback: markPostAsRead,
-                                fullWidth: true)
-                    .padding(.horizontal, -AppConstants.postAndCommentSpacing)
+                                dismissCallback: markPostAsRead)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     .applyNsfwOverlay(postView.post.nsfw || postView.community.nsfw)
+                    .cornerRadius(AppConstants.largeItemCornerRadius)
+                    .clipped()
                 }
                 postBodyView
             }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -203,9 +203,9 @@ struct LargePost: View {
             VStack(spacing: AppConstants.postAndCommentSpacing) {
                 if layoutMode != .minimize {
                     CachedImage(url: url,
-                                maxHeight: layoutMode.maxHeight,
+                                maxHeight: .infinity,
                                 dismissCallback: markPostAsRead)
-                    .frame(maxWidth: .infinity, maxHeight: layoutMode.maxHeight, alignment: .top)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     .applyNsfwOverlay(postView.post.nsfw || postView.community.nsfw)
                     .cornerRadius(AppConstants.largeItemCornerRadius)
                     .clipped()

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -204,11 +204,12 @@ struct LargePost: View {
                 if layoutMode != .minimize {
                     CachedImage(url: url,
                                 maxHeight: .infinity,
-                                dismissCallback: markPostAsRead)
+                                dismissCallback: markPostAsRead,
+                                padding: AppConstants.compactSpacing)
+                    .cornerRadius(AppConstants.largeItemCornerRadius)
+                    .padding(.horizontal, -AppConstants.compactSpacing)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     .applyNsfwOverlay(postView.post.nsfw || postView.community.nsfw)
-                    .cornerRadius(AppConstants.largeItemCornerRadius)
-                    .clipped()
                 }
                 postBodyView
             }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -47,6 +47,7 @@ struct LargePost: View {
     @EnvironmentObject var postTracker: PostTracker
     @EnvironmentObject var appState: AppState
     @AppStorage("shouldBlurNsfw") var shouldBlurNsfw: Bool = true
+    @AppStorage("limitImageHeightInFeed") var limitImageHeightInFeed: Bool = true
 
     // parameters
     let postView: APIPostView
@@ -204,12 +205,14 @@ struct LargePost: View {
             VStack(spacing: AppConstants.postAndCommentSpacing) {
                 if layoutMode != .minimize {
                     CachedImage(url: url,
-                                maxHeight: .infinity,
+                                maxHeight: limitImageHeightInFeed ? layoutMode.maxHeight : .infinity,
                                 dismissCallback: markPostAsRead,
-                                padding: AppConstants.compactSpacing)
+                                padding: limitImageHeightInFeed ? nil : AppConstants.compactSpacing)
                     .cornerRadius(AppConstants.largeItemCornerRadius)
-                    .padding(.horizontal, -AppConstants.compactSpacing)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .padding(.horizontal, limitImageHeightInFeed ? 0 : -AppConstants.compactSpacing)
+                    .frame(maxWidth: .infinity,
+                           maxHeight: limitImageHeightInFeed ? layoutMode.maxHeight : .infinity,
+                           alignment: .top)
                     .applyNsfwOverlay(postView.post.nsfw || postView.community.nsfw)
                 }
                 postBodyView

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -204,11 +204,11 @@ struct LargePost: View {
                 if layoutMode != .minimize {
                     CachedImage(url: url,
                                 maxHeight: .infinity,
-                                dismissCallback: markPostAsRead)
+                                dismissCallback: markPostAsRead,
+                                fullWidth: true)
+                    .padding(.horizontal, -AppConstants.postAndCommentSpacing)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     .applyNsfwOverlay(postView.post.nsfw || postView.community.nsfw)
-                    .cornerRadius(AppConstants.largeItemCornerRadius)
-                    .clipped()
                 }
                 postBodyView
             }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -14,12 +14,12 @@ struct LargePost: View {
     enum LayoutMode {
         case minimize, preferredSize, maximize
         
-        var maxHeight: CGFloat {
+        func getMaxHeight(_ limitHeight: Bool = false) -> CGFloat {
             switch self {
             case .maximize:
                 return .infinity
             case .preferredSize:
-                return AppConstants.maxFeedPostHeight
+                return limitHeight ? AppConstants.maxFeedPostHeight : AppConstants.maxFeedPostHeightExpanded
             case .minimize:
                 return 44
             }
@@ -200,19 +200,17 @@ struct LargePost: View {
     
     @ViewBuilder
     var postContentView: some View {
-        let limitHeight = limitImageHeightInFeed && !isExpanded
         switch postView.postType {
         case .image(let url):
+            let limitHeight = limitImageHeightInFeed && !isExpanded
             VStack(spacing: AppConstants.postAndCommentSpacing) {
                 if layoutMode != .minimize {
                     CachedImage(url: url,
-                                maxHeight: limitHeight ? layoutMode.maxHeight : .infinity,
+                                maxHeight: layoutMode.getMaxHeight(limitHeight),
                                 dismissCallback: markPostAsRead,
-                                cornerRadius: AppConstants.largeItemCornerRadius,
-                                padding: limitHeight ? nil : AppConstants.compactSpacing)
-                    .padding(.horizontal, limitHeight ? 0 : -AppConstants.compactSpacing)
+                                cornerRadius: AppConstants.largeItemCornerRadius)
                     .frame(maxWidth: .infinity,
-                           maxHeight: limitHeight ? layoutMode.maxHeight : .infinity,
+                           maxHeight: layoutMode.getMaxHeight(limitHeight),
                            alignment: .top)
                     .applyNsfwOverlay(postView.post.nsfw || postView.community.nsfw)
                 }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -200,18 +200,19 @@ struct LargePost: View {
     
     @ViewBuilder
     var postContentView: some View {
+        let limitHeight = limitImageHeightInFeed && !isExpanded
         switch postView.postType {
         case .image(let url):
             VStack(spacing: AppConstants.postAndCommentSpacing) {
                 if layoutMode != .minimize {
                     CachedImage(url: url,
-                                maxHeight: limitImageHeightInFeed ? layoutMode.maxHeight : .infinity,
+                                maxHeight: limitHeight ? layoutMode.maxHeight : .infinity,
                                 dismissCallback: markPostAsRead,
                                 cornerRadius: AppConstants.largeItemCornerRadius,
-                                padding: limitImageHeightInFeed ? nil : AppConstants.compactSpacing)
-                    .padding(.horizontal, limitImageHeightInFeed ? 0 : -AppConstants.compactSpacing)
+                                padding: limitHeight ? nil : AppConstants.compactSpacing)
+                    .padding(.horizontal, limitHeight ? 0 : -AppConstants.compactSpacing)
                     .frame(maxWidth: .infinity,
-                           maxHeight: limitImageHeightInFeed ? layoutMode.maxHeight : .infinity,
+                           maxHeight: limitHeight ? layoutMode.maxHeight : .infinity,
                            alignment: .top)
                     .applyNsfwOverlay(postView.post.nsfw || postView.community.nsfw)
                 }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -213,6 +213,7 @@ struct LargePost: View {
                            maxHeight: layoutMode.getMaxHeight(limitHeight),
                            alignment: .top)
                     .applyNsfwOverlay(postView.post.nsfw || postView.community.nsfw)
+                    .clipped()
                 }
                 postBodyView
             }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-import Nuke
 
 struct PostSettingsView: View {
     @EnvironmentObject var appState: AppState
@@ -40,12 +39,6 @@ struct PostSettingsView: View {
     @AppStorage("shouldShowWebsiteHost") var shouldShowWebsiteHost: Bool = true
     @AppStorage("shouldShowWebsiteIcon") var shouldShowWebsiteIcon: Bool = true
     
-    func clearFeedImageCache() {
-        // Clearing cache doesn't seem to work: (shouldn't be a problem for the sizing issue)
-        URLCache.shared.removeAllCachedResponses()
-        ImagePipeline.shared.cache.removeAll()
-    }
-
     var body: some View {
         Form {
             Section {
@@ -167,9 +160,6 @@ struct PostSettingsView: View {
                 )
             }
 
-        }
-        .onChange(of: limitImageHeightInFeed) { _ in
-            clearFeedImageCache()
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Posts")

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -38,7 +38,7 @@ struct PostSettingsView: View {
     @AppStorage("shouldShowWebsiteFaviconAtAll") var shouldShowWebsiteFaviconAtAll: Bool = true
     @AppStorage("shouldShowWebsiteHost") var shouldShowWebsiteHost: Bool = true
     @AppStorage("shouldShowWebsiteIcon") var shouldShowWebsiteIcon: Bool = true
-    
+
     var body: some View {
         Form {
             Section {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import Nuke
 
 struct PostSettingsView: View {
     @EnvironmentObject var appState: AppState
@@ -40,7 +41,9 @@ struct PostSettingsView: View {
     @AppStorage("shouldShowWebsiteIcon") var shouldShowWebsiteIcon: Bool = true
     
     func clearFeedImageCache() {
-        print("clearFeedImageCache now")
+        // Clearing cache doesn't seem to work: (shouldn't be a problem for the sizing issue)
+        URLCache.shared.removeAllCachedResponses()
+        ImagePipeline.shared.cache.removeAll()
     }
 
     var body: some View {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -17,6 +17,7 @@ struct PostSettingsView: View {
     // Thumbnails
     @AppStorage("shouldShowPostThumbnails") var shouldShowPostThumbnails: Bool = true
     @AppStorage("thumbnailsOnRight") var shouldShowThumbnailsOnRight: Bool = false
+    @AppStorage("limitImageHeightInFeed") var limitImageHeightInFeed: Bool = true
     
     // Community
     @AppStorage("shouldShowCommunityServerInPost") var shouldShowCommunityServerInPost: Bool = true
@@ -37,6 +38,10 @@ struct PostSettingsView: View {
     @AppStorage("shouldShowWebsiteFaviconAtAll") var shouldShowWebsiteFaviconAtAll: Bool = true
     @AppStorage("shouldShowWebsiteHost") var shouldShowWebsiteHost: Bool = true
     @AppStorage("shouldShowWebsiteIcon") var shouldShowWebsiteIcon: Bool = true
+    
+    func clearFeedImageCache() {
+        print("clearFeedImageCache now")
+    }
 
     var body: some View {
         Form {
@@ -86,6 +91,10 @@ struct PostSettingsView: View {
                 SwitchableSettingsItem(settingPictureSystemName: "photo",
                                        settingName: "Show Post Thumbnails",
                                        isTicked: $shouldShowPostThumbnails)
+                
+                SwitchableSettingsItem(settingPictureSystemName: AppConstants.limitImageHeightInFeedSymbolName,
+                                       settingName: "Limit Image Height In Feed",
+                                       isTicked: $limitImageHeightInFeed)
             }
             
             Section("Interactions and Info") {
@@ -156,7 +165,9 @@ struct PostSettingsView: View {
             }
 
         }
-        
+        .onChange(of: limitImageHeightInFeed) { _ in
+            clearFeedImageCache()
+        }
         .fancyTabScrollCompatible()
         .navigationTitle("Posts")
         .navigationBarColor()


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #480
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information
Removes limiting the height of images in the feed (large post size).

## Screenshots and Videos

| Currently | New |
|---|---|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 08 08 50](https://github.com/mlemgroup/mlem/assets/20093825/f68dfaee-3e91-4c7f-a334-8ce982c8e09a) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 08 10 36](https://github.com/mlemgroup/mlem/assets/20093825/f4769219-4c0e-4fef-9044-b37673e6926d) |

There are two variants of how to expand the image:

| Masked with padding | full width |
|---|---|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 08 10 02](https://github.com/mlemgroup/mlem/assets/20093825/592b7856-e082-46a9-b1d8-92a0c0f272f2) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 08 10 49](https://github.com/mlemgroup/mlem/assets/20093825/c5fe3d79-8bfd-4372-bfea-16ffa1d61e19) |

The "full width" variant is the latest commit, the "masked with padding" variant is the commit before that.

## Discussion
### Old approach intentional?
I am not sure if the previous behaviour of cutting of the height was intentional, since this approach has the slight downside of potentially having to scroll over a perhaps quite long image post that the user is not interested in. Since this was relatively easy to implement I thought it wouldn't hurt to open a PR to discuss this. 

I'd argue that "the long image is annoying to scroll over" is far less common and having it the other way around, where a comic, meme, etc is being cut off and forces the user to tap, zoom/scroll, and dismiss to view the image happens way more often and is the bigger issue. Additionally, you might see a spoiler of a comic/the image, since the "view port" for the image is centred (aligning to the top while cutting off the height has different downsides ofc).

If the height should be limited for image posts, I think hiding the post content (text) would be the better choice. Better to see the full image and tap to see the discussion about it than see half of both. 

One alternative would also be to only expand the image when there's no text added to it and otherwise keep it the way it currently is. Or make it an option in settings to show images with their full height.

### Between the two variants
I'd go with the full width variant, because the image posts can be better differentiated from link previews and the additional width helps with seeing/reading smaller things in the image. The masked variant looks more uniform and has slightly less height, but I think that's negligible.
