### PR TITLE
Fix enter background crash on iPad

### DIFF
--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -72,6 +72,7 @@ struct HandleLemmyLinksDisplay: ViewModifier {
                         .environmentObject(post.postTracker)
                         .environmentObject(appState)
                         .environmentObject(quickLookState)
+                        .environmentObject(layoutWidgetTracker)
                 case let .lazyLoadPostLinkWithContext(post):
                     LazyLoadExpandedPost(post: post.post, scrollTarget: post.scrollTarget)
                         .environmentObject(quickLookState)


### PR DESCRIPTION
# Checklist
- [ ] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [ ] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
- [ ] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information
Fixes issue where `layoutWidgetTracker` mysteriously disappears from View environment on iPad only in `ExpandedPost` when driven using the `.postLinkWithContext(post)` navigation value.

## About this Pull Request
Fixes the following issues: #765, #776 
