### PR TITLE
Add GitHub action CI builds

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,0 +1,31 @@
+name: CI Build
+
+on:
+    # Run in master as CI
+    push:
+        branches:
+        - master
+    pull_request:
+        branches:
+        - master
+
+jobs:
+  xcode-build:
+    permissions: write-all
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: "Test SDK versions"
+      run: |
+        xcodebuild -showsdks
+    - name: Xcodebuild Action
+      run: |
+        xcodebuild -project ./Mlem.xcodeproj -scheme "Mlem" -sdk "iphonesimulator16.2" -quiet -resultBundlePath "build_results.xcresult"
+    - uses: kishikawakatsumi/xcresulttool@v1
+      with:
+        path: build_results.xcresult
+        upload-bundles: never # Permission issues with uploading
+      if: success() || failure()
+      # ^ This is important because the action will be run
+      # even if the test fails in the previous step.

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   Build:
     permissions: write-all
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         project: Mlem.xcodeproj
         scheme: Mlem
-        destination: platform=Simulator,name=iPhone 14,OS=16.4'
+        destination: platform=Simulator,name=iPhone 14,OS=16.2'
         action: test
 
     #- name: Build with xcodebuild

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         project: Mlem.xcodeproj
         scheme: Mlem
-        destination: platform=iOS Simulator,name=iPhone 14,OS=16.2
+        destination: platform=iOS Simulator,name=iPhone 14,OS=16.4
         action: build
         result-bundle-path: build_results.xcresult
 
@@ -68,7 +68,7 @@ jobs:
       with:
         project: Mlem.xcodeproj
         scheme: Mlem
-        destination: platform=iOS Simulator,name=iPhone 14,OS=16.2
+        destination: platform=iOS Simulator,name=iPhone 14,OS=16.4
         action: test
         result-bundle-path: test_results.xcresult
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -29,14 +29,15 @@ jobs:
         scheme: Mlem
         destination: platform=iOS Simulator,name=iPhone 14,OS=16.2
         action: test
+        result-bundle-path: test_results.xcresult
 
     #- name: Build with xcodebuild
     #  run: |
     #    xcodebuild -project ./Mlem.xcodeproj -scheme "Mlem" -sdk "iphonesimulator16.2" -quiet -resultBundlePath "build_results.xcresult"
-    #- uses: kishikawakatsumi/xcresulttool@v1
-    #  with:
-    #    path: build_results.xcresult
-    #    upload-bundles: never # Permission issues with uploading
-    #  if: success() || failure()
+    - uses: kishikawakatsumi/xcresulttool@v1
+      with:
+        path: test_results.xcresult
+        upload-bundles: never # Permission issues with uploading
+      if: success() || failure()
       # ^ This is important because the action will be run
       # even if the test fails in the previous step.

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI - Build & Test
 
 env:
   XCODE_VERSION: 14.3.1

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -18,26 +18,26 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
     - name: "Test SDK versions"
       run: |
         xcodebuild -showsdks
 
-    - name: "Xcode Test"
+    - name: "Xcode Build"
       uses: sersoft-gmbh/xcodebuild-action@v2
       with:
         project: Mlem.xcodeproj
         scheme: Mlem
         destination: platform=iOS Simulator,name=iPhone 14,OS=16.2
         action: build
-        result-bundle-path: test_results.xcresult
+        result-bundle-path: build_results.xcresult
 
-    #- name: Build with xcodebuild
-    #  run: |
-    #    xcodebuild -project ./Mlem.xcodeproj -scheme "Mlem" -sdk "iphonesimulator16.2" -quiet -resultBundlePath "build_results.xcresult"
     - uses: kishikawakatsumi/xcresulttool@v1
+      name: Publish build results
       with:
-        path: test_results.xcresult
+        path: build_results.xcresult
         upload-bundles: never # Permission issues with uploading
+        show-passed-tests: false
       if: success() || failure()
       # ^ This is important because the action will be run
       # even if the test fails in the previous step.
@@ -48,6 +48,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      
     - name: "Test SDK versions"
       run: |
         xcodebuild -showsdks
@@ -61,10 +62,8 @@ jobs:
         action: test
         result-bundle-path: test_results.xcresult
 
-    #- name: Build with xcodebuild
-    #  run: |
-    #    xcodebuild -project ./Mlem.xcodeproj -scheme "Mlem" -sdk "iphonesimulator16.2" -quiet -resultBundlePath "build_results.xcresult"
     - uses: kishikawakatsumi/xcresulttool@v1
+      name: Publish test results
       with:
         path: test_results.xcresult
         upload-bundles: never # Permission issues with uploading

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,8 +1,5 @@
 name: CI
 
-env:
-  XCODE_VERSION: 14.2.0
-
 on:
     push:
         branches:
@@ -25,7 +22,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       name: Set Xcode Version
       with:
-        xcode-version: "$XCODE_VERSION"
+        xcode-version: "14.2.0"
 
     - name: "Test SDK versions"
       run: |
@@ -60,7 +57,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       name: Set Xcode Version
       with:
