### PR TITLE
Fixed default sidebar avatars

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -11,15 +11,15 @@
 		030AC0522A64666C00037155 /* UserSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030AC0512A64666C00037155 /* UserSettingsView.swift */; };
 		030D4AE62AA1273200A3393D /* ErrorDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030D4AE52AA1273200A3393D /* ErrorDetails.swift */; };
 		030D4AE82AA1278400A3393D /* ErrorDetails+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030D4AE72AA1278400A3393D /* ErrorDetails+Mock.swift */; };
+		030E86392AC6B44B000283A6 /* DeletePictrsFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E86382AC6B44B000283A6 /* DeletePictrsFile.swift */; };
+		030E863B2AC6C3B1000283A6 /* PictrsRespository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E863A2AC6C3B1000283A6 /* PictrsRespository.swift */; };
+		030E863D2AC6C49E000283A6 /* PictrsRepository+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E863C2AC6C49E000283A6 /* PictrsRepository+Dependency.swift */; };
+		030E863F2AC6C5E9000283A6 /* PictrsImageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E863E2AC6C5E9000283A6 /* PictrsImageModel.swift */; };
 		030E86412AC6F692000283A6 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E86402AC6F692000283A6 /* SearchBar.swift */; };
 		030E86442AC6F6D5000283A6 /* SearchBar+NavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E86432AC6F6D5000283A6 /* SearchBar+NavigationView.swift */; };
 		030E86462AC6FC1B000283A6 /* DefaultTextInputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E86452AC6FC1B000283A6 /* DefaultTextInputType.swift */; };
 		030E86482AC6FD1D000283A6 /* _assignIfNotEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E86472AC6FD1D000283A6 /* _assignIfNotEqual.swift */; };
 		030E864C2AC7037F000283A6 /* SearchBarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E864B2AC7037F000283A6 /* SearchBarExtensions.swift */; };
-		030E86392AC6B44B000283A6 /* DeletePictrsFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E86382AC6B44B000283A6 /* DeletePictrsFile.swift */; };
-		030E863B2AC6C3B1000283A6 /* PictrsRespository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E863A2AC6C3B1000283A6 /* PictrsRespository.swift */; };
-		030E863D2AC6C49E000283A6 /* PictrsRepository+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E863C2AC6C49E000283A6 /* PictrsRepository+Dependency.swift */; };
-		030E863F2AC6C5E9000283A6 /* PictrsImageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E863E2AC6C5E9000283A6 /* PictrsImageModel.swift */; };
 		031A93D62AC847DA0077030C /* UploadConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031A93D52AC847DA0077030C /* UploadConfirmationView.swift */; };
 		031BF9532AB24BAF00F4517F /* SiteVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031BF9522AB24BAF00F4517F /* SiteVersion.swift */; };
 		031BF9552AB25AFB00F4517F /* SiteVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031BF9542AB25AFB00F4517F /* SiteVersionTests.swift */; };
@@ -46,23 +46,22 @@
 		03B7AAF12ABE404300068B23 /* ContentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B7AAF02ABE404300068B23 /* ContentModel.swift */; };
 		03B7AAF32ABEF85300068B23 /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B7AAF22ABEF85200068B23 /* UserModel.swift */; };
 		03B7AAF52ABEFA7A00068B23 /* UserResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B7AAF42ABEFA7A00068B23 /* UserResultView.swift */; };
-		03BAA23A2A57DC1400D48252 /* TimestampView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BAA2392A57DC1400D48252 /* TimestampView.swift */; };
+		03BAA23A2A57DC1400D48252 /* PublishedTimestampView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BAA2392A57DC1400D48252 /* PublishedTimestampView.swift */; };
 		03C897F62ABF49BD005F3403 /* Abbreviate Numbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C897F52ABF49BD005F3403 /* Abbreviate Numbers.swift */; };
 		03C897F82ABF652D005F3403 /* SearchRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C897F72ABF652D005F3403 /* SearchRoot.swift */; };
 		03C898012AC04EF9005F3403 /* SearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C898002AC04EF9005F3403 /* SearchResultsView.swift */; };
 		03C898032AC04F61005F3403 /* RecentSearchesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C898022AC04F61005F3403 /* RecentSearchesView.swift */; };
-		03BAA23A2A57DC1400D48252 /* PublishedTimestampView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BAA2392A57DC1400D48252 /* PublishedTimestampView.swift */; };
 		03CB329E2A6D8E910021EF27 /* PostDetailEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CB329D2A6D8E910021EF27 /* PostDetailEditorView.swift */; };
 		03E0B9C82A61F0F400FED265 /* AdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9C72A61F0F400FED265 /* AdvancedSettingsView.swift */; };
 		03E0B9CA2A62B4A400FED265 /* ContributorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9C92A62B4A400FED265 /* ContributorsView.swift */; };
 		03E0B9CC2A62CD5800FED265 /* ThemeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9CB2A62CD5800FED265 /* ThemeSettingsView.swift */; };
