### PR TITLE
Fixed swipey action bad behavior with context menus

### DIFF
--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -348,6 +348,12 @@ struct SwipeyView: ViewModifier {
 // swiftlint:enable function_body_length
 
 extension View {
+    /// Adds swipey actions to a view.
+    ///
+    /// NOTE: if the view you are attaching this to also has a context menu, add the context menu view modifier AFTER the swipey actions modifier! This will prevent the swipey action from triggering and appearing bugged on an aborted context menu pop if the context menu animation initiates.
+    /// - Parameters:
+    ///   - leading: leading edge swipey actions, ordered by ascending swipe distance from leading edge
+    ///   - trailing: trailing edge swipey actions, ordered by ascending swipe distance from leading edge
     @ViewBuilder
     func addSwipeyActions(leading: [SwipeAction?] = [], trailing: [SwipeAction?] = []) -> some View {
         modifier(

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -102,11 +102,6 @@ struct FeedPost: View {
 //                .background(horizontalSizeClass == .regular ? Color.secondarySystemBackground : Color.systemBackground)
 //                .clipShape(RoundedRectangle(cornerRadius: horizontalSizeClass == .regular ? 16 : 0))
 //                .padding(.all, horizontalSizeClass == .regular ? nil : 0)
-                .contextMenu {
-                    ForEach(genMenuFunctions()) { item in
-                        MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
-                    }
-                }
                 .destructiveConfirmation(
                     isPresentingConfirmDestructive: $isPresentingConfirmDestructive,
                     confirmationMenuFunction: confirmationMenuFunction
@@ -121,6 +116,11 @@ struct FeedPost: View {
                         enableSwipeActions ? replySwipeAction : nil
                     ]
                 )
+                .contextMenu {
+                    ForEach(genMenuFunctions()) { item in
+                        MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
+                    }
+                }
         }
     }
 

--- a/Mlem/Views/Tabs/Inbox/Feed/Mentions Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Mentions Feed View.swift
@@ -64,11 +64,6 @@ extension InboxView {
                         await loadTrackerPage(tracker: mentionsTracker)
                     }
                 }
-                .contextMenu {
-                    ForEach(genMentionMenuGroup(mention: mention)) { item in
-                        MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
-                    }
-                }
                 .addSwipeyActions(
                     leading: [
                         upvoteMentionSwipeAction(mentionView: mention),
@@ -79,6 +74,11 @@ extension InboxView {
                         replyToMentionSwipeAction(mentionView: mention)
                     ]
                 )
+                .contextMenu {
+                    ForEach(genMentionMenuGroup(mention: mention)) { item in
+                        MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
+                    }
+                }
         }
         .buttonStyle(EmptyButtonStyle())
     }

--- a/Mlem/Views/Tabs/Inbox/Feed/Messages Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Messages Feed View.swift
@@ -62,11 +62,6 @@ extension InboxView {
                     await loadTrackerPage(tracker: messagesTracker)
                 }
             }
-            .contextMenu {
-                ForEach(genMessageMenuGroup(message: message)) { item in
-                    MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
-                }
-            }
             .addSwipeyActions(
                 leading: [],
                 trailing: [
@@ -74,5 +69,10 @@ extension InboxView {
                     replyToMessageSwipeAction(message: message)
                 ]
             )
+            .contextMenu {
+                ForEach(genMessageMenuGroup(message: message)) { item in
+                    MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
+                }
+            }
     }
 }

--- a/Mlem/Views/Tabs/Inbox/Feed/Replies Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Replies Feed View.swift
@@ -69,11 +69,6 @@ extension InboxView {
                         await loadTrackerPage(tracker: repliesTracker)
                     }
                 }
-                .contextMenu {
-                    ForEach(genCommentReplyMenuGroup(commentReply: reply)) { item in
-                        MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
-                    }
-                }
                 .destructiveConfirmation(
                     isPresentingConfirmDestructive: $isPresentingConfirmDestructive,
                     confirmationMenuFunction: confirmationMenuFunction
@@ -88,6 +83,11 @@ extension InboxView {
                         replyToCommentReplySwipeAction(commentReply: reply)
                     ]
                 )
+                .contextMenu {
+                    ForEach(genCommentReplyMenuGroup(commentReply: reply)) { item in
+                        MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
+                    }
+                }
         }
         .buttonStyle(EmptyButtonStyle())
     }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #621 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR addresses swipey actions and context menus conflicting. Previously, an aborted context menu pop that triggered the animation would invoke the drag handler of the swipey action, leading to the swipey action either jumping to the drag state or, worse, duplicating the view and showing them one atop the other. All .contextMenu view modifiers have been moved to occur *after* swipey action view modifiers, ensuring that the context menu takes priority.