### PR TITLE
Swipe to expand/collapse comments + refactor swipe actions

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2814,7 +2814,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 76ULHQGAPN;
+				DEVELOPMENT_TEAM = 4G96725NK5;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2832,7 +2832,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -2855,7 +2855,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 76ULHQGAPN;
+				DEVELOPMENT_TEAM = 4G96725NK5;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2873,7 +2873,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -69,8 +69,8 @@
 		50A8812A2A72D6BD003E3661 /* CommunityRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A881292A72D6BD003E3661 /* CommunityRepository.swift */; };
 		50A8812C2A72D727003E3661 /* CommunityRepository+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A8812B2A72D727003E3661 /* CommunityRepository+Dependency.swift */; };
 		50A8812E2A72D76C003E3661 /* APIClient+Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A8812D2A72D76C003E3661 /* APIClient+Comment.swift */; };
-		50BC1ABB2A8D6A5A00E3C48B /* ScoringOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BC1ABA2A8D6A5A00E3C48B /* ScoringOperation.swift */; };
 		50BC1AB92A89744200E3C48B /* CommunityListModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BC1AB82A89744200E3C48B /* CommunityListModelTests.swift */; };
+		50BC1ABB2A8D6A5A00E3C48B /* ScoringOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BC1ABA2A8D6A5A00E3C48B /* ScoringOperation.swift */; };
 		50C86ABC2A7E50E200277519 /* PersistenceRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C86ABB2A7E50E200277519 /* PersistenceRepositoryTests.swift */; };
 		50C99B562A61D792005D57DD /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = 50C99B552A61D792005D57DD /* Dependencies */; };
 		50C99B592A61D889005D57DD /* APIClient+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C99B582A61D889005D57DD /* APIClient+Dependency.swift */; };
@@ -394,6 +394,7 @@
 		CDF842682A49FB9000723DA0 /* Inbox View Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF842672A49FB9000723DA0 /* Inbox View Logic.swift */; };
 		CDF8426B2A4A2AB600723DA0 /* Inbox Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8426A2A4A2AB600723DA0 /* Inbox Item.swift */; };
 		CDF8426F2A4A385A00723DA0 /* Inbox Item Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8426E2A4A385A00723DA0 /* Inbox Item Type.swift */; };
+		E453477E2A9DE37300D1B46F /* Array+SafeIndexing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E453477D2A9DE37300D1B46F /* Array+SafeIndexing.swift */; };
 		E453A1D02A81C2140004BB8A /* QuickLookPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */; };
 		E47B2B762A902DE200629AF7 /* SettingsRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47B2B752A902DE200629AF7 /* SettingsRoutes.swift */; };
 		E4902BAB2A9024BF0054FB36 /* SettingsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4902BAA2A9024BF0054FB36 /* SettingsRouter.swift */; };
@@ -484,8 +485,8 @@
 		50A881292A72D6BD003E3661 /* CommunityRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityRepository.swift; sourceTree = "<group>"; };
 		50A8812B2A72D727003E3661 /* CommunityRepository+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommunityRepository+Dependency.swift"; sourceTree = "<group>"; };
 		50A8812D2A72D76C003E3661 /* APIClient+Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Comment.swift"; sourceTree = "<group>"; };
-		50BC1ABA2A8D6A5A00E3C48B /* ScoringOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoringOperation.swift; sourceTree = "<group>"; };
 		50BC1AB82A89744200E3C48B /* CommunityListModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityListModelTests.swift; sourceTree = "<group>"; };
+		50BC1ABA2A8D6A5A00E3C48B /* ScoringOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoringOperation.swift; sourceTree = "<group>"; };
 		50C86ABB2A7E50E200277519 /* PersistenceRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceRepositoryTests.swift; sourceTree = "<group>"; };
 		50C99B582A61D889005D57DD /* APIClient+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Dependency.swift"; sourceTree = "<group>"; };
 		50C99B5B2A61F5EB005D57DD /* CommentRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentRepository.swift; sourceTree = "<group>"; };
@@ -807,6 +808,7 @@
 		CDF842672A49FB9000723DA0 /* Inbox View Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox View Logic.swift"; sourceTree = "<group>"; };
 		CDF8426A2A4A2AB600723DA0 /* Inbox Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox Item.swift"; sourceTree = "<group>"; };
 		CDF8426E2A4A385A00723DA0 /* Inbox Item Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox Item Type.swift"; sourceTree = "<group>"; };
+		E453477D2A9DE37300D1B46F /* Array+SafeIndexing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeIndexing.swift"; sourceTree = "<group>"; };
 		E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewController.swift; sourceTree = "<group>"; };
 		E47B2B752A902DE200629AF7 /* SettingsRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRoutes.swift; sourceTree = "<group>"; };
 		E4902BAA2A9024BF0054FB36 /* SettingsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRouter.swift; sourceTree = "<group>"; };
@@ -1202,6 +1204,7 @@
 				CDA217F22A63202600BDA173 /* NSFW Overlay.swift */,
 				CD69F56E2A41EDF50028D4F7 /* Swipey Actions.swift */,
 				CD6483332A39F1C100EE6CA3 /* API Post View - Post Type.swift */,
