### PR TITLE
0.19 account reauth

### DIFF
--- a/Mlem/API/Models/APIErrorResponse.swift
+++ b/Mlem/API/Models/APIErrorResponse.swift
@@ -36,7 +36,6 @@ private let registrationErrors = [
 ]
 
 extension APIErrorResponse {
-    // var isIncorrectLogin: Bool { possibleCredentialErrors.contains(error) }
     var requires2FA: Bool { possible2FAErrors.contains(error) }
     var isNotLoggedIn: Bool { possibleAuthenticationErrors.contains(error) }
     var userRegistrationPending: Bool { registrationErrors.contains(error) }

--- a/Mlem/API/Models/APIErrorResponse.swift
+++ b/Mlem/API/Models/APIErrorResponse.swift
@@ -18,6 +18,13 @@ private let possibleCredentialErrors = [
     "couldnt_find_that_username_or_email"
 ]
 
+private let possibleAuthenticationErrors = [
+    "incorrect_password",
+    "password_incorrect",
+    "incorrect_login",
+    "not_logged_in"
+]
+
 private let possible2FAErrors = [
     "missing_totp_token",
     "incorrect_totp_token"
@@ -29,9 +36,9 @@ private let registrationErrors = [
 ]
 
 extension APIErrorResponse {
-    var isIncorrectLogin: Bool { possibleCredentialErrors.contains(error) }
+    // var isIncorrectLogin: Bool { possibleCredentialErrors.contains(error) }
     var requires2FA: Bool { possible2FAErrors.contains(error) }
-    var isNotLoggedIn: Bool { error == "not_logged_in" }
+    var isNotLoggedIn: Bool { possibleAuthenticationErrors.contains(error) }
     var userRegistrationPending: Bool { registrationErrors.contains(error) }
     var emailNotVerified: Bool { registrationErrors.contains(error) }
     var instanceIsPrivate: Bool { error == "instance_is_private" }

--- a/Mlem/Error Handling/ErrorHandler.swift
+++ b/Mlem/Error Handling/ErrorHandler.swift
@@ -42,20 +42,20 @@ class ErrorHandler: ObservableObject {
         Task { @MainActor in
             
             if let clientError = error.underlyingError.base as? APIClientError {
-                
                 if case .invalidSession = clientError {
+                    print("HANDLING INVALID SESSION")
                     sessionExpired = true
                     return
                 }
                 
-                if error.title != nil && !InternetConnectionManager.isConnectedToNetwork() {
+                if error.title != nil, !InternetConnectionManager.isConnectedToNetwork() {
                     if showNoInternet {
                         await notifier.add(.noInternet)
                     }
                     return
                 }
                 
-                if case .response(let apiError, _) = clientError {
+                if case let .response(apiError, _) = clientError {
                     await notifier.add(.failure(apiError.error))
                     return
                 }
@@ -66,6 +66,10 @@ class ErrorHandler: ObservableObject {
             // on the values supplied when the error was created
             await notifier.add(error)
         }
+    }
+    
+    func clearExpiredSession() {
+        sessionExpired = false
     }
     
     private func log(_ error: ContextualError, _ file: StaticString, _ function: StaticString, _ line: Int) {

--- a/Mlem/Error Handling/ErrorHandler.swift
+++ b/Mlem/Error Handling/ErrorHandler.swift
@@ -43,7 +43,6 @@ class ErrorHandler: ObservableObject {
             
             if let clientError = error.underlyingError.base as? APIClientError {
                 if case .invalidSession = clientError {
-                    print("HANDLING INVALID SESSION")
                     sessionExpired = true
                     return
                 }

--- a/Mlem/Notifications/NotificationDisplayer.swift
+++ b/Mlem/Notifications/NotificationDisplayer.swift
@@ -11,9 +11,6 @@ import UIKit
 
 /// A class responsible for displaying important notifications to the user
 class NotificationDisplayer {
-    // private static var isPresentingTokenRefreshFlow: Bool = false
-    // @Environment(\.isPresentingTokenRefresh) var isPresentingTokenRefresh
-    
     // MARK: - Public methods
     
     /// A method that displays a `Notifiable` object to the user

--- a/Mlem/Notifications/NotificationDisplayer.swift
+++ b/Mlem/Notifications/NotificationDisplayer.swift
@@ -11,6 +11,9 @@ import UIKit
 
 /// A class responsible for displaying important notifications to the user
 class NotificationDisplayer {
+    // private static var isPresentingTokenRefreshFlow: Bool = false
+    // @Environment(\.isPresentingTokenRefresh) var isPresentingTokenRefresh
+    
     // MARK: - Public methods
     
     /// A method that displays a `Notifiable` object to the user

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -379,6 +379,8 @@ struct AddSavedInstanceView: View {
             message = badCredentialsMessage
         case APIClientError.networking:
             message = "Please check your internet connection and try again"
+        case APIClientError.invalidSession:
+            message = badCredentialsMessage
         case let APIClientError.response(errorResponse, _) where errorResponse.requires2FA:
             message = ""
             
@@ -387,11 +389,6 @@ struct AddSavedInstanceView: View {
             }
             
             return
-//        case let APIClientError.response(errorResponse, _) where errorResponse.isIncorrectLogin:
-//            message = badCredentialsMessage
-        case APIClientError.invalidSession:
-            message = badCredentialsMessage
-            
         case let APIClientError.response(errorResponse, _) where errorResponse.emailNotVerified:
             message = registrationError
             

--- a/Mlem/Views/Shared/Accounts/Add Account View.swift
+++ b/Mlem/Views/Shared/Accounts/Add Account View.swift
@@ -387,7 +387,9 @@ struct AddSavedInstanceView: View {
             }
             
             return
-        case let APIClientError.response(errorResponse, _) where errorResponse.isIncorrectLogin:
+//        case let APIClientError.response(errorResponse, _) where errorResponse.isIncorrectLogin:
+//            message = badCredentialsMessage
+        case APIClientError.invalidSession:
             message = badCredentialsMessage
             
         case let APIClientError.response(errorResponse, _) where errorResponse.emailNotVerified:

--- a/Mlem/Views/Shared/TokenRefreshView.swift
+++ b/Mlem/Views/Shared/TokenRefreshView.swift
@@ -197,8 +197,7 @@ struct TokenRefreshView: View {
         } catch {
             HapticManager.shared.play(haptic: .failure, priority: .high)
             
-            if case let APIClientError.response(apiError, _) = error,
-               apiError.isIncorrectLogin {
+            if case APIClientError.invalidSession = error {
                 updateViewState(.incorrectLogin)
                 selectedField = .password
                 return


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Slack
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR adds some logic to prompt users to reauthenticate if their saved credentials are invalid, namely:
- `invalidSession` errors are now thrown for any credential failure response
  - `AddSavedInstanceView` now catches those as login failures instead of manually checking for `.isIncorrectLogin` on a response error
- The expired session notification sheet is now attached normally to `ContentView` instead of being programmatically presented through the `NotificationDisplayer`
- The expired session notification sheet now resets the `invalidSession` flag on the `ErrorHandler` when dismissed, which prevents an invalid session message being erroneously displayed when cancelling the token refresh and switching accounts

## Testing steps

To simulate the use case of users attempting to use accounts saved in Mlem before their instance updated to 0.19, perform the following:

- Run a local Lemmy instance on a 0.18 stable release build
- Create some accounts and add them to Mlem
- Update the local instance to 0.19
- Relaunch Mlem

The new flow should trigger.

For thoroughness, I have tested both the cases where the accounts were added in an older version of Mlem (`release-1.1`) and the latest TestFlight build (`beta-1.1.1-RC-2`), though that shouldn't matter.