+		03EA79C42AC0D92C00BCDC91 /* PostDetailEditorView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EA79C32AC0D92C00BCDC91 /* PostDetailEditorView+Logic.swift */; };
 		03EC92952AC064AE007BBE7E /* SearchHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC92942AC064AE007BBE7E /* SearchHomeView.swift */; };
 		03EC92972AC069CE007BBE7E /* SearchResultListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC92962AC069CE007BBE7E /* SearchResultListView.swift */; };
+		03EC92992AC0BF8A007BBE7E /* APIClient+Pictrs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC92982AC0BF8A007BBE7E /* APIClient+Pictrs.swift */; };
 		03EEEAF32AB8DCDF0087F8D8 /* CommunityResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EEEAF22AB8DCDF0087F8D8 /* CommunityResultView.swift */; };
 		03EEEAF72AB8ED3C0087F8D8 /* SearchTabPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EEEAF62AB8ED3C0087F8D8 /* SearchTabPicker.swift */; };
 		03EEEAF92ABB985D0087F8D8 /* CommunityModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EEEAF82ABB985D0087F8D8 /* CommunityModel.swift */; };
-		03EA79C42AC0D92C00BCDC91 /* PostDetailEditorView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EA79C32AC0D92C00BCDC91 /* PostDetailEditorView+Logic.swift */; };
-		03EC92992AC0BF8A007BBE7E /* APIClient+Pictrs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC92982AC0BF8A007BBE7E /* APIClient+Pictrs.swift */; };
 		500C168E2A66FAAB006F243B /* HapticManager+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500C168D2A66FAAB006F243B /* HapticManager+Dependency.swift */; };
 		5016A2B12A67EB8600B257E8 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5016A2B02A67EB8600B257E8 /* UIViewController.swift */; };
 		5016A2B32A67EC0700B257E8 /* NotificationDisplayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5016A2B22A67EC0700B257E8 /* NotificationDisplayer.swift */; };
@@ -329,6 +328,7 @@
 		CD18DC6F2A5209C3002C56BC /* MarkPrivateMessageAsReadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD18DC6E2A5209C3002C56BC /* MarkPrivateMessageAsReadRequest.swift */; };
 		CD18DC732A522A7C002C56BC /* CreatePrivateMessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD18DC722A522A7C002C56BC /* CreatePrivateMessageRequest.swift */; };
 		CD2053102AC878B50000AA38 /* UpdatedTimestampView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD20530F2AC878B50000AA38 /* UpdatedTimestampView.swift */; };
+		CD2053142ACBAF150000AA38 /* AvatarType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2053132ACBAF150000AA38 /* AvatarType.swift */; };
 		CD2BD6782A79F55800ECFF89 /* ImageSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2BD6772A79F55800ECFF89 /* ImageSize.swift */; };
 		CD2E182B2A3B708500224F8A /* Settings Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2E182A2A3B708500224F8A /* Settings Options.swift */; };
 		CD309C462A93FBD300988F95 /* Logo View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD309C452A93FBD300988F95 /* Logo View.swift */; };
