### PR TITLE
Made links easier to tap

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -459,6 +459,7 @@
 		CDCBD7282A8D6B7700387A2C /* Instance Picker View Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCBD7272A8D6B7700387A2C /* Instance Picker View Logic.swift */; };
 		CDCBD72B2A8EC0A800387A2C /* Instance Summary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCBD72A2A8EC0A800387A2C /* Instance Summary.swift */; };
 		CDD55D1D2B23BA41002020C7 /* EasyTapLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD55D1C2B23BA41002020C7 /* EasyTapLinkView.swift */; };
+		CDD55D222B2674BD002020C7 /* String+ParseLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD55D212B2674BD002020C7 /* String+ParseLinks.swift */; };
 		CDDB08782A5DF1330075BFEE /* CommentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDB08772A5DF1330075BFEE /* CommentSettingsView.swift */; };
 		CDDB2EDE2A85C2F1001D4B16 /* HapticPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDB2EDD2A85C2F1001D4B16 /* HapticPriority.swift */; };
 		CDDCF6432A66343D003DA3AC /* FancyTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDCF6422A66343D003DA3AC /* FancyTabBar.swift */; };
@@ -991,6 +992,7 @@
 		CDCBD7272A8D6B7700387A2C /* Instance Picker View Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Instance Picker View Logic.swift"; sourceTree = "<group>"; };
 		CDCBD72A2A8EC0A800387A2C /* Instance Summary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Instance Summary.swift"; sourceTree = "<group>"; };
 		CDD55D1C2B23BA41002020C7 /* EasyTapLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EasyTapLinkView.swift; sourceTree = "<group>"; };
+		CDD55D212B2674BD002020C7 /* String+ParseLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ParseLinks.swift"; sourceTree = "<group>"; };
 		CDDB08772A5DF1330075BFEE /* CommentSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSettingsView.swift; sourceTree = "<group>"; };
 		CDDB2EDD2A85C2F1001D4B16 /* HapticPriority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticPriority.swift; sourceTree = "<group>"; };
 		CDDCF6422A66343D003DA3AC /* FancyTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyTabBar.swift; sourceTree = "<group>"; };
@@ -1596,6 +1598,7 @@
 		6332FDC127EFCB530009A98A /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				CDD55D202B2674B3002020C7 /* String */,
 				CD4368D32AE2462A00BD8BD1 /* Tracker Items */,
 				CD18243E2AA8E23100D9BEB5 /* View Modifiers */,
 				63344C612A08460D001BC616 /* View - Border on Specific Sides.swift */,
@@ -2476,6 +2479,14 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
+		CDD55D202B2674B3002020C7 /* String */ = {
+			isa = PBXGroup;
+			children = (
+				CDD55D212B2674BD002020C7 /* String+ParseLinks.swift */,
+			);
+			path = String;
+			sourceTree = "<group>";
+		};
 		CDDCF6412A662444003DA3AC /* Custom Tab Bar */ = {
 			isa = PBXGroup;
 			children = (
@@ -3008,6 +3019,7 @@
 				508845CF2A3641160088E483 /* JSONDecoder+Default.swift in Sources */,
 				637218672A3A2AAD008C4816 /* GetPersonDetails.swift in Sources */,
 				B1A26FE12A44AAB200B91A32 /* Navigation getter.swift in Sources */,
+				CDD55D222B2674BD002020C7 /* String+ParseLinks.swift in Sources */,
 				6332FDC027EFB05F0009A98A /* Settings Item.swift in Sources */,
 				031A93D62AC847DA0077030C /* UploadConfirmationView.swift in Sources */,
 				CD8C55342A95515C0060B75B /* Onboarding Text.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -458,6 +458,7 @@
 		CDCBD7262A8D69A200387A2C /* Instance Picker View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCBD7252A8D69A200387A2C /* Instance Picker View.swift */; };
 		CDCBD7282A8D6B7700387A2C /* Instance Picker View Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCBD7272A8D6B7700387A2C /* Instance Picker View Logic.swift */; };
 		CDCBD72B2A8EC0A800387A2C /* Instance Summary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCBD72A2A8EC0A800387A2C /* Instance Summary.swift */; };
