### PR TITLE
Fix tab reselect logic causing programmatic scrolling to not reliably work

### DIFF
--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -16,7 +16,11 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
     @AppStorage("hasTranslucentInsets") var hasTranslucentInsets: Bool = true
     
     @Binding private var selection: Selection
+    /// Keeps track of tab "re-selected" state.
     @Binding private var navigationSelection: NavigationSelection
+    @State private var __tempNavigationSelection: Int = -1
+    /// We only toggle this to trigger an `onChange` event.
+    @State private var __navigationSelectionSignal: Bool = false
     
     private let content: () -> Content
     
@@ -89,17 +93,26 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                         .highPriorityGesture(
                             TapGesture()
                                 .onEnded {
-                                    /// If user tapped on tab that's already selected.
+                                    /// Emit "re-selected tab" event, if user tapped on tab that's already selected.
                                     if key.hashValue == selection.hashValue {
+                                        /// Set to placeholder value.
+                                        /// Previous implementation used `DispatchQueue.asyncAfter` to set this to its actual value, but that caused bugs when performing UI changes on scroll views. [2023.08]
                                         navigationSelection = TabSelection._tabBarNavigation
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                                            self.navigationSelection = key
-                                        }
+                                        /// Keep track of new selection for use in `onChange` handler.
+                                        __tempNavigationSelection = key.index
+                                        /// Trigger `onChange` event.
+                                        __navigationSelectionSignal.toggle()
                                     }
                                     
                                     selection = key
                                 }
                         )
+                }
+            }
+            /// Workaround for issue where setting `navigationSelection` inside a `Dispatch.asyncAfter` block caused issues when performing programmatic scrolling. [2023.08]
+            .onChange(of: __navigationSelectionSignal) { _ in
+                if let newTabSelection = TabSelection(index: __tempNavigationSelection) {
+                    self.navigationSelection = newTabSelection
                 }
             }
             .gesture(

--- a/Mlem/Enums/TabSelection.swift
+++ b/Mlem/Enums/TabSelection.swift
@@ -29,4 +29,23 @@ enum TabSelection: String, FancyTabBarSelection {
         case ._tabBarNavigation: return .min
         }
     }
+    
+    init?(index: Int) {
+        switch index {
+        case 1:
+            self = .feeds
+        case 2:
+            self = .inbox
+        case 3:
+            self = .profile
+        case 4:
+            self = .search
+        case 5:
+            self = .settings
+        case .min:
+            self = ._tabBarNavigation
+        default:
+            return nil
+        }
+    }
 }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Related to #457
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
When scrolls a scroll view, and then triggers a programmatic "scroll-to" event via `FancyTabBar`, the previous implementation caused programmatic scrolling to not reliably work.
- Note this bug only affects programmatic scrolling while scroll view is actively scrolling/animating scrolling.

Previously, implementation used `DispatchQueue.asyncAfter` to trigger "tab re-selected" event:
- My guess is this method caused any UI logic that relied on state changes performed inside that `asyncAfter` block to "escape" SwiftUI's rendering loop and/or execution context (possibly related to RunLoop in tracking mode).
- This was causing programmatic scrolling to at times fail when scroll view is still animating scrolling.
- Programmatic scrolling would always work when scroll view is stationary.

New implementation makes state changes inside SwiftUI framework:
- Trigger a dummy change event by toggling a Bool value.
- Observe that change using `.onChange`, then make the actual state change inside that `onChange` handler.
