### PR TITLE
Tap tab to navigate

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 		E47B2B762A902DE200629AF7 /* SettingsRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47B2B752A902DE200629AF7 /* SettingsRoutes.swift */; };
 		E4902BAB2A9024BF0054FB36 /* SettingsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4902BAA2A9024BF0054FB36 /* SettingsRouter.swift */; };
 		E49F0E762A90395400BC4EE3 /* NavigationPath+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49F0E752A90395400BC4EE3 /* NavigationPath+Helpers.swift */; };
+		E49F0E7A2A91942B00BC4EE3 /* Environment+ScrollViewProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49F0E792A91942B00BC4EE3 /* Environment+ScrollViewProxy.swift */; };
 		E4D4DBA02A7C7B9D00C4F3DE /* Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D4DB9F2A7C7B9D00C4F3DE /* Comments.swift */; };
 		E4D4DBA22A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D4DBA12A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift */; };
 		E4DDB4322A81819300B3A7E0 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DDB4312A81819300B3A7E0 /* Double.swift */; };
@@ -771,6 +772,7 @@
 		E47B2B752A902DE200629AF7 /* SettingsRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRoutes.swift; sourceTree = "<group>"; };
 		E4902BAA2A9024BF0054FB36 /* SettingsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRouter.swift; sourceTree = "<group>"; };
 		E49F0E752A90395400BC4EE3 /* NavigationPath+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationPath+Helpers.swift"; sourceTree = "<group>"; };
+		E49F0E792A91942B00BC4EE3 /* Environment+ScrollViewProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Environment+ScrollViewProxy.swift"; sourceTree = "<group>"; };
 		E4D4DB9F2A7C7B9D00C4F3DE /* Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comments.swift; sourceTree = "<group>"; };
 		E4D4DBA12A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyTabNavigationSelectionHashValueEnvironmentKey.swift; sourceTree = "<group>"; };
 		E4DDB4312A81819300B3A7E0 /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
@@ -1152,6 +1154,7 @@
 				503A5D742A78EF3C00488C38 /* Encodable+Export.swift */,
 				B1955A202A6145C00056CF99 /* Environment - EasterFlagSetter.swift */,
 				CDE8F2382A68DA7D00E0AE68 /* Environment - Force Onboard.swift */,
+				E49F0E792A91942B00BC4EE3 /* Environment+ScrollViewProxy.swift */,
 				507573902A5AD53C00AA7ABD /* Error+Equatable.swift */,
 				6D8601ED2A43C0B1002A56FC /* Image.swift */,
 				6DA61F842A568F99001EA633 /* Int.swift */,
@@ -2320,6 +2323,7 @@
 				508845CF2A3641160088E483 /* JSONDecoder+Default.swift in Sources */,
 				637218672A3A2AAD008C4816 /* GetPersonDetails.swift in Sources */,
 				CD7B53BB2A5F27DB00006E81 /* Report Private Message.swift in Sources */,
+				E49F0E7A2A91942B00BC4EE3 /* Environment+ScrollViewProxy.swift in Sources */,
 				B1A26FE12A44AAB200B91A32 /* Navigation getter.swift in Sources */,
 				6332FDC027EFB05F0009A98A /* Settings Item.swift in Sources */,
 				50C99B602A6299D8005D57DD /* ErrorHandler.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		CDF8426B2A4A2AB600723DA0 /* Inbox Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8426A2A4A2AB600723DA0 /* Inbox Item.swift */; };
 		CDF8426F2A4A385A00723DA0 /* Inbox Item Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8426E2A4A385A00723DA0 /* Inbox Item Type.swift */; };
 		E453A1D02A81C2140004BB8A /* QuickLookPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */; };
+		E4902BAB2A9024BF0054FB36 /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4902BAA2A9024BF0054FB36 /* NavigationRouter.swift */; };
 		E4D4DBA02A7C7B9D00C4F3DE /* Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D4DB9F2A7C7B9D00C4F3DE /* Comments.swift */; };
 		E4D4DBA22A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D4DBA12A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift */; };
 		E4DDB4322A81819300B3A7E0 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DDB4312A81819300B3A7E0 /* Double.swift */; };
@@ -765,6 +766,7 @@
 		CDF8426A2A4A2AB600723DA0 /* Inbox Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox Item.swift"; sourceTree = "<group>"; };
 		CDF8426E2A4A385A00723DA0 /* Inbox Item Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox Item Type.swift"; sourceTree = "<group>"; };
 		E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewController.swift; sourceTree = "<group>"; };
+		E4902BAA2A9024BF0054FB36 /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
 		E4D4DB9F2A7C7B9D00C4F3DE /* Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comments.swift; sourceTree = "<group>"; };
 		E4D4DBA12A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyTabNavigationSelectionHashValueEnvironmentKey.swift; sourceTree = "<group>"; };
 		E4DDB4312A81819300B3A7E0 /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
@@ -1267,6 +1269,7 @@
 				50C99B572A61D85D005D57DD /* Dependency */,
 				50C99B5A2A61F5BA005D57DD /* Repositories */,
 				507573922A5AD57F00AA7ABD /* Error Handling */,
+				E4902BA92A90245E0054FB36 /* Navigation */,
 				5064D03B2A6DE05000B22EE3 /* Notifications */,
 				63344C5E2A080C5F001BC616 /* Styles */,
 				63F0C7A02A05198600A18C5D /* Enums */,
@@ -1979,6 +1982,14 @@
 			path = "Quick Look";
 			sourceTree = "<group>";
 		};
+		E4902BA92A90245E0054FB36 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				E4902BAA2A9024BF0054FB36 /* NavigationRouter.swift */,
+			);
+			path = Navigation;
+			sourceTree = "<group>";
+		};
 		E4D4DB9E2A7C7A5800C4F3DE /* Animations */ = {
 			isa = PBXGroup;
 			children = (
@@ -2407,6 +2418,7 @@
 				507573912A5AD53C00AA7ABD /* Error+Equatable.swift in Sources */,
 				6D693A482A51B904009E2D76 /* CreateCommentReport.swift in Sources */,
 				CD2E182B2A3B708500224F8A /* Settings Options.swift in Sources */,
+				E4902BAB2A9024BF0054FB36 /* NavigationRouter.swift in Sources */,
 				6307378D2A1CEB7C00039852 /* My Vote.swift in Sources */,
 				50F830FA2A4C935C00D67099 /* FeedTracker.swift in Sources */,
 				CD69F55D2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -375,7 +375,8 @@
 		CDF8426B2A4A2AB600723DA0 /* Inbox Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8426A2A4A2AB600723DA0 /* Inbox Item.swift */; };
 		CDF8426F2A4A385A00723DA0 /* Inbox Item Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8426E2A4A385A00723DA0 /* Inbox Item Type.swift */; };
 		E453A1D02A81C2140004BB8A /* QuickLookPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */; };
-		E4902BAB2A9024BF0054FB36 /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4902BAA2A9024BF0054FB36 /* NavigationRouter.swift */; };
+		E47B2B762A902DE200629AF7 /* SettingsRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47B2B752A902DE200629AF7 /* SettingsRoutes.swift */; };
+		E4902BAB2A9024BF0054FB36 /* SettingsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4902BAA2A9024BF0054FB36 /* SettingsRouter.swift */; };
 		E4D4DBA02A7C7B9D00C4F3DE /* Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D4DB9F2A7C7B9D00C4F3DE /* Comments.swift */; };
 		E4D4DBA22A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D4DBA12A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift */; };
 		E4DDB4322A81819300B3A7E0 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DDB4312A81819300B3A7E0 /* Double.swift */; };
@@ -766,7 +767,8 @@
 		CDF8426A2A4A2AB600723DA0 /* Inbox Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox Item.swift"; sourceTree = "<group>"; };
 		CDF8426E2A4A385A00723DA0 /* Inbox Item Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox Item Type.swift"; sourceTree = "<group>"; };
 		E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewController.swift; sourceTree = "<group>"; };
-		E4902BAA2A9024BF0054FB36 /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
+		E47B2B752A902DE200629AF7 /* SettingsRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRoutes.swift; sourceTree = "<group>"; };
+		E4902BAA2A9024BF0054FB36 /* SettingsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRouter.swift; sourceTree = "<group>"; };
 		E4D4DB9F2A7C7B9D00C4F3DE /* Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comments.swift; sourceTree = "<group>"; };
 		E4D4DBA12A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyTabNavigationSelectionHashValueEnvironmentKey.swift; sourceTree = "<group>"; };
 		E4DDB4312A81819300B3A7E0 /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
@@ -1982,10 +1984,27 @@
 			path = "Quick Look";
 			sourceTree = "<group>";
 		};
+		E47B2B742A902DB400629AF7 /* Route */ = {
+			isa = PBXGroup;
+			children = (
+				E47B2B752A902DE200629AF7 /* SettingsRoutes.swift */,
+			);
+			path = Route;
+			sourceTree = "<group>";
+		};
+		E47B2B772A902E3C00629AF7 /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				E4902BAA2A9024BF0054FB36 /* SettingsRouter.swift */,
+			);
+			path = Router;
+			sourceTree = "<group>";
+		};
 		E4902BA92A90245E0054FB36 /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
