### PR TITLE
introduce alternative session states

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		50CC4A762A9CB9930074C845 /* instance_metadata.json in Resources */ = {isa = PBXBuildFile; fileRef = 50CC4A752A9CB9930074C845 /* instance_metadata.json */; };
 		50CC4A782A9CBDF70074C845 /* TimestampedValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CC4A772A9CBDF60074C845 /* TimestampedValueTests.swift */; };
 		50CC4A7A2A9CC45D0074C845 /* InstanceMetadata+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CC4A792A9CC45C0074C845 /* InstanceMetadata+Mock.swift */; };
+		50D61E5B2AA32B9400A926EC /* APISession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D61E5A2AA32B9400A926EC /* APISession.swift */; };
 		50DBB8E02A805836002870B1 /* MockErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DBB8DF2A805836002870B1 /* MockErrorHandler.swift */; };
 		50DBB8E22A80F9E4002870B1 /* APICommunity+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DBB8E12A80F9E4002870B1 /* APICommunity+Mock.swift */; };
 		50EC39B22A346DDC00E014C2 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EC39B12A346DDC00E014C2 /* URLHandler.swift */; };
@@ -514,6 +515,7 @@
 		50CC4A752A9CB9930074C845 /* instance_metadata.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = instance_metadata.json; sourceTree = "<group>"; };
 		50CC4A772A9CBDF60074C845 /* TimestampedValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimestampedValueTests.swift; sourceTree = "<group>"; };
 		50CC4A792A9CC45C0074C845 /* InstanceMetadata+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InstanceMetadata+Mock.swift"; sourceTree = "<group>"; };
+		50D61E5A2AA32B9400A926EC /* APISession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APISession.swift; sourceTree = "<group>"; };
 		50DBB8DF2A805836002870B1 /* MockErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockErrorHandler.swift; sourceTree = "<group>"; };
 		50DBB8E12A80F9E4002870B1 /* APICommunity+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APICommunity+Mock.swift"; sourceTree = "<group>"; };
 		50EC39B12A346DDC00E014C2 /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
@@ -1479,6 +1481,7 @@
 				637218042A3A2AAD008C4816 /* Models */,
 				637218242A3A2AAD008C4816 /* Requests */,
 				637218422A3A2AAD008C4816 /* APIRequest.swift */,
+				50D61E5A2AA32B9400A926EC /* APISession.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -2577,6 +2580,7 @@
 				63344C602A080CA1001BC616 /* Outlined Web Complex Style.swift in Sources */,
 				63F0C7BF2A058EDE00A18C5D /* Get Correct URL to Endpoint.swift in Sources */,
 				632E8EE827EE63DB007E8D75 /* DownvoteButtonView.swift in Sources */,
+				50D61E5B2AA32B9400A926EC /* APISession.swift in Sources */,
 				CDCBD72B2A8EC0A800387A2C /* Instance Summary.swift in Sources */,
 				CDC1C9412A7ABA9C00072E3D /* ReadMarkStyle.swift in Sources */,
 				6372186D2A3A2AAD008C4816 /* EditComment.swift in Sources */,

--- a/Mlem/API/APIClient.swift
+++ b/Mlem/API/APIClient.swift
@@ -36,26 +36,12 @@ extension APIClientError: CustomStringConvertible {
     }
 }
 