@@ -491,15 +491,15 @@
 		030AC0512A64666C00037155 /* UserSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsView.swift; sourceTree = "<group>"; };
 		030D4AE52AA1273200A3393D /* ErrorDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDetails.swift; sourceTree = "<group>"; };
 		030D4AE72AA1278400A3393D /* ErrorDetails+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ErrorDetails+Mock.swift"; sourceTree = "<group>"; };
+		030E86382AC6B44B000283A6 /* DeletePictrsFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePictrsFile.swift; sourceTree = "<group>"; };
+		030E863A2AC6C3B1000283A6 /* PictrsRespository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PictrsRespository.swift; sourceTree = "<group>"; };
+		030E863C2AC6C49E000283A6 /* PictrsRepository+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PictrsRepository+Dependency.swift"; sourceTree = "<group>"; };
+		030E863E2AC6C5E9000283A6 /* PictrsImageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PictrsImageModel.swift; sourceTree = "<group>"; };
 		030E86402AC6F692000283A6 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		030E86432AC6F6D5000283A6 /* SearchBar+NavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchBar+NavigationView.swift"; sourceTree = "<group>"; };
 		030E86452AC6FC1B000283A6 /* DefaultTextInputType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTextInputType.swift; sourceTree = "<group>"; };
 		030E86472AC6FD1D000283A6 /* _assignIfNotEqual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _assignIfNotEqual.swift; sourceTree = "<group>"; };
 		030E864B2AC7037F000283A6 /* SearchBarExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarExtensions.swift; sourceTree = "<group>"; };
-		030E86382AC6B44B000283A6 /* DeletePictrsFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePictrsFile.swift; sourceTree = "<group>"; };
-		030E863A2AC6C3B1000283A6 /* PictrsRespository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PictrsRespository.swift; sourceTree = "<group>"; };
-		030E863C2AC6C49E000283A6 /* PictrsRepository+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PictrsRepository+Dependency.swift"; sourceTree = "<group>"; };
-		030E863E2AC6C5E9000283A6 /* PictrsImageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PictrsImageModel.swift; sourceTree = "<group>"; };
 		031A93D52AC847DA0077030C /* UploadConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadConfirmationView.swift; sourceTree = "<group>"; };
 		031BF9522AB24BAF00F4517F /* SiteVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteVersion.swift; sourceTree = "<group>"; };
 		031BF9542AB25AFB00F4517F /* SiteVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteVersionTests.swift; sourceTree = "<group>"; };
@@ -526,23 +526,22 @@
 		03B7AAF02ABE404300068B23 /* ContentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentModel.swift; sourceTree = "<group>"; };
 		03B7AAF22ABEF85200068B23 /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
 		03B7AAF42ABEFA7A00068B23 /* UserResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResultView.swift; sourceTree = "<group>"; };
-		03BAA2392A57DC1400D48252 /* TimestampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimestampView.swift; sourceTree = "<group>"; };
+		03BAA2392A57DC1400D48252 /* PublishedTimestampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishedTimestampView.swift; sourceTree = "<group>"; };
 		03C897F52ABF49BD005F3403 /* Abbreviate Numbers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Abbreviate Numbers.swift"; sourceTree = "<group>"; };
 		03C897F72ABF652D005F3403 /* SearchRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRoot.swift; sourceTree = "<group>"; };
 		03C898002AC04EF9005F3403 /* SearchResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsView.swift; sourceTree = "<group>"; };
 		03C898022AC04F61005F3403 /* RecentSearchesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchesView.swift; sourceTree = "<group>"; };
-		03BAA2392A57DC1400D48252 /* PublishedTimestampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishedTimestampView.swift; sourceTree = "<group>"; };
 		03CB329D2A6D8E910021EF27 /* PostDetailEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailEditorView.swift; sourceTree = "<group>"; };
 		03E0B9C72A61F0F400FED265 /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
 		03E0B9C92A62B4A400FED265 /* ContributorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorsView.swift; sourceTree = "<group>"; };
 		03E0B9CB2A62CD5800FED265 /* ThemeSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsView.swift; sourceTree = "<group>"; };
+		03EA79C32AC0D92C00BCDC91 /* PostDetailEditorView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostDetailEditorView+Logic.swift"; sourceTree = "<group>"; };
 		03EC92942AC064AE007BBE7E /* SearchHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHomeView.swift; sourceTree = "<group>"; };
 		03EC92962AC069CE007BBE7E /* SearchResultListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultListView.swift; sourceTree = "<group>"; };
+		03EC92982AC0BF8A007BBE7E /* APIClient+Pictrs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Pictrs.swift"; sourceTree = "<group>"; };
 		03EEEAF22AB8DCDF0087F8D8 /* CommunityResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityResultView.swift; sourceTree = "<group>"; };
 		03EEEAF62AB8ED3C0087F8D8 /* SearchTabPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTabPicker.swift; sourceTree = "<group>"; };
 		03EEEAF82ABB985D0087F8D8 /* CommunityModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityModel.swift; sourceTree = "<group>"; };
-		03EA79C32AC0D92C00BCDC91 /* PostDetailEditorView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostDetailEditorView+Logic.swift"; sourceTree = "<group>"; };
-		03EC92982AC0BF8A007BBE7E /* APIClient+Pictrs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Pictrs.swift"; sourceTree = "<group>"; };
 		500C168D2A66FAAB006F243B /* HapticManager+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HapticManager+Dependency.swift"; sourceTree = "<group>"; };
 		5016A2B02A67EB8600B257E8 /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		5016A2B22A67EC0700B257E8 /* NotificationDisplayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDisplayer.swift; sourceTree = "<group>"; };
@@ -807,6 +806,7 @@
 		CD18DC6E2A5209C3002C56BC /* MarkPrivateMessageAsReadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkPrivateMessageAsReadRequest.swift; sourceTree = "<group>"; };
 		CD18DC722A522A7C002C56BC /* CreatePrivateMessageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePrivateMessageRequest.swift; sourceTree = "<group>"; };
 		CD20530F2AC878B50000AA38 /* UpdatedTimestampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatedTimestampView.swift; sourceTree = "<group>"; };
+		CD2053132ACBAF150000AA38 /* AvatarType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarType.swift; sourceTree = "<group>"; };
 		CD2BD6772A79F55800ECFF89 /* ImageSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSize.swift; sourceTree = "<group>"; };
 		CD2E182A2A3B708500224F8A /* Settings Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Settings Options.swift"; sourceTree = "<group>"; };
 		CD309C452A93FBD300988F95 /* Logo View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logo View.swift"; sourceTree = "<group>"; };
@@ -1909,6 +1909,7 @@
 				CDDCF6522A677F45003DA3AC /* TabSelection.swift */,
 				CDE9CE4E2A7B0B1B002B97DD /* Haptic.swift */,
 				CDEBC3242A9A57D200518D9D /* Content Type.swift */,
