### PR TITLE
Fix issue where cached image may cause parent view layout to break

### DIFF
--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -85,7 +85,7 @@ struct CachedImage: View {
                     .resizable()
                     .aspectRatio(contentMode: contentMode)
                     .cornerRadius(cornerRadius)
-                    .frame(width: size.width, height: size.height)
+                    .frame(idealWidth: size.width, maxHeight: size.height)
                     .clipped()
                     .allowsHitTesting(false)
                     .overlay(alignment: .top) {
@@ -141,15 +141,19 @@ struct CachedImage: View {
             } else if state.error != nil {
                 // Indicates an error
                 imageNotFound()
-                    .frame(width: size.width, height: size.height)
+                    .frame(idealWidth: size.width, maxHeight: size.height)
                     .background(Color(uiColor: .systemGray4))
             } else {
                 ProgressView() // Acts as a placeholder
-                    .frame(width: size.width, height: size.height)
+                    .frame(idealWidth: size.width, maxHeight: size.height)
             }
         }
-        .processors([.resize(size: size)])
-        .frame(width: size.width, height: size.height)
+        .processors([
+            .resize(
+                size: size,
+                contentMode: contentMode == .fill ? .aspectFill : .aspectFit)
+        ])
+        .frame(idealWidth: size.width, maxHeight: size.height)
     }
     
     static func imageNotFoundDefault() -> AnyView {


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Don't see an open issue, but various reports on L/mlemapp, etc.
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
Fixes issue where CachedImage may overflow its expected size:
- Caused image to be partially cut off.
- Caused parent layout to break in some situations.

The following isn't required to fix this issue, but it seemed reasonable to specify `contentMode` when resizing the image:
```
  .processors([
            .resize(
                size: size,
                contentMode: contentMode == .fill ? .aspectFill : .aspectFit)
        ])
```

## Screenshots and Videos
| After  | Before |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 13 mini - 2023-08-26 at 16 53 29](https://github.com/mlemgroup/mlem/assets/2549615/28f1d2de-15a2-464a-b6d6-fefb449bf354)  | ![Simulator Screenshot - iPhone 13 mini - 2023-08-26 at 16 52 27](https://github.com/mlemgroup/mlem/assets/2549615/01c99ea8-d5cf-4871-887d-310a455fd05c) |
| ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-08-26 at 16 53 07](https://github.com/mlemgroup/mlem/assets/2549615/a49c0015-d4ad-4dbd-bf6e-d029e7e8cae9)  | ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-08-26 at 16 52 46](https://github.com/mlemgroup/mlem/assets/2549615/bd989508-f919-4a80-9e7e-661b965aea98)  |