-        xcode-version: "$XCODE_VERSION"
+        xcode-version: "14.2.0"
       
     - name: "Test SDK versions"
       run: |

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,5 +1,10 @@
 name: CI
 
+env:
+  MACOS_AGENT: macos-13
+  XCODE_VERSION: 14.3.1
+  XCODEBUILD_DESTINATION: platform=iOS Simulator,name=iPhone 14,OS=16.4
+
 on:
     push:
         branches:
@@ -14,7 +19,7 @@ on:
 jobs:
   Build:
     permissions: write-all
-    runs-on: macos-13
+    runs-on: "$MACOS_AGENT"
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -22,7 +27,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       name: Set Xcode Version
       with:
-        xcode-version: "14.3.1"
+        xcode-version: "$XCODE_VERSION"
 
     - name: "Test SDK versions"
       run: |
@@ -33,7 +38,7 @@ jobs:
       with:
         project: Mlem.xcodeproj
         scheme: Mlem
-        destination: platform=iOS Simulator,name=iPhone 14,OS=16.4
+        destination: "$XCODEBUILD_DESTINATION"
         action: build
         result-bundle-path: build_results.xcresult
 
@@ -49,7 +54,7 @@ jobs:
 
   Test:
     permissions: write-all
-    runs-on: macos-13
+    runs-on: "$MACOS_AGENT"
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -57,7 +62,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       name: Set Xcode Version
       with:
-        xcode-version: "14.3.1"
+        xcode-version: "$XCODE_VERSION"
       
     - name: "Test SDK versions"
       run: |
@@ -68,7 +73,7 @@ jobs:
       with:
         project: Mlem.xcodeproj
         scheme: Mlem
-        destination: platform=iOS Simulator,name=iPhone 14,OS=16.4
+        destination: "$XCODEBUILD_DESTINATION"
         action: test
         result-bundle-path: test_results.xcresult
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: CI - Build
 
 on:
     push:
@@ -21,7 +21,7 @@ jobs:
     - name: "Test SDK versions"
       run: |
         xcodebuild -showsdks
-    - name: Xcodebuild Action
+    - name: Build with xcodebuild
       run: |
         xcodebuild -project ./Mlem.xcodeproj -scheme "Mlem" -sdk "iphonesimulator16.2" -quiet -resultBundlePath "build_results.xcresult"
     - uses: kishikawakatsumi/xcresulttool@v1

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -57,7 +57,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       name: Set Xcode Version
       with:
-        xcode-version: "14.2.0"
+        xcode-version: "14.3.1"
       
     - name: "Test SDK versions"
       run: |

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -19,6 +19,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - uses: maxim-lobanov/setup-xcode@v1
+      name: Set Xcode Version
+      with:
+        xcode-version: 14.3.1
+
     - name: "Test SDK versions"
       run: |
         xcodebuild -showsdks

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,7 +1,6 @@
 name: CI
 
 env:
-  MACOS_AGENT: macos-13
   XCODE_VERSION: 14.3.1
   XCODEBUILD_DESTINATION: platform=iOS Simulator,name=iPhone 14,OS=16.4
 
@@ -19,7 +18,7 @@ on:
 jobs:
   Build:
     permissions: write-all
-    runs-on: "$MACOS_AGENT"
+    runs-on: macos-13
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -27,7 +26,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       name: Set Xcode Version
       with:
-        xcode-version: "$XCODE_VERSION"
+        xcode-version: "${{ env.XCODE_VERSION }}"
 
     - name: "Test SDK versions"
       run: |
@@ -38,7 +37,7 @@ jobs:
       with:
         project: Mlem.xcodeproj
         scheme: Mlem
-        destination: "$XCODEBUILD_DESTINATION"
+        destination: "${{ env.XCODEBUILD_DESTINATION }}"
         action: build
         result-bundle-path: build_results.xcresult
 
@@ -54,7 +53,7 @@ jobs:
 
   Test:
     permissions: write-all
-    runs-on: "$MACOS_AGENT"
+    runs-on: macos-13
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -62,7 +61,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       name: Set Xcode Version
       with:
-        xcode-version: "$XCODE_VERSION"
+        xcode-version: "${{ env.XCODE_VERSION }}"
       
     - name: "Test SDK versions"
       run: |
@@ -73,7 +72,7 @@ jobs:
       with:
         project: Mlem.xcodeproj
         scheme: Mlem
-        destination: "$XCODEBUILD_DESTINATION"
+        destination: "${{ env.XCODEBUILD_DESTINATION }}"
         action: test
         result-bundle-path: test_results.xcresult
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -49,7 +49,7 @@ jobs:
 
   Test:
     permissions: write-all
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         project: Mlem.xcodeproj
         scheme: Mlem
-        destination: platform=Simulator,name=iPhone 14,OS=16.2'
+        destination: platform=Simulator,name=iPhone 14,OS=16.2
         action: test
 
     #- name: Build with xcodebuild

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,13 +1,15 @@
 name: CI Build
 
 on:
-    # Run in master as CI
     push:
         branches:
         - master
+        - dev
+
     pull_request:
         branches:
         - master
