### PR TITLE
Allow disabling swipe-up for account switcher

### DIFF
--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -32,6 +32,7 @@ struct ContentView: View {
     
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true
     @AppStorage("homeButtonExists") var homeButtonExists: Bool = false
+    @AppStorage("allowTabBarSwipeUpGesture") var allowTabBarSwipeUpGesture: Bool = true
     
     var accessibilityFont: Bool { UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory }
     
@@ -156,7 +157,7 @@ struct ContentView: View {
     }
     
     func showAccountSwitcherDragCallback() {
-        if !homeButtonExists {
+        if !homeButtonExists && allowTabBarSwipeUpGesture {
             isPresentingAccountSwitcher = true
         }
     }

--- a/Mlem/Icons.swift
+++ b/Mlem/Icons.swift
@@ -165,6 +165,7 @@ struct Icons {
     static let leftRight: String = "arrow.left.arrow.right"
     static let developerMode: String = "wrench.adjustable.fill"
     static let limitImageHeightSetting: String = "rectangle.compress.vertical"
+    static let swipeUpGestureSetting: String = "arrow.up.to.line.alt"
     
     // misc
     static let switchUser: String = "person.crop.circle.badge.plus"

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -13,6 +13,8 @@ struct TabBarSettingsView: View {
     @AppStorage("showTabNames") var showTabNames: Bool = true
     @AppStorage("showInboxUnreadBadge") var showInboxUnreadBadge: Bool = true
     @AppStorage("showUserAvatarOnProfileTab") var showUserAvatar: Bool = true
+    @AppStorage("allowTabBarSwipeUpGesture") var allowTabBarSwipeUpGesture: Bool = true
+    @AppStorage("homeButtonExists") var homeButtonExists: Bool = false
         
     @EnvironmentObject var appState: AppState
     
@@ -80,6 +82,15 @@ struct TabBarSettingsView: View {
                     isTicked: profileTabLabel == .anonymous ? .constant(false) : $showUserAvatar
                 )
                 .disabled(profileTabLabel == .anonymous)
+            }
+            if !homeButtonExists {
+                Section {
+                    SwitchableSettingsItem(
+                        settingPictureSystemName: Icons.swipeUpGestureSetting,
+                        settingName: "Swipe Up For Account Switcher",
+                        isTicked: $allowTabBarSwipeUpGesture
+                    )
+                }
             }
         }
         .fancyTabScrollCompatible()


### PR DESCRIPTION
Allows the user to turn off the tab bar swipe-up gesture, which accesses the account switcher. Someone on mlemapp requested this