### PR TITLE
Better 'no posts to be found' message

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		03A1B3F42A83F46200AB0DE0 /* ShareButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A1B3F32A83F46200AB0DE0 /* ShareButtonView.swift */; };
 		03A1B3F72A84000400AB0DE0 /* APIContentAggregatesProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A1B3F62A84000400AB0DE0 /* APIContentAggregatesProtocol.swift */; };
 		03A1B3F92A8400DD00AB0DE0 /* APIContentViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A1B3F82A8400DD00AB0DE0 /* APIContentViewProtocol.swift */; };
+		03A40DAD2AD5EA11005F019F /* NoPostsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A40DAC2AD5EA11005F019F /* NoPostsView.swift */; };
 		03B643572A6864CD00F65700 /* TabBarSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B643562A6864CD00F65700 /* TabBarSettingsView.swift */; };
 		03B7AAEF2ABCB9DC00068B23 /* ContentTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B7AAEE2ABCB9DC00068B23 /* ContentTracker.swift */; };
 		03B7AAF12ABE404300068B23 /* ContentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B7AAF02ABE404300068B23 /* ContentModel.swift */; };
@@ -523,6 +524,7 @@
 		03A1B3F32A83F46200AB0DE0 /* ShareButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareButtonView.swift; sourceTree = "<group>"; };
 		03A1B3F62A84000400AB0DE0 /* APIContentAggregatesProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIContentAggregatesProtocol.swift; sourceTree = "<group>"; };
 		03A1B3F82A8400DD00AB0DE0 /* APIContentViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIContentViewProtocol.swift; sourceTree = "<group>"; };
+		03A40DAC2AD5EA11005F019F /* NoPostsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoPostsView.swift; sourceTree = "<group>"; };
 		03B643562A6864CD00F65700 /* TabBarSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarSettingsView.swift; sourceTree = "<group>"; };
 		03B7AAEE2ABCB9DC00068B23 /* ContentTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTracker.swift; sourceTree = "<group>"; };
 		03B7AAF02ABE404300068B23 /* ContentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentModel.swift; sourceTree = "<group>"; };
@@ -1535,6 +1537,7 @@
 			children = (
 				632578172A29F83C00446A66 /* PostSortMenu.swift */,
 				63344C702A098060001BC616 /* Sidebar View.swift */,
+				03A40DAC2AD5EA11005F019F /* NoPostsView.swift */,
 				6D405B002A43E79400C65F9C /* Sidebar Header Avatar.swift */,
 				6D405B022A43E7DB00C65F9C /* Sidebar Header Label.swift */,
 				6D405B042A43E82300C65F9C /* Sidebar Header.swift */,
@@ -2984,6 +2987,7 @@
 				88B165B82A8643F4007C9115 /* View - NavigationBar Color.swift in Sources */,
 				030AC0522A64666C00037155 /* UserSettingsView.swift in Sources */,
 				CDA2C5262A705D6000649D5A /* PostEditor.swift in Sources */,
+				03A40DAD2AD5EA11005F019F /* NoPostsView.swift in Sources */,
 				6372184A2A3A2AAD008C4816 /* APIPost.swift in Sources */,
 				6D693A3E2A5113DF009E2D76 /* CreatePostReport.swift in Sources */,
 				CD391F942A533B7700E213B5 /* EditorModelProtocol.swift in Sources */,

--- a/Mlem/Error Handling/ErrorHandler.swift
+++ b/Mlem/Error Handling/ErrorHandler.swift
@@ -24,7 +24,13 @@ class ErrorHandler: ObservableObject {
         handle(.init(underlyingError: error), file: file, function: function, line: line)
     }
     
