### PR TITLE
fix - access accounts tracker via dependency

### DIFF
--- a/Mlem/Views/Shared/Accounts/DeleteAccountView.swift
+++ b/Mlem/Views/Shared/Accounts/DeleteAccountView.swift
@@ -10,8 +10,9 @@ import Foundation
 import SwiftUI
 
 struct DeleteAccountView: View {
+    @Dependency(\.accountsTracker) var accountsTracker
+    
     @EnvironmentObject var appState: AppState
-    @EnvironmentObject var accountsTracker: SavedAccountTracker
     
     @Environment(\.dismiss) var dismiss
     @Environment(\.forceOnboard) var forceOnboard


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - No issue, just noticed it and it'd crash if we ever access it 🙈 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request

This (tiny) PR just updates the `DeleteAccountView` to access the accounts tracker via `@Dependency` instead of `@EnvironmentObject`. The change made in #554 means that there is no accounts tracker in the environment so attempting to access it this way will crash the app.

This has snuck through as the work in #554 happened on `dev` before the delete account changes from `master` were re-integrated the other day in #573.