-				E4902BAA2A9024BF0054FB36 /* NavigationRouter.swift */,
+				E47B2B772A902E3C00629AF7 /* Router */,
+				E47B2B742A902DB400629AF7 /* Route */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
@@ -2260,6 +2279,7 @@
 				50C99B592A61D889005D57DD /* APIClient+Dependency.swift in Sources */,
 				CDDCF6572A678298003DA3AC /* FancyTabBarSelection.swift in Sources */,
 				CD3FBCE92A4B482700B2063F /* Generic Merge.swift in Sources */,
+				E47B2B762A902DE200629AF7 /* SettingsRoutes.swift in Sources */,
 				CDA145ED2A510AC100DDAFC9 /* MarkCommentReplyAsReadRequest.swift in Sources */,
 				CD391F982A537E8E00E213B5 /* ReplyToComment.swift in Sources */,
 				5064D03D2A6DE0AA00B22EE3 /* Notifier.swift in Sources */,
@@ -2418,7 +2438,7 @@
 				507573912A5AD53C00AA7ABD /* Error+Equatable.swift in Sources */,
 				6D693A482A51B904009E2D76 /* CreateCommentReport.swift in Sources */,
 				CD2E182B2A3B708500224F8A /* Settings Options.swift in Sources */,
-				E4902BAB2A9024BF0054FB36 /* NavigationRouter.swift in Sources */,
+				E4902BAB2A9024BF0054FB36 /* SettingsRouter.swift in Sources */,
 				6307378D2A1CEB7C00039852 /* My Vote.swift in Sources */,
 				50F830FA2A4C935C00D67099 /* FeedTracker.swift in Sources */,
 				CD69F55D2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		E453A1D02A81C2140004BB8A /* QuickLookPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */; };
 		E47B2B762A902DE200629AF7 /* SettingsRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47B2B752A902DE200629AF7 /* SettingsRoutes.swift */; };
 		E4902BAB2A9024BF0054FB36 /* SettingsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4902BAA2A9024BF0054FB36 /* SettingsRouter.swift */; };
+		E49F0E762A90395400BC4EE3 /* NavigationPath+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49F0E752A90395400BC4EE3 /* NavigationPath+Helpers.swift */; };
 		E4D4DBA02A7C7B9D00C4F3DE /* Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D4DB9F2A7C7B9D00C4F3DE /* Comments.swift */; };
 		E4D4DBA22A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D4DBA12A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift */; };
 		E4DDB4322A81819300B3A7E0 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DDB4312A81819300B3A7E0 /* Double.swift */; };
@@ -769,6 +770,7 @@
 		E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewController.swift; sourceTree = "<group>"; };
 		E47B2B752A902DE200629AF7 /* SettingsRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRoutes.swift; sourceTree = "<group>"; };
 		E4902BAA2A9024BF0054FB36 /* SettingsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRouter.swift; sourceTree = "<group>"; };
+		E49F0E752A90395400BC4EE3 /* NavigationPath+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationPath+Helpers.swift"; sourceTree = "<group>"; };
 		E4D4DB9F2A7C7B9D00C4F3DE /* Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comments.swift; sourceTree = "<group>"; };
 		E4D4DBA12A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyTabNavigationSelectionHashValueEnvironmentKey.swift; sourceTree = "<group>"; };
 		E4DDB4312A81819300B3A7E0 /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
@@ -2003,6 +2005,7 @@
 		E4902BA92A90245E0054FB36 /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
+				E49F0E752A90395400BC4EE3 /* NavigationPath+Helpers.swift */,
 				E47B2B772A902E3C00629AF7 /* Router */,
 				E47B2B742A902DB400629AF7 /* Route */,
 			);
@@ -2343,6 +2346,7 @@
 				CDF842612A49EA3900723DA0 /* Mentions Tracker.swift in Sources */,
 				6D693A4C2A51B99E009E2D76 /* APICommentReport.swift in Sources */,
 				63344C672A08D4E3001BC616 /* AppearanceSettingsView.swift in Sources */,
