### PR TITLE
fix - use separate formatters for parsing inconsistent dates from API

### DIFF
--- a/Mlem/Extensions/JSONDecoder+Default.swift
+++ b/Mlem/Extensions/JSONDecoder+Default.swift
@@ -11,35 +11,34 @@ extension JSONDecoder {
     static var defaultDecoder: JSONDecoder {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-
-        let formatter = DateFormatter()
-
-        formatter.timeZone = .gmt
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-
+        
         let formats = [
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ",
             "yyyy-MM-dd'T'HH:mm:ss.SSSSSS",
-            "yyyy-MM-dd'T'HH:mm:ss.SSSSZ",
-            "yyyy-MM-dd'T'HH:mm:ss.SSSS",
-            "yyyy-MM-dd'T'HH:mm:ss",
-            "yyyy-MM-dd HH:mm:ss.SSSSSS",
-            "yyyy-MM-dd HH:mm:ss",
-            "yyyy-MM-dd"
+            "yyyy-MM-dd'T'HH:mm:ssZ",
+            "yyyy-MM-dd'T'HH:mm:ss"
         ]
+        
+        let formatters = formats.map { format in
+            let formatter = DateFormatter()
+            formatter.timeZone = .gmt
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.dateFormat = format
+            return formatter
+        }
 
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let string = try container.decode(String.self)
 
-            for format in formats {
-                formatter.dateFormat = format
+            for formatter in formatters {
                 if let date = formatter.date(from: string) {
                     return date
                 }
             }
 
             // after some discussion we've agreed to fail the modelling if the date
-            // does match either of the above, as based on the current API source code
+            // does match _any_ of the above, as based on the current API source code
             // it should be one of those
             throw Swift.DecodingError.dataCorrupted(
                 .init(


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Handling inconsistencies in the dates from the API, see #601 for more detail
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This is an alternative approach to the one presented in #601 which does not lose the millisecond precision. 🙌 

There only appears to be _two_ formats (it's actually four, because of the varying inclusion of the `Z`) coming from the instances I can test on, they consist of;

```
yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ
yyyy-MM-dd'T'HH:mm:ss.SSSSSS
yyyy-MM-dd'T'HH:mm:ssZ
yyyy-MM-dd'T'HH:mm:ss
```

The change in this PR changes our logic to create four separate formatters which are then used to parse the date. The reason for creating four formatters is that attempting to use a single one and swapping its `.dateFormat` on the fly appears to cause failures on our end.

## Screenshots and Videos
No UI changes.

## Additional Context
I've removed a few formats in this PR, as I've never seen them returned anywhere and based on the Lemmy source I'm not sure if we would ever see then. Before we merge this PR it'd be good to get some folks to test across as many instances as possible to make sure there aren't any other rogue formats being thrown around 🙈 