### PR TITLE
fixed the widget wizard for ios 17

### DIFF
--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Shared/LayoutWidgetEditView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Shared/LayoutWidgetEditView.swift
@@ -8,25 +8,6 @@
 import Dependencies
 import SwiftUI
 
-private struct WidgetCollectionView: ViewModifier {
-    var collection: LayoutWidgetCollection
-    var rectTransformation: (_ rect: CGRect) -> CGRect
-    
-    func wrappedContent(content: Content, geometry: GeometryProxy) -> some View {
-        let rect = geometry.frame(in: .global)
-        collection.rect = rectTransformation(rect)
-        return content
-    }
-    
-    func body(content: Content) -> some View {
-        Group {
-            GeometryReader { geometry in
-                wrappedContent(content: content, geometry: geometry)
-            }
-        }
-    }
-}
-
 struct LayoutWidgetEditView: View {
     @Environment(\.isPresented) var isPresented
     
@@ -52,14 +33,14 @@ struct LayoutWidgetEditView: View {
         
         let tray = InfiniteWidgetCollection(
             [
-            .upvote,
-            .downvote,
-            .save,
-            .reply,
-            .share,
-            .upvoteCounter,
-            .downvoteCounter,
-            .scoreCounter
+                .upvote,
+                .downvote,
+                .save,
+                .reply,
+                .share,
+                .upvoteCounter,
+                .downvoteCounter,
+                .scoreCounter
             ].map { LayoutWidget($0) }
         )
         
@@ -164,13 +145,20 @@ struct LayoutWidgetEditView: View {
         .animation(.default, value: barCollection.itemsToRender)
         .zIndex(1)
         .transition(.scale(scale: 1))
-        .modifier(WidgetCollectionView(collection: barCollection) { rect in
-            rect
-                .offsetBy(dx: 0, dy: -outerFrame.origin.y)
-                .insetBy(dx: -20, dy: -60)
-        })
         .frame(maxWidth: .infinity)
         .frame(height: 40)
+        .overlay {
+            // little hack to determine the frame after rendering and update the collection
+            GeometryReader { geo in
+                Color.clear
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .onAppear {
+                        barCollection.rect = geo.frame(in: .global)
+                            .offsetBy(dx: 0, dy: -outerFrame.origin.y)
+                            .insetBy(dx: -20, dy: -60)
+                    }
+            }
+        }
     }
     
     func tray(_ outerFrame: CGRect) -> some View {
@@ -192,10 +180,17 @@ struct LayoutWidgetEditView: View {
         }
         .frame(maxWidth: .infinity)
         .frame(height: 300)
-        .modifier(WidgetCollectionView(collection: trayCollection) { rect in
-            rect
-                .offsetBy(dx: 0, dy: -outerFrame.origin.y - 90)
-        })
+        .overlay {
+            // little hack to determine the frame after rendering and update the collection
+            GeometryReader { geo in
+                Color.clear
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .onAppear {
+                        trayCollection.rect = geo.frame(in: .global)
+                            .offsetBy(dx: 0, dy: -outerFrame.origin.y - 90)
+                    }
+            }
+        }
     }
     
     func trayWidgetView(_ widgetType: LayoutWidgetType, widgets: [LayoutWidgetType: LayoutWidget], outerFrame: CGRect) -> some View {


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - nope lol
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR fixes the widget wizard not setting collection rect properly in the view modifier. It replaces that logic with a fun little `.overlay`/`GeometryReader` hack.
