### PR TITLE
Error handling

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		038A16E52A7A97380087987E /* LayoutWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038A16E42A7A97380087987E /* LayoutWidgetView.swift */; };
 		038A16E72A7A9C430087987E /* LayoutWidgetCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038A16E62A7A9C430087987E /* LayoutWidgetCollection.swift */; };
 		038A16E92A7A9C640087987E /* LayoutWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038A16E82A7A9C640087987E /* LayoutWidget.swift */; };
+		039439912A98FA6100463032 /* UserFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039439902A98FA6100463032 /* UserFeedView.swift */; };
+		039439932A99098900463032 /* InternetConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039439922A99098900463032 /* InternetConnectionManager.swift */; };
 		03A1B3F22A83F33900AB0DE0 /* DownvoteCounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A1B3F12A83F33900AB0DE0 /* DownvoteCounterView.swift */; };
 		03A1B3F42A83F46200AB0DE0 /* ShareButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A1B3F32A83F46200AB0DE0 /* ShareButtonView.swift */; };
 		03A1B3F72A84000400AB0DE0 /* APIContentAggregatesProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A1B3F62A84000400AB0DE0 /* APIContentAggregatesProtocol.swift */; };
@@ -420,6 +422,8 @@
 		038A16E42A7A97380087987E /* LayoutWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutWidgetView.swift; sourceTree = "<group>"; };
 		038A16E62A7A9C430087987E /* LayoutWidgetCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutWidgetCollection.swift; sourceTree = "<group>"; };
 		038A16E82A7A9C640087987E /* LayoutWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutWidget.swift; sourceTree = "<group>"; };
+		039439902A98FA6100463032 /* UserFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedView.swift; sourceTree = "<group>"; };
+		039439922A99098900463032 /* InternetConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetConnectionManager.swift; sourceTree = "<group>"; };
 		03A1B3F12A83F33900AB0DE0 /* DownvoteCounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownvoteCounterView.swift; sourceTree = "<group>"; };
 		03A1B3F32A83F46200AB0DE0 /* ShareButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareButtonView.swift; sourceTree = "<group>"; };
 		03A1B3F62A84000400AB0DE0 /* APIContentAggregatesProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIContentAggregatesProtocol.swift; sourceTree = "<group>"; };
@@ -1073,6 +1077,7 @@
 			children = (
 				63F0C7BC2A058CD200A18C5D /* Check if Endpoint Exists.swift */,
 				63F0C7BE2A058EDE00A18C5D /* Get Correct URL to Endpoint.swift */,
+				039439922A99098900463032 /* InternetConnectionManager.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -1662,6 +1667,7 @@
 				6DE1183B2A4A217400810C7E /* Profile View.swift */,
 				63ABCE0D27F894060047A7D0 /* User View.swift */,
 				6DEB0FFA2A4F87BF007CAB99 /* User Moderator View.swift */,
+				039439902A98FA6100463032 /* UserFeedView.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -2264,6 +2270,7 @@
 				63344C6E2A097FA1001BC616 /* View - Hide View.swift in Sources */,
 				5064D0432A6E645D00B22EE3 /* Notifiable.swift in Sources */,
 				6318EDCB27EE4E2200BFCAE8 /* User.swift in Sources */,
+				039439932A99098900463032 /* InternetConnectionManager.swift in Sources */,
 				CD82A2592A71775E00111034 /* UnreadTracker.swift in Sources */,
 				CD3FBCE32A4A844800B2063F /* Replies Feed View.swift in Sources */,
 				637218652A3A2AAD008C4816 /* GetPosts.swift in Sources */,
@@ -2383,6 +2390,7 @@
 				E49F0E762A90395400BC4EE3 /* NavigationPath+Helpers.swift in Sources */,
 				B1955A1F2A606F010056CF99 /* EasterFlagsTracker.swift in Sources */,
 				63D24ED92A169A5F005CCA81 /* UIApplication.swift in Sources */,