+        - dev
 
 jobs:
   xcode-build:

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,4 +1,4 @@
-name: CI - Build & Test
+name: CI
 
 on:
     push:

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       name: Set Xcode Version
       with:
-        xcode-version: "14.2.0"
+        xcode-version: "14.3.1"
 
     - name: "Test SDK versions"
       run: |

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -21,13 +21,22 @@ jobs:
     - name: "Test SDK versions"
       run: |
         xcodebuild -showsdks
-    - name: Build with xcodebuild
-      run: |
-        xcodebuild -project ./Mlem.xcodeproj -scheme "Mlem" -sdk "iphonesimulator16.2" -quiet -resultBundlePath "build_results.xcresult"
-    - uses: kishikawakatsumi/xcresulttool@v1
+
+    - name: "Xcode Test"
+      uses: sersoft-gmbh/xcodebuild-action@v2
       with:
-        path: build_results.xcresult
-        upload-bundles: never # Permission issues with uploading
-      if: success() || failure()
+        project: Mlem.xcodeproj
+        scheme: Mlem
+        destination: platform=Simulator,name=iPhone 14,OS=16.4'
+        action: test
+
+    #- name: Build with xcodebuild
+    #  run: |
+    #    xcodebuild -project ./Mlem.xcodeproj -scheme "Mlem" -sdk "iphonesimulator16.2" -quiet -resultBundlePath "build_results.xcresult"
+    #- uses: kishikawakatsumi/xcresulttool@v1
+    #  with:
+    #    path: build_results.xcresult
+    #    upload-bundles: never # Permission issues with uploading
+    #  if: success() || failure()
       # ^ This is important because the action will be run
       # even if the test fails in the previous step.

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         project: Mlem.xcodeproj
         scheme: Mlem
-        destination: platform=Simulator,name=iPhone 14,OS=16.2
+        destination: platform=iOS Simulator,name=iPhone 14,OS=16.2
         action: test
 
     #- name: Build with xcodebuild

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,4 +1,4 @@
-name: CI - Build
+name: CI - Build & Test
 
 on:
     push:
@@ -12,7 +12,37 @@ on:
         - dev
 
 jobs:
-  xcode-build:
+  Build:
+    permissions: write-all
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: "Test SDK versions"
+      run: |
+        xcodebuild -showsdks
+
+    - name: "Xcode Test"
+      uses: sersoft-gmbh/xcodebuild-action@v2
+      with:
+        project: Mlem.xcodeproj
+        scheme: Mlem
+        destination: platform=iOS Simulator,name=iPhone 14,OS=16.2
+        action: build
+        result-bundle-path: test_results.xcresult
+
+    #- name: Build with xcodebuild
+    #  run: |
+    #    xcodebuild -project ./Mlem.xcodeproj -scheme "Mlem" -sdk "iphonesimulator16.2" -quiet -resultBundlePath "build_results.xcresult"
+    - uses: kishikawakatsumi/xcresulttool@v1
+      with:
+        path: test_results.xcresult
+        upload-bundles: never # Permission issues with uploading
+      if: success() || failure()
+      # ^ This is important because the action will be run
+      # even if the test fails in the previous step.
+
+  Test:
     permissions: write-all
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  XCODE_VERSION: 14.2.0
+
 on:
     push:
         branches:
@@ -22,7 +25,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       name: Set Xcode Version
       with:
-        xcode-version: 14.3.1
+        xcode-version: "$XCODE_VERSION"
 
     - name: "Test SDK versions"
       run: |
@@ -53,6 +56,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
+    - uses: maxim-lobanov/setup-xcode@v1
+      name: Set Xcode Version
+      with:
+        xcode-version: "$XCODE_VERSION"
       
     - name: "Test SDK versions"
       run: |

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -5,6 +5,7 @@ on:
     push:
         branches:
         - master
+        
     # Run when we tweak Swift or supporting files
     pull_request:
         paths:

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI - Lint
 
 on:
     # Run in master as CI

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -1,11 +1,11 @@
-name: CI - Lint
+name: CI
 
 on:
     # Run in master as CI
     push:
         branches:
         - master
-        
+
     # Run when we tweak Swift or supporting files
     pull_request:
         paths:

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -1,4 +1,4 @@
-name: SwiftLint
+name: CI - Lint
 
 on:
     # Run in master as CI

--- a/Mlem.xcodeproj/xcshareddata/xcschemes/Mlem.xcscheme
+++ b/Mlem.xcodeproj/xcshareddata/xcschemes/Mlem.xcscheme
@@ -39,7 +39,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6363D5DF27EE196A00E34822"


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - No issues for this
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR adds two new GitHub Action jobs:
- One that builds with `xcodebuild`
- One that tests with `xcodebuild`

It also disabled the UI tests project from running as it sounds like that is a waste of time and a stubbed out empty project.

## Screenshots and Videos
n/a

## Additional Context
This PR hard codes a specific device to build and test on in the iOS simulator (iPhone 14) as well as an iOS version string.

These will change over time when GitHub updates their MacOS agents but I added a step which prints available combinations so updating will be easy.  These values should be pretty stable (months between changing, not weeks) but we could probably automate the selection somehow with some fancy grep.