+				CD2053132ACBAF150000AA38 /* AvatarType.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2894,6 +2895,7 @@
 				50A881282A71D66B003E3661 /* APIClient+Community.swift in Sources */,
 				6307378D2A1CEB7C00039852 /* My Vote.swift in Sources */,
 				50F830FA2A4C935C00D67099 /* FeedTracker.swift in Sources */,
+				CD2053142ACBAF150000AA38 /* AvatarType.swift in Sources */,
 				CD69F55D2A400DF50028D4F7 /* UIUserInterfaceStyle - SettingsOption conformant.swift in Sources */,
 				CDF1EF182A6C40C9003594B6 /* Menu Button.swift in Sources */,
 				6D91D4552A415994006B8F9A /* CommunityListSidebarEntry.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -329,7 +329,7 @@
 		CD18DC732A522A7C002C56BC /* CreatePrivateMessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD18DC722A522A7C002C56BC /* CreatePrivateMessageRequest.swift */; };
 		CD2053102AC878B50000AA38 /* UpdatedTimestampView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD20530F2AC878B50000AA38 /* UpdatedTimestampView.swift */; };
 		CD2053142ACBAF150000AA38 /* AvatarType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2053132ACBAF150000AA38 /* AvatarType.swift */; };
-		CD2053172ACBBB5A0000AA38 /* DefaultAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2053162ACBBB5A0000AA38 /* DefaultAvatar.swift */; };
+		CD2053172ACBBB5A0000AA38 /* DefaultAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2053162ACBBB5A0000AA38 /* DefaultAvatarView.swift */; };
 		CD2BD6782A79F55800ECFF89 /* ImageSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2BD6772A79F55800ECFF89 /* ImageSize.swift */; };
 		CD2E182B2A3B708500224F8A /* Settings Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2E182A2A3B708500224F8A /* Settings Options.swift */; };
 		CD309C462A93FBD300988F95 /* Logo View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD309C452A93FBD300988F95 /* Logo View.swift */; };
@@ -808,7 +808,7 @@
 		CD18DC722A522A7C002C56BC /* CreatePrivateMessageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePrivateMessageRequest.swift; sourceTree = "<group>"; };
 		CD20530F2AC878B50000AA38 /* UpdatedTimestampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatedTimestampView.swift; sourceTree = "<group>"; };
 		CD2053132ACBAF150000AA38 /* AvatarType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarType.swift; sourceTree = "<group>"; };
-		CD2053162ACBBB5A0000AA38 /* DefaultAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAvatar.swift; sourceTree = "<group>"; };
+		CD2053162ACBBB5A0000AA38 /* DefaultAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAvatarView.swift; sourceTree = "<group>"; };
 		CD2BD6772A79F55800ECFF89 /* ImageSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSize.swift; sourceTree = "<group>"; };
 		CD2E182A2A3B708500224F8A /* Settings Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Settings Options.swift"; sourceTree = "<group>"; };
 		CD309C452A93FBD300988F95 /* Logo View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logo View.swift"; sourceTree = "<group>"; };
@@ -2040,7 +2040,7 @@
 		CD2053152ACBBB490000AA38 /* Avatars */ = {
 			isa = PBXGroup;
 			children = (
-				CD2053162ACBBB5A0000AA38 /* DefaultAvatar.swift */,
+				CD2053162ACBBB5A0000AA38 /* DefaultAvatarView.swift */,
 			);
 			path = Avatars;
 			sourceTree = "<group>";
@@ -2655,7 +2655,7 @@
 				CD863FBA2A6AEB5900A31ED9 /* TabSafeScrollView.swift in Sources */,
 				637218772A3A2AAD008C4816 /* APIRequest.swift in Sources */,
 				63A09B69285F53E9004F0032 /* Error View.swift in Sources */,
-				CD2053172ACBBB5A0000AA38 /* DefaultAvatar.swift in Sources */,
+				CD2053172ACBBB5A0000AA38 /* DefaultAvatarView.swift in Sources */,
 				CD3FBCE72A4A8CE300B2063F /* Messages Feed View.swift in Sources */,
 				63344C582A07DB9A001BC616 /* Array - Move Elements Around.swift in Sources */,
 				03E0B9C82A61F0F400FED265 /* AdvancedSettingsView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@
 		CD18DC732A522A7C002C56BC /* CreatePrivateMessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD18DC722A522A7C002C56BC /* CreatePrivateMessageRequest.swift */; };
 		CD2053102AC878B50000AA38 /* UpdatedTimestampView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD20530F2AC878B50000AA38 /* UpdatedTimestampView.swift */; };
 		CD2053142ACBAF150000AA38 /* AvatarType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2053132ACBAF150000AA38 /* AvatarType.swift */; };
