### PR TITLE
Fix crash when post object originates from link resolver

### DIFF
--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -46,15 +46,16 @@ struct HandleLemmyLinksDisplay: ViewModifier {
                     .environmentObject(CommunitySearchResultsTracker())
                 case .apiPostView(let post):
                     let postModel = PostModel(from: post)
+                    let postTracker = PostTracker(
+                        shouldPerformMergeSorting: false,
+                        internetSpeed: internetSpeed,
+                        initialItems: [postModel],
+                        upvoteOnSave: upvoteOnSave
+                    )
+                    // swiftlint:disable:next redundant_discardable_let
+                    let _ = postTracker.add([postModel])
                     ExpandedPost(post: postModel)
-                        .environmentObject(
-                            PostTracker(
-                                shouldPerformMergeSorting: false,
-                                internetSpeed: internetSpeed,
-                                initialItems: [postModel],
-                                upvoteOnSave: upvoteOnSave
-                            )
-                        )
+                        .environmentObject(postTracker)
                         .environmentObject(appState)
                 case .apiPost(let post):
                     LazyLoadExpandedPost(post: post)

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -26,7 +26,7 @@ class PostTracker: ObservableObject {
     private let upvoteOnSave: Bool
 
     // state drivers
-    @Published var items: [PostModel]
+    @Published private(set) var items: [PostModel]
 
     // utility
     private var ids: Set<ContentModelIdentifier> = .init(minimumCapacity: 1000)


### PR DESCRIPTION
# Pull Request Information

## About this Pull Request
Fixes crash (debug builds)/error with haptics (production) described here: #635 
- Opening a post via a link triggers link resolver logic.
- Link resolver returns post object.
- Navigation maps post to the correct view, but doesn't add it to its environment's `PostTracker`.

Also, made `PostTracker.items` private(set) so external users don't mutate state in unexpected ways (nothing was doing this, but just to be safe).

## Additional Context
I kept it to a simple fix, but at first it was unclear that you have to explicitly call `add(...)` even if you pass `initialItems` on init.
- Probably makes more sense to add `initialItems` on init to reduce awkwardness at call site when we touch `PostTracker` again?