### PR TITLE
Make ErrorView show non-json errors if they occur

### DIFF
--- a/Mlem/Views/Shared/Error View.swift
+++ b/Mlem/Views/Shared/Error View.swift
@@ -35,8 +35,14 @@ struct ErrorView: View {
 
     var body: some View {
         VStack(spacing: 15) {
-            if showingFullError, let errorText = errorDetails.error?.localizedDescription {
-                errorDetails(errorText)
+            if showingFullError {
+                if let error = errorDetails.error {
+                    if let error = error as? APIClientError {
+                        errorDetails(error.description)
+                    } else {
+                        errorDetails(error.localizedDescription)
+                    }
+                }
             } else {
                 if let icon = errorDetails.icon {
                     Image(systemName: icon)


### PR DESCRIPTION
Follow-up from #562. If Lemmy returns a basic text (not json) error, clicking the "Show details" button on the `ErrorView` will let you see the error text that was returned by the API. Previously, it would only show "Json decode error".