### PR TITLE
Show error when instance is private

### DIFF
--- a/Mlem/API/Models/APIErrorResponse.swift
+++ b/Mlem/API/Models/APIErrorResponse.swift
@@ -34,4 +34,5 @@ extension APIErrorResponse {
     var isNotLoggedIn: Bool { error == "not_logged_in" }
     var userRegistrationPending: Bool { registrationErrors.contains(error) }
     var emailNotVerified: Bool { registrationErrors.contains(error) }
+    var instanceIsPrivate: Bool { error == "instance_is_private" }
 }

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -11,6 +11,7 @@ import SwiftUI
 // swiftlint:disable file_length
 enum UserIDRetrievalError: Error {
     case couldNotFetchUserInformation
+    case instanceIsPrivate
 }
 
 enum Field: Hashable {
@@ -353,7 +354,12 @@ struct AddSavedInstanceView: View {
                 .person
         } catch {
             print("getUserId Error info: \(error)")
-            throw UserIDRetrievalError.couldNotFetchUserInformation
+            switch error {
+            case let APIClientError.response(errorResponse, _) where errorResponse.instanceIsPrivate:
+                throw UserIDRetrievalError.instanceIsPrivate
+            default:
+                throw UserIDRetrievalError.couldNotFetchUserInformation
+            }
         }
     }
     
@@ -364,6 +370,8 @@ struct AddSavedInstanceView: View {
             message = "Could not connect to \(instance)"
         case UserIDRetrievalError.couldNotFetchUserInformation:
             message = "Mlem couldn't fetch you account's information.\nFile a bug report."
+        case UserIDRetrievalError.instanceIsPrivate:
+            message = "Instance is private."
         case APIClientError.encoding:
             // TODO: we should add better validation
             //  at the UI layer as encoding failures can be caught

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -371,7 +371,7 @@ struct AddSavedInstanceView: View {
         case UserIDRetrievalError.couldNotFetchUserInformation:
             message = "Mlem couldn't fetch you account's information.\nFile a bug report."
         case UserIDRetrievalError.instanceIsPrivate:
-            message = "\(instance) is private."
+            message = "\(instance) is a private instance."
         case APIClientError.encoding:
             // TODO: we should add better validation
             //  at the UI layer as encoding failures can be caught

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -371,7 +371,7 @@ struct AddSavedInstanceView: View {
         case UserIDRetrievalError.couldNotFetchUserInformation:
             message = "Mlem couldn't fetch you account's information.\nFile a bug report."
         case UserIDRetrievalError.instanceIsPrivate:
-            message = "Instance is private."
+            message = "\(instance) is private."
         case APIClientError.encoding:
             // TODO: we should add better validation
             //  at the UI layer as encoding failures can be caught


### PR DESCRIPTION
Before, if you tried to login to a private instance you'd get a generic 'file a bug report' message. Now you'll see 'instance is private' instead. 

This is very unlikely to happen to anybody. I ran into this whilst setting up a local instance