### PR TITLE
1.1.1 Bugfixes

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -394,6 +394,7 @@
 		CD69F5712A422EDD0028D4F7 /* InteractionBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F5702A422EDD0028D4F7 /* InteractionBarView.swift */; };
 		CD69F5732A4239D70028D4F7 /* Comment Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F5722A4239D70028D4F7 /* Comment Item.swift */; };
 		CD69F5752A42479A0028D4F7 /* Comment Item Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69F5742A42479A0028D4F7 /* Comment Item Logic.swift */; };
+		CD6A2A792B1A553500003E23 /* SuccessResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6A2A782B1A553500003E23 /* SuccessResponse.swift */; };
 		CD6F29A82A77FF1700F20B6B /* MarkPostRead.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6F29A72A77FF1700F20B6B /* MarkPostRead.swift */; };
 		CD6F29AA2A78003A00F20B6B /* PostRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6F29A92A78003A00F20B6B /* PostRepository.swift */; };
 		CD6F29AC2A78015200F20B6B /* PostRepository+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6F29AB2A78015200F20B6B /* PostRepository+Dependency.swift */; };
@@ -908,6 +909,7 @@
 		CD69F5702A422EDD0028D4F7 /* InteractionBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionBarView.swift; sourceTree = "<group>"; };
 		CD69F5722A4239D70028D4F7 /* Comment Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comment Item.swift"; sourceTree = "<group>"; };
 		CD69F5742A42479A0028D4F7 /* Comment Item Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comment Item Logic.swift"; sourceTree = "<group>"; };
+		CD6A2A782B1A553500003E23 /* SuccessResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessResponse.swift; sourceTree = "<group>"; };
 		CD6F29A72A77FF1700F20B6B /* MarkPostRead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkPostRead.swift; sourceTree = "<group>"; };
 		CD6F29A92A78003A00F20B6B /* PostRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRepository.swift; sourceTree = "<group>"; };
 		CD6F29AB2A78015200F20B6B /* PostRepository+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostRepository+Dependency.swift"; sourceTree = "<group>"; };
@@ -1805,6 +1807,7 @@
 		637218042A3A2AAD008C4816 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				CD6A2A772B1A552800003E23 /* Common */,
 				CDF842582A49D23800723DA0 /* Messages */,
 				637218052A3A2AAD008C4816 /* Comments */,
 				6372180B2A3A2AAD008C4816 /* Posts */,
@@ -2298,6 +2301,14 @@
 				CDDB2EDD2A85C2F1001D4B16 /* HapticPriority.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		CD6A2A772B1A552800003E23 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				CD6A2A782B1A553500003E23 /* SuccessResponse.swift */,
