### PR TITLE
made image share share image directly instead of url

### DIFF
--- a/Mlem/Models/User-Interactable/Menu Function.swift
+++ b/Mlem/Models/User-Interactable/Menu Function.swift
@@ -6,19 +6,23 @@
 //
 
 import Foundation
+import SwiftUI
 
 enum MenuFunction: Identifiable {
     var id: String {
         switch self {
         case let .standard(standardMenuFunction):
             return standardMenuFunction.id
-        case let .share(shareMenuFunction):
+        case let .shareUrl(shareMenuFunction):
             return shareMenuFunction.id
+        case let .shareImage(shareImageFunction):
+            return shareImageFunction.id
         }
     }
     
     case standard(StandardMenuFunction)
-    case share(ShareMenuFunction)
+    case shareUrl(ShareMenuFunction)
+    case shareImage(ShareImageFunction)
 }
 
 // some convenience initializers because MenuFunction.standard(StandardMenuFunction...) is ugly
@@ -40,7 +44,11 @@ extension MenuFunction {
     }
     
     static func shareMenuFunction(url: URL) -> MenuFunction {
-        MenuFunction.share(ShareMenuFunction(url: url))
+        MenuFunction.shareUrl(ShareMenuFunction(url: url))
+    }
+    
+    static func shareImageFunction(image: Image) -> MenuFunction {
+        MenuFunction.shareImage(ShareImageFunction(image: image))
     }
 }
 
@@ -49,6 +57,16 @@ struct ShareMenuFunction: Identifiable {
     var id: String { url.absoluteString }
     
     let url: URL
+}
+
+struct ShareImageFunction: Identifiable {
+    let id: String
+    let image: Image
+    
+    init(image: Image) {
+        self.image = image
+        self.id = UUID().uuidString
+    }
 }
 
 /// MenuFunction to perform a generic menu action

--- a/Mlem/Temp Image Viewer/ZoomableImageView.swift
+++ b/Mlem/Temp Image Viewer/ZoomableImageView.swift
@@ -31,7 +31,7 @@ struct ZoomableImageView: View {
                         .scaledToFit()
                         .scaleEffect(zoom)
                         .contextMenu {
-                            ForEach(genMenuFunctions()) { item in
+                            ForEach(genMenuFunctions(image: image)) { item in
                                 MenuButton(menuFunction: item, confirmDestructive: nil)
                             }
                         }
@@ -73,7 +73,7 @@ struct ZoomableImageView: View {
         }
     }
     
-    func genMenuFunctions() -> [MenuFunction] {
+    func genMenuFunctions(image: Image) -> [MenuFunction] {
         var ret: [MenuFunction] = .init()
         
         ret.append(MenuFunction.standardMenuFunction(
@@ -98,7 +98,7 @@ struct ZoomableImageView: View {
             }
         })
         
-        ret.append(MenuFunction.share(ShareMenuFunction(url: url)))
+        ret.append(MenuFunction.shareImageFunction(image: image))
         
         return ret
     }

--- a/Mlem/Views/Shared/Components/Components/Menu Button.swift
+++ b/Mlem/Views/Shared/Components/Components/Menu Button.swift
@@ -14,8 +14,10 @@ struct MenuButton: View {
 
     var body: some View {
         switch menuFunction {
-        case let .share(shareMenuFunction):
+        case let .shareUrl(shareMenuFunction):
             ShareLink(item: shareMenuFunction.url)
+        case let .shareImage(shareImageFunction):
+            ShareLink(item: shareImageFunction.image, preview: .init("photo", image: shareImageFunction.image))
         case let .standard(standardMenuFunction):
             let role: ButtonRole? = standardMenuFunction.destructiveActionPrompt != nil ? .destructive : nil
             Button(role: role) {


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - *list issue(s) here*
- [x] If this PR alters the UI, I have attached pictures/videos

Fixes a bug with the new image viewer where it would share the image URL instead of the image itself. To support this, adds a `.shareImage` case to `MenuFunction`.
