### PR TITLE
Fix quicklook dismiss on rotate

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		CDF842642A49EAFA00723DA0 /* GetPersonMentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF842632A49EAFA00723DA0 /* GetPersonMentions.swift */; };
 		CDF8426B2A4A2AB600723DA0 /* InboxItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8426A2A4A2AB600723DA0 /* InboxItem.swift */; };
 		CDF9EF332AB2845C003F885B /* Icons.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF9EF322AB2845C003F885B /* Icons.swift */; };
+		E409E16E2AFEFB8C0026FDC2 /* QuickLookState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E409E16D2AFEFB8C0026FDC2 /* QuickLookState.swift */; };
 		E40E018C2AABF85500410B2C /* AppRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40E018B2AABF85500410B2C /* AppRoutes.swift */; };
 		E40E018E2AABFBDE00410B2C /* AnyNavigationPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40E018D2AABFBDE00410B2C /* AnyNavigationPath.swift */; };
 		E40E01902AABFC9300410B2C /* AnyNavigablePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40E018F2AABFC9300410B2C /* AnyNavigablePath.swift */; };
@@ -982,6 +983,7 @@
 		CDF842632A49EAFA00723DA0 /* GetPersonMentions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPersonMentions.swift; sourceTree = "<group>"; };
 		CDF8426A2A4A2AB600723DA0 /* InboxItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxItem.swift; sourceTree = "<group>"; };
 		CDF9EF322AB2845C003F885B /* Icons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icons.swift; sourceTree = "<group>"; };
+		E409E16D2AFEFB8C0026FDC2 /* QuickLookState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookState.swift; sourceTree = "<group>"; };
 		E40E018B2AABF85500410B2C /* AppRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRoutes.swift; sourceTree = "<group>"; };
 		E40E018D2AABFBDE00410B2C /* AnyNavigationPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyNavigationPath.swift; sourceTree = "<group>"; };
 		E40E018F2AABFC9300410B2C /* AnyNavigablePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyNavigablePath.swift; sourceTree = "<group>"; };
@@ -1472,6 +1474,7 @@
 				030D4AE52AA1273200A3393D /* ErrorDetails.swift */,
 				CDCBD7232A8D62FF00387A2C /* InstanceMetadata.swift */,
 				50CC4A732A9CB10B0074C845 /* TimestampedValue.swift */,
+				E409E16D2AFEFB8C0026FDC2 /* QuickLookState.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2966,6 +2969,7 @@
 				CD8461662A96F9EB0026A627 /* Website Indicator View.swift in Sources */,
 				038A16E92A7A9C640087987E /* LayoutWidget.swift in Sources */,
 				50811B2E2A92046D006BA3F2 /* URL+Mock.swift in Sources */,