+		CDD55D1D2B23BA41002020C7 /* EasyTapLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD55D1C2B23BA41002020C7 /* EasyTapLinkView.swift */; };
 		CDDB08782A5DF1330075BFEE /* CommentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDB08772A5DF1330075BFEE /* CommentSettingsView.swift */; };
 		CDDB2EDE2A85C2F1001D4B16 /* HapticPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDB2EDD2A85C2F1001D4B16 /* HapticPriority.swift */; };
 		CDDCF6432A66343D003DA3AC /* FancyTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDCF6422A66343D003DA3AC /* FancyTabBar.swift */; };
@@ -989,6 +990,7 @@
 		CDCBD7252A8D69A200387A2C /* Instance Picker View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Instance Picker View.swift"; sourceTree = "<group>"; };
 		CDCBD7272A8D6B7700387A2C /* Instance Picker View Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Instance Picker View Logic.swift"; sourceTree = "<group>"; };
 		CDCBD72A2A8EC0A800387A2C /* Instance Summary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Instance Summary.swift"; sourceTree = "<group>"; };
+		CDD55D1C2B23BA41002020C7 /* EasyTapLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EasyTapLinkView.swift; sourceTree = "<group>"; };
 		CDDB08772A5DF1330075BFEE /* CommentSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSettingsView.swift; sourceTree = "<group>"; };
 		CDDB2EDD2A85C2F1001D4B16 /* HapticPriority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticPriority.swift; sourceTree = "<group>"; };
 		CDDCF6422A66343D003DA3AC /* FancyTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyTabBar.swift; sourceTree = "<group>"; };
@@ -2275,6 +2277,7 @@
 				CD45BCED2A75CA7200A2899C /* Thumbnail Image View.swift */,
 				CDC1C9422A7AC24600072E3D /* ReadCheck.swift */,
 				CD309C452A93FBD300988F95 /* Logo View.swift */,
+				CDD55D1C2B23BA41002020C7 /* EasyTapLinkView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2850,6 +2853,7 @@
 				6372186A2A3A2AAD008C4816 /* GetComment.swift in Sources */,
 				03EC92972AC069CE007BBE7E /* SearchResultListView.swift in Sources */,
 				637218472A3A2AAD008C4816 /* APICommentView.swift in Sources */,
+				CDD55D1D2B23BA41002020C7 /* EasyTapLinkView.swift in Sources */,
 				CDDCF6492A6641F0003DA3AC /* FancyTabItemLabelBuilder.swift in Sources */,
 				63344C542A07D193001BC616 /* FiltersSettingsView.swift in Sources */,
 				E40E01902AABFC9300410B2C /* AnyNavigablePath.swift in Sources */,

--- a/Mlem/API/Internal/HierarchicalComment.swift
+++ b/Mlem/API/Internal/HierarchicalComment.swift
@@ -14,6 +14,7 @@ class HierarchicalComment: ObservableObject {
     /// Indicates comment's position in a post's parent/child comment thread.
     /// Values range from `0...Int.max`, where 0 indicates the parent comment.
     let depth: Int
+    let links: [LinkType]
     
     /// The *closest* parent's collapsed state.
     @Published var isParentCollapsed: Bool = false
@@ -26,6 +27,7 @@ class HierarchicalComment: ObservableObject {
         self.depth = max(0, commentView.comment.path.split(separator: ".").count - 2)
         self.isParentCollapsed = parentCollapsed
         self.isCollapsed = collapsed
+        self.links = comment.comment.content.parseLinks()
     }
 }
 

