### PR TITLE
Colorize voting icons and text in compact posts and comments

### DIFF
--- a/Mlem/Views/Shared/Comments/Components/CommentBodyView.swift
+++ b/Mlem/Views/Shared/Comments/Components/CommentBodyView.swift
@@ -120,17 +120,19 @@ struct CommentBodyView: View {
                     Image(systemName: myVote == .upvote ? Icons.upvoteSquareFill : Icons.upvoteSquare)
                     Text(String(commentView.counts.upvotes))
                 }
+                .foregroundColor(myVote == .upvote ? .upvoteColor : .secondary)
                 
                 HStack(spacing: AppConstants.iconToTextSpacing) {
                     Image(systemName: myVote == .downvote ? Icons.downvoteSquareFill : Icons.downvoteSquare)
                     Text(String(commentView.counts.downvotes))
                 }
+                .foregroundColor(myVote == .downvote ? .downvoteColor : .secondary)
             } else {
                 HStack(spacing: AppConstants.iconToTextSpacing) {
                     Image(systemName: myVote == .resetVote ? Icons.upvoteSquare : myVote.iconNameFill)
                     Text(String(commentView.counts.score))
                 }
-                .foregroundColor(.secondary)
+                .foregroundColor(myVote.color ?? .secondary)
                 .font(.footnote)
             }
         }

--- a/Mlem/Views/Shared/Components/Components/InfoStackView.swift
+++ b/Mlem/Views/Shared/Components/Components/InfoStackView.swift
@@ -24,6 +24,7 @@ struct InfoStackView: View {
     let commentCount: Int?
     let saved: Bool?
     let alignment: HorizontalAlignment
+    let colorizeVotes: Bool
     
     var body: some View {
         HStack {
@@ -70,6 +71,7 @@ struct InfoStackView: View {
             Image(systemName: votes.myVote == .resetVote ? Icons.upvoteSquare : votes.myVote.iconNameFill)
             Text(String(votes.score))
         }
+        .foregroundColor(colorizeVotes ? votes.myVote.color ?? .secondary : .secondary)
         .accessibilityAddTraits(.isStaticText)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(votes.score) net votes")
@@ -81,6 +83,7 @@ struct InfoStackView: View {
             Image(systemName: votes.myVote == .upvote ? Icons.upvoteSquareFill : Icons.upvoteSquare)
             Text(String(votes.upvotes))
         }
+        .foregroundColor(colorizeVotes && votes.myVote == .upvote ? .upvoteColor : .secondary)
         .accessibilityAddTraits(.isStaticText)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(votes.upvotes) upvotes")
@@ -94,6 +97,7 @@ struct InfoStackView: View {
                 : Icons.downvoteSquare)
             Text(String(votes.downvotes))
         }
+        .foregroundColor(colorizeVotes && votes.myVote == .downvote ? .downvoteColor : .secondary)
         .accessibilityAddTraits(.isStaticText)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(votes.downvotes) downvotes")

--- a/Mlem/Views/Shared/Components/InteractionBarView.swift
+++ b/Mlem/Views/Shared/Components/InteractionBarView.swift
@@ -113,7 +113,8 @@ struct InteractionBarView: View {
                         updated: shouldShowTime ? updated : nil,
                         commentCount: shouldShowReplies ? numReplies : nil,
                         saved: shouldShowSaved ? saved : nil,
-                        alignment: infoStackAlignment(offset)
+                        alignment: infoStackAlignment(offset),
+                        colorizeVotes: false
                     )
                     .padding(AppConstants.postAndCommentSpacing)
                     .frame(minWidth: 0, maxWidth: .infinity)

--- a/Mlem/Views/Shared/Posts/Post Sizes/Compact Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Compact Post.swift
@@ -115,7 +115,8 @@ struct CompactPost: View {
                 updated: post.updated,
                 commentCount: post.numReplies,
                 saved: post.saved,
-                alignment: .center
+                alignment: .center,
+                colorizeVotes: true
             )
         }
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - *list issue(s) here*
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
**Describe what this PR contains in as much detail as possible**
This PR adds colors to the upvote/downvote icons and text for posts and comments when in compact views.

## Screenshots and Videos
**In case this PR changes something in the UI, please include screenshots or videos of this new feature**
| | Before | After |
| - | - | - |
| Post | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-08 at 00 01 48](https://github.com/mlemgroup/mlem/assets/1341797/28644aa5-dd59-483b-9299-832d48a15a13) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-08 at 00 00 38](https://github.com/mlemgroup/mlem/assets/1341797/79b7ad83-c390-424a-80df-2a99c267bb70) |
| Comment | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-08 at 00 01 59](https://github.com/mlemgroup/mlem/assets/1341797/de922c1b-0f44-45ca-aeeb-758224972515) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-08 at 00 00 53](https://github.com/mlemgroup/mlem/assets/1341797/b6c511a6-ed8c-4296-916f-e019647d4735) |

## Additional Context
**Any additional context you'd like to add to help us review this PR**
If this was intentionally omitted as a general preference, I can see about integrating a setting for this. However, having colors makes it considerably easier to see that a vote has been placed and is consistent with non-compact views.
