### PR TITLE
Hacked images to be smooth for TF release

### DIFF
--- a/Mlem/Views/Shared/Links/Community/CommunityLinkView.swift
+++ b/Mlem/Views/Shared/Links/Community/CommunityLinkView.swift
@@ -26,7 +26,8 @@ struct CommunityLinkView: View {
     }
 
     var body: some View {
-        NavigationLink(value: community) {
+        // NavigationLink(value: community) {
+        NavigationLink(.apiCommunity(community)) {
             HStack {
                 CommunityLabelView(
                     community: community,

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -93,7 +93,10 @@ struct LargePost: View {
     }
     
     // REMOVEME: needed for TF hack
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
     var screenWidth: CGFloat = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
+    var imageWidth: CGFloat { horizontalSizeClass == .regular ? screenWidth * 0.8 : screenWidth }
+    var imageHeight: CGFloat { horizontalSizeClass == .regular ? 600 : screenWidth }
     
     // initializer--used so we can set showNsfwFilterToggle to false when expanded or true when not
     init(
@@ -207,18 +210,18 @@ struct LargePost: View {
                         url: url,
                         // maxHeight: layoutMode.getMaxHeight(limitHeight),
                         // CHANGEME: hack for TF release
-                        fixedSize: CGSize(width: screenWidth, height: screenWidth),
+                        fixedSize: CGSize(width: imageWidth, height: imageHeight),
                         dismissCallback: markPostAsRead,
                         cornerRadius: AppConstants.largeItemCornerRadius
                     )
-                    .frame(
-                        // CHANGEME: hack for TF release
-                        width: screenWidth,
-                        height: screenWidth,
-                        // maxWidth: .infinity,
-                        // maxHeight: layoutMode.getMaxHeight(limitHeight),
-                        alignment: .top
-                    )
+                    // CHANGEME: hack for TF release
+                    .frame(height: imageHeight)
+                    .frame(maxWidth: .infinity, alignment: .center)
+//                    .frame(
+//                        maxWidth: .infinity,
+//                        maxHeight: layoutMode.getMaxHeight(limitHeight),
+//                        alignment: .top
+//                    )
                     .applyNsfwOverlay(post.post.nsfw || post.community.nsfw, canTapFullImage: isExpanded)
                     .clipped()
                 }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -92,6 +92,9 @@ struct LargePost: View {
         }
     }
     
+    // REMOVEME: needed for TF hack
+    var screenWidth: CGFloat = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
+    
     // initializer--used so we can set showNsfwFilterToggle to false when expanded or true when not
     init(
         post: PostModel,
@@ -202,13 +205,18 @@ struct LargePost: View {
                 if layoutMode != .minimize {
                     CachedImage(
                         url: url,
-                        maxHeight: layoutMode.getMaxHeight(limitHeight),
+                        // maxHeight: layoutMode.getMaxHeight(limitHeight),
+                        // CHANGEME: hack for TF release
+                        fixedSize: CGSize(width: screenWidth, height: screenWidth),
                         dismissCallback: markPostAsRead,
                         cornerRadius: AppConstants.largeItemCornerRadius
                     )
                     .frame(
-                        maxWidth: .infinity,
-                        maxHeight: layoutMode.getMaxHeight(limitHeight),
+                        // CHANGEME: hack for TF release
+                        width: screenWidth,
+                        height: screenWidth,
+                        // maxWidth: .infinity,
+                        // maxHeight: layoutMode.getMaxHeight(limitHeight),
                         alignment: .top
                     )
                     .applyNsfwOverlay(post.post.nsfw || post.community.nsfw, canTapFullImage: isExpanded)

--- a/Mlem/Views/Shared/Website Icon Complex.swift
+++ b/Mlem/Views/Shared/Website Icon Complex.swift
@@ -55,14 +55,23 @@ struct WebsiteIconComplex: View {
         }
         return "some website"
     }
+    
+    // REMOVEME: needed for TF hack
+    var screenWidth: CGFloat = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
 
     var body: some View {
         VStack(spacing: 0) {
             if shouldShowWebsitePreviews, let thumbnailURL = post.thumbnailImageUrl {
-                CachedImage(url: thumbnailURL, shouldExpand: false)
-                    .frame(maxHeight: 400)
-                    .applyNsfwOverlay(post.nsfw)
-                    .clipped()
+                CachedImage(
+                    url: thumbnailURL,
+                    shouldExpand: false,
+                    // CHANGEME: hack for TF release
+                    fixedSize: CGSize(width: screenWidth, height: screenWidth * 0.66)
+                )
+                // .frame(maxHeight: 400)
+                .frame(width: screenWidth, height: screenWidth * 0.66)
+                .applyNsfwOverlay(post.nsfw)
+                .clipped()
             }
             
             VStack(alignment: .leading, spacing: AppConstants.postAndCommentSpacing) {

--- a/Mlem/Views/Shared/Website Icon Complex.swift
+++ b/Mlem/Views/Shared/Website Icon Complex.swift
@@ -57,7 +57,10 @@ struct WebsiteIconComplex: View {
     }
     
     // REMOVEME: needed for TF hack
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
     var screenWidth: CGFloat = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
+    var imageWidth: CGFloat { horizontalSizeClass == .regular ? screenWidth * 0.8 : screenWidth }
+    var imageHeight: CGFloat { horizontalSizeClass == .regular ? 400 : screenWidth * 0.66 }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -66,10 +69,10 @@ struct WebsiteIconComplex: View {
                     url: thumbnailURL,
                     shouldExpand: false,
                     // CHANGEME: hack for TF release
-                    fixedSize: CGSize(width: screenWidth, height: screenWidth * 0.66)
+                    fixedSize: CGSize(width: imageWidth, height: imageHeight)
                 )
                 // .frame(maxHeight: 400)
-                .frame(width: screenWidth, height: screenWidth * 0.66)
+                .frame(width: imageWidth, height: imageHeight)
                 .applyNsfwOverlay(post.nsfw)
                 .clipped()
             }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Slack
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR applies a band-aid fix to scrolling performance by locking all images into a square and all web complexes into a rectangle.

It also updates CommunityLinkView to use the new navigation enum type.
