### PR TITLE
Small improvements to markdown in feed (large post size)

### DIFF
--- a/Mlem/Views/Shared/Markdown View.swift
+++ b/Mlem/Views/Shared/Markdown View.swift
@@ -172,10 +172,16 @@ extension Theme {
                 )
         }
     
-    static let mlemDeemphasized = mlem
+    static let plain = Theme()
+        .link {
+            ForegroundColor(.link)
+        }
         .text {
             ForegroundColor(.secondary)
             FontSize(16)
+        }
+        .code {
+            
         }
 }
 
@@ -222,13 +228,13 @@ struct MarkdownView: View {
     @State var text: String
     let isNsfw: Bool
     let replaceImagesWithEmoji: Bool
-    let isDeemphasized: Bool
+    let isInline: Bool
     
-    init(text: String, isNsfw: Bool, replaceImagesWithEmoji: Bool = false, isDeemphasized: Bool = false) {
-        self.text = text
+    init(text: String, isNsfw: Bool, replaceImagesWithEmoji: Bool = false, isInline: Bool = false) {
+        self.text = isInline ? MarkdownView.prepareInlineMarkdown(text: text) : text
         self.isNsfw = isNsfw
         self.replaceImagesWithEmoji = replaceImagesWithEmoji
-        self.isDeemphasized = isDeemphasized
+        self.isInline = isInline
     }
 
     var body: some View {
@@ -237,7 +243,7 @@ struct MarkdownView: View {
 
     @MainActor func generateView() -> some View {
         let blocks = parseMarkdownForImages(text: text)
-        let theme: Theme = isDeemphasized ? .mlemDeemphasized : .mlem
+        let theme: Theme = isInline ? .plain : .mlem
         
         return VStack {
             ForEach(blocks) { block in
@@ -253,6 +259,13 @@ struct MarkdownView: View {
                 }
             }
         }
+    }
+    
+    static func prepareInlineMarkdown(text: String) -> String {
+        return text
+            .components(separatedBy: .newlines)
+            .joined(separator: " ")
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
     }
     
     func parseMarkdownForImages(text: String) -> [MarkdownBlock] {

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -235,7 +235,7 @@ struct LargePost: View {
                 text: bodyText,
                 isNsfw: postView.post.nsfw,
                 replaceImagesWithEmoji: isExpanded ? false : true,
-                isDeemphasized: isExpanded ? false : true
+                isInline: isExpanded ? false : true
             )
             .id(postView.id)
             .font(.subheadline)


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - #361
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information
This addresses a few of the markdown issues inside the feed (large post size). It's far from being a proper solution for the markdown situation, but it's a small fix that avoids many of the larger issues in the meantime.

## About this Pull Request
- Uses a markdown theme with minimal styling to avoid some of the current issues where the entire post takes on the same styling that the first element in the body has (e.g. everything is a heading, quoted post, ...)
- Also fixes text not being truncated at all in the feed

## Screenshots and Videos
| Previous | New |
|---|---|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 21 26 27](https://github.com/mlemgroup/mlem/assets/20093825/4812d34e-7186-4596-ab2f-3baa63cf6f46)  |  ![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 21 27 34](https://github.com/mlemgroup/mlem/assets/20093825/17603268-10e5-456f-96aa-c074e368463d) |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 21 26 16](https://github.com/mlemgroup/mlem/assets/20093825/ac8d194e-00d3-44be-b4a9-23a57f78e6eb)  | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 21 24 57](https://github.com/mlemgroup/mlem/assets/20093825/48385535-f438-4082-83d6-338106620b25) |

## Discussion 
This doesn't really address #361 in the way it's being described there. I don't think it makes sense to show the exact same markdown from the expanded post in  the feed, it's better to make it a short summary, at least strip away line breaks. That also means block quotes etc would have to be displayed differently.