### PR TITLE
fix - do not pass 'localhost' when present in get user request

### DIFF
--- a/Mlem/API/Requests/Person/GetPersonDetails.swift
+++ b/Mlem/API/Requests/Person/GetPersonDetails.swift
@@ -49,7 +49,9 @@ struct GetPersonDetailsRequest: APIGetRequest {
                 guard let host = instanceURL.host() else {
                     throw GetPersonDetailsRequestError.unableToDetermineInstanceHost
                 }
-                username = "\(username)@\(host)"
+                
+                // when logging into a locally running instance, we don't want to pass `user@localhost`
+                username = host == "localhost" ? username : "\(username)@\(host)"
             }
 
             queryItems.append(.init(name: "username", value: username))


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - no issue, just getting local environments supported
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
Setting up a local environment and we don't want to pass `user@localhost`, as the backend expects the host URL to include a domain. In the case of a local environment passing only the username is what we want to do.

## Screenshots and Videos
| LOCAL |
| --- |
| <img src="https://github.com/mlemgroup/mlem/assets/5231793/3aecd061-1d8a-47a0-8e76-f44e271c1612" width="300"> |

## Additional Context
Instructions on setting up a local development environment can be found here:
https://join-lemmy.org/docs/contributors/02-local-development.html
