### PR TITLE
fix - ensure consistent instance group order

### DIFF
--- a/Mlem/Views/Shared/Accounts/Accounts Page.swift
+++ b/Mlem/Views/Shared/Accounts/Accounts Page.swift
@@ -18,7 +18,7 @@ struct AccountsPage: View {
     @Environment(\.dismiss) var dismiss
     
     var body: some View {
-        let instances = Array(accountsTracker.accountsByInstance.keys)
+        let instances = Array(accountsTracker.accountsByInstance.keys).sorted()
         
         List {
             ForEach(instances, id: \.self) { instance in


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Noticed while playing around with how we manage accounts for other work...
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
A tiny change that ensures the keys we use when rendering the list of accounts are always in a consistent order.

The groups are being stored as a map/dictionary whose keys are unordered, so each time we ask for them we may receive them in a different order.

This applies the default `.sorted()` method to them which will ensure they are always alphabetically ordered.