+			);
+			path = Common;
 			sourceTree = "<group>";
 		};
 		CD82A2512A716B5D00111034 /* Repositories */ = {
@@ -3145,6 +3156,7 @@
 				B1A26FE32A45B11800B91A32 /* View - Handle Lemmy Links.swift in Sources */,
 				03B643572A6864CD00F65700 /* TabBarSettingsView.swift in Sources */,
 				CDF842642A49EAFA00723DA0 /* GetPersonMentions.swift in Sources */,
+				CD6A2A792B1A553500003E23 /* SuccessResponse.swift in Sources */,
 				6D405B052A43E82300C65F9C /* Sidebar Header.swift in Sources */,
 				CD4368B42AE23F3500BD8BD1 /* ChildTrackerProtocol.swift in Sources */,
 				CD4368D92AE2478300BD8BD1 /* MentionModel+InboxItem.swift in Sources */,

--- a/Mlem/API/APIClient/APIClient+Post.swift
+++ b/Mlem/API/APIClient/APIClient+Post.swift
@@ -36,9 +36,11 @@ extension APIClient {
 
     // swiftlint:enable function_parameter_count
     
-    func markPostAsRead(for postId: Int, read: Bool) async throws -> PostResponse {
+    func markPostAsRead(for postId: Int, read: Bool) async throws -> SuccessResponse {
         let request = try MarkPostReadRequest(session: session, postId: postId, read: read)
-        return try await perform(request: request)
+        // TODO: 0.18 deprecation simply return result of perform
+        let compatibilityResponse = try await perform(request: request)
+        return SuccessResponse(from: compatibilityResponse)
     }
     
     func loadPost(id: Int, commentId: Int? = nil) async throws -> APIPostView {

--- a/Mlem/API/Models/Common/SuccessResponse.swift
+++ b/Mlem/API/Models/Common/SuccessResponse.swift
@@ -12,6 +12,7 @@ struct SuccessResponse: Decodable {
     let success: Bool
     
     // TODO: 0.18 deprecation remove all code below this point
+    // To handle multiple API specs, I have defined "compatibility responses" that encompass multiple response specs. These initializers then handle converting the compatibility response to a SuccessResponse.
     init(from compatibilityResponse: MarkReadCompatibilityResponse) {
         if let success = compatibilityResponse.success {
             self.success = success

--- a/Mlem/API/Models/Common/SuccessResponse.swift
+++ b/Mlem/API/Models/Common/SuccessResponse.swift
@@ -1,0 +1,29 @@
+//
+//  SuccessResponse.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-12-01.
+//
+
+import Foundation
+
+// lemmy/crates/api_common/src/lib.rs
+struct SuccessResponse: Decodable {
+    let success: Bool
+    
+    // TODO: 0.18 deprecation remove all code below this point
+    init(from compatibilityResponse: MarkReadCompatibilityResponse) {
+        if let success = compatibilityResponse.success {
+            self.success = success
+        } else if let postView = compatibilityResponse.postView {
+            self.success = true
+        } else {
+            self.success = false
+        }
+    }
+}
+
+struct MarkReadCompatibilityResponse: Decodable {
+    let success: Bool?
+    let postView: APIPostView?
+}

--- a/Mlem/API/Requests/Post/MarkPostRead.swift
+++ b/Mlem/API/Requests/Post/MarkPostRead.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct MarkPostReadRequest: APIPostRequest {
-    typealias Response = PostResponse
+    typealias Response = MarkReadCompatibilityResponse
 
     let instanceURL: URL
     let path = "post/mark_as_read"

--- a/Mlem/Models/Content/Post Model.swift
+++ b/Mlem/Models/Content/Post Model.swift
@@ -17,7 +17,7 @@ struct PostModel {
     var votes: VotesModel
     let numReplies: Int
     let saved: Bool
-    var read: Bool
+    let read: Bool
     let published: Date
     let updated: Date?
     

--- a/Mlem/Models/Content/Post Model.swift
+++ b/Mlem/Models/Content/Post Model.swift
@@ -17,7 +17,7 @@ struct PostModel {
     var votes: VotesModel
     let numReplies: Int
     let saved: Bool
-    let read: Bool
+    var read: Bool
     let published: Date
     let updated: Date?
     

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -232,7 +232,7 @@ class PostTracker: ObservableObject {
     @MainActor
     func removeUserPosts(from personId: Int) {
         filter {
-            $0.creator.id != personId
+            $0.creator.userId != personId
         }
     }
     
@@ -368,7 +368,7 @@ class PostTracker: ObservableObject {
         
         // perform real read
         do {
-            let response = try await postRepository.markRead(postId: post.postId, read: true)
+            let response = try await postRepository.markRead(post: post, read: true)
             await update(with: response)
         } catch {
             hapticManager.play(haptic: .failure, priority: .high)

--- a/Mlem/Repositories/PostRepository.swift
+++ b/Mlem/Repositories/PostRepository.swift
@@ -47,9 +47,13 @@ class PostRepository {
         return PostModel(from: postView)
     }
     
-    func markRead(postId: Int, read: Bool) async throws -> PostModel {
-        let postView = try await apiClient.markPostAsRead(for: postId, read: read).postView
-        return PostModel(from: postView)
+    /// Attempts to mark the given PostModel as read. On success, returns a new PostModel with the updated read state; on failure, returns the original PostModel.
+    /// - Parameters:
+    ///   - post: PostModel to attempt to read
+    ///   - read: Intended read state of the post model (true to mark read, false to mark unread)
+    func markRead(post: PostModel, read: Bool) async throws -> PostModel {
+        let success = try await apiClient.markPostAsRead(for: post.postId, read: read).success
+        return PostModel(from: post, read: success ? read : post.read)
     }
 
     /// Rates a given post. Does not care what the current vote state is; sends the given request no matter what (i.e., calling this with operation .upvote on an already upvoted post will not send a .resetVote, but will instead send a second idempotent .upvote

--- a/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
+++ b/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
@@ -71,9 +71,9 @@ extension ExpandedPost {
     
     func blockUser() async {
         do {
-            let response = try await apiClient.blockPerson(id: post.creator.id, shouldBlock: true)
+            let response = try await apiClient.blockPerson(id: post.creator.userId, shouldBlock: true)
             if response.blocked {
-                postTracker.removeUserPosts(from: post.creator.id)
+                postTracker.removeUserPosts(from: post.creator.userId)
                 hapticManager.play(haptic: .violentSuccess, priority: .high)
                 await notifier.add(.success("Blocked \(post.creator.name)"))
             }
@@ -149,7 +149,7 @@ extension ExpandedPost {
             replyToPost()
         })
         
-        if appState.isCurrentAccountId(post.creator.id) {
+        if appState.isCurrentAccountId(post.creator.userId) {
             // edit
             ret.append(MenuFunction.standardMenuFunction(
                 text: "Edit",

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -228,9 +228,9 @@ struct FeedPost: View {
     func blockUser() async {
         // TODO: migrate to personRepository
         do {
-            let response = try await apiClient.blockPerson(id: post.creator.id, shouldBlock: true)
+            let response = try await apiClient.blockPerson(id: post.creator.userId, shouldBlock: true)
             if response.blocked {
-                postTracker.removeUserPosts(from: post.creator.id)
+                postTracker.removeUserPosts(from: post.creator.userId)
                 hapticManager.play(haptic: .violentSuccess, priority: .high)
                 await notifier.add(.success("Blocked \(post.creator.name)"))
             }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #783 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR includes two small bugfixes:
- Fixed being unable to block users from posts following the migration to `PostModel`. `.id` (hash of the struct) was being passed in instead of `.userId` (Lemmy-side user id), resulting in a 404.
- Fixed marking posts as read not working on 0.19. Added decoding for the new SuccessResponse, and some compatibility logic to handle multiple API versions.