### PR TITLE
fix - pass original values in overload 🤦

### DIFF
--- a/Mlem/Error Handling/ErrorHandler.swift
+++ b/Mlem/Error Handling/ErrorHandler.swift
@@ -22,7 +22,7 @@ class ErrorHandler: ObservableObject {
             return
         }
         
-        handle(.init(underlyingError: error))
+        handle(.init(underlyingError: error), file: file, function: function, line: line)
     }
     
     func handle(_ error: ContextualError?, file: StaticString = #fileID, function: StaticString = #function, line: Int = #line) {


### PR DESCRIPTION
# Pull Request Information

## About this Pull Request
This PR ensures we pass the original file/function/line methods from our overload so they show correctly in the debug output.

Apologies, I'm a silly billy 🙃 
