### PR TITLE
Tweaked NSFW Filter Behavior

### DIFF
--- a/Mlem/Extensions/NSFW Overlay.swift
+++ b/Mlem/Extensions/NSFW Overlay.swift
@@ -9,14 +9,25 @@ import Foundation
 import SwiftUI
 
 struct NSFWOverlay: ViewModifier {
-    let isNsfw: Bool
     @AppStorage("shouldBlurNsfw") var shouldBlurNsfw: Bool = true
+    
+    let isNsfw: Bool
+    let canTapFullImage: Bool
+    
     @State var showNsfwFilterToggle: Bool = true
+    
     var showNsfwFilter: Bool { isNsfw ? shouldBlurNsfw && showNsfwFilterToggle : false }
     
     func body(content: Content) -> some View {
         content
-            .overlay(nsfwOverlay)
+            .overlay {
+                if canTapFullImage {
+                    nsfwOverlay
+                        .onTapGesture { showNsfwFilterToggle.toggle() }
+                } else {
+                    nsfwOverlay
+                }
+            }
     }
     
     @ViewBuilder
@@ -54,7 +65,7 @@ struct NSFWOverlay: ViewModifier {
 }
 
 extension View {
-    func applyNsfwOverlay(_ isNsfw: Bool) -> some View {
-        modifier(NSFWOverlay(isNsfw: isNsfw))
+    func applyNsfwOverlay(_ isNsfw: Bool, canTapFullImage: Bool = false) -> some View {
+        modifier(NSFWOverlay(isNsfw: isNsfw, canTapFullImage: canTapFullImage))
     }
 }

--- a/Mlem/Extensions/NSFW Overlay.swift
+++ b/Mlem/Extensions/NSFW Overlay.swift
@@ -12,7 +12,7 @@ struct NSFWOverlay: ViewModifier {
     @AppStorage("shouldBlurNsfw") var shouldBlurNsfw: Bool = true
     
     let isNsfw: Bool
-    let canTapFullImage: Bool
+    let tapAnywhereToReveal: Bool
     
     @State var showNsfwFilterToggle: Bool = true
     
@@ -21,7 +21,7 @@ struct NSFWOverlay: ViewModifier {
     func body(content: Content) -> some View {
         content
             .overlay {
-                if canTapFullImage {
+                if tapAnywhereToReveal {
                     nsfwOverlay
                         .onTapGesture { showNsfwFilterToggle.toggle() }
                 } else {
@@ -66,6 +66,6 @@ struct NSFWOverlay: ViewModifier {
 
 extension View {
     func applyNsfwOverlay(_ isNsfw: Bool, canTapFullImage: Bool = false) -> some View {
-        modifier(NSFWOverlay(isNsfw: isNsfw, canTapFullImage: canTapFullImage))
+        modifier(NSFWOverlay(isNsfw: isNsfw, tapAnywhereToReveal: canTapFullImage))
     }
 }

--- a/Mlem/Extensions/NSFW Overlay.swift
+++ b/Mlem/Extensions/NSFW Overlay.swift
@@ -37,6 +37,7 @@ struct NSFWOverlay: ViewModifier {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.thinMaterial)
+            .cornerRadius(AppConstants.largeItemCornerRadius)
         } else if isNsfw, shouldBlurNsfw {
             Image(systemName: "eye.slash")
                 .foregroundColor(.white)

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -118,12 +118,16 @@ class PostTracker: ObservableObject {
         
         page = 1
         
+        print("loading page \(page)")
+        
         let newPosts = try await postRepository.loadPage(
             communityId: communityId,
             page: page,
             sort: sort,
             type: feedType
         )
+        
+        print("found \(newPosts.count) posts")
         
         await reset(with: newPosts, filteredWith: filtering)
     }

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -118,16 +118,12 @@ class PostTracker: ObservableObject {
         
         page = 1
         
-        print("loading page \(page)")
-        
         let newPosts = try await postRepository.loadPage(
             communityId: communityId,
             page: page,
             sort: sort,
             type: feedType
         )
-        
-        print("found \(newPosts.count) posts")
         
         await reset(with: newPosts, filteredWith: filtering)
     }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -211,7 +211,7 @@ struct LargePost: View {
                         maxHeight: layoutMode.getMaxHeight(limitHeight),
                         alignment: .top
                     )
-                    .applyNsfwOverlay(post.post.nsfw || post.community.nsfw)
+                    .applyNsfwOverlay(post.post.nsfw || post.community.nsfw, canTapFullImage: isExpanded)
                     .clipped()
                 }
                 postBodyView


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - TF feedback
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

https://github.com/mlemgroup/mlem/assets/44140166/2b7e9982-7664-4014-af22-c7eb53080239

This PR subtly adjusts the behavior of the NSFW filter:
- In feed: behavior unchanged. Tapping the exclamation mark reveals the image; tapping anywhere else navigates to the expanded view
- In expanded view: tapping anywhere on the image reveals the image

To support this, I have added a default-false `tapAnywhereToReveal` bool to the NSFW filter to enable this behavior.
