### PR TITLE
Double Tap for Scroll to Top

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		6DEB0FFD2A4F891B007CAB99 /* User Moderator Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEB0FFC2A4F891B007CAB99 /* User Moderator Link.swift */; };
 		6DFF50432A48DED3001E648D /* Inbox View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFF50422A48DED3001E648D /* Inbox View.swift */; };
 		6DFF50452A48E373001E648D /* GetPrivateMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFF50442A48E373001E648D /* GetPrivateMessages.swift */; };
+		6F872EF22B05431E0035CF54 /* ScrollState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F872EF12B05431E0035CF54 /* ScrollState.swift */; };
 		88B165B82A8643F4007C9115 /* View - NavigationBar Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B165B72A8643F4007C9115 /* View - NavigationBar Color.swift */; };
 		AD1B0D352A5F63F60006F554 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1B0D342A5F63F60006F554 /* AboutView.swift */; };
 		AD1B0D372A5F7A260006F554 /* Licenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1B0D362A5F7A260006F554 /* Licenses.swift */; };
@@ -802,6 +803,7 @@
 		6DEB0FFC2A4F891B007CAB99 /* User Moderator Link.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User Moderator Link.swift"; sourceTree = "<group>"; };
 		6DFF50422A48DED3001E648D /* Inbox View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox View.swift"; sourceTree = "<group>"; };
 		6DFF50442A48E373001E648D /* GetPrivateMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPrivateMessages.swift; sourceTree = "<group>"; };
+		6F872EF12B05431E0035CF54 /* ScrollState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollState.swift; sourceTree = "<group>"; };
 		88B165B72A8643F4007C9115 /* View - NavigationBar Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View - NavigationBar Color.swift"; sourceTree = "<group>"; };
 		AD1B0D342A5F63F60006F554 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		AD1B0D362A5F7A260006F554 /* Licenses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Licenses.swift; sourceTree = "<group>"; };
@@ -1484,6 +1486,7 @@
 				CDCBD7232A8D62FF00387A2C /* InstanceMetadata.swift */,
 				50CC4A732A9CB10B0074C845 /* TimestampedValue.swift */,
 				E409E16D2AFEFB8C0026FDC2 /* QuickLookState.swift */,
+				6F872EF12B05431E0035CF54 /* ScrollState.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2920,6 +2923,7 @@
 				50CC4A7F2AA0D3AA0074C845 /* InstanceMetadataParser.swift in Sources */,
 				CD4368B82AE23F5400BD8BD1 /* ParentTrackerProtocol.swift in Sources */,
 				637218492A3A2AAD008C4816 /* APICommentReplyView.swift in Sources */,
+				6F872EF22B05431E0035CF54 /* ScrollState.swift in Sources */,
 				CD4368C82AE2426700BD8BD1 /* ReplyModel.swift in Sources */,
 				6317ABCB2A37292700603D76 /* FeedType.swift in Sources */,
 				CDC65D8F2A86B6DD007205E5 /* DeleteUser.swift in Sources */,

--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -22,6 +22,8 @@ struct HandleLemmyLinksDisplay: ViewModifier {
     
     @AppStorage("upvoteOnSave") var upvoteOnSave = false
     
+    @StateObject var scrollState = ScrollState()
+    
     // swiftlint:disable function_body_length
     // swiftlint:disable:next cyclomatic_complexity
     func body(content: Content) -> some View {
@@ -33,11 +35,13 @@ struct HandleLemmyLinksDisplay: ViewModifier {
                         .environmentObject(appState)
                         .environmentObject(filtersTracker)
                         .environmentObject(quickLookState)
+                        .environmentObject(scrollState)
                 case .communityLinkWithContext(let context):
                     FeedView(community: context.community, feedType: context.feedType)
                         .environmentObject(appState)
                         .environmentObject(filtersTracker)
                         .environmentObject(quickLookState)
+                        .environmentObject(scrollState)
                 case .communitySidebarLinkWithContext(let context):
                     CommunitySidebarView(
                         community: context.community

--- a/Mlem/Models/ScrollState.swift
+++ b/Mlem/Models/ScrollState.swift
@@ -1,0 +1,13 @@
+//
+//  ScrollState.swift
+//  Mlem
+//
+//  Created by Sumeet Gill on 2023-11-15.
+//
+
+import Foundation
+
+class ScrollState: ObservableObject {
+    var shouldScrollToTop: Bool = false
+    var clickCount: Int = 0
+}

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -10,6 +10,7 @@ import Dependencies
 
 struct FeedRoot: View {
     @EnvironmentObject var appState: AppState
+    @StateObject var scrollState = ScrollState()
     @Environment(\.scenePhase) var phase
     @Environment(\.tabSelectionHashValue) private var selectedTagHashValue
     @Environment(\.tabNavigationSelectionHashValue) private var selectedNavigationTabHashValue
@@ -43,6 +44,7 @@ struct FeedRoot: View {
         )
         .environmentObject(feedTabNavigation)
         .environmentObject(appState)
+        .environmentObject(scrollState)
         .onAppear {
             if rootDetails == nil || shortcutItemToProcess != nil {
                 let feedType = FeedType(rawValue:
@@ -82,6 +84,12 @@ struct FeedRoot: View {
         }
         .onChange(of: selectedNavigationTabHashValue) { newValue in
             if newValue == TabSelection.feeds.hashValue {
+                scrollState.clickCount += 1
+                
+                if scrollState.clickCount == 2 {
+                    scrollState.shouldScrollToTop = true
+                    scrollState.clickCount = 0
+                }
                 print("re-selected \(TabSelection.feeds) tab")
             }
         }

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -26,6 +26,7 @@ struct FeedView: View {
     @AppStorage("showReadPosts") var showReadPosts: Bool = true
     
     @EnvironmentObject var appState: AppState
+    @EnvironmentObject var scrollState: ScrollState
     @EnvironmentObject var filtersTracker: FiltersTracker
     @EnvironmentObject var editorTracker: EditorTracker
     
@@ -65,7 +66,6 @@ struct FeedView: View {
     @State var isLoading: Bool = true
     @State var siteInformationLoading: Bool = true
     @State var shouldLoad: Bool = false
-    @State var scrollToTop: Bool = false
     
     @AppStorage("hasTranslucentInsets") var hasTranslucentInsets: Bool = true
     
@@ -171,10 +171,13 @@ struct FeedView: View {
                 }
             }
             .fancyTabScrollCompatible()
-            .onChange(of: scrollToTop) { value in
+            .onChange(of: scrollState.shouldScrollToTop) { value in
                 if value {
-                    reader.scrollTo("topOfFeed")
-                    scrollToTop = false
+                    withAnimation(.smooth(duration: 5, extraBounce: 3.0)) {
+                        reader.scrollTo("topOfFeed", anchor: .bottomLeading)
+                    }
+                    scrollState.shouldScrollToTop = false
+                    print("scrolled to top")
                 }
             }
         }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - N/A
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request

Adding functionality that scrolls to the top of the feed when a user double clicks the feed button. Just wanted to add it because it's a feature I miss when using Apollo. It's also a way to for me to get more into swiftUI.

The animations are a bit bare bones right now but wanted to get feedback on this before I proceed further.

Note: This currently fails swift lint's `type_body_length` rule since it adds 10 lines of code and the body is already at the max (250). Not sure if that would be open to changing as it does seem a bit restrictive in my opinion.


## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/1139817/26c156ab-8a29-4303-aa5e-f2726e694740


## Additional Context 

Bulk of the "changes" is me adding a ScrollViewReader and state tracker for double clicking the button. Please let me know if you need additional information.