-struct APISession {
-    let token: String
-    let URL: URL
-}
-
 class APIClient {
     let urlSession: URLSession
     let decoder: JSONDecoder
     let transport: (URLSession, URLRequest) async throws -> (Data, URLResponse)
     
-    private var _session: APISession?
-    var session: APISession {
-        get throws {
-            guard let _session else {
-                throw APIClientError.invalidSession
-            }
-            
-            return _session
-        }
-    }
+    private(set) var session: APISession = .undefined
     
     // MARK: - Initialisation
     
@@ -74,7 +60,7 @@ class APIClient {
     /// Configures the clients session based on the passed in account
     /// - Parameter account: a `SavedAccount` to use when configuring the clients session
     func configure(for account: SavedAccount) {
-        _session = .init(token: account.accessToken, URL: account.instanceLink)
+        session = .authenticated(account.instanceLink, account.accessToken)
     }
     
     @discardableResult

--- a/Mlem/API/APIRequest.swift
+++ b/Mlem/API/APIRequest.swift
@@ -9,6 +9,11 @@ import Foundation
 
 // MARK: - APIRequest
 
+enum APIRequestError: Error {
+    case authenticationRequired
+    case undefinedSession
+}
+
 protocol APIRequest {
     associatedtype Response: Decodable
 

--- a/Mlem/API/APISession.swift
+++ b/Mlem/API/APISession.swift
@@ -1,0 +1,44 @@
+//
+//  APISession.swift
+//  Mlem
+//
+//  Created by mormaer on 02/09/2023.
+//
+//
+
+import Foundation
+
+enum APISessionError: Error {
+    case authenticationNotPresent
+    case undefined
+}
+
+/// An enumeration representing possible session states
+enum APISession {
+    case authenticated(URL, String)
+    case unauthenticated(URL)
+    case undefined
+    
+    var token: String {
+        get throws {
+            guard case let .authenticated(_, token) = self else {
+                throw APISessionError.authenticationNotPresent
+            }
+            
+            return token
+        }
+    }
+    
+    var instanceUrl: URL {
+        get throws {
+            switch self {
+            case let .authenticated(url, _):
+                return url
+            case let .unauthenticated(url):
+                return url
+            case .undefined:
+                throw APISessionError.undefined
+            }
+        }
+    }
+}

--- a/Mlem/API/Requests/Comment/CreateComment.swift
+++ b/Mlem/API/Requests/Comment/CreateComment.swift
@@ -30,9 +30,9 @@ struct CreateCommentRequest: APIPostRequest {
         languageId: Int?,
         parentId: Int?,
         postId: Int
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             content: content,
             post_id: postId,
             parent_id: parentId,

--- a/Mlem/API/Requests/Comment/CreateCommentLike.swift
+++ b/Mlem/API/Requests/Comment/CreateCommentLike.swift
@@ -25,9 +25,9 @@ struct CreateCommentLikeRequest: APIPostRequest {
         session: APISession,
         commentId: Int,
         score: Int
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             comment_id: commentId,
             score: score,
             auth: session.token

--- a/Mlem/API/Requests/Comment/CreateCommentReport.swift
+++ b/Mlem/API/Requests/Comment/CreateCommentReport.swift
@@ -25,9 +25,9 @@ struct CreateCommentReportRequest: APIPostRequest {
         session: APISession,
         commentId: Int,
         reason: String
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(auth: session.token, comment_id: commentId, reason: reason)
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(auth: session.token, comment_id: commentId, reason: reason)
     }
 }
 

--- a/Mlem/API/Requests/Comment/DeleteComment.swift
+++ b/Mlem/API/Requests/Comment/DeleteComment.swift
@@ -25,9 +25,9 @@ struct DeleteCommentRequest: APIPostRequest {
         session: APISession,
         commentId: Int,
         deleted: Bool
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             comment_id: commentId,
             deleted: deleted,
             auth: session.token

--- a/Mlem/API/Requests/Comment/EditComment.swift
+++ b/Mlem/API/Requests/Comment/EditComment.swift
@@ -33,16 +33,15 @@ struct EditCommentRequest: APIPutRequest {
         distinguished: Bool?,
         languageId: Int?,
         formId: String?
-    ) {
-        self.instanceURL = session.URL
+    ) throws {
+        self.instanceURL = try session.instanceUrl
 
-        self.body = .init(
+        self.body = try .init(
             comment_id: commentId,
             content: content,
             distinguished: distinguished,
             language_id: languageId,
             form_id: formId,
-
             auth: session.token
         )
     }

--- a/Mlem/API/Requests/Comment/GetComment.swift
+++ b/Mlem/API/Requests/Comment/GetComment.swift
@@ -18,9 +18,9 @@ struct GetCommentRequest: APIGetRequest {
     init(
         session: APISession,
         id: Int
-    ) {
-        self.instanceURL = session.URL
-        self.queryItems = [
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.queryItems = try [
             .init(name: "id", value: id.description),
             .init(name: "auth", value: session.token)
         ]

--- a/Mlem/API/Requests/Comment/GetComments.swift
+++ b/Mlem/API/Requests/Comment/GetComments.swift
@@ -27,10 +27,9 @@ struct GetCommentsRequest: APIGetRequest {
         communityName: String?,
         parentId: Int?,
         savedOnly: Bool?
-    ) {
-        self.instanceURL = session.URL
-        self.queryItems = [
-            .init(name: "auth", value: session.token),
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        var queryItems: [URLQueryItem] = [
             .init(name: "post_id", value: "\(postId)"),
             .init(name: "max_depth", value: "\(maxDepth)"),
             .init(name: "type_", value: type.rawValue),
@@ -42,6 +41,14 @@ struct GetCommentsRequest: APIGetRequest {
             .init(name: "parent_id", value: parentId.map(String.init)),
             .init(name: "saved_only", value: savedOnly.map(String.init))
         ]
+        
+        if let token = try? session.token {
+            queryItems.append(
+                .init(name: "auth", value: token)
+            )
+        }
+        
+        self.queryItems = queryItems
     }
 }
 

--- a/Mlem/API/Requests/Comment/SaveComment.swift
+++ b/Mlem/API/Requests/Comment/SaveComment.swift
@@ -27,13 +27,12 @@ struct SaveCommentRequest: APIPutRequest {
 
         commentId: Int,
         save: Bool
-    ) {
-        self.instanceURL = session.URL
+    ) throws {
+        self.instanceURL = try session.instanceUrl
 
-        self.body = .init(
+        self.body = try .init(
             comment_id: commentId,
             save: save,
-
             auth: session.token
         )
     }

--- a/Mlem/API/Requests/Community/BlockCommunity.swift
+++ b/Mlem/API/Requests/Community/BlockCommunity.swift
@@ -24,15 +24,13 @@ struct BlockCommunityRequest: APIPostRequest {
 
     init(
         session: APISession,
-
         communityId: Int,
         block: Bool
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             community_id: communityId,
             block: block,
-
             auth: session.token
         )
     }

--- a/Mlem/API/Requests/Community/FollowCommunity.swift
+++ b/Mlem/API/Requests/Community/FollowCommunity.swift
@@ -25,9 +25,9 @@ struct FollowCommunityRequest: APIPostRequest {
         session: APISession,
         communityId: Int,
         follow: Bool
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             community_id: communityId,
             follow: follow,
             auth: session.token

--- a/Mlem/API/Requests/Community/GetCommunity.swift
+++ b/Mlem/API/Requests/Community/GetCommunity.swift
@@ -18,12 +18,19 @@ struct GetCommunityRequest: APIGetRequest {
     init(
         session: APISession,
         communityId: Int
-    ) {
-        self.instanceURL = session.URL
-        self.queryItems = [
-            .init(name: "auth", value: session.token),
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        var queryItems: [URLQueryItem] = [
             .init(name: "id", value: "\(communityId)")
         ]
+        
+        if let token = try? session.token {
+            queryItems.append(
+                .init(name: "auth", value: token)
+            )
+        }
+        
+        self.queryItems = queryItems
     }
 }
 

--- a/Mlem/API/Requests/Community/HideCommunity.swift
+++ b/Mlem/API/Requests/Community/HideCommunity.swift
@@ -17,27 +17,23 @@ struct HideCommunityRequest: APIPutRequest {
     // lemmy_api_common::community::HideCommunity
     struct Body: Encodable {
         let community_id: Int
-
         let hidden: Bool
         let reason: String?
-
         let auth: String
     }
 
     init(
         session: APISession,
-
         communityId: Int,
         hidden: Bool,
         reason: String?
-    ) {
-        self.instanceURL = session.URL
+    ) throws {
+        self.instanceURL = try session.instanceUrl
 
-        self.body = .init(
+        self.body = try .init(
             community_id: communityId,
             hidden: hidden,
             reason: reason,
-
             auth: session.token
         )
     }

--- a/Mlem/API/Requests/Community/ListCommunities.swift
+++ b/Mlem/API/Requests/Community/ListCommunities.swift
@@ -17,22 +17,26 @@ struct ListCommunitiesRequest: APIGetRequest {
 
     init(
         session: APISession,
-
         sort: String?,
         page: Int?,
         limit: Int?,
-
         type: String
-    ) {
-        self.instanceURL = session.URL
-        self.queryItems = [
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        var queryItems: [URLQueryItem] = [
             .init(name: "sort", value: sort),
             .init(name: "limit", value: limit?.description),
             .init(name: "page", value: page?.description),
-            .init(name: "type_", value: type),
-
-            .init(name: "auth", value: session.token)
+            .init(name: "type_", value: type)
         ]
+        
+        if let token = try? session.token {
+            queryItems.append(
+                .init(name: "auth", value: token)
+            )
+        }
+        
+        self.queryItems = queryItems
     }
 }
 

--- a/Mlem/API/Requests/Messages/CreatePrivateMessageReportRequest.swift
+++ b/Mlem/API/Requests/Messages/CreatePrivateMessageReportRequest.swift
@@ -25,9 +25,9 @@ struct CreatePrivateMessageReportRequest: APIPostRequest {
         session: APISession,
         privateMessageId: Int,
         reason: String
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(auth: session.token, private_message_id: privateMessageId, reason: reason)
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(auth: session.token, private_message_id: privateMessageId, reason: reason)
     }
 }
 

--- a/Mlem/API/Requests/Messages/CreatePrivateMessageRequest.swift
+++ b/Mlem/API/Requests/Messages/CreatePrivateMessageRequest.swift
@@ -25,8 +25,8 @@ struct CreatePrivateMessageRequest: APIPostRequest {
         session: APISession,
         content: String,
         recipient: APIPerson
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(auth: session.token, content: content, recipient_id: recipient.id)
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(auth: session.token, content: content, recipient_id: recipient.id)
     }
 }

--- a/Mlem/API/Requests/Messages/GetPrivateMessages.swift
+++ b/Mlem/API/Requests/Messages/GetPrivateMessages.swift
@@ -16,7 +16,7 @@ struct GetPrivateMessagesRequest: APIGetRequest {
 
     // lemmy_api_common::person::GetPersonDetails
     init(
-        account: SavedAccount,
+        account: SavedAccount, // TODO: move to session based call, auth required.
         page: Int? = nil,
         limit: Int? = nil,
         unreadOnly: Bool = false

--- a/Mlem/API/Requests/Person/BlockPerson.swift
+++ b/Mlem/API/Requests/Person/BlockPerson.swift
@@ -25,9 +25,9 @@ struct BlockPersonRequest: APIPostRequest {
         session: APISession,
         personId: Int,
         block: Bool
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             person_id: personId,
             block: block,
             auth: session.token

--- a/Mlem/API/Requests/Person/GetPersonDetails.swift
+++ b/Mlem/API/Requests/Person/GetPersonDetails.swift
@@ -35,9 +35,8 @@ struct GetPersonDetailsRequest: APIGetRequest {
             throw GetPersonDetailsRequestError.invalidArguments
         }
 
-        self.instanceURL = session.URL
+        self.instanceURL = try session.instanceUrl
         var queryItems: [URLQueryItem] = [
-            .init(name: "auth", value: session.token),
             .init(name: "sort", value: sort?.rawValue),
             .init(name: "page", value: page?.description),
             .init(name: "limit", value: limit?.description),
@@ -56,6 +55,12 @@ struct GetPersonDetailsRequest: APIGetRequest {
             queryItems.append(.init(name: "username", value: username))
         } else if let personId {
             queryItems.append(.init(name: "person_id", value: "\(personId)"))
+        }
+        
+        if let token = try? session.token {
+            queryItems.append(
+                .init(name: "auth", value: token)
+            )
         }
 
         self.queryItems = queryItems

--- a/Mlem/API/Requests/Person/GetPersonMentions.swift
+++ b/Mlem/API/Requests/Person/GetPersonMentions.swift
@@ -7,11 +7,6 @@
 
 import Foundation
 
-enum GetPersonMentionsRequestError: Error {
-    case invalidArguments
-    case unableToDetermineInstanceHost
-}
-
 struct GetPersonMentionsRequest: APIGetRequest {
     typealias Response = GetPersonMentionsResponse
 
@@ -21,7 +16,7 @@ struct GetPersonMentionsRequest: APIGetRequest {
 
     // lemmy_api_common::person::GetPersonMentions
     init(
-        account: SavedAccount,
+        account: SavedAccount, // TODO: needs to move to session based call...
         sort: PostSortType? = nil,
         page: Int? = nil,
         limit: Int? = nil,

--- a/Mlem/API/Requests/Person/GetPersonUnreadCount.swift
+++ b/Mlem/API/Requests/Person/GetPersonUnreadCount.swift
@@ -14,10 +14,10 @@ public struct GetPersonUnreadCount: APIGetRequest {
     let instanceURL: URL
     let queryItems: [URLQueryItem]
 
-    init(session: APISession) {
-        self.instanceURL = session.URL
+    init(session: APISession) throws {
+        self.instanceURL = try session.instanceUrl
         
-        let queryItems: [URLQueryItem] = [
+        let queryItems: [URLQueryItem] = try [
             .init(name: "auth", value: session.token)
         ]
         self.queryItems = queryItems

--- a/Mlem/API/Requests/Person/GetReplies.swift
+++ b/Mlem/API/Requests/Person/GetReplies.swift
@@ -16,7 +16,7 @@ struct GetRepliesRequest: APIGetRequest {
 
     // lemmy_api_common::person::GetPersonMentions
     init(
-        account: SavedAccount,
+        account: SavedAccount, // TODO: needs to move to session based call... auth needed.
         sort: PostSortType? = nil,
         page: Int? = nil,
         limit: Int? = nil,

--- a/Mlem/API/Requests/Person/MarkAllAsReadRequest.swift
+++ b/Mlem/API/Requests/Person/MarkAllAsReadRequest.swift
@@ -21,9 +21,9 @@ struct MarkAllAsRead: APIPostRequest {
     
     init(
         session: APISession
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             auth: session.token
         )
     }

--- a/Mlem/API/Requests/Person/MarkCommentReplyAsReadRequest.swift
+++ b/Mlem/API/Requests/Person/MarkCommentReplyAsReadRequest.swift
@@ -24,9 +24,9 @@ struct MarkCommentReplyAsRead: APIPostRequest {
         session: APISession,
         commentId: Int,
         read: Bool
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             comment_reply_id: commentId,
             read: read,
             auth: session.token

--- a/Mlem/API/Requests/Person/MarkPersonMentionAsReadRequest.swift
+++ b/Mlem/API/Requests/Person/MarkPersonMentionAsReadRequest.swift
@@ -24,9 +24,9 @@ struct MarkPersonMentionAsRead: APIPostRequest {
         session: APISession,
         personMentionId: Int,
         read: Bool
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             person_mention_id: personMentionId,
             read: read,
             auth: session.token

--- a/Mlem/API/Requests/Person/MarkPrivateMessageAsReadRequest.swift
+++ b/Mlem/API/Requests/Person/MarkPrivateMessageAsReadRequest.swift
@@ -24,9 +24,9 @@ struct MarkPrivateMessageAsRead: APIPostRequest {
         session: APISession,
         privateMessageId: Int,
         read: Bool
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             private_message_id: privateMessageId,
             read: read,
             auth: session.token

--- a/Mlem/API/Requests/Post/CreatePost.swift
+++ b/Mlem/API/Requests/Post/CreatePost.swift
@@ -34,9 +34,9 @@ struct CreatePostRequest: APIPostRequest {
         body: String?,
         // TODO: change to `URL?`
         url: String?
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             auth: session.token,
             community_id: communityId,
             name: name,

--- a/Mlem/API/Requests/Post/CreatePostLike.swift
+++ b/Mlem/API/Requests/Post/CreatePostLike.swift
@@ -25,8 +25,8 @@ struct CreatePostLikeRequest: APIPostRequest {
         session: APISession,
         postId: Int,
         score: ScoringOperation
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(auth: session.token, post_id: postId, score: score.rawValue)
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(auth: session.token, post_id: postId, score: score.rawValue)
     }
 }

--- a/Mlem/API/Requests/Post/CreatePostReport.swift
+++ b/Mlem/API/Requests/Post/CreatePostReport.swift
@@ -25,9 +25,9 @@ struct CreatePostReportRequest: APIPostRequest {
         session: APISession,
         postId: Int,
         reason: String
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(auth: session.token, post_id: postId, reason: reason)
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(auth: session.token, post_id: postId, reason: reason)
     }
 }
 

--- a/Mlem/API/Requests/Post/DeletePost.swift
+++ b/Mlem/API/Requests/Post/DeletePost.swift
@@ -26,9 +26,9 @@ struct DeletePostRequest: APIPostRequest {
         session: APISession,
         postId: Int,
         deleted: Bool
-    ) {
-        self.instanceURL = session.URL
-        self.body = .init(
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
             post_id: postId,
             deleted: deleted,
             auth: session.token

--- a/Mlem/API/Requests/Post/EditPost.swift
+++ b/Mlem/API/Requests/Post/EditPost.swift
@@ -35,17 +35,16 @@ struct EditPostRequest: APIPutRequest {
         body: String?,
         nsfw: Bool?,
         languageId: Int?
-    ) {
-        self.instanceURL = session.URL
+    ) throws {
+        self.instanceURL = try session.instanceUrl
 
-        self.body = .init(
+        self.body = try .init(
             post_id: postId,
             name: name,
             url: URL(string: url ?? ""),
             body: body,
             nsfw: nsfw,
             language_id: languageId,
-
             auth: session.token
         )
     }

--- a/Mlem/API/Requests/Post/GetPost.swift
+++ b/Mlem/API/Requests/Post/GetPost.swift
@@ -19,14 +19,21 @@ struct GetPostRequest: APIGetRequest {
         session: APISession,
         id: Int?,
         commentId: Int?
-    ) {
-        self.instanceURL = session.URL
+    ) throws {
+        self.instanceURL = try session.instanceUrl
 
-        self.queryItems = [
-            .init(name: "auth", value: session.token),
+        var queryItems: [URLQueryItem] = [
             .init(name: "id", value: id?.description),
             .init(name: "comment_id", value: commentId?.description)
         ]
+        
+        if let token = try? session.token {
+            queryItems.append(
+                .init(name: "auth", value: token)
+            )
+        }
+        
+        self.queryItems = queryItems
     }
 }
 

--- a/Mlem/API/Requests/Post/GetPosts.swift
+++ b/Mlem/API/Requests/Post/GetPosts.swift
@@ -16,7 +16,7 @@ struct GetPostsRequest: APIGetRequest {
     let queryItems: [URLQueryItem]
 
     init(
-        account: SavedAccount,
+        account: SavedAccount, // TODO: needs to move to a session based call...
         communityId: Int?,
         page: Int,
         sort: PostSortType?,

--- a/Mlem/API/Requests/Post/MarkPostRead.swift
+++ b/Mlem/API/Requests/Post/MarkPostRead.swift
@@ -24,10 +24,10 @@ struct MarkPostReadRequest: APIPostRequest {
         session: APISession,
         postId: Int,
         read: Bool
-    ) {
-        self.instanceURL = session.URL
+    ) throws {
+        self.instanceURL = try session.instanceUrl
 
-        self.body = .init(
+        self.body = try .init(
             post_id: postId,
             read: read,
             auth: session.token

--- a/Mlem/API/Requests/Post/SavePost.swift
+++ b/Mlem/API/Requests/Post/SavePost.swift
@@ -25,10 +25,10 @@ struct SavePostRequest: APIPutRequest {
         session: APISession,
         postId: Int,
         save: Bool
-    ) {
-        self.instanceURL = session.URL
+    ) throws {
+        self.instanceURL = try session.instanceUrl
 
-        self.body = .init(
+        self.body = try .init(
             post_id: postId,
             save: save,
             auth: session.token

--- a/Mlem/API/Requests/ResolveObject.swift
+++ b/Mlem/API/Requests/ResolveObject.swift
@@ -18,11 +18,10 @@ struct ResolveObjectRequest: APIGetRequest {
     init(
         session: APISession,
         query: String
-    ) {
-        self.instanceURL = session.URL
-        self.queryItems = [
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.queryItems = try [
             .init(name: "q", value: query),
-
             .init(name: "auth", value: session.token)
         ]
     }

--- a/Mlem/API/Requests/SearchRequest.swift
+++ b/Mlem/API/Requests/SearchRequest.swift
@@ -35,10 +35,9 @@ struct SearchRequest: APIGetRequest {
         communityName: String?,
         creatorId: Int?,
         limit: Int?
-    ) {
-        self.instanceURL = session.URL
-        self.queryItems = [
-            .init(name: "auth", value: session.token),
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        var queryItems: [URLQueryItem] = [
             .init(name: "type_", value: searchType.rawValue),
             .init(name: "sort", value: sortOption.rawValue),
             .init(name: "listing_type", value: listingType.rawValue),
@@ -49,6 +48,14 @@ struct SearchRequest: APIGetRequest {
             .init(name: "creator_id", value: creatorId.map(String.init)),
             .init(name: "limit", value: limit.map(String.init))
         ]
+        
+        if let token = try? session.token {
+            queryItems.append(
+                .init(name: "auth", value: token)
+            )
+        }
+        
+        self.queryItems = queryItems
     }
 }
 

--- a/Mlem/API/Requests/Site/GetSite.swift
+++ b/Mlem/API/Requests/Site/GetSite.swift
@@ -17,11 +17,17 @@ struct GetSiteRequest: APIGetRequest {
 
     init(
         session: APISession
-    ) {
-        self.instanceURL = session.URL
-        self.queryItems = [
-            .init(name: "auth", value: session.token)
-        ]
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        var queryItems: [URLQueryItem] = []
+        
+        if let token = try? session.token {
+            queryItems.append(
+                .init(name: "auth", value: token)
+            )
+        }
+        
+        self.queryItems = queryItems
     }
 
     init(

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -20,7 +20,6 @@ enum Field: Hashable {
 
 // swiftlint:disable type_body_length
 struct AddSavedInstanceView: View {
-    
     @Dependency(\.accountsTracker) var accountsTracker
     @Dependency(\.apiClient) var apiClient
     
@@ -346,7 +345,7 @@ struct AddSavedInstanceView: View {
     
     private func getUserID(authToken: String, instanceURL: URL) async throws -> Int {
         // create a session to use for this request, since we're in the process of creating the account...
-        let session = APISession(token: authToken, URL: instanceURL)
+        let session = APISession.authenticated(instanceURL, authToken)
         do {
             return try await apiClient.getPersonDetails(session: session, username: username)
                 .personView


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Prerequisite for #21 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR alters our `APISession` type to be an enumeration that represents different session states which can exist in the application.

**Although the session object has changed, the behaviour in the application will remain the same for now - as we only ever set the session to `.authenticated`, which equates to the previous behaviour where we created it from the users selected account**

Our session object was a struct which contained two non-optional properties, one for the instance URL and another for the users token. This works fine as the application only really has two states, onboarding (no token/url) or logged in (token and url).

As we look to introduce _guest mode_ with #21 we will now have a third state, where a user has a URL for the instance, but no token.

There was the potential to simply change the token value inside the current `APISession` object to be optional, and this would _work_ however it would not accurately model the session state correctly. If we checked for a token and it wasn't there, would that mean we're in guest mode... or was there a logic error somewhere which meant the token got cleared by accident?

Representing the session as an enumeration allows us to communicate our intention clearly, as we can either set the state to be `.authenticated`, `.unauthenticated`, or `.undefined`. There are two main benefits to this:

1. We can't _accidentally_ clear our token, as we'd need to write logic which specifically changes the state from `.authenticated` -> `.unauthenticated`/`.undefined`
2. We can use the states while creating our requests which allows us to catch logic errors where a user with an `.undefined` session attempts to perform a call, or a user with an `.unauthenticated` session attempts to make a call which requires a token.

## Screenshots and Videos
No changes to the UI are introduced by this PR.

## Additional Context
There's a still another couple of bits and pieces which need addressed before guest mode can see the light of day, but now that we can represent an `.unauthenticated` session in the client we're getting closer 🎉 
