### PR TITLE
FIx issue where swipey view actions publishes updates on background t…

### DIFF
--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -18,7 +18,7 @@ public struct SwipeAction {
     
     let symbol: Symbol
     let color: Color
-    let action: () async -> Void
+    let action: () -> Void
 }
 
 // MARK: -
@@ -201,9 +201,7 @@ struct SwipeyView: ViewModifier {
         
         reset()
         
-        Task(priority: .userInitiated) {
-            await swipeAction(at: finalDragPosition)?.action()
-        }
+        swipeAction(at: finalDragPosition)?.action()
     }
     
     private func reset() {

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -227,7 +227,11 @@ extension CommentItem {
         SwipeAction(
             symbol: .init(emptyName: emptyVoteSymbolName, fillName: upvoteSymbolName),
             color: .upvoteColor,
-            action: upvote
+            action: {
+                Task {
+                    await upvote()
+                }
+            }
         )
     }
     
@@ -236,7 +240,11 @@ extension CommentItem {
         return SwipeAction(
             symbol: .init(emptyName: emptyDownvoteSymbolName, fillName: downvoteSymbolName),
             color: .downvoteColor,
-            action: downvote
+            action: {
+                Task {
+                    await downvote()
+                }
+            }
         )
     }
     
@@ -244,7 +252,11 @@ extension CommentItem {
         SwipeAction(
             symbol: .init(emptyName: emptySaveSymbolName, fillName: saveSymbolName),
             color: .saveColor,
-            action: saveComment
+            action: {
+                Task {
+                    await saveComment()
+                }
+            }
         )
     }
 
@@ -252,7 +264,11 @@ extension CommentItem {
         SwipeAction(
             symbol: .init(emptyName: emptyReplySymbolName, fillName: replySymbolName),
             color: .accentColor,
-            action: replyToCommentAsyncWrapper
+            action: {
+                Task {
+                    await replyToCommentAsyncWrapper()
+                }
+            }
         )
     }
     

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -433,7 +433,11 @@ extension FeedPost {
         return SwipeAction(
             symbol: .init(emptyName: emptySymbolName, fillName: fullSymbolName),
             color: .upvoteColor,
-            action: upvotePost
+            action: {
+                Task {
+                    await upvotePost()
+                }
+            }
         )
     }
 
@@ -446,7 +450,11 @@ extension FeedPost {
         return SwipeAction(
             symbol: .init(emptyName: emptySymbolName, fillName: fullSymbolName),
             color: .downvoteColor,
-            action: downvotePost
+            action: {
+                Task {
+                    await downvotePost()
+                }
+            }
         )
     }
 
@@ -457,7 +465,11 @@ extension FeedPost {
         return SwipeAction(
             symbol: .init(emptyName: emptySymbolName, fillName: fullSymbolName),
             color: .saveColor,
-            action: savePost
+            action: {
+                Task {
+                    await savePost()
+                }
+            }
         )
     }
 

--- a/Mlem/Views/Tabs/Search/CommunityResultView.swift
+++ b/Mlem/Views/Tabs/Search/CommunityResultView.swift
@@ -23,7 +23,11 @@ struct CommunityResultView: View {
         return SwipeAction(
             symbol: .init(emptyName: emptySymbolName, fillName: fullSymbolName),
             color: community.subscribed ? .red : .green,
-            action: subscribe
+            action: {
+                Task {
+                    await subscribe()
+                }
+            }
         )
     }
     


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #682, #693 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
Fixes issue where `SwipeAction.action` may attempt to publish changes on background thread, instead of main thread.
- Move structured concurrency logic out of SwipeAction/SwipeyView, and closer to the model layer where it's actually important.
~ For example: Theoretically, we could have a swipe action that's mapped to upvote/downvote (on low power mode) or an automated bug report action that doesn't show any UI. These actions may not necessarily need a `.userInitiated` priority, and SwipeyView wouldn't know and shouldn't have to deal with that.
- Follows `SwiftUI.Button` API pattern (albeit a bit annoying at call site), where call site wraps async calls in an inline synchronous closure.

## Screenshots and Videos
No UI changes.
