### PR TITLE
fix - allow `.admin` value on `APIPerson` to be considered optional

### DIFF
--- a/Mlem/API/Models/Person/APIPerson.swift
+++ b/Mlem/API/Models/Person/APIPerson.swift
@@ -23,7 +23,7 @@ struct APIPerson: Decodable, Identifiable, Hashable {
     let deleted: Bool
     let sharedInboxUrl: URL?
     let matrixUserId: String?
-    let admin: Bool
+    let admin: Bool? // this is no longer returned on beehaw...
     let botAccount: Bool
     let banExpires: Date?
     let instanceId: Int

--- a/Mlem/Views/Shared/Links/User/UserLabelView.swift
+++ b/Mlem/Views/Shared/Links/User/UserLabelView.swift
@@ -21,7 +21,8 @@ struct UserLabelView: View {
     @State var communityContext: GetCommunityResponse?
 
     var blurAvatar: Bool { postContext?.nsfw ?? false ||
-            communityContext?.communityView.community.nsfw ?? false }
+        communityContext?.communityView.community.nsfw ?? false
+    }
     
     init(
         user: APIPerson,
@@ -146,7 +147,7 @@ struct UserLabelView: View {
                 return UserLabelView.flairDeveloper
             }
         }
-        if user.admin {
+        if user.admin == true {
             return UserLabelView.flairAdmin
         }
         if user.botAccount {

--- a/Mlem/Views/Shared/Posts/Post Sizes/Headline Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Headline Post.swift
@@ -24,7 +24,7 @@ struct HeadlinePost: View {
 
     // computed
     var usernameColor: Color {
-        if post.creator.admin {
+        if post.creator.admin == true {
             return .red
         }
         if post.creator.botAccount {


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - beehaw now returning nowt for this value 😞 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
A small change to treat the `.admin` value as optional as currently the Beehaw instance is no longer returning it. The instance is still stating it is running `0.18.4` with no changes, however this appears to not be the case. If the value returns on Beehaw we should make this a non-optional value again [to match the ever accurate and trustworthy documentation](https://join-lemmy.org/api/interfaces/Person.html#admin) of this API.

## Screenshots and Videos
No UI changes.
