### PR TITLE
Editor sheet detents

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -42,10 +42,10 @@
 		503422582AAB798600EFE88D /* AppFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503422572AAB798600EFE88D /* AppFlow.swift */; };
 		503BA26F2A2C94540052516C /* URL+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503BA26E2A2C94540052516C /* URL+Identifiable.swift */; };
 		504106CD2A744D7F000AAEF8 /* CommentRepository+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504106CC2A744D7F000AAEF8 /* CommentRepository+Dependency.swift */; };
-		504ECBAE2AB45B2A006C0B96 /* LemmyURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504ECBAD2AB45B2A006C0B96 /* LemmyURL.swift */; };
-		504ECBB12AB4B101006C0B96 /* LemmyURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504ECBB02AB4B101006C0B96 /* LemmyURLTests.swift */; };
 		504ECBAA2AB27C73006C0B96 /* LandingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504ECBA92AB27C73006C0B96 /* LandingPage.swift */; };
 		504ECBAC2AB27CB1006C0B96 /* OnboardingRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504ECBAB2AB27CB1006C0B96 /* OnboardingRoute.swift */; };
+		504ECBAE2AB45B2A006C0B96 /* LemmyURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504ECBAD2AB45B2A006C0B96 /* LemmyURL.swift */; };
+		504ECBB12AB4B101006C0B96 /* LemmyURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504ECBB02AB4B101006C0B96 /* LemmyURLTests.swift */; };
 		505240E32A86916500EA4558 /* FavoriteCommunitiesTracker+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505240E22A86916500EA4558 /* FavoriteCommunitiesTracker+Dependency.swift */; };
 		505240E52A86E32700EA4558 /* CommunityListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505240E42A86E32700EA4558 /* CommunityListModel.swift */; };
 		505240E72A88D36D00EA4558 /* SectionIndexTitles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505240E62A88D36D00EA4558 /* SectionIndexTitles.swift */; };
@@ -434,6 +434,7 @@
 		E4D4DBA22A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D4DBA12A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift */; };
 		E4DDB4322A81819300B3A7E0 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DDB4312A81819300B3A7E0 /* Double.swift */; };
 		E4DDB4342A819C8000B3A7E0 /* QuickLookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DDB4332A819C8000B3A7E0 /* QuickLookView.swift */; };
+		E4F0B56F2ABD00A000BC3E4A /* PresentationBackgroundInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F0B56E2ABD00A000BC3E4A /* PresentationBackgroundInteraction.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -489,10 +490,10 @@
 		503422572AAB798600EFE88D /* AppFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlow.swift; sourceTree = "<group>"; };
 		503BA26E2A2C94540052516C /* URL+Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Identifiable.swift"; sourceTree = "<group>"; };
 		504106CC2A744D7F000AAEF8 /* CommentRepository+Dependency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentRepository+Dependency.swift"; sourceTree = "<group>"; };
-		504ECBAD2AB45B2A006C0B96 /* LemmyURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LemmyURL.swift; sourceTree = "<group>"; };
-		504ECBB02AB4B101006C0B96 /* LemmyURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LemmyURLTests.swift; sourceTree = "<group>"; };
 		504ECBA92AB27C73006C0B96 /* LandingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingPage.swift; sourceTree = "<group>"; };
 		504ECBAB2AB27CB1006C0B96 /* OnboardingRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRoute.swift; sourceTree = "<group>"; };
+		504ECBAD2AB45B2A006C0B96 /* LemmyURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LemmyURL.swift; sourceTree = "<group>"; };
+		504ECBB02AB4B101006C0B96 /* LemmyURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LemmyURLTests.swift; sourceTree = "<group>"; };
 		505240E22A86916500EA4558 /* FavoriteCommunitiesTracker+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FavoriteCommunitiesTracker+Dependency.swift"; sourceTree = "<group>"; };
 		505240E42A86E32700EA4558 /* CommunityListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityListModel.swift; sourceTree = "<group>"; };
 		505240E62A88D36D00EA4558 /* SectionIndexTitles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIndexTitles.swift; sourceTree = "<group>"; };
@@ -879,6 +880,7 @@
 		E4D4DBA12A7F233200C4F3DE /* FancyTabNavigationSelectionHashValueEnvironmentKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyTabNavigationSelectionHashValueEnvironmentKey.swift; sourceTree = "<group>"; };
 		E4DDB4312A81819300B3A7E0 /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
 		E4DDB4332A819C8000B3A7E0 /* QuickLookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookView.swift; sourceTree = "<group>"; };
+		E4F0B56E2ABD00A000BC3E4A /* PresentationBackgroundInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationBackgroundInteraction.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1074,14 +1076,6 @@
 			path = TabBar;
 			sourceTree = "<group>";
 		};
-		504ECBAF2AB4B0DF006C0B96 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				504ECBB02AB4B101006C0B96 /* LemmyURLTests.swift */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
 		504ECBA82AB27C4C006C0B96 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
