### PR TITLE
Fixed settings icon sizing issues

### DIFF
--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -32,6 +32,7 @@ struct AppConstants {
 
     static let maxFeedPostHeight: CGFloat = 400
     static let maxFeedPostHeightExpanded: CGFloat = 3000
+    static let appIconSize: CGFloat = 60
     static let thumbnailSize: CGFloat = 60
     static let hugeAvatarSize: CGFloat = 120
     static let largeAvatarSize: CGFloat = 32
@@ -40,6 +41,7 @@ struct AppConstants {
     static let largeAvatarSpacing: CGFloat = 10
     static let postAndCommentSpacing: CGFloat = 10 // standard spacing for the app
     static let compactSpacing: CGFloat = 6 // standard spacing for compact things
+    static let appIconCornerRadius: CGFloat = 10
     static let largeItemCornerRadius: CGFloat = 8 // posts, website previews, etc
     static let smallItemCornerRadius: CGFloat = 6 // settings items, compact thumbnails
     static let tinyItemCornerRadius: CGFloat = 4 // buttons

--- a/Mlem/Extensions/AlternativeIconCell.swift
+++ b/Mlem/Extensions/AlternativeIconCell.swift
@@ -21,9 +21,13 @@ struct AlternativeIconCell: View {
                 getImage()
                     .resizable()
                     .scaledToFit()
-                    .frame(width: 60, height: 60)
+                    .frame(width: AppConstants.appIconSize, height: AppConstants.appIconSize)
                     .foregroundColor(Color.white)
-                    .cornerRadius(10.0)
+                    .cornerRadius(AppConstants.appIconCornerRadius)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: AppConstants.appIconCornerRadius)
+                            .stroke(Color(.secondarySystemBackground), lineWidth: 1)
+                    }
                 VStack(alignment: .leading) {
                     Text(icon.name)
                     if let author = icon.author {

--- a/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
@@ -73,16 +73,17 @@ struct SelectableSettingsItem<T: SettingsOptions>: View {
 
 struct SquircleLabelStyle: LabelStyle {
     var color: Color
-    var fontSize: CGFloat = 0 // see adjustedFontSize comment
+    var fontSize: CGFloat = 14
+    let ios16FontSize: CGFloat = 17
     
     /**
-     This computed property handles the fact that on iOS 17, the font size of 17 makes the icons too large. The code will not compile if fontSize itself is either absent or computed, so we just define it, ignore it, and use this one instead
+     This computed property handles the fact that on iOS 17, the font size of 17 makes the icons too large. The code will not compile if fontSize itself is either absent or computed, so we define it above, compute an adjusted value here, and use the computed value.
      */
     var adjustedFontSize: CGFloat {
         if #available(iOS 17.0, *) {
-            return 14
+            return fontSize
         } else {
-            return 17
+            return ios16FontSize
         }
     }
     

--- a/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings Item.swift
@@ -73,14 +73,25 @@ struct SelectableSettingsItem<T: SettingsOptions>: View {
 
 struct SquircleLabelStyle: LabelStyle {
     var color: Color
-    var fontSize: CGFloat = 17
+    var fontSize: CGFloat = 0 // see adjustedFontSize comment
+    
+    /**
+     This computed property handles the fact that on iOS 17, the font size of 17 makes the icons too large. The code will not compile if fontSize itself is either absent or computed, so we just define it, ignore it, and use this one instead
+     */
+    var adjustedFontSize: CGFloat {
+        if #available(iOS 17.0, *) {
+            return 14
+        } else {
+            return 17
+        }
+    }
     
     func makeBody(configuration: Configuration) -> some View {
         Label {
             configuration.title
         } icon: {
             configuration.icon
-                .font(.system(size: fontSize))
+                .font(.system(size: adjustedFontSize))
                 .foregroundColor(.white)
                 .frame(width: AppConstants.settingsIconSize, height: AppConstants.settingsIconSize)
                 .background(color)

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
@@ -26,7 +26,7 @@ struct AppearanceSettingsView: View {
                     }
                 }
                 #if !os(macOS) && !targetEnvironment(macCatalyst)
-                NavigationLink(value: SettingsRoute.appearancePage(.appIcon)) {
+                    NavigationLink(value: SettingsRoute.appearancePage(.appIcon)) {
                         Label {
                             Text("App Icon")
                         } icon: {
@@ -35,6 +35,10 @@ struct AppearanceSettingsView: View {
                                 .scaledToFit()
                                 .frame(width: AppConstants.settingsIconSize, height: AppConstants.settingsIconSize)
                                 .cornerRadius(AppConstants.smallItemCornerRadius)
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: AppConstants.smallItemCornerRadius)
+                                        .stroke(Color(.secondarySystemBackground), lineWidth: 1)
+                                }
                         }
                     }
                 #endif


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #641 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR fixes settings icons displaying as too large on iOS 17. It also adds a very light border to the app icon settings item so that icons with white backgrounds (i.e., Classic Lemmy) have delineated borders.

## iOS 17
<img width="519" alt="iOS 17" src="https://github.com/mlemgroup/mlem/assets/44140166/c3d7ade2-b3c9-4993-b4f3-7d1ed28f8e59">

## iOS 17 (Classic Lemmy icon)
<img width="563" alt="iOS 17 Classic Lemmy" src="https://github.com/mlemgroup/mlem/assets/44140166/962fe7ab-98b2-4885-828c-6fe5b21df5dc">

## iOS 16
<img width="563" alt="iOS 16" src="https://github.com/mlemgroup/mlem/assets/44140166/e92ce74f-fbf7-4b60-8bac-f8080b792432">

