### PR TITLE
Encoding case fix

### DIFF
--- a/Mlem/API/APIClient/APIClient.swift
+++ b/Mlem/API/APIClient/APIClient.swift
@@ -161,7 +161,9 @@ class APIClient {
 
     private func createBodyData(for defintion: any APIRequestBodyProviding) throws -> Data {
         do {
-            return try JSONEncoder().encode(defintion.body)
+            var encoder = JSONEncoder()
+            encoder.keyEncodingStrategy = .convertToSnakeCase
+            return try encoder.encode(defintion.body)
         } catch {
             throw APIClientError.encoding(error)
         }


### PR DESCRIPTION
Currently, when we convert a `Codable` into a JSON, camelCase key names are **not** converted into snake_case. They must be in snake_case for Lemmy to read them. We already decode snake_case into camelCase correctly when we receive a response from the API, but do not convert the keys from snake_case into camelCase when we send a request. This PR fixes this issue.

 This has not caused issues for many parts of the program because one-word keys are the same in both snake_case and camelCase. However, anywhere where we might have been sending multi-word keys will not have been working correctly.