### PR TITLE
Added reselect actions to inbox and profile

### DIFF
--- a/Mlem/Views/Tabs/Inbox/Feed/AllItemsFeedView.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/AllItemsFeedView.swift
@@ -19,6 +19,7 @@ struct AllItemsFeedView: View {
                 noItemsView()
             } else {
                 LazyVStack(spacing: 0) {
+                    EmptyView().id("top")
                     inboxListView()
                 }
             }

--- a/Mlem/Views/Tabs/Inbox/Feed/Mentions Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Mentions Feed View.swift
@@ -16,6 +16,7 @@ struct MentionsFeedView: View {
             noMentionsView()
         } else {
             LazyVStack(spacing: 0) {
+                EmptyView().id("top")
                 mentionsListView()
             }
         }

--- a/Mlem/Views/Tabs/Inbox/Feed/Messages Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Messages Feed View.swift
@@ -16,6 +16,7 @@ struct MessagesFeedView: View {
             noMessagesView()
         } else {
             LazyVStack(spacing: 0) {
+                EmptyView().id("top")
                 messagesListView()
             }
         }

--- a/Mlem/Views/Tabs/Inbox/Feed/Replies Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Replies Feed View.swift
@@ -16,6 +16,7 @@ struct RepliesFeedView: View {
             noRepliesView()
         } else {
             LazyVStack(spacing: 0) {
+                EmptyView().id("top")
                 repliesListView()
             }
         }

--- a/Mlem/Views/Tabs/Profile/Profile View.swift
+++ b/Mlem/Views/Tabs/Profile/Profile View.swift
@@ -22,8 +22,5 @@ struct ProfileView: View {
                 .handleLemmyViews()
         }
         .handleLemmyLinkResolution(navigationPath: .constant(profileTabNavigation))
-        .reselectAction(tab: TabSelection.profile) {
-            print("re-selected profile")
-        }
     }
 }

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -114,48 +114,57 @@ struct UserView: View {
     }
     
     private func view(for userDetails: APIPersonView) -> some View {
-        ScrollView {
-            header(for: userDetails)
-            
-            if let bio = userDetails.person.bio {
-                MarkdownView(text: bio, isNsfw: false).padding()
-            }
-            
-            Picker(selection: $selectionSection, label: Text("Profile Section")) {
-                ForEach(UserViewTab.allCases, id: \.id) { tab in
-                    // Skip tabs that are meant for only our profile
-                    if tab.onlyShowInOwnProfile {
-                        if isShowingOwnProfile() {
+        ScrollViewReader { scrollProxy in
+            ScrollView {
+                EmptyView().id("top")
+                
+                header(for: userDetails)
+                
+                if let bio = userDetails.person.bio {
+                    MarkdownView(text: bio, isNsfw: false).padding()
+                }
+                
+                Picker(selection: $selectionSection, label: Text("Profile Section")) {
+                    ForEach(UserViewTab.allCases, id: \.id) { tab in
+                        // Skip tabs that are meant for only our profile
+                        if tab.onlyShowInOwnProfile {
+                            if isShowingOwnProfile() {
+                                Text(tab.label).tag(tab.rawValue)
+                            }
+                        } else {
                             Text(tab.label).tag(tab.rawValue)
                         }
-                    } else {
-                        Text(tab.label).tag(tab.rawValue)
                     }
                 }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+                
+                UserFeedView(
+                    userID: userID,
+                    privatePostTracker: privatePostTracker,
+                    privateCommentTracker: privateCommentTracker,
+                    selectedTab: $selectionSection
+                )
             }
-            .pickerStyle(.segmented)
-            .padding(.horizontal)
-            
-            UserFeedView(
-                userID: userID,
-                privatePostTracker: privatePostTracker,
-                privateCommentTracker: privateCommentTracker,
-                selectedTab: $selectionSection
-            )
-        }
-        .fancyTabScrollCompatible()
-        .environmentObject(privatePostTracker)
-        .environmentObject(privateCommentTracker)
-        .navigationTitle(userDetails.person.displayName ?? userDetails.person.name)
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationBarColor()
-        .headerProminence(.standard)
-        .refreshable {
-            await tryReloadUser()
-        }.toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                accountSwitcher
-                moderatorButton
+            .fancyTabScrollCompatible()
+            .environmentObject(privatePostTracker)
+            .environmentObject(privateCommentTracker)
+            .navigationTitle(userDetails.person.displayName ?? userDetails.person.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarColor()
+            .headerProminence(.standard)
+            .refreshable {
+                await tryReloadUser()
+            }.toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    accountSwitcher
+                    moderatorButton
+                }
+            }
+            .reselectAction(tab: .profile) {
+                withAnimation {
+                    scrollProxy.scrollTo("top")
+                }
             }
         }
     }

--- a/Mlem/Views/Tabs/Search/SearchView.swift
+++ b/Mlem/Views/Tabs/Search/SearchView.swift
@@ -35,7 +35,6 @@ struct SearchView: View {
     @StateObject var homeContentTracker: ContentTracker<AnyContentModel> = .init()
     
     @State var isSearching: Bool = false
-    @State var searchBarFocused: Bool = true
     @State var page: Page = .home
     
     @State private var recentsScrollToTopSignal: Int = .min

--- a/Mlem/Views/Tabs/Search/SearchView.swift
+++ b/Mlem/Views/Tabs/Search/SearchView.swift
@@ -35,6 +35,7 @@ struct SearchView: View {
     @StateObject var homeContentTracker: ContentTracker<AnyContentModel> = .init()
     
     @State var isSearching: Bool = false
+    @State var searchBarFocused: Bool = true
     @State var page: Page = .home
     
     @State private var recentsScrollToTopSignal: Int = .min
@@ -82,6 +83,9 @@ struct SearchView: View {
                     resultsScrollToTopSignal += 1
                 }
             }
+//            .reselectAction(tab: .search) {
+//                isSearching = true
+//            }
     }
     
     @ViewBuilder

--- a/Mlem/Views/Tabs/Search/SearchView.swift
+++ b/Mlem/Views/Tabs/Search/SearchView.swift
@@ -83,9 +83,6 @@ struct SearchView: View {
                     resultsScrollToTopSignal += 1
                 }
             }
-//            .reselectAction(tab: .search) {
-//                isSearching = true
-//            }
     }
     
     @ViewBuilder
@@ -150,7 +147,6 @@ struct SearchView: View {
 }
 
 extension View {
-    
     @ViewBuilder
     func _opacity(_ opacity: Double, speed: Double) -> some View {
         if #available(iOS 17.0, *) {
@@ -166,12 +162,12 @@ extension View {
         } else {
             self.opacity(opacity)
                 .transaction { transaction in
-                if speed > 0 {
-                    transaction.animation = transaction.animation?.speed(speed)
-                } else {
-                    transaction.animation = nil
+                    if speed > 0 {
+                        transaction.animation = transaction.animation?.speed(speed)
+                    } else {
+                        transaction.animation = nil
+                    }
                 }
-            }
         }
     }
 }
@@ -181,7 +177,6 @@ extension View {
 }
 
 struct SearchViewPreview: View {
-
     @StateObject private var appState: AppState = .init()
     @StateObject private var recentSearchesTracker: RecentSearchesTracker = .init()
 


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - sry
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR adds the reselect scroll-to-top to the inbox and the profile view.

I took a couple hacks at search, but programmatically selecting that search bar turns out to be deeply tricky