### PR TITLE
Avoid search rate limit

### DIFF
--- a/Mlem/Views/Tabs/Search/SearchResultsView.swift
+++ b/Mlem/Views/Tabs/Search/SearchResultsView.swift
@@ -22,7 +22,10 @@ struct SearchResultsView: View {
                 .padding(.top, 8)
             SearchResultListView(showTypeLabel: searchModel.searchTab == .topResults)
         }
-        .onChange(of: searchModel.searchText) { newValue in
+        .onReceive(
+            searchModel.$searchText
+                .debounce(for: .seconds(0.2), scheduler: DispatchQueue.main)
+        ) { newValue in
             if searchModel.previousSearchText != newValue {
                 if !newValue.isEmpty {
                     contentTracker.refresh(using: searchModel.performSearch)


### PR DESCRIPTION
Got a rate limit whilst searching. This PR reduces the number of API requests we make by refreshing the search results less often.

## Before this PR

Search was refreshed every time the search field content is changed (ie, when the user types another letter)

## After this PR

Search is refreshed if the user stops typing for 0.2 seconds (thoughts on this delay? I type faster than 0.2 seconds per key so it works for me, but this may not be true for everyone)