### PR TITLE
fix - limit instance list and add search

### DIFF
--- a/Mlem/Views/Shared/Accounts/Instance Picker View.swift
+++ b/Mlem/Views/Shared/Accounts/Instance Picker View.swift
@@ -21,8 +21,6 @@ struct InstancePickerView: View {
     /// Instances currently accepting new users
     var filteredInstances: ArraySlice<InstanceMetadata>? {
         instances?
-            .sorted(by: { $0.users > $1.users }) // remote source is already sorted by user count but that may change...
-            .filter(\.newUsers) // restrict the list to instances who are accepting new users
             .filter { query.isEmpty || $0.name.lowercased().hasPrefix(query.lowercased()) }
             .prefix(30) // limit to a maximum of 30
     }
@@ -84,6 +82,11 @@ struct InstancePickerView: View {
         .navigationTitle("Instances")
         .task {
             instances = await loadInstances()
+                // remote source is already sorted by user count but that may change...
+                .sorted(by: { $0.users > $1.users })
+                // restrict the list to instances who are currently ccepting new users
+                // also filter on the presence of `nsfw` in the version string
+                .filter { $0.newUsers && !$0.version.contains("nsfw") }
         }
     }
 }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Related to #534 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR limits the number of instances we display during onboarding, and adds basic search functionality to allow the user to find instances which are not shown in the initial 30 that we currently limit to.

## Screenshots and Videos
| VIDEO |
| --- |
| <video src="https://github.com/mlemgroup/mlem/assets/5231793/aedb2515-36bf-49d0-8045-b7dbe1b7bb51" >

## Additional Context
This PR is built on top of #613 