### PR TITLE
Compact UserLabelView spacing tweak

### DIFF
--- a/Mlem/Views/Shared/Links/User/UserLabelView.swift
+++ b/Mlem/Views/Shared/Links/User/UserLabelView.swift
@@ -71,7 +71,10 @@ struct UserLabelView: View {
     var avatarSize: CGFloat { serverInstanceLocation == .bottom ? AppConstants.largeAvatarSize : AppConstants.smallAvatarSize }
 
     var body: some View {
-        HStack(alignment: .center, spacing: AppConstants.largeAvatarSpacing) {
+        HStack(
+            alignment: .center,
+            spacing: serverInstanceLocation == .bottom ? AppConstants.largeAvatarSpacing : 8
+        ) {
             if showAvatar {
                 AvatarView(user: user, avatarSize: avatarSize, blurAvatar: blurAvatar)
                     .accessibilityHidden(true)


### PR DESCRIPTION
Tweaked the spacing between icon and username for the compact `UserLabelView`.

What it looks like currently:

![image](https://github.com/mlemgroup/mlem/assets/78750526/d2ad1ae2-10c4-412a-a502-bb428263cc15)

Proposed change:

![image](https://github.com/mlemgroup/mlem/assets/78750526/0036a6a0-b4b7-4725-a8b3-69265f92e3f6)
