### PR TITLE
Fixed wide banners from derailing whole header

### DIFF
--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header.swift
@@ -29,7 +29,7 @@ struct CommunitySidebarHeader: View {
                         shouldExpand: false,
                         fixedSize: CGSize(width: UIScreen.main.bounds.width, height: 200),
                         contentMode: .fill
-                    )
+                    ).frame(width: UIScreen.main.bounds.width)
                 }
             }
             VStack {
@@ -93,7 +93,7 @@ struct SidebarHeaderPreview: PreviewProvider {
                     title: "TestCommunityWithLongName",
                     subtitle: "@testcommunity@longnamedomain.website",
                     avatarSubtext: .constant("Created 3 days ago"),
-                    bannerURL: URL(string: "https://picsum.photos/seed/mlem-banner/200/300"),
+                    bannerURL: URL(string: "https://picsum.photos/seed/mlem-banner/2000/300"),
                     avatarUrl: URL(string: "https://picsum.photos/seed/mlem-avatar/200"),
                     label1: "Label 1",
                     label2: "Label 2"

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header.swift
@@ -93,7 +93,7 @@ struct SidebarHeaderPreview: PreviewProvider {
                     title: "TestCommunityWithLongName",
                     subtitle: "@testcommunity@longnamedomain.website",
                     avatarSubtext: .constant("Created 3 days ago"),
-                    bannerURL: URL(string: "https://picsum.photos/seed/mlem-banner/2000/300"),
+                    bannerURL: URL(string: "https://picsum.photos/seed/mlem-banner/2001/300"),
                     avatarUrl: URL(string: "https://picsum.photos/seed/mlem-avatar/200"),
                     label1: "Label 1",
                     label2: "Label 2"


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - n/a
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
Wide banners are causing profile/community sidebar views to go off into the sunset.  This attempts to fix that with framing.

## Screenshots and Videos
Before:
<img width="369" alt="Screenshot 2023-09-10 at 10 05 37 AM" src="https://github.com/mlemgroup/mlem/assets/1000311/7d5692c8-d384-45f6-8b67-9984002c611e">

After:

## Additional Context
Not exactly sure of the nuances of `CachedImage`.  This seems to fix it but the params passed into `CachedImage` seem like they would already be restricting it.
<img width="369" alt="Screenshot 2023-09-10 at 10 05 25 AM" src="https://github.com/mlemgroup/mlem/assets/1000311/a3e10d24-6e4e-4072-b0e5-d63ddab4acbf">