+		CD2053172ACBBB5A0000AA38 /* DefaultAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2053162ACBBB5A0000AA38 /* DefaultAvatar.swift */; };
 		CD2BD6782A79F55800ECFF89 /* ImageSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2BD6772A79F55800ECFF89 /* ImageSize.swift */; };
 		CD2E182B2A3B708500224F8A /* Settings Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2E182A2A3B708500224F8A /* Settings Options.swift */; };
 		CD309C462A93FBD300988F95 /* Logo View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD309C452A93FBD300988F95 /* Logo View.swift */; };
@@ -807,6 +808,7 @@
 		CD18DC722A522A7C002C56BC /* CreatePrivateMessageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePrivateMessageRequest.swift; sourceTree = "<group>"; };
 		CD20530F2AC878B50000AA38 /* UpdatedTimestampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatedTimestampView.swift; sourceTree = "<group>"; };
 		CD2053132ACBAF150000AA38 /* AvatarType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarType.swift; sourceTree = "<group>"; };
+		CD2053162ACBBB5A0000AA38 /* DefaultAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAvatar.swift; sourceTree = "<group>"; };
 		CD2BD6772A79F55800ECFF89 /* ImageSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSize.swift; sourceTree = "<group>"; };
 		CD2E182A2A3B708500224F8A /* Settings Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Settings Options.swift"; sourceTree = "<group>"; };
 		CD309C452A93FBD300988F95 /* Logo View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logo View.swift"; sourceTree = "<group>"; };
@@ -1863,6 +1865,7 @@
 		6386E03E2A04570F006B3C1D /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				CD2053152ACBBB490000AA38 /* Avatars */,
 				CD2E147B2A6B2891004198DE /* Components */,
 				6332FDCD27EFDD0A0009A98A /* Accounts */,
 				CD2E147A2A6B2871004198DE /* Comments */,
@@ -2032,6 +2035,14 @@
 				CD18243F2AA8E24100D9BEB5 /* View+DestructiveConfirmation.swift */,
 			);
 			path = "View Modifiers";
