### PR TITLE
Fix large post link type layout

### DIFF
--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -228,7 +228,7 @@ struct LargePost: View {
                 postBodyView
             }
         case .link:
-            VStack(spacing: AppConstants.postAndCommentSpacing) {
+            LazyVStack(spacing: AppConstants.postAndCommentSpacing) {
                 if layoutMode != .minimize {
                     WebsiteIconComplex(post: post.post, onTapActions: markPostAsRead)
                 }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -228,7 +228,7 @@ struct LargePost: View {
                 postBodyView
             }
         case .link:
-            LazyVStack(spacing: AppConstants.postAndCommentSpacing) {
+            VStack(spacing: AppConstants.postAndCommentSpacing) {
                 if layoutMode != .minimize {
                     WebsiteIconComplex(post: post.post, onTapActions: markPostAsRead)
                 }

--- a/Mlem/Views/Shared/Website Icon Complex.swift
+++ b/Mlem/Views/Shared/Website Icon Complex.swift
@@ -63,7 +63,7 @@ struct WebsiteIconComplex: View {
     var imageHeight: CGFloat { horizontalSizeClass == .regular ? 400 : screenWidth * 0.66 }
 
     var body: some View {
-        VStack(spacing: 0) {
+        LazyVStack(spacing: 0) {
             if shouldShowWebsitePreviews, let thumbnailURL = post.thumbnailImageUrl {
                 CachedImage(
                     url: thumbnailURL,


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Resolves issue #630
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
- Fixes `LargePost` layout for `.link` post type getting cut off in landscape mode on iPad (especially when sidebar is open).

## Screenshots and Videos

Before Fix (latest `/dev` build)

![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-09-20 at 00 30 20](https://github.com/mlemgroup/mlem/assets/2549615/32c40949-075b-4de9-be2b-8d4a703c5a14) 

After Fix (iPad)

https://github.com/mlemgroup/mlem/assets/2549615/496d7e22-0984-48dc-813b-d68adc61e516

After Fix (iPhone)

https://github.com/mlemgroup/mlem/assets/2549615/e77e459e-6048-4947-8df7-b7f9cb23d344 

## Additional Context
- Tested on iOS 16.4 simulator, iOS 17 simulator, iPhone 13 mini (iOS 17 RC).