+				E49F0E762A90395400BC4EE3 /* NavigationPath+Helpers.swift in Sources */,
 				B1955A1F2A606F010056CF99 /* EasterFlagsTracker.swift in Sources */,
 				63D24ED92A169A5F005CCA81 /* UIApplication.swift in Sources */,
 				637218482A3A2AAD008C4816 /* APICommentReply.swift in Sources */,

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -26,7 +26,6 @@ struct ContentView: View {
     
     // tabs
     @State private var tabSelection: TabSelection = .feeds
-    @State private var tabNavigation: any FancyTabBarSelection = TabSelection._tabBarNavigation
     @State private var showLoading: Bool = false
     @GestureState private var isDetectingLongPress = false
     
@@ -39,7 +38,7 @@ struct ContentView: View {
     var accessibilityFont: Bool { UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory }
     
     var body: some View {
-        FancyTabBar(selection: $tabSelection, navigationSelection: $tabNavigation, dragUpGestureCallback: showAccountSwitcherDragCallback) {
+        FancyTabBar(selection: $tabSelection, dragUpGestureCallback: showAccountSwitcherDragCallback) {
             Group {
                 FeedRoot(showLoading: showLoading)
                     .fancyTabItem(tag: TabSelection.feeds) {

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -16,7 +16,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
     @AppStorage("hasTranslucentInsets") var hasTranslucentInsets: Bool = true
     
     @Binding private var selection: Selection
-    @Binding private var navigationSelection: NavigationSelection
+    @State private var navigationSelection: NavigationSelection = TabSelection._tabBarNavigation
     @State private var __tempNavigationSelection: Int = -1
     @State private var __tempToggle: Bool = false
     
@@ -28,11 +28,9 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
     var dragUpGestureCallback: (() -> Void)?
     
     init(selection: Binding<Selection>,
-         navigationSelection: Binding<NavigationSelection>,
          dragUpGestureCallback: (() -> Void)? = nil,
          @ViewBuilder content: @escaping () -> Content) {
         self._selection = selection
-        self._navigationSelection = navigationSelection
         self.content = content
         self.dragUpGestureCallback = dragUpGestureCallback
     }

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -97,11 +97,6 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                                         
                                         __tempNavigationSelection = key.index
                                         __tempToggle.toggle()
-                                        
-//                                        navigationSelection = TabSelection._tabBarNavigation
-//                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-//                                            self.navigationSelection = key
-//                                        }
                                     }
                                     
                                     selection = key
@@ -110,9 +105,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                 }
             }
             .onChange(of: self.__tempToggle) { _ in
-//                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                    self.navigationSelection = TabSelection(index: __tempNavigationSelection)!
-//                }
+                navigationSelection = TabSelection(index: __tempNavigationSelection)!
             }
             .gesture(
                 DragGesture()

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -17,6 +17,8 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
     
     @Binding private var selection: Selection
     @Binding private var navigationSelection: NavigationSelection
+    @State private var __tempNavigationSelection: Int = -1
+    @State private var __tempToggle: Bool = false
     
     private let content: () -> Content
     
@@ -92,15 +94,25 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                                     /// If user tapped on tab that's already selected.
                                     if key.hashValue == selection.hashValue {
                                         navigationSelection = TabSelection._tabBarNavigation
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                                            self.navigationSelection = key
-                                        }
+                                        
+                                        __tempNavigationSelection = key.index
+                                        __tempToggle.toggle()
+                                        
+//                                        navigationSelection = TabSelection._tabBarNavigation
+//                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+//                                            self.navigationSelection = key
+//                                        }
                                     }
                                     
                                     selection = key
                                 }
                         )
                 }
+            }
+            .onChange(of: self.__tempToggle) { _ in
+//                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                    self.navigationSelection = TabSelection(index: __tempNavigationSelection)!
+//                }
             }
             .gesture(
                 DragGesture()

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -94,6 +94,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                         .contentShape(Rectangle())
                     // high priority to prevent conflict with long press/drag
                         .highPriorityGesture(
+                            /// If tab already selected, only have gesture for navigation?
                             tapToNavigateMaxCount
                                 .onEnded {
                                     print("uhhh, user hit max tap count, this is really not supposed to happen.")
@@ -117,7 +118,8 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                 }
             }
             .onChange(of: self.__tempToggle) { _ in
-                navigationSelection = TabSelection(index: __tempNavigationSelection)!
+                print("set tab nav selection to -> \(TabSelection(index: __tempNavigationSelection)!.labelText ?? "_")")
+                self.navigationSelection = TabSelection(index: __tempNavigationSelection)!
             }
             .gesture(
                 DragGesture()

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -98,8 +98,8 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
                                 .onEnded {
                                     print("uhhh, user hit max tap count, this is really not supposed to happen.")
                                 }
-                                .exclusively(
-                                    before: tapOnceToNavigate
+                                .simultaneously(
+                                    with: tapOnceToNavigate
                                         .onEnded {
                                             print("tapped once")
                                             /// If user tapped on tab that's already selected.

--- a/Mlem/Data/Document.swift
+++ b/Mlem/Data/Document.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Document: Identifiable {
+struct Document: Identifiable, Hashable {
     let body: String
     var id: Int {
         var hasher = Hasher()

--- a/Mlem/Enums/TabSelection.swift
+++ b/Mlem/Enums/TabSelection.swift
@@ -29,4 +29,23 @@ enum TabSelection: String, FancyTabBarSelection {
         case ._tabBarNavigation: return .min
         }
     }
+    
+    init?(index: Int) {
+        switch index {
+        case 1:
+            self = .feeds
+        case 2:
+            self = .inbox
+        case 3:
+            self = .profile
+        case 4:
+            self = .search
+        case 5:
+            self = .settings
+        case .min:
+            self = ._tabBarNavigation
+        default:
+            return nil
+        }
+    }
 }

--- a/Mlem/Extensions/Environment+ScrollViewProxy.swift
+++ b/Mlem/Extensions/Environment+ScrollViewProxy.swift
@@ -1,0 +1,20 @@
+//
+//  Environment+ScrollViewProxy.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-08-19.
+//
+
+import SwiftUI
+
+private struct ScrollViewProxyEnvironmentKey: EnvironmentKey {
+    static let defaultValue: ScrollViewProxy? = nil
+}
+
+extension EnvironmentValues {
+    /// Each tab has a root scroll view proxy that child views can use to perform scrolling.
+    var tabScrollViewProxy: ScrollViewProxy? {
+        get { self[ScrollViewProxyEnvironmentKey.self] }
+        set { self[ScrollViewProxyEnvironmentKey.self] = newValue }
+    }
+}

--- a/Mlem/Extensions/Navigation getter.swift
+++ b/Mlem/Extensions/Navigation getter.swift
@@ -18,3 +18,14 @@ extension EnvironmentValues {
         set { self[NavigationPathGetter.self] = newValue }
       }
 }
+
+private struct CustomNavigationPath: EnvironmentKey {
+    static let defaultValue: Binding<[MlemRoutes]> = .constant([])
+}
+
+extension EnvironmentValues {
+    var customNavigationPath: Binding<[MlemRoutes]> {
+        get { self[CustomNavigationPath.self] }
+        set { self[CustomNavigationPath.self] = newValue }
+    }
+}

--- a/Mlem/Navigation/NavigationPath+Helpers.swift
+++ b/Mlem/Navigation/NavigationPath+Helpers.swift
@@ -1,0 +1,19 @@
+//
+//  NavigationPath+Helpers.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-08-18.
+//
+
+import SwiftUI
+
+extension NavigationPath {
+    
+    mutating func goBack(popToRoot: Bool = false) {
+        guard !isEmpty else {
+            return
+        }
+        let popDepth = popToRoot ? self.count : 1
+        self.removeLast(popDepth)
+    }
+}

--- a/Mlem/Navigation/NavigationPath+Helpers.swift
+++ b/Mlem/Navigation/NavigationPath+Helpers.swift
@@ -9,11 +9,14 @@ import SwiftUI
 
 extension NavigationPath {
     
-    mutating func goBack(popToRoot: Bool = false) {
+    /// - Returns: Items count on navigation path after performing go back action.
+    @discardableResult
+    mutating func goBack(popToRoot: Bool = false) -> Int {
         guard !isEmpty else {
-            return
+            return 0
         }
         let popDepth = popToRoot ? self.count : 1
         self.removeLast(popDepth)
+        return self.count
     }
 }

--- a/Mlem/Navigation/NavigationRouter.swift
+++ b/Mlem/Navigation/NavigationRouter.swift
@@ -1,0 +1,83 @@
+//
+//  NavigationRouter.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-08-18.
+//
+
+import SwiftUI
+
+extension View {
+    func useSettingsNavigationRouter() -> some View {
+        modifier(SettingsNavigationRouter())
+    }
+}
+
+struct SettingsNavigationRouter: ViewModifier {
+    
+    @Environment(\.navigationPath) private var navigationPath
+    @EnvironmentObject private var layoutWidgetTracker: LayoutWidgetTracker
+
+    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable function_body_length
+    func body(content: Content) -> some View {
+        content
+            .navigationDestination(for: SettingsNavigationRoute.self) { route in
+                switch route {
+                case .accountsPage(let onboarding):
+                    AccountsPage(onboarding: onboarding)
+                case .general:
+                    GeneralSettingsView()
+                case .accessibility:
+                    AccessibilitySettingsView()
+                case .appearance:
+                    AppearanceSettingsView()
+                case .contentFilters:
+                    FiltersSettingsView()
+                case .about:
+                    AboutView(navigationPath: navigationPath)
+                case .advanced:
+                    AdvancedSettingsView()
+                }
+            }
+            .navigationDestination(for: AppearanceSettingsNavigationRoute.self) { route in
+                switch route {
+                case .theme:
+                    ThemeSettingsView()
+                case .appIcon:
+                    IconSettingsView()
+                case .posts:
+                    PostSettingsView()
+                case .comments:
+                    CommentSettingsView()
+                case .communities:
+                    CommunitySettingsView()
+                case .users:
+                    UserSettingsView()
+                case .tabBar:
+                    TabBarSettingsView()
+                }
+            }
+            .navigationDestination(for: CommentSettingsNavigationRoute.self) { route in
+                switch route {
+                case .layoutWidget:
+                    LayoutWidgetEditView(widgets: layoutWidgetTracker.groups.comment, onSave: { widgets in
+                        layoutWidgetTracker.groups.comment = widgets
+                        layoutWidgetTracker.saveLayoutWidgets()
+                    })
+                }
+            }
+            .navigationDestination(for: PostSettingsNavigationRoute.self) { route in
+                switch route {
+                case .customizeWidgets:
+                    /// We really should be passing in the layout widget through the route enum value, but that would involve making layout widget tracker hashable and codable.
+                    LayoutWidgetEditView(widgets: layoutWidgetTracker.groups.post, onSave: { widgets in
+                        layoutWidgetTracker.groups.post = widgets
+                        layoutWidgetTracker.saveLayoutWidgets()
+                    })
+                }
+            }
+    }
+    // swiftlint:enable cyclomatic_complexity
+    // swiftlint:enable function_body_length
+}

--- a/Mlem/Navigation/Route/SettingsRoutes.swift
+++ b/Mlem/Navigation/Route/SettingsRoutes.swift
@@ -1,0 +1,36 @@
+//
+//  SettingsRoutes.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-08-18.
+//
+
+import Foundation
+
+enum SettingsRoute: Hashable, Codable {
+    case accountsPage(onboarding: Bool)
+    case general
+    case accessibility
+    case appearance
+    case contentFilters
+    case about
+    case advanced
+}
+
+enum AppearanceSettingsRoute: Hashable, Codable {
+    case theme
+    case appIcon
+    case posts
+    case comments
+    case communities
+    case users
+    case tabBar
+}
+
+enum CommentSettingsRoute: Hashable, Codable {
+    case layoutWidget
+}
+
+enum PostSettingsRoute: Hashable, Codable {
+    case customizeWidgets
+}

--- a/Mlem/Navigation/Route/SettingsRoutes.swift
+++ b/Mlem/Navigation/Route/SettingsRoutes.swift
@@ -34,3 +34,14 @@ enum CommentSettingsRoute: Hashable, Codable {
 enum PostSettingsRoute: Hashable, Codable {
     case customizeWidgets
 }
+
+enum AboutSettingsRoute: Hashable {
+    case contributors
+    case privacyPolicy(Document)
+    case eula(Document)
+    case licenses
+}
+
+enum LicensesSettingsRoute: Hashable {
+    case licenseDocument(Document)
+}

--- a/Mlem/Navigation/Router/SettingsRouter.swift
+++ b/Mlem/Navigation/Router/SettingsRouter.swift
@@ -1,5 +1,5 @@
 //
-//  NavigationRouter.swift
+//  SettingsRouter.swift
 //  Mlem
 //
 //  Created by Bosco Ho on 2023-08-18.
@@ -9,11 +9,11 @@ import SwiftUI
 
 extension View {
     func useSettingsNavigationRouter() -> some View {
-        modifier(SettingsNavigationRouter())
+        modifier(SettingsRouter())
     }
 }
 
-struct SettingsNavigationRouter: ViewModifier {
+struct SettingsRouter: ViewModifier {
     
     @Environment(\.navigationPath) private var navigationPath
     @EnvironmentObject private var layoutWidgetTracker: LayoutWidgetTracker
@@ -22,7 +22,7 @@ struct SettingsNavigationRouter: ViewModifier {
     // swiftlint:disable function_body_length
     func body(content: Content) -> some View {
         content
-            .navigationDestination(for: SettingsNavigationRoute.self) { route in
+            .navigationDestination(for: SettingsRoute.self) { route in
                 switch route {
                 case .accountsPage(let onboarding):
                     AccountsPage(onboarding: onboarding)
@@ -40,7 +40,7 @@ struct SettingsNavigationRouter: ViewModifier {
                     AdvancedSettingsView()
                 }
             }
-            .navigationDestination(for: AppearanceSettingsNavigationRoute.self) { route in
+            .navigationDestination(for: AppearanceSettingsRoute.self) { route in
                 switch route {
                 case .theme:
                     ThemeSettingsView()
@@ -58,7 +58,7 @@ struct SettingsNavigationRouter: ViewModifier {
                     TabBarSettingsView()
                 }
             }
-            .navigationDestination(for: CommentSettingsNavigationRoute.self) { route in
+            .navigationDestination(for: CommentSettingsRoute.self) { route in
                 switch route {
                 case .layoutWidget:
                     LayoutWidgetEditView(widgets: layoutWidgetTracker.groups.comment, onSave: { widgets in
@@ -67,7 +67,7 @@ struct SettingsNavigationRouter: ViewModifier {
                     })
                 }
             }
-            .navigationDestination(for: PostSettingsNavigationRoute.self) { route in
+            .navigationDestination(for: PostSettingsRoute.self) { route in
                 switch route {
                 case .customizeWidgets:
                     /// We really should be passing in the layout widget through the route enum value, but that would involve making layout widget tracker hashable and codable.

--- a/Mlem/Navigation/Router/SettingsRouter.swift
+++ b/Mlem/Navigation/Router/SettingsRouter.swift
@@ -10,6 +10,11 @@ import SwiftUI
 extension View {
     func useSettingsNavigationRouter() -> some View {
         modifier(SettingsRouter())
+            .modifier(AppearanceSettingsRouter())
+            .modifier(CommentSettingsRouter())
+            .modifier(PostSettingsRouter())
+            .modifier(AboutSettingsRouter())
+            .modifier(LicensesSettingsRouter())
     }
 }
 
@@ -18,8 +23,6 @@ struct SettingsRouter: ViewModifier {
     @Environment(\.navigationPath) private var navigationPath
     @EnvironmentObject private var layoutWidgetTracker: LayoutWidgetTracker
 
-    // swiftlint:disable cyclomatic_complexity
-    // swiftlint:disable function_body_length
     func body(content: Content) -> some View {
         content
             .navigationDestination(for: SettingsRoute.self) { route in
@@ -40,6 +43,13 @@ struct SettingsRouter: ViewModifier {
                     AdvancedSettingsView()
                 }
             }
+    }
+}
+
+private struct AppearanceSettingsRouter: ViewModifier {
+
+    func body(content: Content) -> some View {
+        content
             .navigationDestination(for: AppearanceSettingsRoute.self) { route in
                 switch route {
                 case .theme:
@@ -58,6 +68,15 @@ struct SettingsRouter: ViewModifier {
                     TabBarSettingsView()
                 }
             }
+    }
+}
+
+private struct CommentSettingsRouter: ViewModifier {
+    
+    @EnvironmentObject private var layoutWidgetTracker: LayoutWidgetTracker
+    
+    func body(content: Content) -> some View {
+        content
             .navigationDestination(for: CommentSettingsRoute.self) { route in
                 switch route {
                 case .layoutWidget:
@@ -67,6 +86,15 @@ struct SettingsRouter: ViewModifier {
                     })
                 }
             }
+    }
+}
+
+private struct PostSettingsRouter: ViewModifier {
+    
+    @EnvironmentObject private var layoutWidgetTracker: LayoutWidgetTracker
+
+    func body(content: Content) -> some View {
+        content
             .navigationDestination(for: PostSettingsRoute.self) { route in
                 switch route {
                 case .customizeWidgets:
@@ -77,6 +105,13 @@ struct SettingsRouter: ViewModifier {
                     })
                 }
             }
+    }
+}
+
+private struct AboutSettingsRouter: ViewModifier {
+    
+    func body(content: Content) -> some View {
+        content
             .navigationDestination(for: AboutSettingsRoute.self) { route in
                 switch route {
                 case .contributors:
@@ -89,6 +124,13 @@ struct SettingsRouter: ViewModifier {
                     LicensesView()
                 }
             }
+    }
+}
+
+private struct LicensesSettingsRouter: ViewModifier {
+    
+    func body(content: Content) -> some View {
+        content
             .navigationDestination(for: LicensesSettingsRoute.self) { route in
                 switch route {
                 case .licenseDocument(let doc):
@@ -96,6 +138,4 @@ struct SettingsRouter: ViewModifier {
                 }
             }
     }
-    // swiftlint:enable cyclomatic_complexity
-    // swiftlint:enable function_body_length
 }

--- a/Mlem/Navigation/Router/SettingsRouter.swift
+++ b/Mlem/Navigation/Router/SettingsRouter.swift
@@ -77,6 +77,24 @@ struct SettingsRouter: ViewModifier {
                     })
                 }
             }
+            .navigationDestination(for: AboutSettingsRoute.self) { route in
+                switch route {
+                case .contributors:
+                    ContributorsView()
+                case .eula(let doc):
+                    DocumentView(text: doc.body)
+                case .privacyPolicy(let doc):
+                    DocumentView(text: doc.body)
+                case .licenses:
+                    LicensesView()
+                }
+            }
+            .navigationDestination(for: LicensesSettingsRoute.self) { route in
+                switch route {
+                case .licenseDocument(let doc):
+                    DocumentView(text: doc.body)
+                }
+            }
     }
     // swiftlint:enable cyclomatic_complexity
     // swiftlint:enable function_body_length

--- a/Mlem/Views/Shared/Links/Community Link View.swift
+++ b/Mlem/Views/Shared/Links/Community Link View.swift
@@ -44,7 +44,7 @@ struct CommunityLinkView: View {
     }
     
     var body: some View {
-        NavigationLink(value: community) {
+        NavigationLink(value: MlemRoutes.apiCommunity(community)) {
             HStack {
                 CommunityLabel(community: community,
                                serverInstanceLocation: serverInstanceLocation,

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -18,6 +18,7 @@ struct FeedRoot: View {
     @AppStorage("defaultPostSorting") var defaultPostSorting: PostSortType = .hot
 
     @State var navigationPath = NavigationPath()
+    @State private var customNavigationPath: [MlemRoutes] = []
 
     @State var rootDetails: CommunityLinkWithContext?
     
@@ -30,7 +31,7 @@ struct FeedRoot: View {
         } detail: {
             if let rootDetails {
                 ScrollViewReader { proxy in
-                    NavigationStack(path: $navigationPath) {
+                    NavigationStack(path: $customNavigationPath) {
                         FeedView(
                             community: rootDetails.community,
                             feedType: rootDetails.feedType,
@@ -52,6 +53,7 @@ struct FeedRoot: View {
             navigationPath: $navigationPath
         )
         .environment(\.navigationPath, $navigationPath)
+        .environment(\.customNavigationPath, $customNavigationPath)
         .environmentObject(appState)
         .environmentObject(accountsTracker)
         .onAppear {
@@ -93,10 +95,17 @@ struct FeedRoot: View {
                 print("switched to Feed tab")
             }
         }
-        .onChange(of: selectedNavigationTabHashValue) { newValue in
-            if newValue == TabSelection.feeds.hashValue {
-                print("re-selected \(TabSelection.feeds) tab")
+//        .onChange(of: selectedNavigationTabHashValue) { newValue in
+//            if newValue == TabSelection.feeds.hashValue {
+//                print("re-selected \(TabSelection.feeds) tab")
+//            }
+//        }
+        .overlay(alignment: .center) {
+            #if DEBUG
+            GroupBox {
+                Text("NavigationPath.count: \(navigationPath.count)")
             }
+            #endif
         }
     }
 }

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -30,15 +30,18 @@ struct FeedRoot: View {
                 .id(appState.currentActiveAccount.id)
         } detail: {
             if let rootDetails {
-                NavigationStack(path: $navigationPath) {
-                    FeedView(
-                        community: rootDetails.community,
-                        feedType: rootDetails.feedType,
-                        sortType: defaultPostSorting,
-                        showLoading: showLoading
-                    )
-                    .environmentObject(appState)
-                    .handleLemmyViews()
+                ScrollViewReader { proxy in
+                    NavigationStack(path: $navigationPath) {
+                        FeedView(
+                            community: rootDetails.community,
+                            feedType: rootDetails.feedType,
+                            sortType: defaultPostSorting,
+                            showLoading: showLoading
+                        )
+                        .environmentObject(appState)
+                        .environment(\.tabScrollViewProxy, proxy)
+                        .handleLemmyViews()
+                    }
                 }
                 .id(rootDetails.id + appState.currentActiveAccount.id)
             } else {

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -22,9 +22,8 @@ struct FeedRoot: View {
     @State var rootDetails: CommunityLinkWithContext?
     
     let showLoading: Bool
-
+    
     var body: some View {
-
         NavigationSplitView {
             CommunityListView(selectedCommunity: $rootDetails)
                 .id(appState.currentActiveAccount.id)
@@ -36,7 +35,8 @@ struct FeedRoot: View {
                             community: rootDetails.community,
                             feedType: rootDetails.feedType,
                             sortType: defaultPostSorting,
-                            showLoading: showLoading
+                            showLoading: showLoading,
+                            rootDetails: $rootDetails
                         )
                         .environmentObject(appState)
                         .environment(\.tabScrollViewProxy, proxy)

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -143,9 +143,7 @@ struct FeedView: View {
                         if navigationPath.wrappedValue.isEmpty {
                             if scrollToTopAppeared {
                                 /// Already scrolled to top: Pop to sidebar.
-                                withAnimation {
-                                    rootDetails = nil
-                                }
+                                rootDetails = nil
                             } else {
                                 withAnimation {
                                     scrollViewProxy?.scrollTo(scrollToTop, anchor: .top)

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -29,7 +29,8 @@ struct FeedView: View {
     
     @Environment(\.tabNavigationSelectionHashValue) private var selectedNavigationTabHashValue
     @Environment(\.tabScrollViewProxy) private var scrollViewProxy
-    @Environment(\.navigationPath) private var navigationPath
+//    @Environment(\.navigationPath) private var navigationPath
+    @Environment(\.customNavigationPath) private var navigationPath
     
     // MARK: Parameters and init
     
@@ -139,6 +140,7 @@ struct FeedView: View {
                 }
                 .onChange(of: selectedNavigationTabHashValue) { newValue in
                     if newValue == TabSelection.feeds.hashValue {
+                        /// Go back in subviews, check if navigato
                         print("re-selected \(TabSelection.feeds) tab")
                         if navigationPath.wrappedValue.isEmpty {
                             if scrollToTopAppeared {
@@ -150,7 +152,8 @@ struct FeedView: View {
                                 }
                             }
                         } else {
-                            navigationPath.wrappedValue.goBack()
+                            let count = navigationPath.wrappedValue.popLast()
+                            print("navigate go back -> \(count)")
                         }
                     }
                 }
@@ -180,7 +183,7 @@ struct FeedView: View {
     @ViewBuilder
     private func feedPost(for postView: APIPostView) -> some View {
         VStack(spacing: 0) {
-            NavigationLink(value: PostLinkWithContext(post: postView, postTracker: postTracker)) {
+            NavigationLink(value: MlemRoutes.postLinkWithContext(PostLinkWithContext(post: postView, postTracker: postTracker))) {
                 FeedPost(
                     postView: postView,
                     showPostCreator: shouldShowPostCreator,

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -11,9 +11,7 @@ import Dependencies
 
 // swiftlint:disable type_body_length
 struct FeedView: View {
-    
-    @State private var scrollToFlag: Int = 0
-    
+        
     // MARK: Environment and settings
     
     @Dependency(\.hapticManager) var hapticManager
@@ -127,11 +125,10 @@ struct FeedView: View {
     
     @ViewBuilder
     private var contentView: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                //            if postTracker.items.isEmpty {
-                //                noPostsView()
-                //            } else {
+        ScrollView {
+            if postTracker.items.isEmpty {
+                noPostsView()
+            } else {
                 LazyVStack(spacing: 0) {
                     scrollToView
                     
@@ -141,15 +138,9 @@ struct FeedView: View {
                     
                     EndOfFeedView(isLoading: isLoading)
                 }
-                .onChange(of: scrollToFlag, perform: { _ in
-                    withAnimation {
-                        proxy.scrollTo(scrollToTop, anchor: .top)
-                    }
-                })
                 .onChange(of: selectedNavigationTabHashValue) { newValue in
                     if newValue == TabSelection.feeds.hashValue {
-                        print("FeedView received Tab re-tap event")
-//                        print("re-selected \(TabSelection.feeds) tab")
+                        print("re-selected \(TabSelection.feeds) tab")
 #if DEBUG
                         if navigationPath.wrappedValue.isEmpty {
                             if scrollToTopAppeared {
@@ -158,31 +149,16 @@ struct FeedView: View {
                                     rootDetails = nil
                                 }
                             } else {
-                                print("FeedView performing Tab re-tap action...scroll to top")
-                                scrollToFlag += 1
-//                                DispatchQueue.main.async {
-//                                    withAnimation {
-//                                        proxy.scrollTo(scrollToTop, anchor: .top)
-//                                    }
-//                                }
+                                withAnimation {
+                                    scrollViewProxy?.scrollTo(scrollToTop, anchor: .top)
+                                }
                             }
                         } else {
                             navigationPath.wrappedValue.goBack()
                         }
 #endif
-//                    }
                     }
                 }
-            }
-            .overlay(alignment: .bottom) {
-                Button {
-                    scrollToFlag += 1
-                } label: {
-                    Text("Scroll To Top")
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(.pink)
-                .padding(4)
             }
         }
         .fancyTabScrollCompatible()

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -141,7 +141,6 @@ struct FeedView: View {
                 .onChange(of: selectedNavigationTabHashValue) { newValue in
                     if newValue == TabSelection.feeds.hashValue {
                         print("re-selected \(TabSelection.feeds) tab")
-#if DEBUG
                         if navigationPath.wrappedValue.isEmpty {
                             if scrollToTopAppeared {
                                 /// Already scrolled to top: Pop to sidebar.
@@ -156,7 +155,6 @@ struct FeedView: View {
                         } else {
                             navigationPath.wrappedValue.goBack()
                         }
-#endif
                     }
                 }
             }

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -9,7 +9,6 @@ import Foundation
 import SwiftUI
 import Dependencies
 
-// swiftlint:disable type_body_length
 struct FeedView: View {
         
     // MARK: Environment and settings
@@ -296,8 +295,6 @@ struct FeedView: View {
     private var scrollToView: some View {
         HStack(spacing: 0) {
             EmptyView()
-//            Divider()
-//                .opacity(0)
         }
         .frame(height: 1)
         .id(scrollToTop)
@@ -309,4 +306,3 @@ struct FeedView: View {
         }
     }
 }
-// swiftlint:enable type_body_length

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -114,7 +114,6 @@ struct InboxView: View {
                     .onChange(of: selectedNavigationTabHashValue) { newValue in
                         if newValue == TabSelection.inbox.hashValue {
                             print("re-selected \(TabSelection.inbox) tab")
-#if DEBUG
                             if navigationPath.isEmpty, let scrollToTopId {
                                 withAnimation {
                                     proxy.scrollTo(scrollToTopId, anchor: .bottom)
@@ -122,7 +121,6 @@ struct InboxView: View {
                             } else {
                                 navigationPath.goBack()
                             }
-#endif
                         }
                     }
             }

--- a/Mlem/Views/Tabs/Profile/Profile View.swift
+++ b/Mlem/Views/Tabs/Profile/Profile View.swift
@@ -24,8 +24,12 @@ struct ProfileView: View {
     
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            UserView(userID: userID)
-                .handleLemmyViews()
+            ScrollViewReader { proxy in
+                UserView(userID: userID)
+                    .handleLemmyViews()
+                    .environment(\.tabScrollViewProxy, proxy)
+                    .environment(\.navigationPath, $navigationPath)
+            }
         }
         .handleLemmyLinkResolution(navigationPath: $navigationPath)
         .onChange(of: selectedTagHashValue) { newValue in

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -65,7 +65,6 @@ struct UserView: View {
             .onChange(of: selectedNavigationTabHashValue) { newValue in
                 if newValue == TabSelection.profile.hashValue {
                     print("re-selected \(TabSelection.profile) tab")
-#if DEBUG
                     if navigationPath.wrappedValue.isEmpty {
                         withAnimation {
                             scrollViewProxy?.scrollTo(scrollToTop, anchor: .bottom)
@@ -73,7 +72,6 @@ struct UserView: View {
                     } else {
                         navigationPath.wrappedValue.goBack()
                     }
-#endif
                 }
             }
     }

--- a/Mlem/Views/Tabs/Search/Search View.swift
+++ b/Mlem/Views/Tabs/Search/Search View.swift
@@ -53,7 +53,6 @@ struct SearchView: View {
                     .onChange(of: selectedNavigationTabHashValue) { newValue in
                         if newValue == TabSelection.search.hashValue {
                             print("re-selected \(TabSelection.search) tab")
-#if DEBUG
                             if navigationPath.isEmpty, let scrollToId {
                                 withAnimation {
                                     proxy.scrollTo(scrollToId, anchor: .bottom)
@@ -61,7 +60,6 @@ struct SearchView: View {
                             } else {
                                 navigationPath.goBack()
                             }
-#endif
                         }
                     }
             }

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -7,6 +7,16 @@
 
 import SwiftUI
 
+enum SettingsNavigationRoute: Hashable, Codable {
+    case accountsPage(onboarding: Bool)
+    case general
+    case accessibility
+    case appearance
+    case contentFilters
+    case about
+    case advanced
+}
+
 struct SettingsView: View {
 
     @EnvironmentObject var appState: AppState
@@ -20,51 +30,37 @@ struct SettingsView: View {
         NavigationStack(path: $navigationPath) {
             List {
                 Section {
-                    NavigationLink {
-                        AccountsPage(onboarding: false)
-                    } label: {
+                    NavigationLink(value: SettingsNavigationRoute.accountsPage(onboarding: false)) {
                         Label("Accounts", systemImage: "person.fill").labelStyle(SquircleLabelStyle(color: .teal))
                     }
                 }
                 Section {
-                    NavigationLink {
-                        GeneralSettingsView()
-                    } label: {
+                    NavigationLink(value: SettingsNavigationRoute.general) {
                         Label("General", systemImage: "gear").labelStyle(SquircleLabelStyle(color: .gray))
                     }
                     
-                    NavigationLink {
-                        AccessibilitySettingsView()
-                    } label: {
+                    NavigationLink(value: SettingsNavigationRoute.accessibility) {
                         // apparently the Apple a11y symbol isn't an SFSymbol
                         Label("Accessibility", systemImage: "hand.point.up.braille.fill").labelStyle(SquircleLabelStyle(color: .blue))
                     }
                     
-                    NavigationLink {
-                        AppearanceSettingsView()
-                    } label: {
+                    NavigationLink(value: SettingsNavigationRoute.appearance) {
                         Label("Appearance", systemImage: "paintbrush.fill").labelStyle(SquircleLabelStyle(color: .pink))
                     }
 
-                    NavigationLink {
-                        FiltersSettingsView()
-                    } label: {
+                    NavigationLink(value: SettingsNavigationRoute.contentFilters) {
                         Label("Content Filters", systemImage: "line.3.horizontal.decrease").labelStyle(SquircleLabelStyle(color: .orange))
                     }
                 }
                 
                 Section {
-                    NavigationLink {
-                        AboutView(navigationPath: $navigationPath)
-                    } label: {
+                    NavigationLink(value: SettingsNavigationRoute.about) {
                         Label("About Mlem", systemImage: "info").labelStyle(SquircleLabelStyle(color: .blue))
                     }
                 }
                 
                 Section {
-                    NavigationLink {
-                        AdvancedSettingsView()
-                    } label: {
+                    NavigationLink(value: SettingsNavigationRoute.advanced) {
                         Label("Advanced", systemImage: "gearshape.2.fill").labelStyle(SquircleLabelStyle(color: .gray))
                     }
                 }
@@ -74,7 +70,24 @@ struct SettingsView: View {
             .navigationTitle("Settings")
             .navigationBarColor()
             .navigationBarTitleDisplayMode(.inline)
-
+            .navigationDestination(for: SettingsNavigationRoute.self) { route in
+                switch route {
+                case .accountsPage(let onboarding):
+                    AccountsPage(onboarding: onboarding)
+                case .general:
+                    GeneralSettingsView()
+                case .accessibility:
+                    AccessibilitySettingsView()
+                case .appearance:
+                    AppearanceSettingsView()
+                case .contentFilters:
+                    FiltersSettingsView()
+                case .about:
+                    AboutView(navigationPath: $navigationPath)
+                case .advanced:
+                    AdvancedSettingsView()
+                }
+            }
         }
         .handleLemmyLinkResolution(navigationPath: $navigationPath)
         .onChange(of: selectedTagHashValue) { newValue in

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -65,7 +65,6 @@ struct SettingsView: View {
                 .onChange(of: selectedNavigationTabHashValue) { newValue in
                     if newValue == TabSelection.settings.hashValue {
                         print("re-selected \(TabSelection.settings) tab")
-#if DEBUG
                         if navigationPath.isEmpty {
                             withAnimation {
                                 proxy.scrollTo(scrollToTop, anchor: .bottom)
@@ -73,7 +72,6 @@ struct SettingsView: View {
                         } else {
                             navigationPath.goBack()
                         }
-#endif
                     }
                 }
             }

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -74,7 +74,12 @@ struct SettingsView: View {
         .onChange(of: selectedNavigationTabHashValue) { newValue in
             if newValue == TabSelection.settings.hashValue {
                 print("re-selected \(TabSelection.settings) tab")
-                
+                if navigationPath.isEmpty == false {
+                    /// Navigate back on this stack.
+                    navigationPath.removeLast()
+                } else {
+                    /// Scroll to top.
+                }
             }
         }
     }

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -67,66 +67,13 @@ struct SettingsView: View {
                     }
                 }
             }
+            .environment(\.navigationPath, $navigationPath)
             .fancyTabScrollCompatible()
             .handleLemmyViews()
             .navigationTitle("Settings")
             .navigationBarColor()
             .navigationBarTitleDisplayMode(.inline)
-            .navigationDestination(for: SettingsNavigationRoute.self) { route in
-                switch route {
-                case .accountsPage(let onboarding):
-                    AccountsPage(onboarding: onboarding)
-                case .general:
-                    GeneralSettingsView()
-                case .accessibility:
-                    AccessibilitySettingsView()
-                case .appearance:
-                    AppearanceSettingsView()
-                case .contentFilters:
-                    FiltersSettingsView()
-                case .about:
-                    AboutView(navigationPath: $navigationPath)
-                case .advanced:
-                    AdvancedSettingsView()
-                }
-            }
-            .navigationDestination(for: AppearanceSettingsNavigationRoute.self) { route in
-                switch route {
-                case .theme:
-                    ThemeSettingsView()
-                case .appIcon:
-                    IconSettingsView()
-                case .posts:
-                    PostSettingsView()
-                case .comments:
-                    CommentSettingsView()
-                case .communities:
-                    CommunitySettingsView()
-                case .users:
-                    UserSettingsView()
-                case .tabBar:
-                    TabBarSettingsView()
-                }
-            }
-            .navigationDestination(for: CommentSettingsNavigationRoute.self) { route in
-                switch route {
-                case .layoutWidget:
-                    LayoutWidgetEditView(widgets: layoutWidgetTracker.groups.comment, onSave: { widgets in
-                        layoutWidgetTracker.groups.comment = widgets
-                        layoutWidgetTracker.saveLayoutWidgets()
-                    })
-                }
-            }
-            .navigationDestination(for: PostSettingsNavigationRoute.self) { route in
-                switch route {
-                case .customizeWidgets:
-                    /// We really should be passing in the layout widget through the route enum value, but that would involve making layout widget tracker hashable and codable.
-                    LayoutWidgetEditView(widgets: layoutWidgetTracker.groups.post, onSave: { widgets in
-                        layoutWidgetTracker.groups.post = widgets
-                        layoutWidgetTracker.saveLayoutWidgets()
-                    })
-                }
-            }
+            .useSettingsNavigationRouter()
         }
         .handleLemmyLinkResolution(navigationPath: $navigationPath)
         .onChange(of: selectedTagHashValue) { newValue in

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -20,6 +20,8 @@ enum SettingsNavigationRoute: Hashable, Codable {
 struct SettingsView: View {
 
     @EnvironmentObject var appState: AppState
+    @EnvironmentObject var layoutWidgetTracker: LayoutWidgetTracker
+
     @State var navigationPath = NavigationPath()
 
     @Environment(\.openURL) private var openURL
@@ -86,6 +88,43 @@ struct SettingsView: View {
                     AboutView(navigationPath: $navigationPath)
                 case .advanced:
                     AdvancedSettingsView()
+                }
+            }
+            .navigationDestination(for: AppearanceSettingsNavigationRoute.self) { route in
+                switch route {
+                case .theme:
+                    ThemeSettingsView()
+                case .appIcon:
+                    IconSettingsView()
+                case .posts:
+                    PostSettingsView()
+                case .comments:
+                    CommentSettingsView()
+                case .communities:
+                    CommunitySettingsView()
+                case .users:
+                    UserSettingsView()
+                case .tabBar:
+                    TabBarSettingsView()
+                }
+            }
+            .navigationDestination(for: CommentSettingsNavigationRoute.self) { route in
+                switch route {
+                case .layoutWidget:
+                    LayoutWidgetEditView(widgets: layoutWidgetTracker.groups.comment, onSave: { widgets in
+                        layoutWidgetTracker.groups.comment = widgets
+                        layoutWidgetTracker.saveLayoutWidgets()
+                    })
+                }
+            }
+            .navigationDestination(for: PostSettingsNavigationRoute.self) { route in
+                switch route {
+                case .customizeWidgets:
+                    /// We really should be passing in the layout widget through the route enum value, but that would involve making layout widget tracker hashable and codable.
+                    LayoutWidgetEditView(widgets: layoutWidgetTracker.groups.post, onSave: { widgets in
+                        layoutWidgetTracker.groups.post = widgets
+                        layoutWidgetTracker.saveLayoutWidgets()
+                    })
                 }
             }
         }

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -74,12 +74,9 @@ struct SettingsView: View {
         .onChange(of: selectedNavigationTabHashValue) { newValue in
             if newValue == TabSelection.settings.hashValue {
                 print("re-selected \(TabSelection.settings) tab")
-                if navigationPath.isEmpty == false {
-                    /// Navigate back on this stack.
-                    navigationPath.removeLast()
-                } else {
-                    /// Scroll to top.
-                }
+                #if DEBUG
+                navigationPath.goBack()
+                #endif
             }
         }
     }

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -18,42 +18,62 @@ struct SettingsView: View {
     @Environment(\.tabSelectionHashValue) private var selectedTagHashValue
     @Environment(\.tabNavigationSelectionHashValue) private var selectedNavigationTabHashValue
 
+    @Namespace var scrollToTop
+    
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            List {
-                Section {
-                    NavigationLink(value: SettingsRoute.accountsPage(onboarding: false)) {
-                        Label("Accounts", systemImage: "person.fill").labelStyle(SquircleLabelStyle(color: .teal))
+            ScrollViewReader { proxy in
+                List {
+                    Section {
+                        NavigationLink(value: SettingsRoute.accountsPage(onboarding: false)) {
+                            Label("Accounts", systemImage: "person.fill").labelStyle(SquircleLabelStyle(color: .teal))
+                        }
+                        .id(scrollToTop)
                     }
-                }
-                Section {
-                    NavigationLink(value: SettingsRoute.general) {
-                        Label("General", systemImage: "gear").labelStyle(SquircleLabelStyle(color: .gray))
+                    Section {
+                        NavigationLink(value: SettingsRoute.general) {
+                            Label("General", systemImage: "gear").labelStyle(SquircleLabelStyle(color: .gray))
+                        }
+                        
+                        NavigationLink(value: SettingsRoute.accessibility) {
+                            // apparently the Apple a11y symbol isn't an SFSymbol
+                            Label("Accessibility", systemImage: "hand.point.up.braille.fill").labelStyle(SquircleLabelStyle(color: .blue))
+                        }
+                        
+                        NavigationLink(value: SettingsRoute.appearance) {
+                            Label("Appearance", systemImage: "paintbrush.fill").labelStyle(SquircleLabelStyle(color: .pink))
+                        }
+                        
+                        NavigationLink(value: SettingsRoute.contentFilters) {
+                            Label("Content Filters", systemImage: "line.3.horizontal.decrease")
+                                .labelStyle(SquircleLabelStyle(color: .orange))
+                        }
                     }
                     
-                    NavigationLink(value: SettingsRoute.accessibility) {
-                        // apparently the Apple a11y symbol isn't an SFSymbol
-                        Label("Accessibility", systemImage: "hand.point.up.braille.fill").labelStyle(SquircleLabelStyle(color: .blue))
+                    Section {
+                        NavigationLink(value: SettingsRoute.about) {
+                            Label("About Mlem", systemImage: "info").labelStyle(SquircleLabelStyle(color: .blue))
+                        }
                     }
                     
-                    NavigationLink(value: SettingsRoute.appearance) {
-                        Label("Appearance", systemImage: "paintbrush.fill").labelStyle(SquircleLabelStyle(color: .pink))
-                    }
-
-                    NavigationLink(value: SettingsRoute.contentFilters) {
-                        Label("Content Filters", systemImage: "line.3.horizontal.decrease").labelStyle(SquircleLabelStyle(color: .orange))
+                    Section {
+                        NavigationLink(value: SettingsRoute.advanced) {
+                            Label("Advanced", systemImage: "gearshape.2.fill").labelStyle(SquircleLabelStyle(color: .gray))
+                        }
                     }
                 }
-                
-                Section {
-                    NavigationLink(value: SettingsRoute.about) {
-                        Label("About Mlem", systemImage: "info").labelStyle(SquircleLabelStyle(color: .blue))
-                    }
-                }
-                
-                Section {
-                    NavigationLink(value: SettingsRoute.advanced) {
-                        Label("Advanced", systemImage: "gearshape.2.fill").labelStyle(SquircleLabelStyle(color: .gray))
+                .onChange(of: selectedNavigationTabHashValue) { newValue in
+                    if newValue == TabSelection.settings.hashValue {
+                        print("re-selected \(TabSelection.settings) tab")
+#if DEBUG
+                        if navigationPath.isEmpty {
+                            withAnimation {
+                                proxy.scrollTo(scrollToTop, anchor: .bottom)
+                            }
+                        } else {
+                            navigationPath.goBack()
+                        }
+#endif
                     }
                 }
             }
@@ -69,14 +89,6 @@ struct SettingsView: View {
         .onChange(of: selectedTagHashValue) { newValue in
             if newValue == TabSelection.settings.hashValue {
                 print("switched to Settings tab")
-            }
-        }
-        .onChange(of: selectedNavigationTabHashValue) { newValue in
-            if newValue == TabSelection.settings.hashValue {
-                print("re-selected \(TabSelection.settings) tab")
-                #if DEBUG
-                navigationPath.goBack()
-                #endif
             }
         }
     }

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -7,16 +7,6 @@
 
 import SwiftUI
 
-enum SettingsNavigationRoute: Hashable, Codable {
-    case accountsPage(onboarding: Bool)
-    case general
-    case accessibility
-    case appearance
-    case contentFilters
-    case about
-    case advanced
-}
-
 struct SettingsView: View {
 
     @EnvironmentObject var appState: AppState
@@ -32,37 +22,37 @@ struct SettingsView: View {
         NavigationStack(path: $navigationPath) {
             List {
                 Section {
-                    NavigationLink(value: SettingsNavigationRoute.accountsPage(onboarding: false)) {
+                    NavigationLink(value: SettingsRoute.accountsPage(onboarding: false)) {
                         Label("Accounts", systemImage: "person.fill").labelStyle(SquircleLabelStyle(color: .teal))
                     }
                 }
                 Section {
-                    NavigationLink(value: SettingsNavigationRoute.general) {
+                    NavigationLink(value: SettingsRoute.general) {
                         Label("General", systemImage: "gear").labelStyle(SquircleLabelStyle(color: .gray))
                     }
                     
-                    NavigationLink(value: SettingsNavigationRoute.accessibility) {
+                    NavigationLink(value: SettingsRoute.accessibility) {
                         // apparently the Apple a11y symbol isn't an SFSymbol
                         Label("Accessibility", systemImage: "hand.point.up.braille.fill").labelStyle(SquircleLabelStyle(color: .blue))
                     }
                     
-                    NavigationLink(value: SettingsNavigationRoute.appearance) {
+                    NavigationLink(value: SettingsRoute.appearance) {
                         Label("Appearance", systemImage: "paintbrush.fill").labelStyle(SquircleLabelStyle(color: .pink))
                     }
 
-                    NavigationLink(value: SettingsNavigationRoute.contentFilters) {
+                    NavigationLink(value: SettingsRoute.contentFilters) {
                         Label("Content Filters", systemImage: "line.3.horizontal.decrease").labelStyle(SquircleLabelStyle(color: .orange))
                     }
                 }
                 
                 Section {
-                    NavigationLink(value: SettingsNavigationRoute.about) {
+                    NavigationLink(value: SettingsRoute.about) {
                         Label("About Mlem", systemImage: "info").labelStyle(SquircleLabelStyle(color: .blue))
                     }
                 }
                 
                 Section {
-                    NavigationLink(value: SettingsNavigationRoute.advanced) {
+                    NavigationLink(value: SettingsRoute.advanced) {
                         Label("Advanced", systemImage: "gearshape.2.fill").labelStyle(SquircleLabelStyle(color: .gray))
                     }
                 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
@@ -43,27 +43,19 @@ struct AboutView: View {
                     }
                     .buttonStyle(SettingsButtonStyle())
 
-                    NavigationLink {
-                        ContributorsView()
-                    } label: {
+                    NavigationLink(value: AboutSettingsRoute.contributors) {
                         Label("Contributors", systemImage: "person.2.fill").labelStyle(SquircleLabelStyle(color: .teal))
                     }
                 }
 
                 Section {
-                    NavigationLink {
-                        DocumentView(text: privacyPolicy.body)
-                    } label: {
+                    NavigationLink(value: AboutSettingsRoute.privacyPolicy(privacyPolicy)) {
                         Label("Privacy Policy", systemImage: "hand.raised.fill").labelStyle(SquircleLabelStyle(color: .blue))
                     }
-                    NavigationLink {
-                        DocumentView(text: eula.body)
-                    } label: {
+                    NavigationLink(value: AboutSettingsRoute.eula(eula)) {
                         Label("EULA", systemImage: "doc.plaintext.fill").labelStyle(SquircleLabelStyle(color: .purple))
                     }
-                    NavigationLink {
-                        LicensesView()
-                    } label: {
+                    NavigationLink(value: AboutSettingsRoute.licenses) {
                         Label("Licenses", systemImage: "doc.fill").labelStyle(SquircleLabelStyle(color: .orange))
                     }
                 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
@@ -28,23 +28,13 @@ struct LicensesView: View {
                 }
                 
                 Section("Open Source Licenses") {
+                    NavigationLink("KeychainAccess", value: LicensesSettingsRoute.licenseDocument(keychainAccessLicense))
                     
-                    NavigationLink("KeychainAccess") {
-                        DocumentView(text: keychainAccessLicense.body)
-                    }
-                    
-                    NavigationLink("Nuke") {
-                        DocumentView(text: nukeLicense.body)
-                    }
-                    
-                    NavigationLink("Swift Dependencies") {
-                        DocumentView(text: swiftDependenciesLicense.body)
-                    }
-                    
-                    NavigationLink("Swift Markdown UI") {
-                        DocumentView(text: swiftMarkdownUILIcense.body)
-                    }
-                    
+                    NavigationLink("Nuke", value: LicensesSettingsRoute.licenseDocument(nukeLicense))
+
+                    NavigationLink("Swift Dependencies", value: LicensesSettingsRoute.licenseDocument(swiftDependenciesLicense))
+
+                    NavigationLink("Swift Markdown UI", value: LicensesSettingsRoute.licenseDocument(swiftMarkdownUILIcense))
                 }
             }
             .fancyTabScrollCompatible()

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
@@ -7,6 +7,16 @@
 
 import SwiftUI
 
+enum AppearanceSettingsNavigationRoute: Hashable, Codable {
+    case theme
+    case appIcon
+    case posts
+    case comments
+    case communities
+    case users
+    case tabBar
+}
+
 struct AppearanceSettingsView: View {
 
     @AppStorage("lightOrDarkMode") var lightOrDarkMode: UIUserInterfaceStyle = .unspecified
@@ -14,9 +24,7 @@ struct AppearanceSettingsView: View {
     var body: some View {
         List {
             Section {
-                NavigationLink {
-                    ThemeSettingsView()
-                } label: {
+                NavigationLink(value: AppearanceSettingsNavigationRoute.theme) {
                     switch lightOrDarkMode {
                     case .unspecified:
                         ThemeLabel(title: "Theme", color1: .white, color2: .black)
@@ -29,9 +37,7 @@ struct AppearanceSettingsView: View {
                     }
                 }
 #if !os(macOS) && !targetEnvironment(macCatalyst)
-                NavigationLink {
-                    IconSettingsView()
-                } label: {
+                NavigationLink(value: AppearanceSettingsNavigationRoute.appIcon) {
                     Label {
                         Text("App Icon")
                     } icon: {
@@ -46,34 +52,24 @@ struct AppearanceSettingsView: View {
             }
             
             Section {
-                NavigationLink {
-                    PostSettingsView()
-                } label: {
+                NavigationLink(value: AppearanceSettingsNavigationRoute.posts) {
                     Label("Posts", systemImage: "doc.plaintext.fill").labelStyle(SquircleLabelStyle(color: .pink))
                 }
                 
-                NavigationLink {
-                    CommentSettingsView()
-                } label: {
+                NavigationLink(value: AppearanceSettingsNavigationRoute.comments) {
                     Label("Comments", systemImage: "bubble.left.fill").labelStyle(SquircleLabelStyle(color: .orange))
                 }
                 
-                NavigationLink {
-                    CommunitySettingsView()
-                } label: {
+                NavigationLink(value: AppearanceSettingsNavigationRoute.communities) {
                     Label("Communities", systemImage: "house.fill").labelStyle(SquircleLabelStyle(color: .green, fontSize: 15))
                 }
                 
-                NavigationLink {
-                    UserSettingsView()
-                } label: {
+                NavigationLink(value: AppearanceSettingsNavigationRoute.users) {
                     Label("Users", systemImage: "person.fill").labelStyle(SquircleLabelStyle(color: .blue))
                 }
             }
             Section {
-                NavigationLink {
-                    TabBarSettingsView()
-                } label: {
+                NavigationLink(value: AppearanceSettingsNavigationRoute.tabBar) {
                     Label("Tab Bar", systemImage: "square").labelStyle(SquircleLabelStyle(color: .purple))
                 }
             }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
@@ -7,16 +7,6 @@
 
 import SwiftUI
 
-enum AppearanceSettingsNavigationRoute: Hashable, Codable {
-    case theme
-    case appIcon
-    case posts
-    case comments
-    case communities
-    case users
-    case tabBar
-}
-
 struct AppearanceSettingsView: View {
 
     @AppStorage("lightOrDarkMode") var lightOrDarkMode: UIUserInterfaceStyle = .unspecified
@@ -24,7 +14,7 @@ struct AppearanceSettingsView: View {
     var body: some View {
         List {
             Section {
-                NavigationLink(value: AppearanceSettingsNavigationRoute.theme) {
+                NavigationLink(value: AppearanceSettingsRoute.theme) {
                     switch lightOrDarkMode {
                     case .unspecified:
                         ThemeLabel(title: "Theme", color1: .white, color2: .black)
@@ -37,7 +27,7 @@ struct AppearanceSettingsView: View {
                     }
                 }
 #if !os(macOS) && !targetEnvironment(macCatalyst)
-                NavigationLink(value: AppearanceSettingsNavigationRoute.appIcon) {
+                NavigationLink(value: AppearanceSettingsRoute.appIcon) {
                     Label {
                         Text("App Icon")
                     } icon: {
@@ -52,24 +42,24 @@ struct AppearanceSettingsView: View {
             }
             
             Section {
-                NavigationLink(value: AppearanceSettingsNavigationRoute.posts) {
+                NavigationLink(value: AppearanceSettingsRoute.posts) {
                     Label("Posts", systemImage: "doc.plaintext.fill").labelStyle(SquircleLabelStyle(color: .pink))
                 }
                 
-                NavigationLink(value: AppearanceSettingsNavigationRoute.comments) {
+                NavigationLink(value: AppearanceSettingsRoute.comments) {
                     Label("Comments", systemImage: "bubble.left.fill").labelStyle(SquircleLabelStyle(color: .orange))
                 }
                 
-                NavigationLink(value: AppearanceSettingsNavigationRoute.communities) {
+                NavigationLink(value: AppearanceSettingsRoute.communities) {
                     Label("Communities", systemImage: "house.fill").labelStyle(SquircleLabelStyle(color: .green, fontSize: 15))
                 }
                 
-                NavigationLink(value: AppearanceSettingsNavigationRoute.users) {
+                NavigationLink(value: AppearanceSettingsRoute.users) {
                     Label("Users", systemImage: "person.fill").labelStyle(SquircleLabelStyle(color: .blue))
                 }
             }
             Section {
-                NavigationLink(value: AppearanceSettingsNavigationRoute.tabBar) {
+                NavigationLink(value: AppearanceSettingsRoute.tabBar) {
                     Label("Tab Bar", systemImage: "square").labelStyle(SquircleLabelStyle(color: .purple))
                 }
             }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -8,6 +8,10 @@
 import Foundation
 import SwiftUI
 
+enum CommentSettingsNavigationRoute: Hashable, Codable {
+    case layoutWidget
+}
+
 struct CommentSettingsView: View {
     @EnvironmentObject var layoutWidgetTracker: LayoutWidgetTracker
     
@@ -27,12 +31,7 @@ struct CommentSettingsView: View {
                                        settingName: "Compact Comments",
                                        isTicked: $compactComments)
                 
-                NavigationLink {
-                    LayoutWidgetEditView(widgets: layoutWidgetTracker.groups.comment, onSave: { widgets in
-                        layoutWidgetTracker.groups.comment = widgets
-                        layoutWidgetTracker.saveLayoutWidgets()
-                    })
-                } label: {
+                NavigationLink(value: CommentSettingsNavigationRoute.layoutWidget) {
                     Label {
                         Text("Customize Widgets")
                     } icon: {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -8,10 +8,6 @@
 import Foundation
 import SwiftUI
 
-enum CommentSettingsNavigationRoute: Hashable, Codable {
-    case layoutWidget
-}
-
 struct CommentSettingsView: View {
     @EnvironmentObject var layoutWidgetTracker: LayoutWidgetTracker
     
@@ -31,7 +27,7 @@ struct CommentSettingsView: View {
                                        settingName: "Compact Comments",
                                        isTicked: $compactComments)
                 
-                NavigationLink(value: CommentSettingsNavigationRoute.layoutWidget) {
+                NavigationLink(value: CommentSettingsRoute.layoutWidget) {
                     Label {
                         Text("Customize Widgets")
                     } icon: {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -8,10 +8,6 @@
 import Foundation
 import SwiftUI
 
-enum PostSettingsNavigationRoute: Hashable, Codable {
-    case customizeWidgets
-}
-
 struct PostSettingsView: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var layoutWidgetTracker: LayoutWidgetTracker
@@ -53,7 +49,7 @@ struct PostSettingsView: View {
                     options: PostSize.allCases
                 )
             
-                NavigationLink(value: PostSettingsNavigationRoute.customizeWidgets) {
+                NavigationLink(value: PostSettingsRoute.customizeWidgets) {
                     Label {
                         Text("Customize Widgets")
                     } icon: {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -8,6 +8,10 @@
 import Foundation
 import SwiftUI
 
+enum PostSettingsNavigationRoute: Hashable, Codable {
+    case customizeWidgets
+}
+
 struct PostSettingsView: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var layoutWidgetTracker: LayoutWidgetTracker
@@ -49,12 +53,7 @@ struct PostSettingsView: View {
                     options: PostSize.allCases
                 )
             
-                NavigationLink {
-                    LayoutWidgetEditView(widgets: layoutWidgetTracker.groups.post, onSave: { widgets in
-                        layoutWidgetTracker.groups.post = widgets
-                        layoutWidgetTracker.saveLayoutWidgets()
-                    })
-                } label: {
+                NavigationLink(value: PostSettingsNavigationRoute.customizeWidgets) {
                     Label {
                         Text("Customize Widgets")
                     } icon: {


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - partially addresses [#42](https://github.com/mlemgroup/mlem/issues/42)
      - continuation of #457 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
Adds tap tab bar to navigate back to Feed, Inbox, Profile, Search tabs:
- Tapping on tab bar pops to previous page.
- When on root page, tapping on tap bar scrolls to top.
- Specific to Feed tab, tapping on tab when root page is already scrolled to top causes it to pop back to Community sidebar list view.

## Known Issues:
- Animation doesn't happen at times when popping back to Community sidebar list (seems to be the same SwiftUI bug that causes pushing navigation links/destinations to not animate).
- When scrolling to top while scroll view is already scrolling, scrolling temporarily stops before animating scroll to top (all the tabs are getting updated whenever a tab is (re)selected, causing this issue).

## Additional Context
Next steps after this PR:
- Allow user to customize behaviour:
-- Always pop to root on tap.
-- Scroll to top before popping back.
- Tap to focus on search/form field when scrolled to top on root page.
- Add haptic feedback to tabs.
