### PR TITLE
New Sort Options

### DIFF
--- a/Mlem/Enums/Settings/PostSortType.swift
+++ b/Mlem/Enums/Settings/PostSortType.swift
@@ -6,12 +6,17 @@
 //
 
 import Foundation
+import Dependencies
 
 enum PostSortType: String, Codable, CaseIterable, Identifiable {
+    @Dependency(\.siteInformation) static var siteInformation
+    
     case hot = "Hot"
     case active = "Active"
     case new = "New"
     case old = "Old"
+    case scaled = "Scaled"
+    case controversial = "Controversial"
     case newComments = "NewComments"
     case mostComments = "MostComments"
     case topHour = "TopHour"
@@ -20,13 +25,55 @@ enum PostSortType: String, Codable, CaseIterable, Identifiable {
     case topDay = "TopDay"
     case topWeek = "TopWeek"
     case topMonth = "TopMonth"
+    case topThreeMonth = "TopThreeMonth"
+    case topSixMonth = "TopSixMonth"
+    case topNineMonth = "TopNineMonth"
     case topYear = "TopYear"
     case topAll = "TopAll"
     
     var id: Self { self }
     
-    static var outerTypes: [PostSortType] { [.hot, .active, .new, .old, .newComments, .mostComments] }
-    static var topTypes: [PostSortType] { [.topHour, .topSixHour, .topTwelveHour, .topDay, .topWeek, .topMonth, .topYear, .topAll] }
+    static var outerTypes: [PostSortType] { [
+        .hot,
+        .scaled,
+        .active,
+        .new,
+        .old,
+        .newComments,
+        .mostComments,
+        .controversial
+    ] }
+    
+    static var topTypes: [PostSortType] { [
+        .topHour,
+        .topSixHour,
+        .topTwelveHour,
+        .topDay,
+        .topWeek,
+        .topMonth,
+        .topThreeMonth,
+        .topSixMonth,
+        .topNineMonth,
+        .topYear,
+        .topAll
+    ] }
+    
+    static var availableOuterTypes: [PostSortType] { filterTypes(outerTypes) }
+    static var availableTopTypes: [PostSortType] { filterTypes(topTypes) }
+    
+    private static func filterTypes(_ types: [PostSortType]) -> [PostSortType] {
+        guard let siteVersion = siteInformation.version else { return types }
+        return types.filter { siteVersion >= $0.minimumVersion }
+    }
+    
+    var minimumVersion: SiteVersion {
+        switch self {
+        case .controversial, .scaled:
+            return .init("0.19.0")
+        default:
+            return .zero
+        }
+    }
     
     var description: String {
         switch self {
@@ -42,6 +89,12 @@ enum PostSortType: String, Codable, CaseIterable, Identifiable {
             return "Top of the week"
         case .topMonth:
             return "Top of the month"
+        case .topThreeMonth:
+            return "Top of the last 3 months"
+        case .topSixMonth:
+            return "Top of the last 6 months"
+        case .topNineMonth:
+            return "Top of the last 9 months"
         case .topYear:
             return "Top of the year"
         case .topAll:
@@ -71,6 +124,12 @@ extension PostSortType: SettingsOptions {
             return "Week"
         case .topMonth:
             return "Month"
+        case .topThreeMonth:
+            return "3 Months"
+        case .topSixMonth:
+            return "6 Months"
+        case .topNineMonth:
+            return "9 Months"
         case .topYear:
             return "Year"
         case .topAll:
@@ -86,10 +145,12 @@ extension PostSortType: AssociatedIcon {
         switch self {
         case .active: return Icons.activeSort
         case .hot: return Icons.hotSort
+        case .scaled: return Icons.scaledSort
         case .new: return Icons.newSort
         case .old: return Icons.oldSort
         case .newComments: return Icons.newCommentsSort
         case .mostComments: return Icons.mostCommentsSort
+        case .controversial: return Icons.controversialSort
         default: return Icons.timeSort
         }
     }
@@ -98,10 +159,12 @@ extension PostSortType: AssociatedIcon {
         switch self {
         case .active: return Icons.activeSortFill
         case .hot: return Icons.hotSortFill
+        case .scaled: return Icons.scaledSortFill
         case .new: return Icons.newSortFill
         case .old: return Icons.oldSortFill
         case .newComments: return Icons.newCommentsSortFill
         case .mostComments: return Icons.mostCommentsSortFill
+        case .controversial: return Icons.controversialSortFill
         default: return Icons.timeSortFill
         }
     }

--- a/Mlem/Icons.swift
+++ b/Mlem/Icons.swift
@@ -74,6 +74,8 @@ struct Icons {
     static let activeSortFill: String = "popcorn.fill"
     static let hotSort: String = "flame"
     static let hotSortFill: String = "flame.fill"
+    static let scaledSort: String = "arrow.up.left.and.down.right.and.arrow.up.right.and.down.left"
+    static let scaledSortFill: String = "arrow.up.left.and.down.right.and.arrow.up.right.and.down.left"
     static let newSort: String = "hare"
     static let newSortFill: String = "hare.fill"
     static let oldSort: String = "tortoise"
@@ -82,11 +84,13 @@ struct Icons {
     static let newCommentsSortFill: String = "exclamationmark.bubble.fill"
     static let mostCommentsSort: String = "bubble.left.and.bubble.right"
     static let mostCommentsSortFill: String = "bubble.left.and.bubble.right.fill"
+    static let controversialSort: String = "bolt"
+    static let controversialSortFill: String = "bolt.fill"
     static let topSortMenu: String = "text.line.first.and.arrowtriangle.forward"
     static let topSort: String = "trophy"
     static let topSortFill: String = "trophy.fill"
     static let timeSort: String = "calendar.day.timeline.leading"
-    static let timeSortFill: String = "calendar.day.timeline.leading.fill"
+    static let timeSortFill: String = "calendar.day.timeline.leading"
     
     // user flairs
     static let developerFlair: String = "hammer.fill"

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -88,7 +88,7 @@ extension FeedView {
     // MARK: Menus
     
     func genOuterSortMenuFunctions() -> [MenuFunction] {
-        PostSortType.outerTypes.map { type in
+        PostSortType.availableOuterTypes.map { type in
             let isSelected = postSortType == type
             let imageName = isSelected ? type.iconNameFill : type.iconName
             return MenuFunction.standardMenuFunction(
@@ -103,7 +103,7 @@ extension FeedView {
     }
     
     func genTopSortMenuFunctions() -> [MenuFunction] {
-        PostSortType.topTypes.map { type in
+        PostSortType.availableTopTypes.map { type in
             let isSelected = postSortType == type
             return MenuFunction.standardMenuFunction(
                 text: type.description,


### PR DESCRIPTION
Adds five new sort options:

- `scaled`
- `controversial`
- `top 3 months`
- `top 6 months`
- `top 9 months`

`scaled` and `controversial` are 0.19.0+ whilst the new `top` modes are available on the latest release version. The 0.19.0+ sort modes are hidden on instances that aren't running 0.19.0 or above.

Potential problem with this implementation:

You can still set the default sort mode to a mode that isn't available on your instance. If the user chooses an unsupported sort mode as the default, it would obviously be selected in the feed and they would see an error. I _could_ filter out the modes that aren't available from the default sort-mode picker - this doesn't remove the problem though, because the user could set the default sort mode on a 1.19.0 instance and then switch accounts to an older instance, and they would still see an error. 


Closes #673
Closes #321