### PR TITLE
System tab, Fancy bar

### DIFF
--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -37,59 +37,57 @@ struct ContentView: View {
     
     var body: some View {
         FancyTabBar(selection: $tabSelection, navigationSelection: $tabNavigation, dragUpGestureCallback: showAccountSwitcherDragCallback) {
-            Group {
-                FeedRoot()
-                    .fancyTabItem(tag: TabSelection.feeds) {
-                        FancyTabBarLabel(
-                            tag: TabSelection.feeds,
-                            symbolConfiguration: .feed
-                        )
-                    }
-                
-                // wrapping these two behind a check for an active user, as of now we'll always have one
-                // but when guest mode arrives we'll either omit these entirely, or replace them with a
-                // guest mode specific tab for sign in / change instance screen.
-                if let account = appState.currentActiveAccount {
-                    InboxView()
-                        .fancyTabItem(tag: TabSelection.inbox) {
-                            FancyTabBarLabel(
-                                tag: TabSelection.inbox,
-                                symbolConfiguration: .inbox,
-                                badgeCount: showInboxUnreadBadge ? unreadTracker.total : 0
-                            )
-                        }
-                    
-                    ProfileView(userID: account.id)
-                        .fancyTabItem(tag: TabSelection.profile) {
-                            FancyTabBarLabel(
-                                tag: TabSelection.profile,
-                                customText: appState.tabDisplayName,
-                                symbolConfiguration: .init(
-                                    symbol: FancyTabBarLabel.SymbolConfiguration.profile.symbol,
-                                    activeSymbol: FancyTabBarLabel.SymbolConfiguration.profile.activeSymbol,
-                                    remoteSymbolUrl: appState.profileTabRemoteSymbolUrl
-                                )
-                            )
-                            .simultaneousGesture(accountSwitchLongPress)
-                        }
+            FeedRoot()
+                .fancyTabItem(tag: TabSelection.feeds) {
+                    FancyTabBarLabel(
+                        tag: TabSelection.feeds,
+                        symbolConfiguration: .feed
+                    )
                 }
-                
-                SearchRoot()
-                    .fancyTabItem(tag: TabSelection.search) {
+            
+            // wrapping these two behind a check for an active user, as of now we'll always have one
+            // but when guest mode arrives we'll either omit these entirely, or replace them with a
+            // guest mode specific tab for sign in / change instance screen.
+            if let account = appState.currentActiveAccount {
+                InboxView()
+                    .fancyTabItem(tag: TabSelection.inbox) {
                         FancyTabBarLabel(
-                            tag: TabSelection.search,
-                            symbolConfiguration: .search
+                            tag: TabSelection.inbox,
+                            symbolConfiguration: .inbox,
+                            badgeCount: showInboxUnreadBadge ? unreadTracker.total : 0
                         )
                     }
                 
-                SettingsView()
-                    .fancyTabItem(tag: TabSelection.settings) {
+                ProfileView(userID: account.id)
+                    .fancyTabItem(tag: TabSelection.profile) {
                         FancyTabBarLabel(
-                            tag: TabSelection.settings,
-                            symbolConfiguration: .settings
+                            tag: TabSelection.profile,
+                            customText: appState.tabDisplayName,
+                            symbolConfiguration: .init(
+                                symbol: FancyTabBarLabel.SymbolConfiguration.profile.symbol,
+                                activeSymbol: FancyTabBarLabel.SymbolConfiguration.profile.activeSymbol,
+                                remoteSymbolUrl: appState.profileTabRemoteSymbolUrl
+                            )
                         )
+                        .simultaneousGesture(accountSwitchLongPress)
                     }
             }
+            
+            SearchRoot()
+                .fancyTabItem(tag: TabSelection.search) {
+                    FancyTabBarLabel(
+                        tag: TabSelection.search,
+                        symbolConfiguration: .search
+                    )
+                }
+            
+            SettingsView()
+                .fancyTabItem(tag: TabSelection.settings) {
+                    FancyTabBarLabel(
+                        tag: TabSelection.settings,
+                        symbolConfiguration: .settings
+                    )
+                }
         }
         .task(id: appState.currentActiveAccount) {
             accountChanged()

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -36,30 +36,37 @@ struct ContentView: View {
     var accessibilityFont: Bool { UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory }
     
     var body: some View {
-        FancyTabBar(selection: $tabSelection, navigationSelection: $tabNavigation, dragUpGestureCallback: showAccountSwitcherDragCallback) {
-            FeedRoot()
-                .fancyTabItem(tag: TabSelection.feeds) {
-                    FancyTabBarLabel(
-                        tag: TabSelection.feeds,
-                        symbolConfiguration: .feed
+        FancyTabBar(
+            selection: $tabSelection,
+            navigationSelection: $tabNavigation,
+            dragUpGestureCallback: showAccountSwitcherDragCallback,
+            tabItemKeys: [
+                .feeds,
+                .inbox,
+                .profile,
+                .search,
+                .settings
+            ],
+            tabItems: [
+                .feeds: .init(tag: .feeds, label: {
+                    AnyView(
+                        FancyTabBarLabel(
+                            tag: TabSelection.feeds,
+                            symbolConfiguration: .feed
+                        )
                     )
-                }
-            
-            // wrapping these two behind a check for an active user, as of now we'll always have one
-            // but when guest mode arrives we'll either omit these entirely, or replace them with a
-            // guest mode specific tab for sign in / change instance screen.
-            if let account = appState.currentActiveAccount {
-                InboxView()
-                    .fancyTabItem(tag: TabSelection.inbox) {
+                }),
+                .inbox: .init(tag: .inbox, label: {
+                    AnyView(
                         FancyTabBarLabel(
                             tag: TabSelection.inbox,
                             symbolConfiguration: .inbox,
                             badgeCount: showInboxUnreadBadge ? unreadTracker.total : 0
                         )
-                    }
-                
-                ProfileView(userID: account.id)
-                    .fancyTabItem(tag: TabSelection.profile) {
+                    )
+                }),
+                .profile: .init(tag: .profile, label: {
+                    AnyView(
                         FancyTabBarLabel(
                             tag: TabSelection.profile,
                             customText: appState.tabDisplayName,
@@ -70,24 +77,45 @@ struct ContentView: View {
                             )
                         )
                         .simultaneousGesture(accountSwitchLongPress)
-                    }
+                    )
+                }),
+                .search: .init(tag: .search, label: {
+                    AnyView(
+                        FancyTabBarLabel(
+                            tag: TabSelection.search,
+                            symbolConfiguration: .search
+                        )
+                    )
+                }),
+                .settings: .init(tag: .settings, label: {
+                    AnyView(
+                        FancyTabBarLabel(
+                            tag: TabSelection.settings,
+                            symbolConfiguration: .settings
+                        )
+                    )
+                })
+            ]
+        ) {
+            FeedRoot()
+                .tag(TabSelection.feeds)
+            
+            // wrapping these two behind a check for an active user, as of now we'll always have one
+            // but when guest mode arrives we'll either omit these entirely, or replace them with a
+            // guest mode specific tab for sign in / change instance screen.
+            if let account = appState.currentActiveAccount {
+                InboxView()
+                    .tag(TabSelection.inbox)
+                
+                ProfileView(userID: account.id)
+                    .tag(TabSelection.profile)
             }
             
             SearchRoot()
-                .fancyTabItem(tag: TabSelection.search) {
-                    FancyTabBarLabel(
-                        tag: TabSelection.search,
-                        symbolConfiguration: .search
-                    )
-                }
+                .tag(TabSelection.search)
             
             SettingsView()
-                .fancyTabItem(tag: TabSelection.settings) {
-                    FancyTabBarLabel(
-                        tag: TabSelection.settings,
-                        symbolConfiguration: .settings
-                    )
-                }
+                .tag(TabSelection.settings)
         }
         .task(id: appState.currentActiveAccount) {
             accountChanged()

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -32,10 +32,14 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
         selection: Binding<Selection>,
         navigationSelection: Binding<NavigationSelection>,
         dragUpGestureCallback: (() -> Void)? = nil,
+        tabItemKeys: [Selection],
+        tabItems: [Selection: FancyTabItemLabelBuilder<Selection>],
         @ViewBuilder content: @escaping () -> Content
     ) {
         self._selection = selection
         self._navigationSelection = navigationSelection
+        self._tabItemKeys = .init(initialValue: tabItemKeys)
+        self._tabItems = .init(initialValue: tabItems)
         self.content = content
         self.dragUpGestureCallback = dragUpGestureCallback
     }
@@ -54,12 +58,6 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
             }
             .environment(\.tabSelectionHashValue, selection.hashValue)
             .environment(\.tabNavigationSelectionHashValue, navigationSelection.hashValue)
-            .onPreferenceChange(FancyTabItemPreferenceKey<Selection>.self) {
-                tabItemKeys = $0
-            }
-            .onPreferenceChange(FancyTabItemLabelBuilderPreferenceKey<Selection>.self) {
-                tabItems = $0
-            }
     }
     
     private func getAccessibilityLabel(tab: Selection) -> String {

--- a/Mlem/Custom Tab Bar/FancyTabBar.swift
+++ b/Mlem/Custom Tab Bar/FancyTabBar.swift
@@ -41,7 +41,7 @@ struct FancyTabBar<Selection: FancyTabBarSelection, Content: View>: View {
     }
     
     var body: some View {
-        ZStack(content: content)
+        TabView(selection: $selection, content: content)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .safeAreaInset(edge: .bottom, alignment: .center) {
                 // this VStack/Spacer()/ignoresSafeArea thing prevents the keyboard from pushing the bar up

--- a/Mlem/Custom Tab Bar/FancyTabItemViewModifier.swift
+++ b/Mlem/Custom Tab Bar/FancyTabItemViewModifier.swift
@@ -22,6 +22,7 @@ struct FancyTabItem<Selection: FancyTabBarSelection, V: View>: ViewModifier {
     
     func body(content: Content) -> some View {
         content
+            .tag(tag)
             .zIndex(selectedTagHashValue == tagHashValue ? 1 : 0)
             // this little preference tells the parent bar that this tab item exists
             .preference(key: FancyTabItemPreferenceKey<Selection>.self, value: [tag])

--- a/Mlem/Custom Tab Bar/TabSafeScrollView.swift
+++ b/Mlem/Custom Tab Bar/TabSafeScrollView.swift
@@ -11,10 +11,10 @@ import SwiftUI
 struct TabSafeScrollView: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .safeAreaInset(edge: .bottom) {
-                Spacer()
-                    .frame(height: AppConstants.fancyTabBarHeight)
-            }
+//            .safeAreaInset(edge: .bottom) {
+//                Spacer()
+//                    .frame(height: AppConstants.fancyTabBarHeight)
+//            }
     }
 }
 


### PR DESCRIPTION
# Pull Request Information

## About this Pull Request
This draft PR contains a working version of FancyTabBar that renders content using the system TabView while keeping the fanciness of FancyTabBar itself, with the following improvement:
- The system `TabView` lazy loads each tab vertical, so on cold launch, the app only loads the initially selected tab. Our current ZStack loads all views up front.

Todo:
- [ ] Accessibility check.
- [ ] Since tabs are lazy loaded now, should check if anything is broken that may have relied on all tab verticals being loaded.
- [ ] UI regressions (already commented out `TabSafeScrollView`, but might be missing other things).
- [ ] Improve how we construct label builders (this draft PR just hard codes it at the moment).

## Screenshots and Videos
No visual changes:
- Tab bar is still FancyTabBar, only content view has changed.

## Additional Context
Unfortunately, this doesn't fix issue where switching tabs causes all loaded views to perform significant re-renders, causing performance issues (but if only one tab is loaded, it only re-renders that one view, so that's a small win, I guess).
