### PR TITLE
allow control of transport behaviour in `APIClient`

### DIFF
--- a/Mlem/API/APIClient.swift
+++ b/Mlem/API/APIClient.swift
@@ -31,6 +31,7 @@ class APIClient {
 
     let urlSession: URLSession
     let decoder: JSONDecoder
+    let transport: (URLSession, URLRequest) async throws -> (Data, URLResponse)
     
     private var _session: APISession?
     private var session: APISession {
@@ -45,9 +46,14 @@ class APIClient {
     
     // MARK: - Initialisation
     
-    init(session: URLSession = .init(configuration: .default), decoder: JSONDecoder = .defaultDecoder) {
+    init(
+        session: URLSession = .init(configuration: .default),
+        decoder: JSONDecoder = .defaultDecoder,
+        transport: @escaping (URLSession, URLRequest) async throws -> (Data, URLResponse)
+    ) {
         self.urlSession = session
         self.decoder = decoder
+        self.transport = transport
     }
     
     // MARK: - Public methods
@@ -95,7 +101,7 @@ class APIClient {
     
     private func execute(_ urlRequest: URLRequest) async throws -> (Data, URLResponse) {
         do {
-            return try await urlSession.data(for: urlRequest)
+            return try await transport(urlSession, urlRequest)
         } catch {
             if case URLError.cancelled = error as NSError {
                 throw APIClientError.cancelled

--- a/Mlem/Dependency/APIClient+Dependency.swift
+++ b/Mlem/Dependency/APIClient+Dependency.swift
@@ -7,14 +7,16 @@
 //
 
 import Dependencies
+import Foundation
 
 extension APIClient: DependencyKey {
-  static let liveValue = APIClient()
+    static let liveValue = APIClient { urlSession, urlRequest in try await urlSession.data(for: urlRequest) }
+    static let testValue = APIClient(transport: unimplemented())
 }
 
 extension DependencyValues {
-  var apiClient: APIClient {
-    get { self[APIClient.self] }
-    set { self[APIClient.self] = newValue }
-  }
+    var apiClient: APIClient {
+        get { self[APIClient.self] }
+        set { self[APIClient.self] = newValue }
+    }
 }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Small tweak to allow/improve testability of the application
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR is the small change I had looked to make on one of my other branches which ended up requiring the big ol' refactor that was #519.

This change introduces a `transport` function which is passed to the `APIClient` when it is initialised that describes how it will interact with the network. The one that is now passed in at the live values dependency injection point is the same behaviour as before so there is no change seen when running the application.

However, it now allows us to pass different values under test.

The value currently sent to the test value is `unimplemented()` which will cause any test that attempts to hit the network to fail immediately. In general our tests should not be expected to touch the network layer (we'll more often stub the repository layer).

If we did want to hit the client under test and return mocked data this change also makes that possible as we could do something along the lines of:
```swift
let model = withDependencies {
    $0.apiClient = .init(transport: { _, request in
        guard let urlString = request.url?.absoluteString else {
            throw APIClientError.cancelled
        }
                
        switch urlString {
        case "some_url_we_care_about":
        // return whatever data/response we want...
            return (Data(), URLResponse())
        default:
            throw APIClientError.cancelled
        }
    }) 
} operation: {
    SomeModel()
}
```

The ability to stub at this layer would come in handy if we started introducing caching to the repositories, as we could assert what URLs are being hit etc... but as above, most tests will not touch the client at all - and so the `.testValue` supplied is `unimplemented` to fail if they do.