### PR TITLE
Fixed inbox unread counter bug

### DIFF
--- a/Mlem/Views/Tabs/Inbox/Inbox View Logic.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View Logic.swift
@@ -147,7 +147,16 @@ extension InboxView {
     
     // MARK: - Replies
     
+    /// Marks a comment reply as read or unread. Has no effect if the requested read status is already the current read status
+    /// - Parameters:
+    ///   - commentReplyView: commentReplyView to mark
+    ///   - read: true to mark as read, false to mark as unread
     func markCommentReplyRead(commentReplyView: APICommentReplyView, read: Bool) async {
+        // skip noop case
+        guard commentReplyView.commentReply.read != read else {
+            return
+        }
+        
         do {
             let response = try await commentRepository.markCommentReadStatus(
                 id: commentReplyView.id,
@@ -212,7 +221,16 @@ extension InboxView {
     
     // MARK: Mentions
     
+    /// Marks a person mention as read or unread. Has no effect if the requested read status is already the current read status
+    /// - Parameters:
+    ///   - mention: mention to mark
+    ///   - read: true to mark as read, false to mark as unread
     func markMentionRead(mention: APIPersonMentionView, read: Bool) async {
+        // skip noop case
+        guard mention.personMention.read != read else {
+            return
+        }
+        
         do {
             let updatedMention = try await apiClient.markPersonMentionAsRead(
                 mentionId: mention.personMention.id,


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #696 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR fixes a bug where interacting with inbox items would increment the inbox unread counter.

It introduces a guard on the markMentionRead and markReplyRead to no-op if the call would have no effect.