+			sourceTree = "<group>";
+		};
+		CD2053152ACBBB490000AA38 /* Avatars */ = {
+			isa = PBXGroup;
+			children = (
+				CD2053162ACBBB5A0000AA38 /* DefaultAvatar.swift */,
+			);
+			path = Avatars;
 			sourceTree = "<group>";
 		};
 		CD2E14782A6B283D004198DE /* Feeds */ = {
@@ -2644,6 +2655,7 @@
 				CD863FBA2A6AEB5900A31ED9 /* TabSafeScrollView.swift in Sources */,
 				637218772A3A2AAD008C4816 /* APIRequest.swift in Sources */,
 				63A09B69285F53E9004F0032 /* Error View.swift in Sources */,
+				CD2053172ACBBB5A0000AA38 /* DefaultAvatar.swift in Sources */,
 				CD3FBCE72A4A8CE300B2063F /* Messages Feed View.swift in Sources */,
 				63344C582A07DB9A001BC616 /* Array - Move Elements Around.swift in Sources */,
 				03E0B9C82A61F0F400FED265 /* AdvancedSettingsView.swift in Sources */,

--- a/Mlem/Enums/AvatarType.swift
+++ b/Mlem/Enums/AvatarType.swift
@@ -1,0 +1,13 @@
+//
+//  AvatarType.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-10-02.
+//
+
+import Foundation
+
+/// Enum of things that can have avatars
+enum AvatarType {
+    case user, community
+}

--- a/Mlem/Enums/AvatarType.swift
+++ b/Mlem/Enums/AvatarType.swift
@@ -11,3 +11,23 @@ import Foundation
 enum AvatarType {
     case user, community
 }
+
+extension AvatarType: AssociatedIcon {
+    var iconName: String {
+        switch self {
+        case .user:
+            return Icons.user
+        case .community:
+            return Icons.community
+        }
+    }
+    
+    var iconNameFill: String {
+        switch self {
+        case .user:
+            return Icons.userFill
+        case .community:
+            return Icons.communityFill
+        }
+    }
+}

--- a/Mlem/Views/Shared/Avatars/DefaultAvatar.swift
+++ b/Mlem/Views/Shared/Avatars/DefaultAvatar.swift
@@ -1,0 +1,21 @@
+//
+//  DefaultAvatar.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-10-02.
+//
+
+import Foundation
+import SwiftUI
+
+struct DefaultAvatar: View {
+    let avatarType: AvatarType
+    
+    var body: some View {
+        Image(systemName: avatarType.iconNameFill)
+            .resizable()
+            .scaledToFill()
+            .background(.white)
+            .foregroundStyle(Color.gray.gradient)
+    }
+}

--- a/Mlem/Views/Shared/Avatars/DefaultAvatarView.swift
+++ b/Mlem/Views/Shared/Avatars/DefaultAvatarView.swift
@@ -1,5 +1,5 @@
 //
-//  DefaultAvatar.swift
+//  DefaultAvatarView.swift
 //  Mlem
 //
 //  Created by Eric Andrews on 2023-10-02.
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-struct DefaultAvatar: View {
+struct DefaultAvatarView: View {
     let avatarType: AvatarType
     
     var body: some View {

--- a/Mlem/Views/Shared/Links/AvatarView.swift
+++ b/Mlem/Views/Shared/Links/AvatarView.swift
@@ -10,8 +10,6 @@ struct AvatarView: View {
     // Don't clip the avatars of communities from these instances
     static let unclippedInstances = ["beehaw.org"]
     
-    enum AvatarType { case community, user }
-    
     let type: AvatarType
     let url: URL?
     let avatarSize: CGFloat
@@ -48,21 +46,15 @@ struct AvatarView: View {
 
         return !unclippedInstances.contains(hostString)
     }
-
+    
     var body: some View {
-        Group {
-            if let url {
-                CachedImage(
-                    url: url.withIcon64Parameters,
-                    shouldExpand: false,
-                    fixedSize: CGSize(width: avatarSize, height: avatarSize),
-                    imageNotFound: defaultAvatar,
-                    contentMode: .fill
-                )
-            } else {
-                defaultAvatar()
-            }
-        }
+        CachedImage(
+            url: url?.withIcon64Parameters,
+            shouldExpand: false,
+            fixedSize: CGSize(width: avatarSize, height: avatarSize),
+            imageNotFound: { AnyView(DefaultAvatar(avatarType: type)) },
+            contentMode: .fill
+        )
         .frame(width: avatarSize, height: avatarSize)
         .accessibilityHidden(true)
         .blur(radius: blurAvatar ? 4 : 0)
@@ -72,26 +64,5 @@ struct AvatarView: View {
                 lineColor,
                 lineWidth: clipAvatar ? 1 : 0
             ))
-    }
-
-    private func defaultAvatar() -> AnyView {
-        switch type {
-        case .community:
-            return AnyView(
-                Image(systemName: Icons.communityFill)
-                    .resizable()
-                    .scaledToFill()
-                    .background(.white)
-                    .foregroundStyle(Color.gray.gradient)
-            )
-        case .user:
-            return AnyView(
-                Image(systemName: Icons.userFill)
-                    .resizable()
-                    .scaledToFill()
-                    .background(.white)
-                    .foregroundStyle(Color.gray.gradient)
-            )
-        }
     }
 }

--- a/Mlem/Views/Shared/Links/AvatarView.swift
+++ b/Mlem/Views/Shared/Links/AvatarView.swift
@@ -52,7 +52,7 @@ struct AvatarView: View {
             url: url?.withIcon64Parameters,
             shouldExpand: false,
             fixedSize: CGSize(width: avatarSize, height: avatarSize),
-            imageNotFound: { AnyView(DefaultAvatar(avatarType: type)) },
+            imageNotFound: { AnyView(DefaultAvatarView(avatarType: type)) },
             contentMode: .fill
         )
         .frame(width: avatarSize, height: avatarSize)

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
@@ -36,19 +36,20 @@ struct SidebarHeaderAvatar: View {
     
     @ViewBuilder
     var avatar: some View {
-        if let avatarURL = imageUrl {
-            CachedImage(
-                url: avatarURL,
-                shouldExpand: false,
-                fixedSize: CGSize(width: AppConstants.hugeAvatarSize, height: AppConstants.hugeAvatarSize),
-                contentMode: .fill
-            )
-        } else {
-            VStack(alignment: .center) {
-                Image(systemName: imageName)
-                    .font(.system(size: AppConstants.hugeAvatarSize)) // SF Symbols are apparently font
-                    .foregroundStyle(Color.gray.gradient)
-            }
-        }
+        CachedImage(
+            url: imageUrl,
+            shouldExpand: false,
+            fixedSize: CGSize(width: AppConstants.hugeAvatarSize, height: AppConstants.hugeAvatarSize),
+            imageNotFound: fallbackAvatar,
+            contentMode: .fill
+        )
+    }
+    
+    func fallbackAvatar() -> AnyView {
+        AnyView(
+            Image(systemName: imageName)
+                .font(.system(size: AppConstants.hugeAvatarSize)) // SF Symbols are apparently font
+                .foregroundStyle(Color.gray.gradient)
+        )
     }
 }

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
@@ -9,10 +9,20 @@ import Foundation
 
 import SwiftUI
 
-struct CommunitySidebarHeaderAvatar: View {
+struct SidebarHeaderAvatar: View {
     @State var shouldClipAvatar: Bool = false
     @State var imageUrl: URL?
+    let avatarType: AvatarType
 
+    var imageName: String {
+        switch avatarType {
+        case .user:
+            Icons.user
+        case .community:
+            Icons.community
+        }
+    }
+    
     var body: some View {
         avatar
             .frame(width: AppConstants.hugeAvatarSize, height: AppConstants.hugeAvatarSize)
@@ -35,11 +45,9 @@ struct CommunitySidebarHeaderAvatar: View {
             )
         } else {
             VStack(alignment: .center) {
-                Spacer()
-                    .frame(height: 20)
-                Image(systemName: Icons.user)
+                Image(systemName: imageName)
                     .font(.system(size: AppConstants.hugeAvatarSize)) // SF Symbols are apparently font
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(Color.gray.gradient)
             }
         }
     }

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
@@ -15,33 +15,19 @@ struct SidebarHeaderAvatar: View {
     let avatarType: AvatarType
     
     var body: some View {
-        avatar
-            .frame(width: AppConstants.hugeAvatarSize, height: AppConstants.hugeAvatarSize)
-            .clipShape(Circle())
-            .overlay(Circle()
-                .stroke(.secondary, lineWidth: shouldClipAvatar ? 2 : 0))
-            .shadow(radius: 10)
-            .background(shouldClipAvatar ? Circle()
-                .foregroundColor(.systemBackground) : nil)
-    }
-    
-    @ViewBuilder
-    var avatar: some View {
         CachedImage(
             url: imageUrl,
             shouldExpand: false,
             fixedSize: CGSize(width: AppConstants.hugeAvatarSize, height: AppConstants.hugeAvatarSize),
-            imageNotFound: fallbackAvatar,
+            imageNotFound: { AnyView(DefaultAvatar(avatarType: avatarType)) },
             contentMode: .fill
         )
-    }
-    
-    func fallbackAvatar() -> AnyView {
-        AnyView(
-            Image(systemName: avatarType.iconNameFill)
-                .font(.system(size: AppConstants.hugeAvatarSize)) // SF Symbols are apparently font
-                .background(.white)
-                .foregroundStyle(Color.gray.gradient)
-        )
+        .frame(width: AppConstants.hugeAvatarSize, height: AppConstants.hugeAvatarSize)
+        .clipShape(Circle())
+        .overlay(Circle()
+            .stroke(.secondary, lineWidth: shouldClipAvatar ? 2 : 0))
+        .shadow(radius: 10)
+        .background(shouldClipAvatar ? Circle()
+            .foregroundColor(.systemBackground) : nil)
     }
 }

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
@@ -19,7 +19,7 @@ struct SidebarHeaderAvatar: View {
             url: imageUrl,
             shouldExpand: false,
             fixedSize: CGSize(width: AppConstants.hugeAvatarSize, height: AppConstants.hugeAvatarSize),
-            imageNotFound: { AnyView(DefaultAvatar(avatarType: avatarType)) },
+            imageNotFound: { AnyView(DefaultAvatarView(avatarType: avatarType)) },
             contentMode: .fill
         )
         .frame(width: AppConstants.hugeAvatarSize, height: AppConstants.hugeAvatarSize)

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
@@ -17,9 +17,9 @@ struct SidebarHeaderAvatar: View {
     var imageName: String {
         switch avatarType {
         case .user:
-            Icons.user
+            return Icons.user
         case .community:
-            Icons.community
+            return Icons.community
         }
     }
     

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header Avatar.swift
@@ -13,15 +13,6 @@ struct SidebarHeaderAvatar: View {
     @State var shouldClipAvatar: Bool = false
     @State var imageUrl: URL?
     let avatarType: AvatarType
-
-    var imageName: String {
-        switch avatarType {
-        case .user:
-            return Icons.user
-        case .community:
-            return Icons.community
-        }
-    }
     
     var body: some View {
         avatar
@@ -47,8 +38,9 @@ struct SidebarHeaderAvatar: View {
     
     func fallbackAvatar() -> AnyView {
         AnyView(
-            Image(systemName: imageName)
+            Image(systemName: avatarType.iconNameFill)
                 .font(.system(size: AppConstants.hugeAvatarSize)) // SF Symbols are apparently font
+                .background(.white)
                 .foregroundStyle(Color.gray.gradient)
         )
     }

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar Header.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar Header.swift
@@ -19,6 +19,8 @@ struct CommunitySidebarHeader: View {
     var label1: String?
     var label2: String?
     
+    let avatarType: AvatarType
+    
     var body: some View {
         ZStack(alignment: .top) {
             // Banner
@@ -38,9 +40,10 @@ struct CommunitySidebarHeader: View {
                 }
                 HStack(alignment: .top) {
                     VStack(alignment: .leading) {
-                        CommunitySidebarHeaderAvatar(
+                        SidebarHeaderAvatar(
                             shouldClipAvatar: AvatarView.shouldClipCommunityAvatar(url: avatarUrl),
-                            imageUrl: avatarUrl
+                            imageUrl: avatarUrl,
+                            avatarType: avatarType
                         )
                         
                         Button {
@@ -96,7 +99,8 @@ struct SidebarHeaderPreview: PreviewProvider {
                     bannerURL: URL(string: "https://picsum.photos/seed/mlem-banner/2001/300"),
                     avatarUrl: URL(string: "https://picsum.photos/seed/mlem-avatar/200"),
                     label1: "Label 1",
-                    label2: "Label 2"
+                    label2: "Label 2",
+                    avatarType: .community
                 )
                 Divider()
                 CommunitySidebarHeader(
@@ -106,7 +110,8 @@ struct SidebarHeaderPreview: PreviewProvider {
                     bannerURL: URL(string: "https://picsum.photos/seed/mlem-banner/200/300"),
                     avatarUrl: URL(string: "https://picsum.photos/seed/mlem-avatar/200"),
                     label1: "Label 1",
-                    label2: "Label 2"
+                    label2: "Label 2",
+                    avatarType: .community
                 )
                 Divider()
                 CommunitySidebarHeader(
@@ -116,7 +121,8 @@ struct SidebarHeaderPreview: PreviewProvider {
                     bannerURL: URL(string: "https://picsum.photos/seed/mlem-banner/200/300"),
                     avatarUrl: nil,
                     label1: "Label 1",
-                    label2: "Label 2"
+                    label2: "Label 2",
+                    avatarType: .community
                 )
                 Divider()
                 CommunitySidebarHeader(
@@ -126,7 +132,8 @@ struct SidebarHeaderPreview: PreviewProvider {
                     bannerURL: nil,
                     avatarUrl: URL(string: "https://picsum.photos/seed/mlem-avatar/200"),
                     label1: "Label 1",
-                    label2: "Label 2"
+                    label2: "Label 2",
+                    avatarType: .community
                 )
                 Divider()
                 CommunitySidebarHeader(
@@ -136,7 +143,8 @@ struct SidebarHeaderPreview: PreviewProvider {
                     bannerURL: nil,
                     avatarUrl: nil,
                     label1: "Label 1",
-                    label2: "Label 2"
+                    label2: "Label 2",
+                    avatarType: .community
                 )
                 Spacer()
             }

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar View.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar View.swift
@@ -69,7 +69,8 @@ struct CommunitySidebarView: View {
                 avatarSubtext: .constant("Created \(getRelativeTime(date: communityDetails.communityView.community.published))"),
                 bannerURL: shouldShowCommunityHeaders ? communityDetails.communityView.community.bannerUrl : nil,
                 avatarUrl: communityDetails.communityView.community.iconUrl,
-                label1: "\(communityDetails.communityView.counts.subscribers) Subscribers"
+                label1: "\(communityDetails.communityView.counts.subscribers) Subscribers",
+                avatarType: .community
             )
             
             Picker(selection: $selectionSection, label: Text("Profile Section")) {

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -104,7 +104,8 @@ struct UserView: View {
             bannerURL: shouldShowUserHeaders ? userDetails.person.bannerUrl : nil,
             avatarUrl: userDetails.person.avatarUrl,
             label1: "\(userDetails.counts.commentCount) Comments",
-            label2: "\(userDetails.counts.postCount) Posts"
+            label2: "\(userDetails.counts.postCount) Posts",
+            avatarType: .user
         )
     }
     


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #688 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR fixes two problems relating to sidebar avatars, described in #688. It also takes the opportunity to rename `CommunitySidebarHeaderAvatar` to `SidebarHeaderAvatar`, since it is used for both, and increase code reuse around default avatars (extracted `AvatarType` to be a regular enum conforming to `AssociatedIcon`, and created a `DefaultAvatarView` to unify handling fallback avatars.

**Current** | **Incoming**
---|---
<img width="563" alt="oldUser" src="https://github.com/mlemgroup/mlem/assets/44140166/ab91b484-366b-43b2-837c-27c572901b35"> | <img width="563" alt="newUser" src="https://github.com/mlemgroup/mlem/assets/44140166/a1482145-b56a-4ed2-a99a-e0576f5b3aa5">
<img width="563" alt="oldCommunity" src="https://github.com/mlemgroup/mlem/assets/44140166/f6165780-45ff-4957-934a-e2939137a179"> | <img width="563" alt="newCommunity" src="https://github.com/mlemgroup/mlem/assets/44140166/9ff0c2eb-d1d8-43de-bddc-1bafa8ed38ed">