### PR TITLE
made info stack less broken with many widgets

### DIFF
--- a/Mlem/Views/Shared/Components/InteractionBarView.swift
+++ b/Mlem/Views/Shared/Components/InteractionBarView.swift
@@ -48,7 +48,7 @@ struct InteractionBarView: View {
     
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(Array(widgets.enumerated()), id: \.element) { offset, widget in
+            ForEach(Array(widgets.enumerated()), id: \.offset) { offset, widget in
                 switch widget {
                 case .scoreCounter:
                     ScoreCounterView(
@@ -114,7 +114,8 @@ struct InteractionBarView: View {
                         alignment: infoStackAlignment(offset)
                     )
                     .padding(AppConstants.postAndCommentSpacing)
-                    .frame(maxWidth: .infinity)
+                    .fixedSize()
+                    .frame(minWidth: 0, maxWidth: .infinity)
                 }
             }
         }


### PR DESCRIPTION
Two small changes to how the interaction bar works:

- Widgets are now assigned id based on offset (prevents id conflicts with multi-widgets)
- InfoStack now bleeds behind widgets if out of space
<img width="396" alt="Screenshot 2023-09-04 at 9 11 44 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/b51d8e26-96ab-4ba5-9132-cd9c4699acd8">
