### PR TITLE
Add ability to block community directly from post

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		50F2851C2A5C5C1500CF8865 /* TokenRefreshView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F2851B2A5C5C1500CF8865 /* TokenRefreshView.swift */; };
 		50F830F82A4C92BF00D67099 /* FeedTrackerItemProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F830F72A4C92BF00D67099 /* FeedTrackerItemProviding.swift */; };
 		50F830FA2A4C935C00D67099 /* FeedTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F830F92A4C935C00D67099 /* FeedTracker.swift */; };
+		53103A7B2A8A23AA0063DA2F /* BlockCommunityLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53103A7A2A8A23AA0063DA2F /* BlockCommunityLogic.swift */; };
 		630737892A1CD1E900039852 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630737882A1CD1E900039852 /* String.swift */; };
 		6307378B2A1CE2B300039852 /* Rate Post or Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6307378A2A1CE2B300039852 /* Rate Post or Comment.swift */; };
 		6307378D2A1CEB7C00039852 /* My Vote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6307378C2A1CEB7C00039852 /* My Vote.swift */; };
@@ -446,6 +447,7 @@
 		50F2851B2A5C5C1500CF8865 /* TokenRefreshView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRefreshView.swift; sourceTree = "<group>"; };
 		50F830F72A4C92BF00D67099 /* FeedTrackerItemProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedTrackerItemProviding.swift; sourceTree = "<group>"; };
 		50F830F92A4C935C00D67099 /* FeedTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedTracker.swift; sourceTree = "<group>"; };
+		53103A7A2A8A23AA0063DA2F /* BlockCommunityLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockCommunityLogic.swift; sourceTree = "<group>"; };
 		630737882A1CD1E900039852 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		6307378A2A1CE2B300039852 /* Rate Post or Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rate Post or Comment.swift"; sourceTree = "<group>"; };
 		6307378C2A1CEB7C00039852 /* My Vote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "My Vote.swift"; sourceTree = "<group>"; };
@@ -1054,6 +1056,7 @@
 				CD18DC702A520A60002C56BC /* MarkPrivateMessageAsRead.swift */,
 				CD18DC742A522B38002C56BC /* SendPrivateMessage.swift */,
 				ADDC9E3B2A5CF02A00383D58 /* BlockPersonLogic.swift */,
+				53103A7A2A8A23AA0063DA2F /* BlockCommunityLogic.swift */,
 				CD7B53BA2A5F27DB00006E81 /* Report Private Message.swift */,
 			);
 			path = Participating;
@@ -2340,6 +2343,7 @@
 				CD18DC6B2A5202D4002C56BC /* MarkPersonMentionAsReadRequest.swift in Sources */,
 				CD82A2502A7162D400111034 /* GetPersonUnreadCount.swift in Sources */,
 				CD82A24C2A70A26900111034 /* View - CustomBadge.swift in Sources */,
+				53103A7B2A8A23AA0063DA2F /* BlockCommunityLogic.swift in Sources */,
 				B1CB6E752A4C729D00DA9675 /* Bundle - Current App Icon.swift in Sources */,
 				6363D60427EE20A200E34822 /* Expanded Post.swift in Sources */,
 				6DE1183C2A4A217400810C7E /* Profile View.swift in Sources */,

--- a/Mlem/Logic/Participating/BlockCommunityLogic.swift
+++ b/Mlem/Logic/Participating/BlockCommunityLogic.swift
@@ -1,0 +1,23 @@
+//
+//  BlockCommunityLogic.swift
+//  Mlem
+//
+//  Created by Ben Baron on 8/14/23.
+//
+
+import Foundation
+
+@MainActor
+func blockCommunity(
+    account: SavedAccount,
+    community: APICommunity,
+    blocked: Bool) async throws -> Bool {
+        let request = BlockCommunityRequest(
+            account: account,
+            communityId: community.id,
+            block: blocked
+        )
+        let response = try await APIClient().perform(request: request)
+        HapticManager.shared.play(haptic: .violentSuccess, priority: .high)
+        return response.blocked
+    }

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -288,6 +288,28 @@ struct FeedPost: View {
             )
         }
     }
+    
+    func blockCommunity() async {
+        do {
+            let blocked = try await Mlem.blockCommunity(
+                account: appState.currentActiveAccount,
+                community: postView.community,
+                blocked: true
+            )
+            if blocked {
+                postTracker.removePosts(from: postView.creator.id)
+                await notifier.add(.success("Blocked \(postView.community.name)"))
+            }
+        } catch {
+            errorHandler.handle(
+                .init(
+                    message: "Unable to block \(postView.community.name)",
+                    style: .toast,
+                    underlyingError: error
+                )
+            )
+        }
+    }
 
     func replyToPost() {
         editorTracker.openEditor(with: ConcreteEditorModel(appState: appState,
@@ -450,6 +472,17 @@ struct FeedPost: View {
             enabled: true) {
                 Task(priority: .userInitiated) {
                     await blockUser()
+                }
+            })
+        
+        // block community
+        ret.append(MenuFunction(
+            text: "Block Community",
+            imageName: AppConstants.blockSymbolName,
+            destructiveActionPrompt: nil,
+            enabled: true) {
+                Task(priority: .userInitiated) {
+                    await blockCommunity()
                 }
             })
 


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - I opened the issue but don't have perms to assign: https://github.com/mlemgroup/mlem/issues/485
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This adds an option to the FeedPost view options menu to directly block the community it's from instead of having to first open the community to do it. This is especially useful in the All feed to block communities you don't want as they federate to your server.

I tried to copy the logic used in the "Block User" button. Please feel free to refactor/change it, or let me know what to change if you prefer it done in a different way.

## Screenshots and Videos
[Screenshot](https://github.com/mlemgroup/mlem/assets/350423/a701e318-37e1-4b5f-a84a-48b9ddc16ac7) and [Video](https://github.com/mlemgroup/mlem/assets/350423/b66e0ac8-f335-4a55-99d5-468690139d6f)

## Additional Context
More details in this issue:
Closes https://github.com/mlemgroup/mlem/issues/485