+				E453477D2A9DE37300D1B46F /* Array+SafeIndexing.swift */,
 				63344C572A07DB9A001BC616 /* Array - Move Elements Around.swift */,
 				63344C552A07D81D001BC616 /* Array - Prepend.swift */,
 				B1CB6E742A4C729D00DA9675 /* Bundle - Current App Icon.swift */,
@@ -2486,6 +2489,7 @@
 				50A8812C2A72D727003E3661 /* CommunityRepository+Dependency.swift in Sources */,
 				0394398F2A98EB2300463032 /* APIComment+Mock.swift in Sources */,
 				63CE4E732A06F5A100405271 /* Access Token.swift in Sources */,
+				E453477E2A9DE37300D1B46F /* Array+SafeIndexing.swift in Sources */,
 				CD9DD8852A62302A0044EA8E /* ConcreteEditorModel.swift in Sources */,
 				CD4E98A32A69BEDC0026C4D9 /* IconSettingsView.swift in Sources */,
 				637218692A3A2AAD008C4816 /* CreateCommentLike.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2814,7 +2814,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 4G96725NK5;
+				DEVELOPMENT_TEAM = 76ULHQGAPN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2832,7 +2832,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -2855,7 +2855,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 4G96725NK5;
+				DEVELOPMENT_TEAM = 76ULHQGAPN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -2873,7 +2873,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -23,17 +23,6 @@ struct AppConstants {
     // MARK: - Keychain
 
     static let keychain: Keychain = .init(service: "com.hanners.Mlem-keychain")
-
-    // MARK: - SwipeyView drag action thresholds
-    
-    static let swipeActionDragThresholds: [CGFloat] = [
-        Self.shortSwipeDragMin,
-        Self.longSwipeDragMin,
-        Self.tertiarySwipeDragMin
-    ]
-    static let shortSwipeDragMin: CGFloat = 60
-    static let longSwipeDragMin: CGFloat = 150
-    static let tertiarySwipeDragMin: CGFloat = 240
     
     // MARK: - Text Fields
     static let textFieldVariableLineLimit: ClosedRange<Int> = 1...10

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -33,7 +33,7 @@ struct AppConstants {
     ]
     static let shortSwipeDragMin: CGFloat = 60
     static let longSwipeDragMin: CGFloat = 150
-    static let tertiarySwipeDragMin: CGFloat = 270
+    static let tertiarySwipeDragMin: CGFloat = 240
     
     // MARK: - Text Fields
     static let textFieldVariableLineLimit: ClosedRange<Int> = 1...10

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -24,10 +24,16 @@ struct AppConstants {
 
     static let keychain: Keychain = .init(service: "com.hanners.Mlem-keychain")
 
-    // MARK: - DragGesture thresholds
-
-    static let longSwipeDragMin: CGFloat = 150
+    // MARK: - SwipeyView drag action thresholds
+    
+    static let swipeActionDragThresholds: [CGFloat] = [
+        Self.shortSwipeDragMin,
+        Self.longSwipeDragMin,
+        Self.tertiarySwipeDragMin
+    ]
     static let shortSwipeDragMin: CGFloat = 60
+    static let longSwipeDragMin: CGFloat = 150
+    static let tertiarySwipeDragMin: CGFloat = 270
     
     // MARK: - Text Fields
     static let textFieldVariableLineLimit: ClosedRange<Int> = 1...10

--- a/Mlem/Extensions/Array+SafeIndexing.swift
+++ b/Mlem/Extensions/Array+SafeIndexing.swift
@@ -1,0 +1,18 @@
+//
+//  Array+SafeIndexing.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-08-29.
+//
+
+import Foundation
+
+extension Array {
+    public subscript(safeIndex index: Int) -> Element? {
+        guard index >= 0, index < endIndex else {
+            return nil
+        }
+        
+        return self[index]
+    }
+}

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -271,9 +271,9 @@ struct SwipeyView: ViewModifier {
     
     // MARK: -
     
-    private func swipeAction(at position: CGFloat) -> SwipeAction? {
-        let edge = edgeForActions(at: position)
-        let index = actionIndex(edge: edge, at: position)
+    private func swipeAction(at dragPosition: CGFloat) -> SwipeAction? {
+        let edge = edgeForActions(at: dragPosition)
+        let index = actionIndex(edge: edge, at: dragPosition)
         let action = action(edge: edge, index: index)
         return action
     }

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -220,7 +220,6 @@ struct SwipeyView: ViewModifier {
         }
         
         guard let thresholdIndex else {
-            print(#function, "thresholdIndex == nil at this drag position")
             return nil
         }
         
@@ -266,23 +265,17 @@ struct SwipeyView: ViewModifier {
         }
         
         // From nil -> 0 -> 1 -> 2, etc, where nil is no action, and 0 is the primary action.
-//        print("pIndex \(previousIndex) -> cIndex: \(currentIndex)")
-        
         // Swiping towards to primary action.
         // Index values are always >= 0 for both leading/trailing edges.
         // Since nil indicates no action, we use -1 to represent nil instead (lol, yes).
         if (currentIndex ?? -1) < (previousIndex ?? -1) {
-//            print("mushyInfo.low\n")
             return (.mushyInfo, .low)
         } else {
             if previousIndex == nil {
-//                print("gentleInfo.high\n")
                 return (.gentleInfo, .high)
             } else if previousIndex == 1 {
-//                print("firmerInfo.high\n")
                 return (.firmerInfo, .high)
             } else {
-//                print("firmerInfo.high\n")
                 return (.firmerInfo, .high)
             }
         }

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -51,20 +51,7 @@ struct SwipeyView: ViewModifier {
     
     init(configuration: SwipeConfiguration) {
         self.actions = configuration
-
-        // assert that no secondary action exists without a primary action
-        // this is logically equivalent to (primaryAction == nil -> secondaryAction == nil)
-        assert(
-            primaryLeadingAction != nil || secondaryLeadingAction == nil,
-            "No secondary action \(secondaryLeadingAction != nil) should be present without a primary \(primaryLeadingAction == nil)"
-        )
         
-        assert(
-            primaryTrailingAction != nil || secondaryTrailingAction == nil,
-            "No secondary action should be present without a primary"
-        )
-        
-        // other init
         _leadingSwipeSymbol = State(initialValue: primaryLeadingAction?.symbol.fillName)
         _trailingSwipeSymbol = State(initialValue: primaryTrailingAction?.symbol.fillName)
     }

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -43,9 +43,7 @@ struct SwipeyView: ViewModifier {
     @State var trailingSwipeSymbol: String?
     
     private var primaryLeadingAction: SwipeAction? { actions.leadingActions.first }
-    private var secondaryLeadingAction: SwipeAction? { actions.leadingActions[safeIndex: 1] }
     private var primaryTrailingAction: SwipeAction? { actions.trailingActions.first }
-    private var secondaryTrailingAction: SwipeAction? { actions.trailingActions[safeIndex: 1] }
     
     let actions: SwipeConfiguration
     

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -22,11 +22,11 @@ struct SwipeAction {
 struct SwipeConfiguration {
     let primaryLeading: SwipeAction?
     let secondaryLeading: SwipeAction?
-//    let tertiaryLeading: SwipeAction?
+    let tertiaryLeading: SwipeAction?
     
     let primaryTrailing: SwipeAction?
     let secondaryTrailing: SwipeAction?
-//    let tertiaryTrailing: SwipeAction?
+    let tertiaryTrailing: SwipeAction?
 }
 
 struct SwipeyView: ViewModifier {
@@ -61,6 +61,21 @@ struct SwipeyView: ViewModifier {
         primaryTrailingAction: SwipeAction?,
         secondaryTrailingAction: SwipeAction?
     ) {
+        self.init(
+            configuration: .init(
+                primaryLeading: primaryLeadingAction,
+                secondaryLeading: secondaryLeadingAction,
+                tertiaryLeading: nil,
+                primaryTrailing: primaryTrailingAction,
+                secondaryTrailing: secondaryTrailingAction,
+                tertiaryTrailing: nil
+            )
+        )
+    }
+    
+    init(configuration: SwipeConfiguration) {
+        self.actions = configuration
+
         // assert that no secondary action exists without a primary action
         // this is logically equivalent to (primaryAction == nil -> secondaryAction == nil)
         assert(
@@ -72,12 +87,6 @@ struct SwipeyView: ViewModifier {
             primaryTrailingAction != nil || secondaryTrailingAction == nil,
             "No secondary action should be present without a primary"
         )
-        
-        self.actions = .init(
-            primaryLeading: primaryLeadingAction,
-            secondaryLeading: secondaryLeadingAction,
-            primaryTrailing: primaryTrailingAction,
-            secondaryTrailing: secondaryTrailingAction)
         
         // other init
         _leadingSwipeSymbol = State(initialValue: primaryLeadingAction?.symbol.fillName)
@@ -281,5 +290,10 @@ extension View {
                 secondaryTrailingAction: secondaryTrailingAction
             )
         )
+    }
+    
+    @ViewBuilder
+    func addSwipeyActions(configuration: SwipeConfiguration) -> some View {
+        modifier(SwipeyView(configuration: configuration))
     }
 }

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -125,24 +125,7 @@ struct SwipeyView: ViewModifier {
                     let edgeForActions = self.edgeForActions(at: dragPosition)
                     let actionIndex = self.actionIndex(edge: edgeForActions, at: dragPosition)
                     let action = self.action(edge: edgeForActions, index: actionIndex)
-                    
-                    let threshold: CGFloat = {
-                        guard let actionIndex else {
-                            switch edgeForActions {
-                            case .leading:
-                                return AppConstants.shortSwipeDragMin
-                            case .trailing:
-                                return -AppConstants.shortSwipeDragMin
-                            }
-                        }
-                        
-                        switch edgeForActions {
-                        case .leading:
-                            return AppConstants.swipeActionDragThresholds[actionIndex]
-                        case .trailing:
-                            return -AppConstants.swipeActionDragThresholds[actionIndex]
-                        }
-                    }()
+                    let threshold = self.actionThreshold(edge: edgeForActions, index: actionIndex)
                     
                     // update color and symbol. If crossed an edge, play a gentle haptic
                     switch edgeForActions {
@@ -334,6 +317,31 @@ struct SwipeyView: ViewModifier {
 #endif
                 return (.firmerInfo, .high)
             }
+        }
+    }
+    
+    /// Get the threshold (in screen points) required to trigger a particular action.
+    /// - Parameter edge: Show actions on this edge.
+    /// - Parameter index: Index of the action in question.
+    /// - Returns: Negative values for trailing actions along the x-axis.
+    private func actionThreshold(
+        edge edgeForActions: HorizontalEdge,
+        index actionIndex: Array<CGFloat>.Index?
+    ) -> CGFloat {
+        guard let actionIndex else {
+            switch edgeForActions {
+            case .leading:
+                return AppConstants.shortSwipeDragMin
+            case .trailing:
+                return -AppConstants.shortSwipeDragMin
+            }
+        }
+        
+        switch edgeForActions {
+        case .leading:
+            return AppConstants.swipeActionDragThresholds[actionIndex]
+        case .trailing:
+            return -AppConstants.swipeActionDragThresholds[actionIndex]
         }
     }
 }

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -49,20 +49,6 @@ struct SwipeyView: ViewModifier {
     
     let actions: SwipeConfiguration
     
-    init(
-        primaryLeadingAction: SwipeAction?,
-        secondaryLeadingAction: SwipeAction?,
-        primaryTrailingAction: SwipeAction?,
-        secondaryTrailingAction: SwipeAction?
-    ) {
-        self.init(
-            configuration: .init(
-                leadingActions: [primaryLeadingAction, secondaryLeadingAction].compactMap { $0 },
-                trailingActions: [primaryTrailingAction, secondaryTrailingAction].compactMap { $0 }
-            )
-        )
-    }
-    
     init(configuration: SwipeConfiguration) {
         self.actions = configuration
 
@@ -355,25 +341,16 @@ struct SwipeyView: ViewModifier {
 // swiftlint:enable function_body_length
 
 extension View {
-    @ViewBuilder
-    func addSwipeyActions(
-        primaryLeadingAction: SwipeAction?,
-        secondaryLeadingAction: SwipeAction?,
-        primaryTrailingAction: SwipeAction?,
-        secondaryTrailingAction: SwipeAction?
-    ) -> some View {
-        modifier(
-            SwipeyView(
-                primaryLeadingAction: primaryLeadingAction,
-                secondaryLeadingAction: secondaryLeadingAction,
-                primaryTrailingAction: primaryTrailingAction,
-                secondaryTrailingAction: secondaryTrailingAction
-            )
-        )
-    }
     
     @ViewBuilder
-    func addSwipeyActions(configuration: SwipeConfiguration) -> some View {
-        modifier(SwipeyView(configuration: configuration))
+    func addSwipeyActions(leading: [SwipeAction?], trailing: [SwipeAction?]) -> some View {
+        modifier(
+            SwipeyView(
+                configuration: .init(
+                    leadingActions: leading,
+                    trailingActions: trailing
+                )
+            )
+        )
     }
 }

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -28,6 +28,10 @@ public struct SwipeConfiguration {
     let trailingActions: [SwipeAction]
     
     init(leadingActions: [SwipeAction?], trailingActions: [SwipeAction?]) {
+        assert(
+            leadingActions.count <= 3 && trailingActions.count <= 3,
+            "Getting a little swipey aren't we? Ask your fellow Mlem'ers if you really need more than 3 swipe actions =)"
+        )
         self.leadingActions = leadingActions.compactMap { $0 }
         self.trailingActions = trailingActions.compactMap { $0 }
     }

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -251,13 +251,35 @@ struct SwipeyView: ViewModifier {
     }
     
     private func actionIndex(edge: HorizontalEdge, at dragPosition: CGFloat) -> Array<CGFloat>.Index? {
-        AppConstants.swipeActionDragThresholds.lastIndex {
+        /// Map a `dragPosition` to a `dragThreshold`, which tells us what swipe action to perform, where `nil` is no action, `1` is primary, `2` is secondary, etc.
+        let thresholdIndex = AppConstants.swipeActionDragThresholds.lastIndex {
             switch edge {
             case .leading:
                 return dragPosition > $0
             case .trailing:
                 return dragPosition < -$0
             }
+        }
+        
+        guard let thresholdIndex else {
+            print(#function, "thresholdIndex == nil at this drag position")
+            return nil
+        }
+        
+        /// There may not be an associated action for a threshold.
+        switch edge {
+        case .leading:
+            if thresholdIndex > (actions.leadingActions.endIndex - 1) {
+                print(#function, "leading action not configured for this threshold")
+                return actions.leadingActions.endIndex - 1
+            }
+            return thresholdIndex
+        case .trailing:
+            if thresholdIndex > (actions.trailingActions.endIndex - 1) {
+                print(#function, "trailing action not configured for this threshold")
+                return actions.trailingActions.endIndex - 1
+            }
+            return thresholdIndex
         }
     }
     

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -83,7 +83,6 @@ struct SwipeyView: ViewModifier {
         _trailingSwipeSymbol = State(initialValue: primaryTrailingAction?.symbol.fillName)
     }
     
-    // swiftlint:disable cyclomatic_complexity
     // swiftlint:disable function_body_length
     func body(content: Content) -> some View {
         content
@@ -353,8 +352,6 @@ struct SwipeyView: ViewModifier {
         }
     }
 }
-
-// swiftlint:enable cyclomatic_complexity
 // swiftlint:enable function_body_length
 
 extension View {

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -20,13 +20,15 @@ struct SwipeAction {
 }
 
 struct SwipeConfiguration {
-    let primaryLeading: SwipeAction?
-    let secondaryLeading: SwipeAction?
-    let tertiaryLeading: SwipeAction?
+    /// In ascending order of appearance.
+    let leadingActions: [SwipeAction]
+    /// In ascending order of appearance.
+    let trailingActions: [SwipeAction]
     
-    let primaryTrailing: SwipeAction?
-    let secondaryTrailing: SwipeAction?
-    let tertiaryTrailing: SwipeAction?
+    init(leadingActions: [SwipeAction?], trailingActions: [SwipeAction?]) {
+        self.leadingActions = leadingActions.compactMap { $0 }
+        self.trailingActions = trailingActions.compactMap { $0 }
+    }
 }
 
 struct SwipeyView: ViewModifier {
@@ -40,18 +42,10 @@ struct SwipeyView: ViewModifier {
     @State var leadingSwipeSymbol: String?
     @State var trailingSwipeSymbol: String?
     
-    private var primaryLeadingAction: SwipeAction? {
-        actions.primaryLeading
-    }
-    private var secondaryLeadingAction: SwipeAction? {
-        actions.secondaryLeading
-    }
-    private var primaryTrailingAction: SwipeAction? {
-        actions.primaryTrailing
-    }
-    private var secondaryTrailingAction: SwipeAction? {
-        actions.secondaryTrailing
-    }
+    private var primaryLeadingAction: SwipeAction? { actions.leadingActions.first }
+    private var secondaryLeadingAction: SwipeAction? { actions.leadingActions[safeIndex: 1] }
+    private var primaryTrailingAction: SwipeAction? { actions.trailingActions.first }
+    private var secondaryTrailingAction: SwipeAction? { actions.trailingActions[safeIndex: 1] }
     
     let actions: SwipeConfiguration
     
@@ -63,12 +57,8 @@ struct SwipeyView: ViewModifier {
     ) {
         self.init(
             configuration: .init(
-                primaryLeading: primaryLeadingAction,
-                secondaryLeading: secondaryLeadingAction,
-                tertiaryLeading: nil,
-                primaryTrailing: primaryTrailingAction,
-                secondaryTrailing: secondaryTrailingAction,
-                tertiaryTrailing: nil
+                leadingActions: [primaryLeadingAction, secondaryLeadingAction].compactMap { $0 },
+                trailingActions: [primaryTrailingAction, secondaryTrailingAction].compactMap { $0 }
             )
         )
     }

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -222,6 +222,8 @@ struct SwipeyView: ViewModifier {
     
     // MARK: -
     
+    /// Get the swipe action a specific drag position.
+    /// - Parameter dragPosition: Along the x-axis.
     private func swipeAction(at dragPosition: CGFloat) -> SwipeAction? {
         let edge = edgeForActions(at: dragPosition)
         let index = actionIndex(edge: edge, at: dragPosition)
@@ -229,10 +231,13 @@ struct SwipeyView: ViewModifier {
         return action
     }
     
+    /// For a particular `dragPosition`, returns the relevant edge for which to show/perform actions.
     private func edgeForActions(at dragPosition: CGFloat) -> HorizontalEdge {
         dragPosition > 0 ? .leading : .trailing
     }
     
+    /// Index of the action along the specified edge at the specified drag position.
+    /// - Returns: A `nil` value denotes the state where swiping has begun, but not enough to trigger any actions.
     private func actionIndex(edge: HorizontalEdge, at dragPosition: CGFloat) -> Array<CGFloat>.Index? {
         /// Map a `dragPosition` to a `dragThreshold`, which tells us what swipe action to perform, where `nil` is no action, `1` is primary, `2` is secondary, etc.
         let thresholdIndex = AppConstants.swipeActionDragThresholds.lastIndex {
@@ -266,6 +271,7 @@ struct SwipeyView: ViewModifier {
         }
     }
     
+    /// Get the action associated with an edge at the specified index.
     private func action(edge: HorizontalEdge, index actionIndex: Array<CGFloat>.Index?) -> SwipeAction? {
         guard let actionIndex else {
             return nil
@@ -278,6 +284,8 @@ struct SwipeyView: ViewModifier {
         }
     }
     
+    /// Maps swipe action transitions into an appropriate haptic info payload for haptic playback purposes.
+    /// - No-op if both indexes are the same (i.e. transition isn't happening).
     private func hapticInfo(
         transitioningFrom previousIndex: Array<CGFloat>.Index?,
         to currentIndex: Array<CGFloat>.Index?

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -266,33 +266,23 @@ struct SwipeyView: ViewModifier {
         }
         
         // From nil -> 0 -> 1 -> 2, etc, where nil is no action, and 0 is the primary action.
-#if DEBUG
-        print("pIndex \(previousIndex) -> cIndex: \(currentIndex)")
-#endif
+//        print("pIndex \(previousIndex) -> cIndex: \(currentIndex)")
         
         // Swiping towards to primary action.
         // Index values are always >= 0 for both leading/trailing edges.
         // Since nil indicates no action, we use -1 to represent nil instead (lol, yes).
         if (currentIndex ?? -1) < (previousIndex ?? -1) {
-#if DEBUG
-            print("mushyInfo.low\n")
-#endif
+//            print("mushyInfo.low\n")
             return (.mushyInfo, .low)
         } else {
             if previousIndex == nil {
-#if DEBUG
-                print("gentleInfo.high\n")
-#endif
+//                print("gentleInfo.high\n")
                 return (.gentleInfo, .high)
             } else if previousIndex == 1 {
-#if DEBUG
-                print("firmerInfo.high\n")
-#endif
+//                print("firmerInfo.high\n")
                 return (.firmerInfo, .high)
             } else {
-#if DEBUG
-                print("firmerInfo.high\n")
-#endif
+//                print("firmerInfo.high\n")
                 return (.firmerInfo, .high)
             }
         }

--- a/Mlem/Views/Shared/Comments/Comment Item Logic.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item Logic.swift
@@ -134,6 +134,15 @@ extension CommentItem {
         }
     }
     
+    func toggleCollapsed() {
+        withAnimation(.showHideComment(!hierarchicalComment.isCollapsed)) {
+            // Perhaps we want an explict flag for this in the future?
+            if !showPostContext {
+                commentTracker.setCollapsed(!hierarchicalComment.isCollapsed, comment: hierarchicalComment)
+            }
+        }
+    }
+    
     // MARK: helpers
     
     // swiftlint:disable function_body_length

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -218,8 +218,8 @@ extension CommentItem {
     private var saveSymbolName: String { displayedSaved ? "bookmark.slash.fill" : "bookmark.fill" }
     private var emptyReplySymbolName: String { "arrowshape.turn.up.left" }
     private var replySymbolName: String { "arrowshape.turn.up.left.fill" }
-    private var emptyCollapseSymbolName: String { "arrow.down.right.and.arrow.up.left.square" }
-    private var collapseSymbolName: String { "arrow.down.right.and.arrow.up.left.square.fill" }
+    private var emptyCollapseSymbolName: String { "arrow.up.left.and.arrow.down.right.circle" }
+    private var collapseSymbolName: String { "arrow.up.left.and.arrow.down.right.circle.fill" }
     
     var upvoteSwipeAction: SwipeAction {
         SwipeAction(

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -192,10 +192,8 @@ struct CommentItem: View {
         }
         .background(Color.systemBackground)
         .addSwipeyActions(
-            configuration: .init(
-                leadingActions: enableSwipeActions ? [upvoteSwipeAction, downvoteSwipeAction] : [],
-                trailingActions: enableSwipeActions ? [saveSwipeAction, replySwipeAction, expandCollapseCommentAction] : []
-            )
+            leading: enableSwipeActions ? [upvoteSwipeAction, downvoteSwipeAction] : [],
+            trailing: enableSwipeActions ? [saveSwipeAction, replySwipeAction, expandCollapseCommentAction] : []
         )
         .border(width: borderWidth, edges: [.leading], color: threadingColors[depth % threadingColors.count])
 //        .sheet(isPresented: $isComposingReport) {

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -194,7 +194,7 @@ struct CommentItem: View {
         .addSwipeyActions(
             configuration: .init(
                 leadingActions: enableSwipeActions ? [upvoteSwipeAction, downvoteSwipeAction] : [],
-                trailingActions: enableSwipeActions ? [saveSwipeAction, replySwipeAction, collapseCommentAction] : []
+                trailingActions: enableSwipeActions ? [saveSwipeAction, replySwipeAction, expandCollapseCommentAction] : []
             )
         )
         .border(width: borderWidth, edges: [.leading], color: threadingColors[depth % threadingColors.count])
@@ -269,7 +269,7 @@ extension CommentItem {
         )
     }
     
-    var collapseCommentAction: SwipeAction {
+    var expandCollapseCommentAction: SwipeAction {
         SwipeAction(
             symbol: .init(
                 emptyName: hierarchicalComment.isCollapsed ? emptyCollapseSymbolName : emptyExpandSymbolName,

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -193,12 +193,8 @@ struct CommentItem: View {
         .background(Color.systemBackground)
         .addSwipeyActions(
             configuration: .init(
-                primaryLeading: enableSwipeActions ? upvoteSwipeAction : nil,
-                secondaryLeading: enableSwipeActions ? downvoteSwipeAction : nil,
-                tertiaryLeading: nil,
-                primaryTrailing: enableSwipeActions ? saveSwipeAction : nil,
-                secondaryTrailing: enableSwipeActions ? replySwipeAction : nil,
-                tertiaryTrailing: enableSwipeActions ? collapseCommentAction : nil
+                leadingActions: enableSwipeActions ? [upvoteSwipeAction, downvoteSwipeAction] : [],
+                trailingActions: enableSwipeActions ? [saveSwipeAction, replySwipeAction, collapseCommentAction] : []
             )
         )
         .border(width: borderWidth, edges: [.leading], color: threadingColors[depth % threadingColors.count])

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -218,8 +218,23 @@ extension CommentItem {
     private var saveSymbolName: String { displayedSaved ? "bookmark.slash.fill" : "bookmark.fill" }
     private var emptyReplySymbolName: String { "arrowshape.turn.up.left" }
     private var replySymbolName: String { "arrowshape.turn.up.left.fill" }
-    private var emptyCollapseSymbolName: String { "arrow.up.left.and.arrow.down.right.circle" }
-    private var collapseSymbolName: String { "arrow.up.left.and.arrow.down.right.circle.fill" }
+    
+    private var emptyCollapseSymbolName: String { 
+//        "arrow.up.left.and.arrow.down.right.circle"
+        "arrow.up.and.line.horizontal.and.arrow.down"
+    }
+    private var collapseSymbolName: String {
+//        "arrow.up.left.and.arrow.down.right.circle.fill"
+        "arrow.up.and.line.horizontal.and.arrow.down"
+    }
+    private var emptyExpandSymbolName: String {
+//        "arrow.down.right.and.arrow.up.left.circle"
+        "arrow.down.and.line.horizontal.and.arrow.up"
+    }
+    private var expandSymbolName: String {
+//        "arrow.down.right.and.arrow.up.left.circle.fill"
+        "arrow.down.and.line.horizontal.and.arrow.up"
+    }
     
     var upvoteSwipeAction: SwipeAction {
         SwipeAction(
@@ -256,7 +271,9 @@ extension CommentItem {
     
     var collapseCommentAction: SwipeAction {
         SwipeAction(
-            symbol: .init(emptyName: emptyCollapseSymbolName, fillName: collapseSymbolName),
+            symbol: .init(
+                emptyName: hierarchicalComment.isCollapsed ? emptyCollapseSymbolName : emptyExpandSymbolName,
+                fillName: hierarchicalComment.isCollapsed ? collapseSymbolName : expandSymbolName),
             color: .teal,
             action: toggleCollapsed
         )

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -179,12 +179,7 @@ struct CommentItem: View {
         }
         .contentShape(Rectangle()) // allow taps in blank space to register
         .onTapGesture {
-            withAnimation(.showHideComment(!hierarchicalComment.isCollapsed)) {
-                // Perhaps we want an explict flag for this in the future?
-                if !showPostContext {
-                    commentTracker.setCollapsed(!hierarchicalComment.isCollapsed, comment: hierarchicalComment)
-                }
-            }
+            toggleCollapsed()
         }
         .contextMenu {
             ForEach(genMenuFunctions()) { item in
@@ -197,10 +192,14 @@ struct CommentItem: View {
         }
         .background(Color.systemBackground)
         .addSwipeyActions(
-            primaryLeadingAction: enableSwipeActions ? upvoteSwipeAction : nil,
-            secondaryLeadingAction: enableSwipeActions ? downvoteSwipeAction : nil,
-            primaryTrailingAction: enableSwipeActions ? saveSwipeAction : nil,
-            secondaryTrailingAction: enableSwipeActions ? replySwipeAction : nil
+            configuration: .init(
+                primaryLeading: enableSwipeActions ? upvoteSwipeAction : nil,
+                secondaryLeading: enableSwipeActions ? downvoteSwipeAction : nil,
+                tertiaryLeading: nil,
+                primaryTrailing: enableSwipeActions ? saveSwipeAction : nil,
+                secondaryTrailing: enableSwipeActions ? replySwipeAction : nil,
+                tertiaryTrailing: enableSwipeActions ? collapseCommentAction : nil
+            )
         )
         .border(width: borderWidth, edges: [.leading], color: threadingColors[depth % threadingColors.count])
 //        .sheet(isPresented: $isComposingReport) {
@@ -223,6 +222,8 @@ extension CommentItem {
     private var saveSymbolName: String { displayedSaved ? "bookmark.slash.fill" : "bookmark.fill" }
     private var emptyReplySymbolName: String { "arrowshape.turn.up.left" }
     private var replySymbolName: String { "arrowshape.turn.up.left.fill" }
+    private var emptyCollapseSymbolName: String { "arrow.down.right.and.arrow.up.left.square" }
+    private var collapseSymbolName: String { "arrow.down.right.and.arrow.up.left.square.fill" }
     
     var upvoteSwipeAction: SwipeAction {
         SwipeAction(
@@ -254,6 +255,14 @@ extension CommentItem {
             symbol: .init(emptyName: emptyReplySymbolName, fillName: replySymbolName),
             color: .accentColor,
             action: replyToCommentAsyncWrapper
+        )
+    }
+    
+    var collapseCommentAction: SwipeAction {
+        SwipeAction(
+            symbol: .init(emptyName: emptyCollapseSymbolName, fillName: collapseSymbolName),
+            color: .teal,
+            action: toggleCollapsed
         )
     }
 }

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -216,23 +216,10 @@ extension CommentItem {
     private var saveSymbolName: String { displayedSaved ? "bookmark.slash.fill" : "bookmark.fill" }
     private var emptyReplySymbolName: String { "arrowshape.turn.up.left" }
     private var replySymbolName: String { "arrowshape.turn.up.left.fill" }
-    
-    private var emptyCollapseSymbolName: String { 
-//        "arrow.up.left.and.arrow.down.right.circle"
-        "arrow.up.and.line.horizontal.and.arrow.down"
-    }
-    private var collapseSymbolName: String {
-//        "arrow.up.left.and.arrow.down.right.circle.fill"
-        "arrow.up.and.line.horizontal.and.arrow.down"
-    }
-    private var emptyExpandSymbolName: String {
-//        "arrow.down.right.and.arrow.up.left.circle"
-        "arrow.down.and.line.horizontal.and.arrow.up"
-    }
-    private var expandSymbolName: String {
-//        "arrow.down.right.and.arrow.up.left.circle.fill"
-        "arrow.down.and.line.horizontal.and.arrow.up"
-    }
+    private var emptyCollapseSymbolName: String { "arrow.up.and.line.horizontal.and.arrow.down" }
+    private var collapseSymbolName: String { "arrow.up.and.line.horizontal.and.arrow.down" }
+    private var emptyExpandSymbolName: String { "arrow.down.and.line.horizontal.and.arrow.up" }
+    private var expandSymbolName: String { "arrow.down.and.line.horizontal.and.arrow.up" }
     
     var upvoteSwipeAction: SwipeAction {
         SwipeAction(

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -272,7 +272,7 @@ extension CommentItem {
             symbol: .init(
                 emptyName: hierarchicalComment.isCollapsed ? emptyCollapseSymbolName : emptyExpandSymbolName,
                 fillName: hierarchicalComment.isCollapsed ? collapseSymbolName : expandSymbolName),
-            color: .teal,
+            color: .orange,
             action: toggleCollapsed
         )
     }

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -108,10 +108,14 @@ struct FeedPost: View {
                     }
                 }
                 .addSwipeyActions(
-                    primaryLeadingAction: enableSwipeActions ? upvoteSwipeAction : nil,
-                    secondaryLeadingAction: enableSwipeActions ? downvoteSwipeAction : nil,
-                    primaryTrailingAction: enableSwipeActions ? saveSwipeAction : nil,
-                    secondaryTrailingAction: enableSwipeActions ? replySwipeAction : nil
+                    leading: [
+                        enableSwipeActions ? upvoteSwipeAction : nil,
+                        enableSwipeActions ? downvoteSwipeAction : nil
+                    ],
+                    trailing: [
+                        enableSwipeActions ? saveSwipeAction : nil,
+                        enableSwipeActions ? replySwipeAction : nil
+                    ]
                 )
         }
     }

--- a/Mlem/Views/Tabs/Inbox/Feed/Mentions Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Mentions Feed View.swift
@@ -75,12 +75,15 @@ extension InboxView {
                     }
                 }
                 .addSwipeyActions(
-                    primaryLeadingAction: upvoteMentionSwipeAction(mentionView: mention),
-                    secondaryLeadingAction: downvoteMentionSwipeAction(mentionView: mention),
-                    primaryTrailingAction: toggleMentionReadSwipeAction(mentionView: mention),
-                    secondaryTrailingAction: replyToMentionSwipeAction(mentionView: mention)
-                )
-        }
+                    leading: [
+                        upvoteMentionSwipeAction(mentionView: mention),
+                        downvoteMentionSwipeAction(mentionView: mention)
+                    ],
+                    trailing: [
+                        toggleMentionReadSwipeAction(mentionView: mention),
+                        replyToMentionSwipeAction(mentionView: mention)
+                    ]
+                )        }
         .buttonStyle(EmptyButtonStyle())
     }
 }

--- a/Mlem/Views/Tabs/Inbox/Feed/Messages Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Messages Feed View.swift
@@ -72,10 +72,11 @@ extension InboxView {
                 }
             }
             .addSwipeyActions(
-                primaryLeadingAction: nil,
-                secondaryLeadingAction: nil,
-                primaryTrailingAction: toggleMessageReadSwipeAction(message: message),
-                secondaryTrailingAction: replyToMessageSwipeAction(message: message)
+                leading: [],
+                trailing: [
+                    toggleMessageReadSwipeAction(message: message),
+                    replyToMessageSwipeAction(message: message)
+                ]
             )
     }
 }

--- a/Mlem/Views/Tabs/Inbox/Feed/Replies Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Replies Feed View.swift
@@ -80,10 +80,14 @@ extension InboxView {
                     }
                 }
                 .addSwipeyActions(
-                    primaryLeadingAction: upvoteCommentReplySwipeAction(commentReply: reply),
-                    secondaryLeadingAction: downvoteCommentReplySwipeAction(commentReply: reply),
-                    primaryTrailingAction: toggleCommentReplyReadSwipeAction(commentReply: reply),
-                    secondaryTrailingAction: replyToCommentReplySwipeAction(commentReply: reply)
+                    leading: [
+                        upvoteCommentReplySwipeAction(commentReply: reply),
+                        downvoteCommentReplySwipeAction(commentReply: reply)
+                    ],
+                    trailing: [
+                        toggleCommentReplyReadSwipeAction(commentReply: reply),
+                        replyToCommentReplySwipeAction(commentReply: reply)
+                    ]
                 )
         }
         .buttonStyle(EmptyButtonStyle())


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #473
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
1. Adds a trailing swipe action to expand/collapse comments (`CommentItem`).
2. Refactors SwipeyView to support multiple leading/trailing actions along with predefined swipe drag action thresholds.
- This should help us get closer to allowing users customize swipe actions like in Apollo.

## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/2549615/75971a4a-2bd2-4df6-b093-3243f9268d50



