### PR TITLE
Fixed settings icon regression

### DIFF
--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -25,7 +25,8 @@ struct AppConstants {
     static let keychain: Keychain = .init(service: "com.hanners.Mlem-keychain")
     
     // MARK: - Text Fields
-    static let textFieldVariableLineLimit: ClosedRange<Int> = 1...10
+
+    static let textFieldVariableLineLimit: ClosedRange<Int> = 1 ... 10
     
     // MARK: - Sizes
 
@@ -147,6 +148,10 @@ struct AppConstants {
     static let transparencySymbolName: String = "square.on.square.intersection.dashed"
     static let presentSymbolName: String = "circle.fill"
     static let absentSymbolName: String = "circle"
+    static let iconSymbolName: String = "fleuron"
+    static let userSymbolName: String = "person.circle"
+    static let bannerSymbolName: String = "flag"
+    static let communitySymbolName: String = "building.2.crop.circle"
     
     // MARK: - Other
 

--- a/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct SwitchableSettingsItem: View {
+    @AppStorage("showSettingsIcons") var showSettingsIcons: Bool = true
+    
     let settingPictureSystemName: String
     let settingPictureColor: Color
     let settingName: String
@@ -32,14 +34,18 @@ struct SwitchableSettingsItem: View {
             Label {
                 Text(settingName)
             } icon: {
-                Image(systemName: settingPictureSystemName)
-                    .foregroundColor(settingPictureColor)
+                if showSettingsIcons {
+                    Image(systemName: settingPictureSystemName)
+                        .foregroundColor(settingPictureColor)
+                }
             }
         }
     }
 }
 
 struct SelectableSettingsItem<T: SettingsOptions>: View {
+    @AppStorage("showSettingsIcons") var showSettingsIcons: Bool = true
+    
     let settingIconSystemName: String
     let settingName: String
     @Binding var currentValue: T
@@ -56,8 +62,10 @@ struct SelectableSettingsItem<T: SettingsOptions>: View {
             Label {
                 Text(settingName)
             } icon: {
-                Image(systemName: settingIconSystemName)
-                    .foregroundColor(.pink)
+                if showSettingsIcons {
+                    Image(systemName: settingIconSystemName)
+                        .foregroundColor(.pink)
+                }
             }
         }
     }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -12,6 +12,7 @@ struct AccessibilitySettingsView: View {
     @AppStorage("reakMarkStyle") var readMarkStyle: ReadMarkStyle = .bar
     @AppStorage("readBarThickness") var readBarThickness: Int = 3
     @AppStorage("hasTranslucentInsets") var hasTranslucentInsets: Bool = true
+    @AppStorage("showSettingsIcons") var showSettingsIcons: Bool = true
     
     @State private var readBarThicknessSlider: CGFloat = 3.0
     
@@ -30,9 +31,11 @@ struct AccessibilitySettingsView: View {
                         Label {
                             Text("Bar Thickness")
                         } icon: {
-                            Image(systemName: "rectangle.leftthird.inset.filled")
-                                .foregroundColor(.pink)
-                                .opacity(readMarkStyle == .bar ? 1 : 0.4)
+                            if showSettingsIcons {
+                                Image(systemName: "rectangle.leftthird.inset.filled")
+                                    .foregroundColor(.pink)
+                                    .opacity(readMarkStyle == .bar ? 1 : 0.4)
+                            }
                         }
                         
                         Spacer()
@@ -74,6 +77,16 @@ struct AccessibilitySettingsView: View {
                 )
             } header: {
                 Text("Transparency")
+            }
+            
+            Section {
+                SwitchableSettingsItem(
+                    settingPictureSystemName: AppConstants.iconSymbolName,
+                    settingName: "Show Settings Icons",
+                    isTicked: $showSettingsIcons
+                )
+            } header: {
+                Text("Icons")
             }
         }
         .fancyTabScrollCompatible()

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -27,6 +27,8 @@ struct CommentSettingsView: View {
     @EnvironmentObject var layoutWidgetTracker: LayoutWidgetTracker
     
     @AppStorage("compactComments") var compactComments: Bool = false
+    @AppStorage("showSettingsIcons") var showSettingsIcons: Bool = true
+    
     // interactions and info
     @AppStorage("shouldShowScoreInCommentBar") var shouldShowScoreInCommentBar: Bool = false
     @AppStorage("showCommentDownvotesSeparately") var showCommentDownvotesSeparately: Bool = false
@@ -51,8 +53,10 @@ struct CommentSettingsView: View {
                     Label {
                         Text("Customize Widgets")
                     } icon: {
-                        Image(systemName: "wand.and.stars")
-                            .foregroundColor(.pink)
+                        if showSettingsIcons {
+                            Image(systemName: "wand.and.stars")
+                                .foregroundColor(.pink)
+                        }
                     }
                 }
             } footer: {
@@ -93,9 +97,11 @@ struct CommentSettingsView: View {
             }
             
             Section {
-                SwitchableSettingsItem(settingPictureSystemName: "circle",
-                                       settingName: "Show Jump Button",
-                                       isTicked: $showCommentJumpButton)
+                SwitchableSettingsItem(
+                    settingPictureSystemName: "chevron.down.circle",
+                    settingName: "Show Jump Button",
+                    isTicked: $showCommentJumpButton
+                )
                 SelectableSettingsItem(
                     settingIconSystemName: "arrow.left.arrow.right",
                     settingName: "Side",

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
@@ -11,14 +11,16 @@ struct CommunitySettingsView: View {
     
     var body: some View {
         Form {
-            Section {
-                Toggle("Show Avatars", isOn: $shouldShowCommunityIcons)
-            }
-            Section {
-                Toggle("Show Banners", isOn: $shouldShowCommunityHeaders)
-            } footer: {
-                Text("The community banner is shown in the community sidebar menu.")
-            }
+            SwitchableSettingsItem(
+                settingPictureSystemName: AppConstants.communitySymbolName,
+                settingName: "Show Avatars",
+                isTicked: $shouldShowCommunityIcons
+            )
+            SwitchableSettingsItem(
+                settingPictureSystemName: AppConstants.bannerSymbolName,
+                settingName: "Show Banners",
+                isTicked: $shouldShowCommunityHeaders
+            )
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Communities")

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -12,6 +12,7 @@ struct PostSettingsView: View {
     @EnvironmentObject var layoutWidgetTracker: LayoutWidgetTracker
     
     @AppStorage("postSize") var postSize: PostSize = .headline
+    @AppStorage("showSettingsIcons") var showSettingsIcons: Bool = true
     
     // Thumbnails
     @AppStorage("shouldShowPostThumbnails") var shouldShowPostThumbnails: Bool = true
@@ -52,8 +53,10 @@ struct PostSettingsView: View {
                     Label {
                         Text("Customize Widgets")
                     } icon: {
-                        Image(systemName: "wand.and.stars")
-                            .foregroundColor(.pink)
+                        if showSettingsIcons {
+                            Image(systemName: "wand.and.stars")
+                                .foregroundColor(.pink)
+                        }
                     }
                 }
                 
@@ -156,7 +159,7 @@ struct PostSettingsView: View {
                 .padding(.horizontal)
                 
                 SwitchableSettingsItem(
-                    settingPictureSystemName: "network",
+                    settingPictureSystemName: "link",
                     settingName: "Show Website Address",
                     isTicked: $shouldShowWebsiteHost
                 )

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
@@ -13,14 +13,16 @@ struct UserSettingsView: View {
     
     var body: some View {
         Form {
-            Section {
-                Toggle("Show Avatars", isOn: $shouldShowUserAvatars)
-            }
-            Section {
-                Toggle("Show Banners", isOn: $shouldShowUserHeaders)
-            } footer: {
-                Text("Show a user's banner on their profile.")
-            }
+            SwitchableSettingsItem(
+                settingPictureSystemName: AppConstants.userSymbolName,
+                settingName: "Show Avatars",
+                isTicked: $shouldShowUserAvatars
+            )
+            SwitchableSettingsItem(
+                settingPictureSystemName: AppConstants.bannerSymbolName,
+                settingName: "Show Banners",
+                isTicked: $shouldShowUserHeaders
+            )
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Users")

--- a/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
@@ -9,6 +9,8 @@ import Dependencies
 import SwiftUI
 
 struct FiltersSettingsView: View {
+    @AppStorage("showSettingsIcons") var showSettingsIcons: Bool = true
+    
     @Dependency(\.errorHandler) var errorHandler
     @Dependency(\.persistenceRepository) var persistenceRepository
     
@@ -53,7 +55,13 @@ struct FiltersSettingsView: View {
                 Button {
                     isShowingKeywordImporter = true
                 } label: {
-                    Label("Import Filters", systemImage: "square.and.arrow.down")
+                    Label {
+                        Text("Import Filters")
+                    } icon: {
+                        if showSettingsIcons {
+                            Image(systemName: "square.and.arrow.down")
+                        }
+                    }
                 }
                 .fileImporter(isPresented: $isShowingKeywordImporter, allowedContentTypes: [.json]) { result in
                     do {
@@ -99,9 +107,15 @@ struct FiltersSettingsView: View {
                 Button(role: .destructive) {
                     isShowingFilterDeletionConfirmation = true
                 } label: {
-                    Label("Delete All Filters", systemImage: "trash")
-                        .foregroundColor(.red)
-                        .opacity(filtersTracker.filteredKeywords.isEmpty ? 0.6 : 1)
+                    Label {
+                        Text("Delete All Filters")
+                    } icon: {
+                        if showSettingsIcons {
+                            Image(systemName: "trash")
+                        }
+                    }
+                    .foregroundColor(.red)
+                    .opacity(filtersTracker.filteredKeywords.isEmpty ? 0.6 : 1)
                 }
                 .disabled(filtersTracker.filteredKeywords.isEmpty)
                 .confirmationDialog(

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -21,6 +21,8 @@ struct GeneralSettingsView: View {
     
     @AppStorage("hapticLevel") var hapticLevel: HapticPriority = .low
     @AppStorage("upvoteOnSave") var upvoteOnSave: Bool = false
+    
+    @AppStorage("showSettingsIcons") var showSettingsIcons: Bool = false
 
     @EnvironmentObject var appState: AppState
 
@@ -107,9 +109,15 @@ struct GeneralSettingsView: View {
                 Button(role: .destructive) {
                     isShowingFavoritesDeletionConfirmation.toggle()
                 } label: {
-                    Label("Delete Community Favorites", systemImage: "trash")
-                        .foregroundColor(.red)
-                        .opacity(favoriteCommunitiesTracker.favoritesForCurrentAccount.isEmpty ? 0.6 : 1)
+                    Label {
+                        Text("Delete Community Favorites")
+                    } icon: {
+                        if showSettingsIcons {
+                            Image(systemName: "trash")
+                        }
+                    }
+                    .foregroundColor(.red)
+                    .opacity(favoriteCommunitiesTracker.favoritesForCurrentAccount.isEmpty ? 0.6 : 1)
                 }
                 .disabled(favoriteCommunitiesTracker.favoritesForCurrentAccount.isEmpty)
                 .confirmationDialog(


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #596
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR fixes a regression where settings did all feature icons--a feature that is important to enable our dyslexic users to navigate the hefty stack of settings we offer.

It also introduces an option to disable settings icons and removes some unnecessary descriptive text.

<img width="563" alt="Screenshot 2023-09-13 at 12 03 47 AM" src="https://github.com/mlemgroup/mlem/assets/44140166/773a7376-12d6-49fa-a4ac-8b1d903b38b4">
<img width="563" alt="Screenshot 2023-09-13 at 12 03 54 AM" src="https://github.com/mlemgroup/mlem/assets/44140166/8f298bff-5f94-4f9e-868b-fdfef46b9aec">
<img width="563" alt="Screenshot 2023-09-13 at 12 10 44 AM" src="https://github.com/mlemgroup/mlem/assets/44140166/3c171d76-0062-4721-a8e1-2761922f128e">