+				039439912A98FA6100463032 /* UserFeedView.swift in Sources */,
 				637218482A3A2AAD008C4816 /* APICommentReply.swift in Sources */,
 				637218502A3A2AAD008C4816 /* APIPersonAggregates.swift in Sources */,
 				6D693A422A5114DF009E2D76 /* APIPostReport.swift in Sources */,

--- a/Mlem/Error Handling/ErrorHandler.swift
+++ b/Mlem/Error Handling/ErrorHandler.swift
@@ -42,7 +42,7 @@ class ErrorHandler: ObservableObject {
                     return
                 }
                 
-                if !InternetConnectionManager.isConnectedToNetwork() && error.title != nil {
+                if error.title != nil && !InternetConnectionManager.isConnectedToNetwork() {
                     await notifier.add(.noInternet)
                     return
                 }

--- a/Mlem/Error Handling/ErrorHandler.swift
+++ b/Mlem/Error Handling/ErrorHandler.swift
@@ -34,17 +34,22 @@ class ErrorHandler: ObservableObject {
         #endif
 
         Task { @MainActor in
+            
             if let clientError = error.underlyingError.base as? APIClientError {
-                switch clientError {
-                case .invalidSession:
+                
+                if case .invalidSession = clientError {
                     sessionExpired = true
                     return
-                case let .response(apiError, _):
-                    // this will display API errors as simple error toasts
+                }
+                
+                if !InternetConnectionManager.isConnectedToNetwork() && error.message != nil {
+                    await notifier.add(.noInternet)
+                    return
+                }
+                
+                if case .response(let apiError, _) = clientError {
                     await notifier.add(.failure(apiError.error))
                     return
-                default:
-                    break
                 }
             }
             

--- a/Mlem/Error Handling/ErrorHandler.swift
+++ b/Mlem/Error Handling/ErrorHandler.swift
@@ -42,7 +42,7 @@ class ErrorHandler: ObservableObject {
                     return
                 }
                 
-                if !InternetConnectionManager.isConnectedToNetwork() && error.message != nil {
+                if !InternetConnectionManager.isConnectedToNetwork() && error.title != nil {
                     await notifier.add(.noInternet)
                     return
                 }

--- a/Mlem/Logic/Networking/InternetConnectionManager.swift
+++ b/Mlem/Logic/Networking/InternetConnectionManager.swift
@@ -1,0 +1,35 @@
+//
+//  Reachibility.swift
+//  Mlem
+//
+//  Created by Sjmarf on 25/08/2023.
+//
+
+import Foundation
+import SystemConfiguration
+
+public class InternetConnectionManager {
+    public static func isConnectedToNetwork() -> Bool {
+        
+        var zeroAddress = sockaddr_in()
+        zeroAddress.sin_len = UInt8(MemoryLayout.size(ofValue: zeroAddress))
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+        guard let defaultRouteReachability = withUnsafePointer(to: &zeroAddress, {
+            
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                SCNetworkReachabilityCreateWithAddress(nil, $0)
+            }
+            
+        }) else {
+            return false
+        }
+        var flags = SCNetworkReachabilityFlags()
+        if !SCNetworkReachabilityGetFlags(defaultRouteReachability, &flags) {
+            return false
+        }
+        let isReachable = (flags.rawValue & UInt32(kSCNetworkFlagsReachable)) != 0
+        let needsConnection = (flags.rawValue & UInt32(kSCNetworkFlagsConnectionRequired)) != 0
+        return (isReachable && !needsConnection)
+    }
+    
+}

--- a/Mlem/Notifications/NotificationDisplayer.swift
+++ b/Mlem/Notifications/NotificationDisplayer.swift
@@ -84,6 +84,8 @@ class NotificationDisplayer {
             toast = .init(title: title, subtitle: nil, style: .error)
         case let .detailedFailure(title, subtitle):
             toast = .init(title: title, subtitle: subtitle, style: .error)
+        case .noInternet:
+            toast = .init(title: "You're offline", subtitle: nil, style: .noInternet)
         }
         
         await display(toast: toast)
@@ -218,6 +220,7 @@ private struct Toast: View {
         case success
         case error
         case loader
+        case noInternet
         case reward(String?)
     }
     
@@ -266,6 +269,9 @@ private struct Toast: View {
                 .foregroundColor(.green)
         case .error:
             Image(systemName: "xmark")
+                .foregroundColor(.red)
+        case .noInternet:
+            Image(systemName: "wifi.slash")
                 .foregroundColor(.red)
         case .loader:
             ProgressView()

--- a/Mlem/Notifications/NotificationMessage.swift
+++ b/Mlem/Notifications/NotificationMessage.swift
@@ -11,6 +11,7 @@ import Foundation
 /// a simple enumeration representing messages we wish to display to the user
 enum NotificationMessage: Notifiable {
     case success(String)
+    case noInternet
     case detailedSuccess(title: String, subtitle: String)
     case failure(String)
     case detailedFailure(title: String, subtitle: String)

--- a/Mlem/Views/Shared/Error View.swift
+++ b/Mlem/Views/Shared/Error View.swift
@@ -6,16 +6,131 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
+import Combine
+
+struct ErrorDetails {
+    var title: String?
+    var body: String?
+    var error: Error?
+    var icon: String?
+    var buttonText: String?
+    var refresh: (() async -> Bool)?
+    var autoRefresh: Bool = false
+}
 
 struct ErrorView: View {
-    let errorMessage: String
+    @AppStorage("developerMode") var developerMode: Bool = false
+    
+    @State var errorDetails: ErrorDetails
+    
+    @State private var showingFullError: Bool = false
+    @State private var refreshInProgress: Bool = false
+    
+    var timer = Timer.publish(every: 1, tolerance: 0.5, on: .main, in: .common)
+        .autoconnect()
+    
+    init(_ errorDetails: ErrorDetails) {
+        var errorDetails = errorDetails
+        if !InternetConnectionManager.isConnectedToNetwork() {
+            if errorDetails.title == nil {
+                errorDetails.title = "You're offline"
+                errorDetails.body = nil
+                errorDetails.icon = "wifi.slash"
+                errorDetails.autoRefresh = true
+            }
+        }
+        _errorDetails = State(wrappedValue: errorDetails)
+    }
 
     var body: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "xmark.circle")
-            Text(errorMessage)
+        VStack(spacing: 15) {
+            if showingFullError, let errorText = errorDetails.error?.localizedDescription {
+                errorDetails(errorText)
+            } else {
+                if let icon = errorDetails.icon {
+                    Image(systemName: icon)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: 50)
+                }
+                if let body = errorDetails.body {
+                    Text(errorDetails.title ?? "Something went wrong.")
+                        .font(.title3.bold())
+                        .foregroundStyle(.primary)
+                    Text(body)
+                } else {
+                    Text(errorDetails.title ?? "Something went wrong.")
+                        .font(.title3.bold())
+                        .foregroundStyle(.primary)
+                }
+                if let refresh = errorDetails.refresh {
+                    if !errorDetails.autoRefresh {
+                        Button {
+                            Task {
+                                refreshInProgress = true
+                                if await refresh() {
+                                    timer.upstream.connect().cancel()
+                                }
+                                refreshInProgress = false
+                            }
+                        } label: {
+                            HStack(spacing: 10) {
+                                Text(errorDetails.buttonText ?? "Try again")
+                                ProgressView()
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+            }
+            
+            if errorDetails.error != nil && (errorDetails.title == nil || developerMode) {
+                Button("Show details") {
+                    showingFullError.toggle()
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.tertiary)
+            }
+            
         }
         .padding()
         .foregroundColor(.secondary)
+        
+        .onDisappear {
+            timer.upstream.connect().cancel()
+        }
+        
+        .onReceive(timer) { _ in
+            if errorDetails.autoRefresh, let refresh = errorDetails.refresh {
+                Task {
+                    if await refresh() {
+                        timer.upstream.connect().cancel()
+                    }
+                }
+            }
+        }
+        
+        .animation(.default, value: showingFullError)
+        .padding()
+    }
+        
+    @ViewBuilder
+    func errorDetails(_ errorText: String) -> some View {
+        VStack {
+            Text(errorText)
+                .foregroundStyle(.red)
+            Divider()
+            Button {
+                UIPasteboard.general.setValue(errorText,
+                                              forPasteboardType: UTType.plainText.identifier)
+            } label: {
+                Label("Copy", systemImage: "square.on.square")
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(10)
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: AppConstants.smallItemCornerRadius))
     }
 }

--- a/Mlem/Views/Shared/Error View.swift
+++ b/Mlem/Views/Shared/Error View.swift
@@ -54,34 +54,28 @@ struct ErrorView: View {
                         .aspectRatio(contentMode: .fit)
                         .frame(height: 50)
                 }
-                if let body = errorDetails.body {
-                    Text(errorDetails.title ?? "Something went wrong.")
-                        .font(.title3.bold())
-                        .foregroundStyle(.primary)
-                    Text(body)
-                } else {
-                    Text(errorDetails.title ?? "Something went wrong.")
-                        .font(.title3.bold())
-                        .foregroundStyle(.primary)
-                }
-                if let refresh = errorDetails.refresh {
-                    if !errorDetails.autoRefresh {
-                        Button {
-                            Task {
-                                refreshInProgress = true
-                                if await refresh() {
-                                    timer.upstream.connect().cancel()
-                                }
-                                refreshInProgress = false
+                Text(errorDetails.title ?? "Something went wrong.")
+                    .font(.title3.bold())
+                    .foregroundStyle(.primary)
+                
+                if let body = errorDetails.body { Text(body) }
+                
+                if !errorDetails.autoRefresh, let refresh = errorDetails.refresh {
+                    Button {
+                        Task {
+                            refreshInProgress = true
+                            if await refresh() {
+                                timer.upstream.connect().cancel()
                             }
-                        } label: {
-                            HStack(spacing: 10) {
-                                Text(errorDetails.buttonText ?? "Try again")
-                                ProgressView()
-                            }
+                            refreshInProgress = false
                         }
-                        .buttonStyle(.bordered)
+                    } label: {
+                        HStack(spacing: 10) {
+                            Text(errorDetails.buttonText ?? "Try again")
+                            ProgressView()
+                        }
                     }
+                    .buttonStyle(.bordered)
                 }
             }
             

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -39,6 +39,8 @@ struct ExpandedPost: View {
     @EnvironmentObject var postTracker: PostTracker
     @State var post: APIPostView
     
+    @State var commentErrorDetails: ErrorDetails?
+    
     @State var dirtyVote: ScoringOperation = .resetVote
     @State var dirtyScore: Int = 0
     @State var dirtySaved: Bool = false
@@ -175,7 +177,9 @@ struct ExpandedPost: View {
      */
     @ViewBuilder
     private func noCommentsView() -> some View {
-        if isLoading {
+        if let details = commentErrorDetails {
+            ErrorView(details)
+        } else if isLoading {
             LoadingView(whatIsLoading: .comments)
         } else {
             VStack(spacing: 2) {

--- a/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
+++ b/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
@@ -316,15 +316,12 @@ extension ExpandedPost {
             let comments = try await commentRepository.comments(for: post.post.id)
             commentTracker.comments = sortComments(comments, by: commentSortingType)
         } catch {
-            if commentErrorDetails == nil {
-                errorHandler.handle(.init(
-                    title: "Failed to refresh",
-                    message: "Please try again",
-                    underlyingError: error
-                ))
-            } else {
-                commentErrorDetails = ErrorDetails(error: error, refresh: loadComments)
-            }
+            errorHandler.handle(.init(
+                title: "Failed to refresh",
+                message: "Please try again",
+                underlyingError: error
+                )
+            )
         }
     }
 

--- a/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
+++ b/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
@@ -292,6 +292,7 @@ extension ExpandedPost {
 
     // swiftlint:enable function_body_length
 
+    @discardableResult
     func loadComments() async -> Bool {
         defer { isLoading = false }
         isLoading = true
@@ -315,14 +316,14 @@ extension ExpandedPost {
             let comments = try await commentRepository.comments(for: post.post.id)
             commentTracker.comments = sortComments(comments, by: commentSortingType)
         } catch {
-            if !InternetConnectionManager.isConnectedToNetwork() {
-                await notifier.add(.failure("You're offline"))
-            } else {
+            if commentErrorDetails == nil {
                 errorHandler.handle(.init(
                     title: "Failed to refresh",
                     message: "Please try again",
                     underlyingError: error
                 ))
+            } else {
+                commentErrorDetails = ErrorDetails(error: error, refresh: loadComments)
             }
         }
     }

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -220,17 +220,13 @@ struct UserView: View {
                     return userDetails != nil
                 })
             } else {
-                if !InternetConnectionManager.isConnectedToNetwork() {
-                    await notifier.add(.failure("You're offline"))
-                } else {
-                    errorHandler.handle(
-                        .init(
-                            title: "Couldn't load user info",
-                            message: "There was an error while loading user information.\nTry again later.",
-                            underlyingError: error
-                        )
+                errorHandler.handle(
+                    .init(
+                        title: "Couldn't load user info",
+                        message: "There was an error while loading user information.\nTry again later.",
+                        underlyingError: error
                     )
-                }
+                )
             }
         }
     }

--- a/Mlem/Views/Tabs/Profile/UserFeedView.swift
+++ b/Mlem/Views/Tabs/Profile/UserFeedView.swift
@@ -1,0 +1,158 @@
+//
+//  UserFeedView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 25/08/2023.
+//
+
+import SwiftUI
+
+struct UserFeedView: View {
+    
+    var userID: Int
+    @StateObject var privatePostTracker: PostTracker
+    @StateObject var privateCommentTracker: CommentTracker
+    
+    @Binding var selectedTab: UserViewTab
+    
+    struct FeedItem: Identifiable {
+        let id = UUID()
+        let published: Date
+        let comment: HierarchicalComment?
+        let post: APIPostView?
+    }
+    
+    var body: some View {
+        let feed = generateFeed()
+            .sorted(by: {
+                $0.published > $1.published
+            })
+        
+        if feed.isEmpty {
+            emptyFeed
+        } else {
+            if selectedTab == .posts {
+                VStack(spacing: 0) {
+                    content(feed)
+                }
+            } else {
+                LazyVStack(spacing: 0) {
+                    content(feed)
+                }
+            }
+        }
+    }
+    
+    func content(_ feed: [FeedItem]) -> some View {
+        ForEach(feed) { feedItem in
+            if let post = feedItem.post {
+                postEntry(for: post)
+            }
+            if let comment = feedItem.comment {
+                commentEntry(for: comment)
+            }
+        }
+    }
+    
+    func generateFeed() -> [FeedItem] {
+        switch selectedTab {
+        case .overview:
+            generateMixedFeed(savedItems: false)
+        case .saved:
+            generateMixedFeed(savedItems: true)
+        case .comments:
+            generateCommentFeed()
+        case .posts:
+            generatePostFeed()
+        }
+    }
+    
+    private func postEntry(for post: APIPostView) -> some View {
+        NavigationLink(value: PostLinkWithContext(post: post, postTracker: privatePostTracker)) {
+            VStack(spacing: 0) {
+                FeedPost(
+                    postView: post,
+                    showPostCreator: false,
+                    showCommunity: true
+                )
+                
+                Divider()
+            }
+        }
+        .buttonStyle(.plain)
+    }
+    
+    private func commentEntry(for comment: HierarchicalComment) -> some View {
+        VStack(spacing: 0) {
+            CommentItem(
+                hierarchicalComment: comment,
+                postContext: nil,
+                indentBehaviour: .never,
+                showPostContext: true,
+                showCommentCreator: false
+            )
+            
+            Divider()
+        }
+    }
+    
+    @ViewBuilder
+    private var emptyFeed: some View {
+        HStack {
+            Spacer()
+            Text("Nothing to see here, get out there and make some stuff!")
+                .padding()
+                .font(.headline)
+                .opacity(0.5)
+            Spacer()
+        }
+        .background()
+    }
+    
+    private func generateCommentFeed(savedItems: Bool = false) -> [FeedItem] {
+        privateCommentTracker.comments
+            // Matched saved state
+            .filter {
+                if savedItems {
+                    return $0.commentView.saved
+                } else {
+                    // If we unfavorited something while
+                    // here we don't want it showing up in our feed
+                    return $0.commentView.creator.id == userID
+                }
+            }
+        
+            // Create Feed Items
+            .map {
+                FeedItem(published: $0.commentView.comment.published, comment: $0, post: nil)
+            }
+    }
+    
+    private func generatePostFeed(savedItems: Bool = false) -> [FeedItem] {
+        privatePostTracker.items
+            // Matched saved state
+            .filter {
+                if savedItems {
+                    return $0.saved
+                } else {
+                    // If we unfavorited something while
+                    // here we don't want it showing up in our feed
+                    return $0.creator.id == userID
+                }
+            }
+        
+            // Create Feed Items
+            .map {
+                FeedItem(published: $0.post.published, comment: nil, post: $0)
+            }
+    }
+    
+    private func generateMixedFeed(savedItems: Bool) -> [FeedItem] {
+        var result: [FeedItem] = []
+        
+        result.append(contentsOf: generatePostFeed(savedItems: savedItems))
+        result.append(contentsOf: generateCommentFeed(savedItems: savedItems))
+        
+        return result
+    }
+}

--- a/Mlem/Views/Tabs/Settings/Components/Views/Advanced/AdvancedSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Advanced/AdvancedSettingsView.swift
@@ -9,10 +9,20 @@ import Nuke
 import SwiftUI
 
 struct AdvancedSettingsView: View {
+    @AppStorage("developerMode") var developerMode: Bool = false
+    
     @State private var diskUsage: Int64 = 0
     
     var body: some View {
         List {
+            Section {
+                SwitchableSettingsItem(
+                    settingPictureSystemName: "wrench.adjustable.fill",
+                    settingName: "Developer Mode",
+                    isTicked: $developerMode
+                )
+            }
+            
             Section {
                 HStack {
                     Text("Cache")


### PR DESCRIPTION
I've made some changes to the way errors are handled in the `ExpandedPostView` and `UserView`. I've also refactored `UserView` quite a bit.

Error changes:

If the error handler is told to show an alert, and the internet is offline, it will show a simple "You're offline" toast instead of a full error message. 

<img src="https://github.com/mlemgroup/mlem/assets/78750526/46e2c3eb-7bcf-4635-86fe-df59b5ec0da9" width=50% />
<br/>  
<br/>  
If the user loads a comments page, and an error is thrown, the error message will be shown inline instead of as an alert. This makes it less intrusive. If the error was caused by the user being offline, the page will attempt to reconnect every second. If the internet comes back online, it will load the comments automatically. 

<br/> 
<br/>  

<img src="https://github.com/mlemgroup/mlem/assets/78750526/bff26de1-16bd-41f3-a022-4be6a24a6e1e" width=50% />

<br/>
<br/> 

If the error was _not_ caused by the internet being offline, it'll instead show "Something went wrong" with a "Try again" button that the user can press to attempt to load the comments again. There is also a small button that allows the user to read the full error message (this is just `error.localizedDescription`). 

If there are any common errors that come up here (I'm not aware of any myself), we should provide more user-friendly descriptions for those errors instead of relying on the debug description. If a custom description were to be provided for an error, the button to show the full error message won't be shown - unless "Developer Mode" is enabled in Settings, in which case viewing the full error will always be an option.

All of the above only applies to the _first_ time the comments are loaded - if the user refreshes the page and an error is thrown, the regular error handler is used instead. 

I've implemented the same system for `UserView`. I'd like to expand this system to more places in future, if others approve.