--- a/Mlem/Extensions/String/String+ParseLinks.swift
+++ b/Mlem/Extensions/String/String+ParseLinks.swift
@@ -31,6 +31,10 @@ extension String {
         let markdownLinks: [LinkType] = matches(of: /(^|[^\!])\[(?'title'[^\[]*)\]\((?'link'[^\s\)]*)\)/)
             .compactMap { match in
                 if let url = URL(string: String(match.link)) {
+                    // if the label is just the URL that the link points to, ignore it--the raw link parser will capture the same link and display it with the host as url, and this one would be duplicate. If the label URL is different from the target URL, display with label URL as label and target URL as target
+                    if let labelUrl = URL(string: String(match.title)), labelUrl == url {
+                        return nil
+                    }
                     return .website(
                         self.distance(from: self.startIndex, to: match.range.lowerBound),
                         String(match.title), url

--- a/Mlem/Extensions/String/String+ParseLinks.swift
+++ b/Mlem/Extensions/String/String+ParseLinks.swift
@@ -1,0 +1,75 @@
+//
+//  String+ParseLinks.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-12-10.
+//
+
+import Foundation
+
+extension String {
+    func parseLinks() -> [LinkType] {
+        // regex to match raw links not embedded in Markdown
+        // (^|[^(\]\()]) ignores anything after a markdown link format (preceded by start of string or anything but '](')
+        // (?'link'(http:|https:)+[^\s]+[\w]) matches anything starting with http: or https: and captures it as link
+        let rawLinks: [LinkType] = matches(of: /(^|[^(\]\()])(?'link'(http:|https:)+[^\s]+[\w])/)
+            .compactMap { match in
+                if let url = URL(string: String(match.link)) {
+                    return .website(
+                        self.distance(from: self.startIndex, to: match.range.lowerBound),
+                        String(url.host() ?? "Website"),
+                        url
+                    )
+                }
+                return nil
+            }
+        
+        // regex to match markdown links
+        // [^\!]? ensures we ignore image links
+        // \[(?'title'[^\[]*)\] matches '[title]' and captures 'title' as title
+        // \((?'url'[^\s\)]*)\) matches '(url)' and captures 'url' as url
+        let markdownLinks: [LinkType] = matches(of: /[^\!]?\[(?'title'[^\[]*)\]\((?'link'[^\s\)]*)\)/)
+            .compactMap { match in
+                if let url = URL(string: String(match.link)) {
+                    return .website(
+                        self.distance(from: self.startIndex, to: match.range.lowerBound),
+                        String(match.title), url
+                    )
+                }
+                return nil
+            }
+        
+        // regex to match user links
+        // \!(?'name'[^\s]+) matches '!user' and captures 'user' as name
+        // \@(?'instance'[^\s]+) matches '@instance' and captures 'instance' as instance
+        let userLinks: [LinkType] = matches(of: /\@(?'name'[^\s]+)\@(?'instance'[^\s]+)/)
+            .compactMap { match in
+                if let url = URL(string: String(match.output.0)) {
+                    return .user(
+                        self.distance(from: self.startIndex, to: match.range.lowerBound),
+                        String(match.name),
+                        String(match.instance),
+                        url
+                    )
+                }
+                return nil
+            }
+        
+        // same as above but with \! at the start
+        let communityLinks: [LinkType] = matches(of: /\!(?'name'[^\s]+)\@(?'instance'[^\s]+)/)
+            .compactMap { match in
+                if let url = URL(string: String(match.output.0)) {
+                    return .community(
+                        self.distance(from: self.startIndex, to: match.range.lowerBound),
+                        String(match.name),
+                        String(match.instance),
+                        url
+                    )
+                }
+                return nil
+            }
+        
+        // sort links by position in body and return
+        return (rawLinks + markdownLinks + userLinks + communityLinks).sorted { $0.position < $1.position }
+    }
+}

--- a/Mlem/Extensions/String/String+ParseLinks.swift
+++ b/Mlem/Extensions/String/String+ParseLinks.swift
@@ -12,7 +12,6 @@ extension String {
         // regex to match raw links not embedded in Markdown
         // (^|[^(\]\()]) ignores anything after a markdown link format (preceded by start of string or anything but '](')
         // (?'link'(http:|https:)+[^\s]+[\w]) matches anything starting with http: or https: and captures it as link
-        // let rawLinks: [LinkType] = matches(of: /(^|[^(\]\()])(?'link'(http:|https:)+[^\s]+[\w])/)
         let rawLinks: [LinkType] = matches(of: /(^|[^(\]\()])(?'link'(http:|https:)+[^\s\[\]]+[\w])/)
             .compactMap { match in
                 if let url = URL(string: String(match.link)) {

--- a/Mlem/Extensions/String/String+ParseLinks.swift
+++ b/Mlem/Extensions/String/String+ParseLinks.swift
@@ -12,7 +12,8 @@ extension String {
         // regex to match raw links not embedded in Markdown
         // (^|[^(\]\()]) ignores anything after a markdown link format (preceded by start of string or anything but '](')
         // (?'link'(http:|https:)+[^\s]+[\w]) matches anything starting with http: or https: and captures it as link
-        let rawLinks: [LinkType] = matches(of: /(^|[^(\]\()])(?'link'(http:|https:)+[^\s]+[\w])/)
+        // let rawLinks: [LinkType] = matches(of: /(^|[^(\]\()])(?'link'(http:|https:)+[^\s]+[\w])/)
+        let rawLinks: [LinkType] = matches(of: /(^|[^(\]\()])(?'link'(http:|https:)+[^\s\[\]]+[\w])/)
             .compactMap { match in
                 if let url = URL(string: String(match.link)) {
                     return .website(
@@ -41,8 +42,9 @@ extension String {
         
         // regex to match user links
         // \!(?'name'[^\s]+) matches '!user' and captures 'user' as name
-        // \@(?'instance'[^\s]+) matches '@instance' and captures 'instance' as instance
-        let userLinks: [LinkType] = matches(of: /\@(?'name'[^\s]+)\@(?'instance'[^\s]+)/)
+        // \@(?'instance'[^\s(\]\()]+)\] matches '@instance' and captures 'instance' as instance, excluding cases where instance is followed by '](' (suggesting a username embedded in a link)
+        // \]?(\s|$) ensures that usernames wrapped in [] that are not part of links get appropriately parsed
+        let userLinks: [LinkType] = matches(of: /\@(?'name'[^\s]+)\@(?'instance'[^\s(\]\()]+)\]?(\s|$)/)
             .compactMap { match in
                 if let url = URL(string: String(match.output.0)) {
                     return .user(
@@ -56,7 +58,7 @@ extension String {
             }
         
         // same as above but with \! at the start
-        let communityLinks: [LinkType] = matches(of: /\!(?'name'[^\s]+)\@(?'instance'[^\s]+)/)
+        let communityLinks: [LinkType] = matches(of: /\!(?'name'[^\s]+)\@(?'instance'[^\s(\]\()]+)\]?(\s|$)/)
             .compactMap { match in
                 if let url = URL(string: String(match.output.0)) {
                     return .community(

--- a/Mlem/Extensions/String/String+ParseLinks.swift
+++ b/Mlem/Extensions/String/String+ParseLinks.swift
@@ -25,10 +25,10 @@ extension String {
             }
         
         // regex to match markdown links
-        // [^\!]? ensures we ignore image links
+        // ([^\!]|^) ensures we ignore image links (matches start of string or anything but !)
         // \[(?'title'[^\[]*)\] matches '[title]' and captures 'title' as title
         // \((?'url'[^\s\)]*)\) matches '(url)' and captures 'url' as url
-        let markdownLinks: [LinkType] = matches(of: /[^\!]?\[(?'title'[^\[]*)\]\((?'link'[^\s\)]*)\)/)
+        let markdownLinks: [LinkType] = matches(of: /(^|[^\!])\[(?'title'[^\[]*)\]\((?'link'[^\s\)]*)\)/)
             .compactMap { match in
                 if let url = URL(string: String(match.link)) {
                     return .website(

--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -219,18 +219,35 @@ struct HandleLemmyLinkResolution<Path: AnyNavigablePath>: ViewModifier {
                 await notifier.performWithLoader {
                     var lookup = url.absoluteString
                     lookup = lookup.replacingOccurrences(of: "mlem://", with: "https://")
-                    if lookup.contains("@"), !lookup.contains("!") {
-                        // SUS I think this might be a community link
+                    var altLookup: String?
+                    
+                    // anything with an @ gets parsed to mailto: by Markdown
+                    if lookup.starts(with: "mailto:") {
+                        // SUS I think this might be a community or user link
                         let processedLookup = lookup
                             .replacing(/.*\/c\//, with: "")
                             .replacingOccurrences(of: "mailto:", with: "")
-                        lookup = "!\(processedLookup)"
+                        
+                        // the mailto: strips the ! and @, so we have to try both
+                        lookup = "!\(processedLookup)" // community
+                        altLookup = "@\(processedLookup)" // user
                     }
                     
-                    print("lookup: \(lookup) (original: \(url.absoluteString))")
+                    print("lookup: \(lookup), altLookup: \(String(describing: altLookup)) (original: \(url.absoluteString))")
                     // Wooo this is a lemmy server we're talking to! time to parse this url and push it to the stack
                     do {
-                        let resolved = try await resolve(query: lookup)
+                        var resolved: Bool
+                        if let altLookup {
+                            do {
+                                resolved = try await resolve(query: lookup)
+                            } catch {
+                                resolved = try await resolve(query: altLookup)
+                            }
+                        } else {
+                            resolved = try await resolve(query: lookup)
+                        }
+                        
+                        // let resolved = try await resolve(query: lookup)
                         
                         if resolved {
                             // as the link was handled we return, else it would also be passed to the default URL handling below
@@ -283,7 +300,8 @@ struct HandleLemmyLinkResolution<Path: AnyNavigablePath>: ViewModifier {
                     try navigationPath.wrappedValue.append(Path.makeRoute(object.person))
                     return true
                 case let .community(object):
-                    try navigationPath.wrappedValue.append(Path.makeRoute(object))
+                    // TODO: routes should all be based on middleware models, and the resolution should return a middleware model
+                    try navigationPath.wrappedValue.append(Path.makeRoute(CommunityModel(from: object)))
                     return true
                 case .comment:
                     return false

--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -247,8 +247,6 @@ struct HandleLemmyLinkResolution<Path: AnyNavigablePath>: ViewModifier {
                             resolved = try await resolve(query: lookup)
                         }
                         
-                        // let resolved = try await resolve(query: lookup)
-                        
                         if resolved {
                             // as the link was handled we return, else it would also be passed to the default URL handling below
                             return

--- a/Mlem/Models/Composers/Response Composers/Replies/ReplyToComment.swift
+++ b/Mlem/Models/Composers/Response Composers/Replies/ReplyToComment.swift
@@ -35,7 +35,8 @@ struct ReplyToComment: ResponseEditorModel {
             isParentCollapsed: .constant(false),
             isCollapsed: .constant(false),
             showPostContext: true,
-            menuFunctions: []
+            menuFunctions: [],
+            links: []
         )
         .padding(.horizontal))
     }

--- a/Mlem/Models/Composers/Response Composers/Reports/ReportComment.swift
+++ b/Mlem/Models/Composers/Response Composers/Reports/ReportComment.swift
@@ -24,7 +24,8 @@ struct ReportComment: ResponseEditorModel {
             isParentCollapsed: .constant(false),
             isCollapsed: .constant(false),
             showPostContext: true,
-            menuFunctions: []
+            menuFunctions: [],
+            links: []
         )
         .padding(.horizontal, AppConstants.postAndCommentSpacing))
     }

--- a/Mlem/Models/Content/Post Model.swift
+++ b/Mlem/Models/Content/Post Model.swift
@@ -20,6 +20,7 @@ struct PostModel {
     let read: Bool
     let published: Date
     let updated: Date?
+    let links: [URL]
     
     var uid: ContentModelIdentifier { .init(contentType: .post, contentId: postId) }
     
@@ -36,6 +37,9 @@ struct PostModel {
         self.read = apiPostView.read
         self.published = apiPostView.published
         self.updated = apiPostView.post.updated
+        
+        self.links = PostModel.parseLinks(from: post.body)
+        print(links)
     }
     
     /// Creates a PostModel from another PostModel. Any provided field values will override values in post.
@@ -73,6 +77,9 @@ struct PostModel {
         self.read = read ?? other.read
         self.published = published ?? other.published
         self.updated = updated ?? other.updated
+        
+        self.links = PostModel.parseLinks(from: post?.body)
+        print(links)
     }
     
     var postType: PostType {
@@ -88,6 +95,27 @@ struct PostModel {
         }
 
         return .titleOnly
+    }
+    
+    static func parseLinks(from body: String?) -> [URL] {
+        guard let body else {
+            return []
+        }
+        
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            assertionFailure("Failed to initialize link detector")
+            return []
+        }
+        
+        let matches = detector.matches(
+            in: body,
+            options: .reportCompletion,
+            range: NSRange(location: 0, length: body.count)
+        )
+        
+        return matches.compactMap { match in
+            match.url
+        }
     }
 }
 

--- a/Mlem/Models/Content/Post Model.swift
+++ b/Mlem/Models/Content/Post Model.swift
@@ -99,66 +99,7 @@ struct PostModel {
         guard let body else {
             return []
         }
-        
-        // regex to match raw links not embedded in Markdown
-        // (^|[^(\]\()]) ignores anything after a markdown link format (preceded by start of string or anything but '](')
-        // (?'link'(http:|https:)+[^\s]+[\w]) matches anything starting with http: or https: and captures it as link
-        let rawLinks: [LinkType] = body
-            .matches(of: /(^|[^(\]\()])(?'link'(http:|https:)+[^\s]+[\w])/)
-            .compactMap { match in
-                if let url = URL(string: String(match.link)) {
-                    return .website(body.distance(from: body.startIndex, to: match.range.lowerBound), String(url.host() ?? "Website"), url)
-                }
-                return nil
-            }
-        
-        // regex to match markdown links
-        // [^\!]? ensures we ignore image links
-        // \[(?'title'[^\[]*)\] matches '[title]' and captures 'title' as title
-        // \((?'url'[^\s\)]*)\) matches '(url)' and captures 'url' as url
-        let markdownLinks: [LinkType] = body
-            .matches(of: /[^\!]?\[(?'title'[^\[]*)\]\((?'link'[^\s\)]*)\)/)
-            .compactMap { match in
-                if let url = URL(string: String(match.link)) {
-                    return .website(body.distance(from: body.startIndex, to: match.range.lowerBound), String(match.title), url)
-                }
-                return nil
-            }
-        
-        // regex to match user links
-        // \!(?'name'[^\s]+) matches '!user' and captures 'user' as name
-        // \@(?'instance'[^\s]+) matches '@instance' and captures 'instance' as instance
-        let userLinks: [LinkType] = body
-            .matches(of: /\@(?'name'[^\s]+)\@(?'instance'[^\s]+)/)
-            .compactMap { match in
-                if let url = URL(string: String(match.output.0)) {
-                    return .user(
-                        body.distance(from: body.startIndex, to: match.range.lowerBound),
-                        String(match.name),
-                        String(match.instance),
-                        url
-                    )
-                }
-                return nil
-            }
-                
-        // same as above but with \! at the start
-        let communityLinks: [LinkType] = body
-            .matches(of: /\!(?'name'[^\s]+)\@(?'instance'[^\s]+)/)
-            .compactMap { match in
-                if let url = URL(string: String(match.output.0)) {
-                    return .community(
-                        body.distance(from: body.startIndex, to: match.range.lowerBound),
-                        String(match.name),
-                        String(match.instance),
-                        url
-                    )
-                }
-                return nil
-            }
-        
-        // sort links by position in body and return
-        return (rawLinks + markdownLinks + userLinks + communityLinks).sorted { $0.position < $1.position }
+        return body.parseLinks()
     }
 }
 

--- a/Mlem/Models/Content/Post Model.swift
+++ b/Mlem/Models/Content/Post Model.swift
@@ -77,7 +77,7 @@ struct PostModel {
         self.published = published ?? other.published
         self.updated = updated ?? other.updated
         
-        self.links = PostModel.parseLinks(from: post?.body)
+        self.links = PostModel.parseLinks(from: self.post.body)
     }
     
     var postType: PostType {

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -153,7 +153,8 @@ struct CommentItem: View {
                     isParentCollapsed: $hierarchicalComment.isParentCollapsed,
                     isCollapsed: $hierarchicalComment.isCollapsed,
                     showPostContext: showPostContext,
-                    menuFunctions: genMenuFunctions()
+                    menuFunctions: genMenuFunctions(),
+                    links: hierarchicalComment.links
                 )
                 // top and bottom spacing uses default even when compact--it's *too* compact otherwise
                 .padding(.top, AppConstants.postAndCommentSpacing)

--- a/Mlem/Views/Shared/Comments/Components/CommentBodyView.swift
+++ b/Mlem/Views/Shared/Comments/Components/CommentBodyView.swift
@@ -20,6 +20,7 @@ struct CommentBodyView: View {
     let showPostContext: Bool
     let commentorLabel: String
     let menuFunctions: [MenuFunction]
+    let links: [LinkType]
     
     var myVote: ScoringOperation { commentView.myVote ?? .resetVote }
     
@@ -40,7 +41,8 @@ struct CommentBodyView: View {
         isParentCollapsed: Binding<Bool>,
         isCollapsed: Binding<Bool>,
         showPostContext: Bool,
-        menuFunctions: [MenuFunction]
+        menuFunctions: [MenuFunction],
+        links: [LinkType]
     ) {
         self._isParentCollapsed = isParentCollapsed
         self._isCollapsed = isCollapsed
@@ -48,6 +50,7 @@ struct CommentBodyView: View {
         self.commentView = commentView
         self.showPostContext = showPostContext
         self.menuFunctions = menuFunctions
+        self.links = links
         
         let commentor = commentView.creator
         let publishedAgo: String = getTimeIntervalFromNow(date: commentView.comment.published)
@@ -90,6 +93,10 @@ struct CommentBodyView: View {
                     MarkdownView(text: commentView.comment.content, isNsfw: commentView.post.nsfw)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
                         .transition(.markdownView())
+                    
+                    ForEach(links) { link in
+                        EasyTapLinkView(linkType: link)
+                    }
                 }
             }
             

--- a/Mlem/Views/Shared/Comments/Components/Embedded Post.swift
+++ b/Mlem/Views/Shared/Comments/Components/Embedded Post.swift
@@ -29,7 +29,6 @@ struct EmbeddedPost: View {
     // TODO:
     // - beautify
     // - enrich info
-    // - navigation link to post
     var body: some View {
         NavigationLink(.lazyLoadPostLinkWithContext(.init(
             post: post,

--- a/Mlem/Views/Shared/Components/EasyTapLinkView.swift
+++ b/Mlem/Views/Shared/Components/EasyTapLinkView.swift
@@ -8,30 +8,78 @@
 import Foundation
 import SwiftUI
 
+/// Enumerates the types of links
+/// Equatable so that things like PostModel can be equatable
+enum LinkType {
+    // TODO: capture internal Lemmy links:
+    // - users
+    // - communities
+    // - posts
+    // - comments
+    
+    case website(String, URL)
+    
+    var title: String {
+        switch self {
+        case let .website(title, _):
+            return title
+        }
+    }
+}
+
+extension LinkType: Hashable, Identifiable {
+    func hash(into hasher: inout Hasher) {
+        switch self {
+        case let .website(title, url):
+            hasher.combine(0)
+            hasher.combine(title)
+            hasher.combine(url)
+        }
+    }
+    
+    var id: Int { hashValue }
+}
+
 struct EasyTapLinkView: View {
     @Environment(\.openURL) private var openURL
     
-    let title: String
-    let url: URL
+    let linkType: LinkType
     
     var body: some View {
+        switch linkType {
+        case let .website(_, url):
+            content
+                .onTapGesture {
+                    openURL(url)
+                }
+        }
+    }
+    
+    var content: some View {
         VStack(alignment: .leading, spacing: 5) {
-            Text(title)
+            Text(linkType.title)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .foregroundColor(.secondary)
                 .font(.subheadline)
                 .bold()
-            HStack(alignment: .center, spacing: 0.0) {
-                Text(url.description)
-                    .foregroundColor(.secondary)
-                    .font(.footnote)
-            }
+            
+            caption
         }
         .padding(AppConstants.postAndCommentSpacing)
         .background(RoundedRectangle(cornerRadius: AppConstants.largeItemCornerRadius)
             .foregroundColor(Color(UIColor.secondarySystemBackground)))
-        .onTapGesture {
-            openURL(url)
+    }
+    
+    var caption: some View {
+        switch linkType {
+        case let .website(_, url):
+            websiteCaption(url: url)
         }
+    }
+    
+    private func websiteCaption(url: URL) -> some View {
+        Text(url.description)
+            .foregroundColor(.secondary)
+            .font(.footnote)
     }
 }

--- a/Mlem/Views/Shared/Components/EasyTapLinkView.swift
+++ b/Mlem/Views/Shared/Components/EasyTapLinkView.swift
@@ -97,6 +97,7 @@ struct EasyTapLinkView: View {
                 .bold()
             
             caption
+                .lineLimit(1)
         }
         .padding(AppConstants.postAndCommentSpacing)
         .background(RoundedRectangle(cornerRadius: AppConstants.largeItemCornerRadius)

--- a/Mlem/Views/Shared/Components/EasyTapLinkView.swift
+++ b/Mlem/Views/Shared/Components/EasyTapLinkView.swift
@@ -1,0 +1,37 @@
+//
+//  TappableLinkView.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-12-08.
+//
+
+import Foundation
+import SwiftUI
+
+struct EasyTapLinkView: View {
+    @Environment(\.openURL) private var openURL
+    
+    let title: String
+    let url: URL
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .foregroundColor(.secondary)
+                .font(.subheadline)
+                .bold()
+            HStack(alignment: .center, spacing: 0.0) {
+                Text(url.description)
+                    .foregroundColor(.secondary)
+                    .font(.footnote)
+            }
+        }
+        .padding(AppConstants.postAndCommentSpacing)
+        .background(RoundedRectangle(cornerRadius: AppConstants.largeItemCornerRadius)
+            .foregroundColor(Color(UIColor.secondarySystemBackground)))
+        .onTapGesture {
+            openURL(url)
+        }
+    }
+}

--- a/Mlem/Views/Shared/Components/EasyTapLinkView.swift
+++ b/Mlem/Views/Shared/Components/EasyTapLinkView.swift
@@ -57,15 +57,18 @@ enum LinkType {
 extension LinkType: Hashable, Identifiable {
     func hash(into hasher: inout Hasher) {
         switch self {
-        case let .website(_, title, url):
+        case let .website(position, title, url):
             hasher.combine(0)
+            hasher.combine(position)
             hasher.combine(title)
             hasher.combine(url)
-        case let .user(_, _, _, url):
+        case let .user(position, _, _, url):
             hasher.combine(1)
+            hasher.combine(position)
             hasher.combine(url)
-        case let .community(_, _, _, url):
+        case let .community(position, _, _, url):
             hasher.combine(2)
+            hasher.combine(position)
             hasher.combine(url)
         }
     }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -249,7 +249,8 @@ struct LargePost: View {
                 
                 if layoutMode == .maximize {
                     ForEach(post.links) { link in
-                        EasyTapLinkView(title: "Some Title", url: link)
+                        // EasyTapLinkView(title: "Some Title", url: link)
+                        EasyTapLinkView(linkType: link)
                     }
                 }
             }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -249,7 +249,6 @@ struct LargePost: View {
                 
                 if layoutMode == .maximize {
                     ForEach(post.links) { link in
-                        // EasyTapLinkView(title: "Some Title", url: link)
                         EasyTapLinkView(linkType: link)
                     }
                 }

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -7,7 +7,6 @@
 
 import Dependencies
 import Foundation
-import LinkPresentation
 import SwiftUI
 
 struct LargePost: View {

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -7,6 +7,7 @@
 
 import Dependencies
 import Foundation
+import LinkPresentation
 import SwiftUI
 
 struct LargePost: View {
@@ -235,15 +236,23 @@ struct LargePost: View {
     @ViewBuilder
     var postBodyView: some View {
         if let bodyText = post.post.body, !bodyText.isEmpty {
-            MarkdownView(
-                text: postBodyText(bodyText, layoutMode: layoutMode),
-                isNsfw: post.post.nsfw,
-                replaceImagesWithEmoji: isExpanded ? false : true,
-                isInline: isExpanded ? false : true
-            )
-            .id(post.id)
-            .font(.subheadline)
-            .lineLimit(layoutMode.lineLimit)
+            VStack {
+                MarkdownView(
+                    text: postBodyText(bodyText, layoutMode: layoutMode),
+                    isNsfw: post.post.nsfw,
+                    replaceImagesWithEmoji: isExpanded ? false : true,
+                    isInline: isExpanded ? false : true
+                )
+                .id(post.id)
+                .font(.subheadline)
+                .lineLimit(layoutMode.lineLimit)
+                
+                if layoutMode == .maximize {
+                    ForEach(post.links) { link in
+                        EasyTapLinkView(title: "Some Title", url: link)
+                    }
+                }
+            }
         }
     }
     


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #746 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR makes links embedded in post and comment content easier to hit by parsing them out of the body and aggregating them as nice easy-to-tap elements at the bottom. Links are given a title and caption according to the following schema:
- Raw links: destination host, full url
- Markdown links: markdown label, full url
- User links: /u/username, username@instance
- Community links: /c/community, community@instance

This PR also modifies the link handling code a little bit to properly allow navigation to communities using webfingers links (`!community@instance`)--Markdown parses those into `mailto:` links, so any `mailto:` link is parsed back into its webfingers format and resolved.

<img width="563" alt="Screenshot 2023-12-10 at 5 45 55 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/c6ae7dc5-2d5d-4641-bbd8-75e4d559f004">

<img width="563" alt="Screenshot 2023-12-10 at 5 46 05 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/57aa6ea8-fb79-46a2-972f-88a853830ebc">
