### PR TITLE
Fixed profile refresh problems

### DIFF
--- a/Mlem/API/Internal/HierarchicalComment.swift
+++ b/Mlem/API/Internal/HierarchicalComment.swift
@@ -39,6 +39,16 @@ extension HierarchicalComment: Equatable {
     }
 }
 
+extension HierarchicalComment: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(commentView.id)
+        hasher.combine(commentView.comment.updated)
+        hasher.combine(commentView.counts.upvotes)
+        hasher.combine(commentView.counts.downvotes)
+        hasher.combine(commentView.myVote)
+    }
+}
+
 extension [HierarchicalComment] {
     /// A method to insert an updated `APICommentView` into this array of `HierarchicalComment`
     /// - Parameter commentView: The `APICommentView` you wish to insert

--- a/Mlem/Enums/Content Type.swift
+++ b/Mlem/Enums/Content Type.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum ContentType: Int, Codable {
-    case post, community, user
+    case post, comment, community, user
 }

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -165,7 +165,7 @@ class PostTracker: ObservableObject {
     }
     
     @MainActor
-    private func reset(
+    func reset(
         with newItems: [PostModel] = .init(),
         filteredWith filter: @escaping (_: PostModel) -> Bool = { _ in true }
     ) {

--- a/Mlem/Models/Trackers/RecentSearchesTracker.swift
+++ b/Mlem/Models/Trackers/RecentSearchesTracker.swift
@@ -34,8 +34,10 @@ class RecentSearchesTracker: ObservableObject {
                     let community: CommunityModel = try await communityRepository.loadDetails(for: id.contentId)
                     newSearches.append(AnyContentModel(community))
                 case .user:
-                    let user = try await personRepository.loadDetails(for: id.contentId)
+                    let user = try await personRepository.loadUser(for: id.contentId)
                     newSearches.append(AnyContentModel(user))
+                case .comment:
+                    break
                 }
             }
             

--- a/Mlem/Repositories/PersonRepository.swift
+++ b/Mlem/Repositories/PersonRepository.swift
@@ -29,9 +29,22 @@ class PersonRepository {
         return users
     }
     
-    func loadDetails(for id: Int) async throws -> UserModel {
+    /// Gets the UserModel for a given user
+    /// - Parameter id: id of the user to get
+    /// - Returns: UserModel for the given user
+    func getUser(for id: Int) async throws -> UserModel {
         let response = try await apiClient.getPersonDetails(for: id, limit: 1, savedOnly: false)
         return UserModel(from: response.personView)
+    }
+    
+    /// Gets full user details for the given user
+    /// - Parameters:
+    ///   - id: user id to get for
+    ///   - limit: max number of content items to fetch
+    ///   - savedOnly: if present, whether to fetch saved items; calling user must be the requested user
+    /// - Returns: GetPersonDetailsResponse for the given user
+    func getUserDetails(for id: Int, limit: Int, savedOnly: Bool = false) async throws -> GetPersonDetailsResponse {
+        try await apiClient.getPersonDetails(for: id, limit: limit, savedOnly: savedOnly)
     }
     
     func getUnreadCounts() async throws -> APIPersonUnreadCounts {

--- a/Mlem/Repositories/PersonRepository.swift
+++ b/Mlem/Repositories/PersonRepository.swift
@@ -29,10 +29,11 @@ class PersonRepository {
         return users
     }
     
+    // TODO: rename to loadUser
     /// Gets the UserModel for a given user
     /// - Parameter id: id of the user to get
     /// - Returns: UserModel for the given user
-    func getUser(for id: Int) async throws -> UserModel {
+    func loadDetails(for id: Int) async throws -> UserModel {
         let response = try await apiClient.getPersonDetails(for: id, limit: 1, savedOnly: false)
         return UserModel(from: response.personView)
     }

--- a/Mlem/Repositories/PersonRepository.swift
+++ b/Mlem/Repositories/PersonRepository.swift
@@ -29,11 +29,10 @@ class PersonRepository {
         return users
     }
     
-    // TODO: rename to loadUser
     /// Gets the UserModel for a given user
     /// - Parameter id: id of the user to get
     /// - Returns: UserModel for the given user
-    func loadDetails(for id: Int) async throws -> UserModel {
+    func loadUser(for id: Int) async throws -> UserModel {
         let response = try await apiClient.getPersonDetails(for: id, limit: 1, savedOnly: false)
         return UserModel(from: response.personView)
     }
@@ -44,7 +43,7 @@ class PersonRepository {
     ///   - limit: max number of content items to fetch
     ///   - savedOnly: if present, whether to fetch saved items; calling user must be the requested user
     /// - Returns: GetPersonDetailsResponse for the given user
-    func getUserDetails(for id: Int, limit: Int, savedOnly: Bool = false) async throws -> GetPersonDetailsResponse {
+    func loadUserDetails(for id: Int, limit: Int, savedOnly: Bool = false) async throws -> GetPersonDetailsResponse {
         try await apiClient.getPersonDetails(for: id, limit: limit, savedOnly: savedOnly)
     }
     

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -201,10 +201,10 @@ struct UserView: View {
     // swiftlint:disable function_body_length
     private func tryReloadUser() async {
         do {
-            let authoredContent = try await personRepository.getUserDetails(for: userID, limit: internetSpeed.pageSize)
+            let authoredContent = try await personRepository.loadUserDetails(for: userID, limit: internetSpeed.pageSize)
             var savedContentData: GetPersonDetailsResponse?
             if isShowingOwnProfile() {
-                savedContentData = try await personRepository.getUserDetails(
+                savedContentData = try await personRepository.loadUserDetails(
                     for: userID,
                     limit: internetSpeed.pageSize,
                     savedOnly: true


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #686 
      - closes #327 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR fixes two problems with the profile:
1. Refreshing own profile always throws an error. This was caused by the refresh function opportunistically trying to update the app state with the new profile information, which was in turn causing a view rerender and therefore cancelling the saved items load task. I have moved that logic to happen after saved items are loaded and added a comment re: long-term opportunistic profile refresh
2. Upvote counts don't update when refreshing. This was caused by the profile simply trying to *add* the new (refreshed) items to the trackers, which led to them all being rejected because they were dupes. I changed the behavior to *reset* the trackers instead, which is fine because we never perform any load action other than reload (though that should also be changed later). I have also made the items `Hashable` based on the underlying content hash and given them a `ContentModelIdentifier` uid, which allows them to be rerendered appropriately.

For cleanliness, I also moved the loading calls into the person repository.