+				E409E16E2AFEFB8C0026FDC2 /* QuickLookState.swift in Sources */,
 				CD3FBCE52A4A89B900B2063F /* Mentions Feed View.swift in Sources */,
 				CD391F962A535F5400E213B5 /* ResponseEditorView.swift in Sources */,
 				03EEEAF92ABB985D0087F8D8 /* CommunityModel.swift in Sources */,

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -33,6 +33,8 @@ struct ContentView: View {
     @AppStorage("homeButtonExists") var homeButtonExists: Bool = false
     @AppStorage("allowTabBarSwipeUpGesture") var allowTabBarSwipeUpGesture: Bool = true
     
+    @StateObject private var quickLookState: QuickLookState = .init()
+    
     var accessibilityFont: Bool { UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory }
     
     var body: some View {
@@ -129,9 +131,13 @@ struct ContentView: View {
             .presentationDetents([.medium, .large], selection: .constant(.large))
             ._presentationBackgroundInteraction(enabledUpThrough: .medium)
         }
+        .fullScreenCover(item: $quickLookState.url) { url in
+            QuickLookView(urls: [url])
+        }
         .environment(\.openURL, OpenURLAction(handler: didReceiveURL))
         .environmentObject(editorTracker)
         .environmentObject(unreadTracker)
+        .environmentObject(quickLookState)
         .onChange(of: scenePhase) { phase in
             // when app moves into background, hide the account switcher. This prevents the app from reopening with the switcher enabled.
             if phase != .active {

--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -16,6 +16,7 @@ struct HandleLemmyLinksDisplay: ViewModifier {
     @EnvironmentObject private var layoutWidgetTracker: LayoutWidgetTracker
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var filtersTracker: FiltersTracker
+    @EnvironmentObject private var quickLookState: QuickLookState
     
     @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
     
@@ -31,10 +32,12 @@ struct HandleLemmyLinksDisplay: ViewModifier {
                     FeedView(community: community, feedType: .all)
                         .environmentObject(appState)
                         .environmentObject(filtersTracker)
+                        .environmentObject(quickLookState)
                 case .communityLinkWithContext(let context):
                     FeedView(community: context.community, feedType: context.feedType)
                         .environmentObject(appState)
                         .environmentObject(filtersTracker)
+                        .environmentObject(quickLookState)
                 case .communitySidebarLinkWithContext(let context):
                     CommunitySidebarView(
                         community: context.community
@@ -53,22 +56,29 @@ struct HandleLemmyLinksDisplay: ViewModifier {
                     ExpandedPost(post: postModel)
                         .environmentObject(postTracker)
                         .environmentObject(appState)
+                        .environmentObject(quickLookState)
                 case .apiPost(let post):
                     LazyLoadExpandedPost(post: post)
+                        .environmentObject(quickLookState)
                 case .apiPerson(let user):
                     UserView(userID: user.id)
+                        .environmentObject(quickLookState)
                 case .userProfile(let user):
                     UserView(userID: user.userId)
                         .environmentObject(appState)
+                        .environmentObject(quickLookState)
                 case .postLinkWithContext(let post):
                     ExpandedPost(post: post.post, scrollTarget: post.scrollTarget)
                         .environmentObject(post.postTracker)
                         .environmentObject(appState)
+                        .environmentObject(quickLookState)
                 case .lazyLoadPostLinkWithContext(let post):
                     LazyLoadExpandedPost(post: post.post, scrollTarget: post.scrollTarget)
+                        .environmentObject(quickLookState)
                 case .userModeratorLink(let user):
                     UserModeratorView(userDetails: user.user, moderatedCommunities: user.moderatedCommunities)
                         .environmentObject(appState)
+                        .environmentObject(quickLookState)
                 case .settings(let page):
                     settingsDestination(for: page)
                 case .aboutSettings(let page):

--- a/Mlem/Models/QuickLookState.swift
+++ b/Mlem/Models/QuickLookState.swift
@@ -1,0 +1,12 @@
+//
+//  QuickLookState.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-11-10.
+//
+
+import Foundation
+
+final class QuickLookState: ObservableObject {
+    @Published var url: URL?
+}

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -31,8 +31,8 @@ struct CachedImage: View {
     let cornerRadius: CGFloat
     let errorBackgroundColor: Color
     
-    // Optional callback triggered when the quicklook preview is dismissed
-    let dismissCallback: (() -> Void)?
+    // Optional callback triggered when the quicklook preview is presented on tap gesture.
+    let onTapCallback: (() -> Void)?
     
     init(
         url: URL?,
@@ -42,7 +42,7 @@ struct CachedImage: View {
         imageNotFound: @escaping () -> AnyView = imageNotFoundDefault,
         errorBackgroundColor: Color = Color(uiColor: .systemGray4),
         contentMode: ContentMode = .fit,
-        dismissCallback: (() -> Void)? = nil,
+        onTapCallback: (() -> Void)? = nil,
         cornerRadius: CGFloat? = nil
     ) {
         self.url = url
@@ -51,7 +51,7 @@ struct CachedImage: View {
         self.imageNotFound = imageNotFound
         self.errorBackgroundColor = errorBackgroundColor
         self.contentMode = contentMode
-        self.dismissCallback = dismissCallback
+        self.onTapCallback = onTapCallback
         self.cornerRadius = cornerRadius ?? 0
         
         self.screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
@@ -136,7 +136,7 @@ struct CachedImage: View {
                                     await MainActor.run {
                                         quickLookState.url = quicklook
                                         /// Since quickLookState is a global state, calling callback on tap ensures we only call one callback (i.e. the one user requested to view). [2023.11]
-                                        dismissCallback?()
+                                        onTapCallback?()
                                         /// It takes some time for actual QuickLookUI to appear:
                                         /// Ideally, progress view is removed once QuickLookUI fully appears. 
                                         /// [2023.11]

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -134,20 +134,20 @@ struct CachedImage: View {
                                     }
                                     try data.write(to: quicklook)
                                     await MainActor.run {
-                                        /// It takes some time for actual UI to appear.
+                                        quickLookState.url = quicklook
+                                        /// Since quickLookState is a global state, calling callback on tap ensures we only call one callback (i.e. the one user requested to view). [2023.11]
+                                        dismissCallback?()
+                                        /// It takes some time for actual QuickLookUI to appear:
+                                        /// Ideally, progress view is removed once QuickLookUI fully appears. 
+                                        /// [2023.11]
                                         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                                             isPresentingQuickLook = false
                                         }
-                                        quickLookState.url = quicklook
                                     }
                                 } catch {
                                     print(String(describing: error))
+                                    isPresentingQuickLook = false
                                 }
-                            }
-                        }
-                        .onChange(of: quickLookState.url) { url in
-                            if url == nil, let dismissCallback {
-                                dismissCallback()
                             }
                         }
                 } else {

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -21,6 +21,8 @@ struct CachedImage: View {
     @State var shouldRecomputeSize: Bool
     @State private var quickLookUrl: URL?
     
+    @EnvironmentObject private var quickLookState: QuickLookState
+    
     var imageNotFound: () -> AnyView
     
     let maxHeight: CGFloat
@@ -121,20 +123,17 @@ struct CachedImage: View {
                                     }
                                     try data.write(to: quicklook)
                                     await MainActor.run {
-                                        quickLookUrl = quicklook
+                                        quickLookState.url = quicklook
                                     }
                                 } catch {
                                     print(String(describing: error))
                                 }
                             }
                         }
-                        .onChange(of: quickLookUrl) { url in
+                        .onChange(of: quickLookState.url) { url in
                             if url == nil, let dismissCallback {
                                 dismissCallback()
                             }
-                        }
-                        .fullScreenCover(item: $quickLookUrl) { url in
-                            QuickLookView(urls: [url])
                         }
                 } else {
                     imageView

--- a/Mlem/Views/Shared/Components/Thumbnail Image View.swift
+++ b/Mlem/Views/Shared/Components/Thumbnail Image View.swift
@@ -32,7 +32,7 @@ struct ThumbnailImageView: View {
                     url: url,
                     fixedSize: size,
                     contentMode: .fill,
-                    dismissCallback: markPostAsRead
+                    onTapCallback: markPostAsRead
                 )
                 .blur(radius: showNsfwFilter ? 8 : 0)
             case let .link(url):

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -13,7 +13,6 @@
 // swiftlint:disable type_body_length
 
 import Dependencies
-import QuickLook
 import SwiftUI
 
 /// Displays a single post in the feed

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -203,7 +203,7 @@ struct LargePost: View {
                     CachedImage(
                         url: url,
                         maxHeight: layoutMode.getMaxHeight(limitHeight),
-                        dismissCallback: markPostAsRead,
+                        onTapCallback: markPostAsRead,
                         cornerRadius: AppConstants.largeItemCornerRadius
                     )
                     .frame(


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #747 (reported via Lemmy community)
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
1. Fixes issue where rotating device while QuickLookUI is presented causes that UI to be dismissed.
2. Adds a progress view overlay on top of CachedImage while QuickLookUI is preparing to open, since sometimes QuickLookUI doesn't immediately open on tap gesture.

## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/2549615/31b792ff-7480-4df8-82c3-f61818a5e0e0

## Additional Context
Rotation bug **might** not be reproducible in iOS simulator.
