### PR TITLE
Comment background color fix

### DIFF
--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -187,11 +187,6 @@ struct CommentItem: View {
         .onTapGesture {
             toggleCollapsed()
         }
-        .contextMenu {
-            ForEach(genMenuFunctions()) { item in
-                MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
-            }
-        }
         .destructiveConfirmation(
             isPresentingConfirmDestructive: $isPresentingConfirmDestructive,
             confirmationMenuFunction: confirmationMenuFunction
@@ -202,6 +197,11 @@ struct CommentItem: View {
             trailing: enableSwipeActions ? [saveSwipeAction, replySwipeAction, expandCollapseCommentAction] : []
         )
         .border(width: borderWidth, edges: [.leading], color: threadingColors[depth % threadingColors.count])
+        .contextMenu {
+            ForEach(genMenuFunctions()) { item in
+                MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
+            }
+        }
     }
     // swiftlint:enable function_body_length
 }


### PR DESCRIPTION
Fixed an issue where comments would have a transparent background in the context menu.


| Before  | After |
| ------------- | ------------- |
| <img width="376" alt="Screenshot 2023-09-24 at 16 27 36" src="https://github.com/mlemgroup/mlem/assets/78750526/a07cbf0d-8c20-410e-824b-c6dfe73a665b">  | <img width="382" alt="Screenshot 2023-09-24 at 16 27 58" src="https://github.com/mlemgroup/mlem/assets/78750526/2cb34b66-2692-43dc-b418-c23519d36329">  |