-    func handle(_ error: ContextualError?, file: StaticString = #fileID, function: StaticString = #function, line: Int = #line) {
+    func handle(
+        _ error: ContextualError?,
+        file: StaticString = #fileID,
+        function: StaticString = #function,
+        line: Int = #line,
+        showNoInternet: Bool = true
+    ) {
         guard let error else {
             return
         }
@@ -43,7 +49,9 @@ class ErrorHandler: ObservableObject {
                 }
                 
                 if error.title != nil && !InternetConnectionManager.isConnectedToNetwork() {
-                    await notifier.add(.noInternet)
+                    if showNoInternet {
+                        await notifier.add(.noInternet)
+                    }
                     return
                 }
                 

--- a/Mlem/Icons.swift
+++ b/Mlem/Icons.swift
@@ -51,6 +51,7 @@ struct Icons {
     static let titleOnlyPost: String = "character.bubble"
     static let pinned: String = "pin.fill"
     static let websiteIcon: String = "globe"
+    static let hideRead: String = "book"
     
     // post sizes
     static let postSizeSetting: String = "rectangle.expand.vertical"

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -10,6 +10,9 @@ import Foundation
 import Nuke
 import SwiftUI
 
+enum PostFilterReason {
+    case read, keyword
+}
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
 /// New post tracker built on top of the PostRepository instead of calling the API directly. Because this thing works fundamentally differently from the old one, it can't conform to FeedTracker--that's going to need a revamp down the line once everything uses nice shiny middleware models, so for now we're going to have to put up with some ugly
@@ -32,6 +35,7 @@ class PostTracker: ObservableObject {
     private var ids: Set<ContentModelIdentifier> = .init(minimumCapacity: 1000)
     private(set) var isLoading: Bool = false // accessible but not published because it causes lots of bad view redraws
     private(set) var page: Int = 1
+    private(set) var hiddenItems: [PostFilterReason: Int] = .init()
     
     private var hasReachedEnd: Bool = false
     
@@ -62,7 +66,7 @@ class PostTracker: ObservableObject {
         communityId: Int?,
         sort: PostSortType?,
         type: FeedType,
-        filtering: @escaping (_: PostModel) -> Bool = { _ in true }
+        filtering: @escaping (_: PostModel) -> PostFilterReason? = { _ in nil }
     ) async throws {
         let currentPage = page
         
@@ -99,7 +103,7 @@ class PostTracker: ObservableObject {
         }
         
         // don't preload filtered images
-        preloadImages(newPosts.filter(filtering))
+        preloadImages(filterItems(items: newPosts, with: filtering))
     }
     
     /// Loads a single post and adds it to the tracker
@@ -117,7 +121,7 @@ class PostTracker: ObservableObject {
         sort: PostSortType?,
         feedType: FeedType,
         clearBeforeFetch: Bool = false,
-        filtering: @escaping (_: PostModel) -> Bool = { _ in true }
+        filtering: @escaping (_: PostModel) -> PostFilterReason? = { _ in nil }
     ) async throws {
         if clearBeforeFetch {
             await reset()
@@ -144,10 +148,10 @@ class PostTracker: ObservableObject {
     ///   - preload: true if the new post's image should be preloaded
     func add(
         _ newItems: [PostModel],
-        filtering: @escaping (_: PostModel) -> Bool = { _ in true },
+        filtering: @escaping (_: PostModel) -> PostFilterReason? = { _ in nil },
         preload: Bool = false
     ) {
-        let accepted = dedupedItems(from: newItems.filter(filtering))
+        let accepted = dedupedItems(from: filterItems(items: newItems, with: filtering))
         
         if preload { preloadImages(newItems) }
         
@@ -167,12 +171,15 @@ class PostTracker: ObservableObject {
     @MainActor
     func reset(
         with newItems: [PostModel] = .init(),
-        filteredWith filter: @escaping (_: PostModel) -> Bool = { _ in true }
+        filteredWith filter: @escaping (_: PostModel) -> PostFilterReason? = { _ in nil }
     ) {
         hasReachedEnd = false
         page = newItems.isEmpty ? 1 : 2
+        if page == 1 {
+            hiddenItems.removeAll()
+        }
         ids = .init(minimumCapacity: 1000)
-        items = dedupedItems(from: newItems.filter(filter))
+        items = dedupedItems(from: filterItems(items: newItems, with: filter))
     }
 
     /// Determines whether the tracker should load more items
@@ -457,6 +464,19 @@ class PostTracker: ObservableObject {
     /// Filters a list of PostModels to only those PostModels not present in ids. Updates ids.
     private func dedupedItems(from newItems: [PostModel]) -> [PostModel] {
         newItems.filter { ids.insert($0.uid).inserted }
+    }
+    
+    private func filterItems(
+        items: [PostModel],
+        with filtering: @escaping (_: PostModel) -> PostFilterReason? = { _ in nil }
+    ) -> [PostModel] {
+        return items.filter { item in
+            if let reason = filtering(item) {
+                self.hiddenItems[reason] = self.hiddenItems[reason, default: 0] + 1
+                return false
+            }
+            return true
+        }
     }
 }
 

--- a/Mlem/Views/Shared/Loading View.swift
+++ b/Mlem/Views/Shared/Loading View.swift
@@ -53,6 +53,8 @@ struct LoadingView: View {
     }
 }
 
-#Preview {
-    LoadingView(whatIsLoading: .posts)
+struct LoadingView_Preview: PreviewProvider {
+    static var previews: some View {
+        LoadingView(whatIsLoading: .posts)
+    }
 }

--- a/Mlem/Views/Shared/Loading View.swift
+++ b/Mlem/Views/Shared/Loading View.swift
@@ -15,7 +15,7 @@ struct LoadingView: View {
     let whatIsLoading: PossibleThingsToLoad
 
     var body: some View {
-        VStack {
+        VStack(spacing: AppConstants.postAndCommentSpacing) {
             Spacer()
 
             ProgressView()
@@ -51,4 +51,8 @@ struct LoadingView: View {
         .foregroundColor(.secondary)
         .frame(maxWidth: .infinity)
     }
+}
+
+#Preview {
+    LoadingView(whatIsLoading: .posts)
 }

--- a/Mlem/Views/Shared/Loading View.swift
+++ b/Mlem/Views/Shared/Loading View.swift
@@ -53,7 +53,7 @@ struct LoadingView: View {
     }
 }
 
-struct LoadingView_Preview: PreviewProvider {
+struct LoadingViewPreview: PreviewProvider {
     static var previews: some View {
         LoadingView(whatIsLoading: .posts)
     }

--- a/Mlem/Views/Tabs/Feeds/Components/NoPostsView.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/NoPostsView.swift
@@ -1,0 +1,82 @@
+//
+//  NoPostsView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 10/10/2023.
+//
+
+import SwiftUI
+
+struct NoPostsView: View {
+    @EnvironmentObject var postTracker: PostTracker
+    
+    @Binding var isLoading: Bool
+    @Binding var postSortType: PostSortType
+    @Binding var showReadPosts: Bool
+    
+    var body: some View {
+        VStack {
+            if !isLoading {
+                VStack(alignment: .center, spacing: AppConstants.postAndCommentSpacing) {
+                    
+                    Image(systemName: Icons.noPosts)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 50)
+                        .padding(.bottom)
+                    Text(title)
+                    
+                    let unreadItems = postTracker.hiddenItems[.read, default: 0]
+                    if unreadItems != 0 {
+                        Text(
+                            (unreadItems == 1 ? "1 available post was" : "\(unreadItems) available posts were")
+                            + " hidden because you have 'hide read' enabled."
+                        )
+                        .foregroundStyle(.tertiary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, 20)
+                        
+                    }
+                    buttons
+                }
+                .foregroundStyle(.secondary)
+            }
+        }
+    }
+    
+    var title: String {
+        if PostSortType.topTypes.contains(postSortType) && postSortType != .topAll {
+            return "No posts found from the last \(postSortType.label.lowercased())."
+        }
+        return "No posts found."
+    }
+    
+    @ViewBuilder
+    var buttons: some View {
+        VStack {
+            if postSortType != .hot {
+                Button {
+                    isLoading = true
+                    postSortType = .hot
+                } label: {
+                    Label("Switch to Hot", systemImage: Icons.hotSort)
+                }
+            }
+            if postTracker.hiddenItems[.read, default: 0] > 0 {
+                Button {
+                    if !showReadPosts {
+                        isLoading = true
+                        showReadPosts = true
+                    }
+                } label: {
+                    Text("Show read posts")
+                }
+            }
+        }
+        .foregroundStyle(.secondary)
+        .buttonStyle(.bordered)
+        .padding(.top)
+        .padding(.horizontal, 20)
+    }
+}

--- a/Mlem/Views/Tabs/Feeds/Components/NoPostsView.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/NoPostsView.swift
@@ -30,8 +30,7 @@ struct NoPostsView: View {
                     
                     if unreadItems != 0 {
                         Text(
-                            (unreadItems == 1 ? "1 available post was" : "\(unreadItems) available posts were")
-                            + " hidden because you have 'hide read' enabled."
+                            "\(unreadItems) read post\(unreadItems == 1 ? " has" : "s have") been hidden."
                         )
                         .foregroundStyle(.tertiary)
                         .multilineTextAlignment(.center)

--- a/Mlem/Views/Tabs/Feeds/Components/NoPostsView.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/NoPostsView.swift
@@ -19,14 +19,15 @@ struct NoPostsView: View {
             if !isLoading {
                 VStack(alignment: .center, spacing: AppConstants.postAndCommentSpacing) {
                     
+                    let unreadItems = postTracker.hiddenItems[.read, default: 0]
+                    
                     Image(systemName: Icons.noPosts)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width: 50)
-                        .padding(.bottom)
+                        .frame(width: unreadItems == 0 ? 35 : 50)
+                        .padding(.bottom, unreadItems == 0 ? 8: 12)
                     Text(title)
                     
-                    let unreadItems = postTracker.hiddenItems[.read, default: 0]
                     if unreadItems != 0 {
                         Text(
                             (unreadItems == 1 ? "1 available post was" : "\(unreadItems) available posts were")

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -36,7 +36,8 @@ extension FeedView {
         }
     }
     
-    func refreshFeed() async {
+    @discardableResult
+    func refreshFeed() async -> Bool {
         // NOTE: refresh doesn't need to touch isLoading because that visual cue is handled by .refreshable
         do {
             try await postTracker.refresh(
@@ -45,8 +46,11 @@ extension FeedView {
                 feedType: feedType,
                 filtering: filter
             )
+            errorDetails = nil
+            return true
         } catch {
             handle(error)
+            return false
         }
     }
     
@@ -79,7 +83,8 @@ extension FeedView {
                         title: "Could not load community information",
                         message: "The server might be overloaded.\nTry again later.",
                         underlyingError: error
-                    )
+                    ),
+                    showNoInternet: false
                 )
             }
         }
@@ -267,25 +272,18 @@ extension FeedView {
     // MARK: Helper Functions
     
     private func handle(_ error: Error) {
-        let title: String?
-        let errorMessage: String?
-        
+
         switch error {
         case APIClientError.networking:
             guard postTracker.items.isEmpty else {
                 return
             }
-            
-            title = "Unable to connect to Lemmy"
-            errorMessage = "Please check your internet connection and try again"
+            errorDetails = .init(title: "Unable to connect to Lemmy", error: error, refresh: self.refreshFeed)
+            return
         default:
-            title = nil
-            errorMessage = nil
+            break
         }
-        
-        errorHandler.handle(
-            .init(title: title, message: errorMessage, underlyingError: error)
-        )
+        errorDetails = .init(error: error, refresh: self.refreshFeed)
     }
     
     private func filter(postView: PostModel) -> PostFilterReason? {

--- a/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View Logic.swift
@@ -288,9 +288,10 @@ extension FeedView {
         )
     }
     
-    private func filter(postView: PostModel) -> Bool {
-        !postView.post.name.lowercased().contains(filtersTracker.filteredKeywords) &&
-            (showReadPosts || !postView.read)
+    private func filter(postView: PostModel) -> PostFilterReason? {
+        guard !postView.post.name.lowercased().contains(filtersTracker.filteredKeywords) else { return .keyword }
+        guard showReadPosts || !postView.read else { return .read }
+        return nil
     }
     
     private func subscribe(communityId: Int, shouldSubscribe: Bool) async {

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -34,6 +34,8 @@ struct FeedView: View {
     let showLoading: Bool
     @State var feedType: FeedType
     
+    @State var errorDetails: ErrorDetails?
+    
     init(
         community: APICommunity?,
         feedType: FeedType,
@@ -151,7 +153,10 @@ struct FeedView: View {
     @ViewBuilder
     private func noPostsView() -> some View {
         VStack {
-            if isLoading {
+            if let errorDetails = errorDetails {
+                ErrorView(errorDetails)
+                    .frame(maxWidth: .infinity)
+            } else if isLoading {
                 LoadingView(whatIsLoading: .posts)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .transition(.opacity)

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -62,7 +62,7 @@ struct FeedView: View {
     
     @State var communityDetails: GetCommunityResponse?
     @State var postSortType: PostSortType
-    @State var isLoading: Bool = false
+    @State var isLoading: Bool = true
     @State var shouldLoad: Bool = false
     
     @AppStorage("hasTranslucentInsets") var hasTranslucentInsets: Bool = true
@@ -128,17 +128,21 @@ struct FeedView: View {
     @ViewBuilder
     private var contentView: some View {
         ScrollView {
-            if postTracker.items.isEmpty {
-                noPostsView()
-            } else {
+            if !postTracker.items.isEmpty {
                 LazyVStack(spacing: 0) {
                     // note: using .uid here because .id causes swipe actions to break--state changes still seem to properly trigger rerenders this way 🤔
                     ForEach(postTracker.items, id: \.uid) { post in
                         feedPost(for: post)
                     }
                     
-                    EndOfFeedView(isLoading: isLoading)
+                    EndOfFeedView(isLoading: isLoading && postTracker.page > 1)
                 }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .overlay {
+            if postTracker.items.isEmpty {
+                noPostsView()
             }
         }
         .fancyTabScrollCompatible()
@@ -146,17 +150,17 @@ struct FeedView: View {
     
     @ViewBuilder
     private func noPostsView() -> some View {
-        if isLoading {
-            LoadingView(whatIsLoading: .posts)
-        } else {
-            VStack(alignment: .center, spacing: 5) {
-                Image(systemName: Icons.noPosts)
-                Text("No posts to be found")
+        VStack {
+            if isLoading {
+                LoadingView(whatIsLoading: .posts)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .transition(.opacity)
+            } else {
+                NoPostsView(isLoading: $isLoading, postSortType: $postSortType, showReadPosts: $showReadPosts)
+                    .transition(.scale(scale: 0.9).combined(with: .opacity))
             }
-            .padding()
-            .foregroundColor(.secondary)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .animation(.easeOut(duration: 0.1), value: isLoading)
     }
     
     // MARK: Helper Views


### PR DESCRIPTION
Centered the loading graphic and replace "no posts to be found" message (see images).
<p float="left">
<img src="https://github.com/mlemgroup/mlem/assets/78750526/37913fad-3fa9-40cd-bd24-7f105aff7235" width=40%>
<img src="https://github.com/mlemgroup/mlem/assets/78750526/e101fcbd-543a-4626-b844-5e22f856abfe" width=40%>
</p>
<p float="left">
<img src="https://github.com/mlemgroup/mlem/assets/78750526/fd6fcaa2-b3ad-477c-adc3-17d89920c418" width=40%>
<img src="https://github.com/mlemgroup/mlem/assets/78750526/0ce32013-1022-4b5a-b4a9-0f9bd67340a1" width=40%>
</p>