@@ -1090,6 +1084,14 @@
 				504ECBAB2AB27CB1006C0B96 /* OnboardingRoute.swift */,
 			);
 			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		504ECBAF2AB4B0DF006C0B96 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				504ECBB02AB4B101006C0B96 /* LemmyURLTests.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		5064D03B2A6DE05000B22EE3 /* Notifications */ = {
@@ -1357,6 +1359,7 @@
 				508845CE2A3641160088E483 /* JSONDecoder+Default.swift */,
 				B1A26FE02A44AAB200B91A32 /* Navigation getter.swift */,
 				B104A6DF2A59C19400B3E725 /* OperationQueue - Easy init.swift */,
+				E4F0B56E2ABD00A000BC3E4A /* PresentationBackgroundInteraction.swift */,
 				6386E0392A0455BC006B3C1D /* String - Contains Elements From Array.swift */,
 				630737882A1CD1E900039852 /* String.swift */,
 				5064D0402A6E63E000B22EE3 /* Task+Notifiable.swift */,
@@ -2627,6 +2630,7 @@
 				505240E72A88D36D00EA4558 /* SectionIndexTitles.swift in Sources */,
 				5064D0452A71549C00B22EE3 /* NotificationMessage.swift in Sources */,
 				63344C4D2A07ABEE001BC616 /* Community.swift in Sources */,
+				E4F0B56F2ABD00A000BC3E4A /* PresentationBackgroundInteraction.swift in Sources */,
 				CDF842612A49EA3900723DA0 /* Mentions Tracker.swift in Sources */,
 				6D693A4C2A51B99E009E2D76 /* APICommentReport.swift in Sources */,
 				63344C672A08D4E3001BC616 /* AppearanceSettingsView.swift in Sources */,

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -119,11 +119,13 @@ struct ContentView: View {
             NavigationStack {
                 ResponseEditorView(concreteEditorModel: editing)
             }
+            .presentationDetents([.medium, .large])
         }
         .sheet(item: $editorTracker.editPost) { editing in
             NavigationStack {
                 PostComposerView(editModel: editing)
             }
+            .presentationDetents([.medium, .large])
         }
         .environment(\.openURL, OpenURLAction(handler: didReceiveURL))
         .environmentObject(editorTracker)

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -120,12 +120,14 @@ struct ContentView: View {
                 ResponseEditorView(concreteEditorModel: editing)
             }
             .presentationDetents([.medium, .large])
+            ._presentationBackgroundInteraction(enabledUpThrough: .medium)
         }
         .sheet(item: $editorTracker.editPost) { editing in
             NavigationStack {
                 PostComposerView(editModel: editing)
             }
             .presentationDetents([.medium, .large])
+            ._presentationBackgroundInteraction(enabledUpThrough: .medium)
         }
         .environment(\.openURL, OpenURLAction(handler: didReceiveURL))
         .environmentObject(editorTracker)

--- a/Mlem/Extensions/PresentationBackgroundInteraction.swift
+++ b/Mlem/Extensions/PresentationBackgroundInteraction.swift
@@ -1,0 +1,20 @@
+//
+//  PresentationBackgroundInteraction.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-09-21.
+//
+
+import SwiftUI
+
+extension View {
+    
+    /// No-op prior to iOS 16.4.
+    func _presentationBackgroundInteraction(enabledUpThrough detent: PresentationDetent) -> some View {
+        if #available(iOS 16.4, *) {
+            return self.presentationBackgroundInteraction(.enabled(upThrough: detent))
+        } else {
+            return self
+        }
+    }
+}

--- a/Mlem/Views/Shared/Composer/PostComposerView.swift
+++ b/Mlem/Views/Shared/Composer/PostComposerView.swift
@@ -22,6 +22,10 @@ struct PostComposerView: View {
     @State var postBody: String
     @State var isNSFW: Bool
     
+    private var hasPostContent: Bool {
+        !postTitle.isEmpty || !postURL.isEmpty || !postBody.isEmpty
+    }
+    
     init(editModel: PostEditorModel) {
         self.postTracker = editModel.postTracker
         self.editModel = editModel
@@ -67,6 +71,7 @@ struct PostComposerView: View {
             
             dismiss()
         }
+        .interactiveDismissDisabled(hasPostContent)
     }
 }
 

--- a/Mlem/Views/Shared/Composer/ResponseEditorView.swift
+++ b/Mlem/Views/Shared/Composer/ResponseEditorView.swift
@@ -100,6 +100,7 @@ struct ResponseEditorView: View {
         .navigationBarColor()
         .navigationTitle(editorModel.modalName)
         .navigationBarTitleDisplayMode(.inline)
+        .interactiveDismissDisabled(isReadyToReply)
     }
     
     @MainActor


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #602 
      - User feedback: Want to read what they're responding to while create/editing.
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR includes two UI changes to Post editor and Response editor when presented as sheets:
1. Adds `.medium` presentation detent, while allowing users to interact with the view behind it while in `.medium` detent.
- Note: Interaction with view behind is only available on iOS 16.4 or later.
2. Disable interactive dismissal when editor has content.

## Additional Notes
Sheet initially presents at `.medium` detent before moving to `.large` on initial presentation:
- To immediately present sheet in `.large`, we should pass a `selection` binding to `.presentationDetents(...)`, but doing so causes the content view to call into its body, resulting in visible lag when switching between detents.  
- To workaround this animation hitch, we could move the detent binding into each of the composer views, but we would also need to move the sheet's NavigationStack into the composers view, as well, since `.sheet(...)` expects presentation detent modifiers to be applied on the root view.

## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/2549615/d7a846fa-5d18-42f9-ba49-8bfe3d9d1769

https://github.com/mlemgroup/mlem/assets/2549615/ac67551f-fcea-44df-9d25-5468a0085248
