### PR TITLE
Tab Bar Navigation

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -508,6 +508,8 @@
 		E453A1D02A81C2140004BB8A /* QuickLookPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */; };
 		E46AF98E2B29A4AA0087FDF3 /* DismissAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46AF98D2B29A4AA0087FDF3 /* DismissAction.swift */; };
 		E46AF9902B29A50A0087FDF3 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = E46AF98F2B29A50A0087FDF3 /* README.md */; };
+		E46AF9922B29AA350087FDF3 /* ScrollToView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46AF9912B29AA340087FDF3 /* ScrollToView.swift */; };
+		E46AF9942B29AB270087FDF3 /* Environment+ScrollViewReaderProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46AF9932B29AB270087FDF3 /* Environment+ScrollViewReaderProxy.swift */; };
 		E47478132AAC350E001CB1AC /* NavigationLink+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47478122AAC350E001CB1AC /* NavigationLink+Helpers.swift */; };
 		E47478152AAC3C19001CB1AC /* NavigationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47478142AAC3C19001CB1AC /* NavigationContext.swift */; };
 		E47B2B762A902DE200629AF7 /* SettingsValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47B2B752A902DE200629AF7 /* SettingsValues.swift */; };
@@ -1037,6 +1039,8 @@
 		E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewController.swift; sourceTree = "<group>"; };
 		E46AF98D2B29A4AA0087FDF3 /* DismissAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DismissAction.swift; sourceTree = "<group>"; };
 		E46AF98F2B29A50A0087FDF3 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		E46AF9912B29AA340087FDF3 /* ScrollToView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollToView.swift; sourceTree = "<group>"; };
+		E46AF9932B29AB270087FDF3 /* Environment+ScrollViewReaderProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Environment+ScrollViewReaderProxy.swift"; sourceTree = "<group>"; };
 		E47478122AAC350E001CB1AC /* NavigationLink+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationLink+Helpers.swift"; sourceTree = "<group>"; };
 		E47478142AAC3C19001CB1AC /* NavigationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationContext.swift; sourceTree = "<group>"; };
 		E47B2B752A902DE200629AF7 /* SettingsValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsValues.swift; sourceTree = "<group>"; };
@@ -1610,6 +1614,7 @@
 				6D15D74B2A44DC240061B5CB /* Date.swift */,
 				63A200522A2DDD38005CDDE3 /* Dictionary - Append.swift */,
 				E4DDB4312A81819300B3A7E0 /* Double.swift */,
+				E46AF9932B29AB270087FDF3 /* Environment+ScrollViewReaderProxy.swift */,
 				B1955A202A6145C00056CF99 /* Environment - EasterFlagSetter.swift */,
 				507573902A5AD53C00AA7ABD /* Error+Equatable.swift */,
 				6D8601ED2A43C0B1002A56FC /* Image.swift */,
@@ -2063,6 +2068,7 @@
 				CD863FBB2A6B026400A31ED9 /* DocumentView.swift */,
 				030E86422AC6F6CB000283A6 /* Search Bar */,
 				CD20530F2AC878B50000AA38 /* UpdatedTimestampView.swift */,
+				E46AF9912B29AA340087FDF3 /* ScrollToView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -3158,6 +3164,7 @@
 				637218622A3A2AAD008C4816 /* DeletePost.swift in Sources */,
 				505240E32A86916500EA4558 /* FavoriteCommunitiesTracker+Dependency.swift in Sources */,
 				6332FDC327EFCB5F0009A98A /* Color.swift in Sources */,
+				E46AF9942B29AB270087FDF3 /* Environment+ScrollViewReaderProxy.swift in Sources */,
 				637218432A3A2AAD008C4816 /* APIClient.swift in Sources */,
 				CD82A2572A716D7C00111034 /* PersonRepository+Dependency.swift in Sources */,
 				63DF71F12A02999C002AC14E /* App Constants.swift in Sources */,
@@ -3254,6 +3261,7 @@
 				03A40DAD2AD5EA11005F019F /* NoPostsView.swift in Sources */,
 				6372184A2A3A2AAD008C4816 /* APIPost.swift in Sources */,
 				6D693A3E2A5113DF009E2D76 /* CreatePostReport.swift in Sources */,
+				E46AF9922B29AA350087FDF3 /* ScrollToView.swift in Sources */,
 				CD391F942A533B7700E213B5 /* EditorModelProtocol.swift in Sources */,
 				CD69F56F2A41EDF50028D4F7 /* Swipey Actions.swift in Sources */,
 				637218632A3A2AAD008C4816 /* CreatePost.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -506,6 +506,8 @@
 		E42D9B5A2AD6802B0087693C /* OnboardingRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42D9B592AD6802B0087693C /* OnboardingRoutes.swift */; };
 		E453477E2A9DE37300D1B46F /* Array+SafeIndexing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E453477D2A9DE37300D1B46F /* Array+SafeIndexing.swift */; };
 		E453A1D02A81C2140004BB8A /* QuickLookPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */; };
+		E46AF98E2B29A4AA0087FDF3 /* DismissAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46AF98D2B29A4AA0087FDF3 /* DismissAction.swift */; };
+		E46AF9902B29A50A0087FDF3 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = E46AF98F2B29A50A0087FDF3 /* README.md */; };
 		E47478132AAC350E001CB1AC /* NavigationLink+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47478122AAC350E001CB1AC /* NavigationLink+Helpers.swift */; };
 		E47478152AAC3C19001CB1AC /* NavigationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47478142AAC3C19001CB1AC /* NavigationContext.swift */; };
 		E47B2B762A902DE200629AF7 /* SettingsValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47B2B752A902DE200629AF7 /* SettingsValues.swift */; };
@@ -1033,6 +1035,8 @@
 		E42D9B592AD6802B0087693C /* OnboardingRoutes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingRoutes.swift; sourceTree = "<group>"; };
 		E453477D2A9DE37300D1B46F /* Array+SafeIndexing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeIndexing.swift"; sourceTree = "<group>"; };
 		E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewController.swift; sourceTree = "<group>"; };
+		E46AF98D2B29A4AA0087FDF3 /* DismissAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DismissAction.swift; sourceTree = "<group>"; };
+		E46AF98F2B29A50A0087FDF3 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		E47478122AAC350E001CB1AC /* NavigationLink+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationLink+Helpers.swift"; sourceTree = "<group>"; };
 		E47478142AAC3C19001CB1AC /* NavigationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationContext.swift; sourceTree = "<group>"; };
 		E47B2B752A902DE200629AF7 /* SettingsValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsValues.swift; sourceTree = "<group>"; };
@@ -2621,8 +2625,10 @@
 		E4902BA92A90245E0054FB36 /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
+				E46AF98F2B29A50A0087FDF3 /* README.md */,
 				E40E018F2AABFC9300410B2C /* AnyNavigablePath.swift */,
 				E40E018D2AABFBDE00410B2C /* AnyNavigationPath.swift */,
+				E46AF98D2B29A4AA0087FDF3 /* DismissAction.swift */,
 				E47478142AAC3C19001CB1AC /* NavigationContext.swift */,
 				E47478122AAC350E001CB1AC /* NavigationLink+Helpers.swift */,
 				E49F0E752A90395400BC4EE3 /* NavigationPath+Helpers.swift */,
@@ -2780,6 +2786,7 @@
 				CDE9CE652A7B338E002B97DD /* Violent Success.ahap in Resources */,
 				CDE9CE512A7B0C66002B97DD /* Light Success.ahap in Resources */,
 				CDE9CE532A7B1100002B97DD /* Mushy Info.ahap in Resources */,
+				E46AF9902B29A50A0087FDF3 /* README.md in Resources */,
 				CDE9CE612A7B32EB002B97DD /* Destructive Success.ahap in Resources */,
 				6332FDBD27EFAF7C0009A98A /* Settings.bundle in Resources */,
 				6363D5C927EE196A00E34822 /* Assets.xcassets in Resources */,
@@ -3104,6 +3111,7 @@
 				6D80037B2A46458800363206 /* Lazy Load Expanded Post.swift in Sources */,
 				6372184F2A3A2AAD008C4816 /* APIPerson.swift in Sources */,
 				CD4368BC2AE23F6F00BD8BD1 /* TrackerSort.swift in Sources */,
+				E46AF98E2B29A4AA0087FDF3 /* DismissAction.swift in Sources */,
 				CD45BCEE2A75CA7200A2899C /* Thumbnail Image View.swift in Sources */,
 				03A1B3F92A8400DD00AB0DE0 /* APIContentViewProtocol.swift in Sources */,
 				6322A5D027F8629700135D4F /* UserLinkView.swift in Sources */,

--- a/Mlem/Extensions/Environment+ScrollViewReaderProxy.swift
+++ b/Mlem/Extensions/Environment+ScrollViewReaderProxy.swift
@@ -1,0 +1,19 @@
+//
+//  Environment+ScrollViewReaderProxy.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-09-12.
+//
+
+import SwiftUI
+
+private struct ScrollViewReaderProxy: EnvironmentKey {
+    static let defaultValue: ScrollViewProxy? = nil
+}
+
+extension EnvironmentValues {
+    var scrollViewProxy: ScrollViewProxy? {
+        get { self[ScrollViewReaderProxy.self] }
+        set { self[ScrollViewReaderProxy.self] = newValue }
+    }
+}

--- a/Mlem/Extensions/IconSettingsView.swift
+++ b/Mlem/Extensions/IconSettingsView.swift
@@ -31,6 +31,7 @@ struct IconSettingsView: View {
             iconsList()
         }
         .fancyTabScrollCompatible()
+        .hoistNavigation()
         .navigationTitle("App Icon")
     }
     

--- a/Mlem/Navigation/DismissAction.swift
+++ b/Mlem/Navigation/DismissAction.swift
@@ -185,7 +185,7 @@ struct PerformTabBarNavigation: ViewModifier {
     @Environment(\.navigationPathWithRoutes) private var routesNavigationPath
     
     @Environment(\.tabSelectionHashValue) private var selectedTabHashValue
-    @Environment(\.tabNavigationSelectionHashValue) private var selectedNavigationTabHashValue
+    @Environment(\.tabReselectionHashValue) private var selectedNavigationTabHashValue
 
     private var navigationPath: [AnyRoute] {
         guard let selectedTabHashValue else {

--- a/Mlem/Navigation/DismissAction.swift
+++ b/Mlem/Navigation/DismissAction.swift
@@ -1,0 +1,253 @@
+//
+//  DismissAction.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-09-08.
+//
+
+import Dependencies
+import Foundation
+import SwiftUI
+
+// MARK: - Navigation
+final class Navigation: ObservableObject {
+    
+    enum PrimaryAction {
+        case dismiss
+    }
+    
+    /// Return `true` to indicate that an auxiliary action was performed.
+    typealias AuxiliaryAction = () -> Bool
+    
+    var pathActions: [Int: (dismiss: DismissAction?, auxiliaryAction: AuxiliaryAction?)] = [:]
+    
+    /// Navigation always performs dismiss action (if available), but may choose to perform an auxiliary action first.
+    ///
+    /// This action includes support for popping back to sidebar view in a `NavigationSplitView`.
+    var dismiss: DismissAction?
+    /// An auxiliary action may consist of multiple sub-actions: To do so, simply configure this action to return false once all sub-actions have been (or can no longer be) performed.
+    ///
+    /// - Warning: Navigation may skip this action, depending on user preference or other factors. Do not perform critical logic in this action.
+    var auxiliaryAction: AuxiliaryAction?
+}
+
+// MARK: - Navigation Behaviour
+extension Navigation {
+    
+    enum Behaviour {
+        /// Mimics Apple platforms tab bar navigation behaviour (i.e. pop to root regardless of navigation stack size, then scroll to top).
+        case system
+        /// Only perform the primary action for navigation (this defaults to dismiss action).
+        case primary
+        /// Perform the auxiliary action(s) first, if specified, before proceeding with the primary action.
+        case primaryAuxiliary
+    }
+}
+
+// MARK: - Hoist dismiss action
+extension View {
+    
+    /// - Parameter dismiss: Pass in the `@Environment(\.dismiss)` property declared in the view being modified.
+    /// - Note: See `hoistNavigation(_ primaryAction:...)`, if declaring dismiss action in your view causes SwiftUI to enter an infinite loop.
+    func hoistNavigation(
+        dismiss: DismissAction,
+        auxiliaryAction: Navigation.AuxiliaryAction? = nil
+    ) -> some View {
+        // TODO: Possibly allow injection. If not, deprecate and remove this function.
+        modifier(
+            NavigationDismissHoisting(
+                auxiliaryAction: auxiliaryAction
+            )
+        )
+    }
+    
+    /// This view modifier variant manages the primary action on behalf of caller.
+    ///
+    /// In some view configurations, declaring the `@Environment(\.dismiss)` property may cause SwiftUI to enter an infinite loop. If so, use this view modifier, instead.
+    func hoistNavigation(
+        _ primaryAction: Navigation.PrimaryAction = .dismiss,
+        auxiliaryAction: Navigation.AuxiliaryAction? = nil
+    ) -> some View {
+        modifier(
+            NavigationDismissHoisting(
+                auxiliaryAction: auxiliaryAction
+            )
+        )
+    }
+}
+
+/// `NavigationDismissView` works around an issue where adding an `@Environment(\.dismiss)` property in some view configurations causes SwiftUI to enter infinite loop.
+///
+/// Technical Note:
+/// - Note: In some configurations, declaring the `@Environment(\.dismiss) var` inside a view modifier causes SwiftUI to enter into infinite loop. [2023.09]
+/// - Note: This view allows us to conditionally move where we declare the dismiss action, if some view (modifier) configuration causes SwiftUI to enter infinite loop. [2023.11]
+private struct NavigationDismissView<Content: View>: View {
+    
+    @Environment(\.dismiss) private var dismissAction
+    private let content: (DismissAction) -> Content
+    
+    init(@ViewBuilder content: @escaping (DismissAction) -> Content) {
+        self.content = content
+    }
+    
+    var body: some View {
+        content(dismissAction)
+    }
+}
+
+struct NavigationDismissHoisting: ViewModifier {
+    
+    private typealias AnyRoute = any Hashable
+    
+    @EnvironmentObject private var navigation: Navigation
+    
+    @Environment(\.navigationPathWithRoutes) private var routesNavigationPath
+    
+    @Environment(\.tabSelectionHashValue) private var selectedTabHashValue
+    
+    private var navigationPath: [AnyRoute] {
+        guard let selectedTabHashValue else {
+            return []
+        }
+        guard selectedTabHashValue.hashValue != TabSelection._tabBarNavigation.hashValue else {
+            assertionFailure()
+            return []
+        }
+        return routesNavigationPath.wrappedValue
+    }
+    
+    let auxiliaryAction: Navigation.AuxiliaryAction?
+    
+    @State private var didAppear = false
+    
+    func body(content: Content) -> some View {
+        NavigationDismissView { dismiss in
+            content
+                .onAppear {
+                    defer { didAppear = true }
+                    
+                    /// This must only be called once:
+                    /// For example, user may wish to drag to peek at the previous view, but then cancel that drag action. During this, the previous view's .onAppear will get called. If we run this logic for that view again, the actual top view's dismiss action will get lost. [2023.09]
+                    if didAppear == false {
+                        #if DEBUG
+                        print("onAppear: hoist navigation dismiss action")
+                        #endif
+                        navigation.dismiss = dismiss
+                        navigation.auxiliaryAction = auxiliaryAction
+                        let pathIndex = max(0, navigationPath.count)
+                        #if DEBUG
+                        print("     adding path action at index -> \(pathIndex)")
+                        #endif
+                        navigation.pathActions[pathIndex] = (dismiss, auxiliaryAction)
+                        #if DEBUG
+                        print("     navigation -> \(Unmanaged.passUnretained(navigation).toOpaque())")
+                        #endif
+                    }
+                }
+                .onDisappear {
+                    #if DEBUG
+                    print("onDisappear: path count -> \(navigationPath.count), action count -> \(navigation.pathActions.count)")
+                    print("     navigation -> \(Unmanaged.passUnretained(navigation).toOpaque())")
+                    #endif
+                    
+                    let removeIndex = navigationPath.count + 1
+                    // swiftlint:disable unused_optional_binding
+                    if let _ = navigation.pathActions.removeValue(forKey: removeIndex) {
+                        #if DEBUG
+                        // swiftlint:enable unused_optional_binding
+                        print("     removed path action at index -> \(removeIndex)")
+                        #endif
+                    } else {
+                        #if DEBUG
+                        print("     no path action to remove at index -> \(removeIndex)")
+                        #endif
+                    }
+                }
+        }
+    }
+}
+
+// MARK: - Enable tab bar navigation
+extension View {
+    
+    /// Unconditionally enable tab bar navigation.
+    func tabBarNavigationEnabled(_ tab: TabSelection, _ navigator: Navigation) -> some View {
+        modifier(PerformTabBarNavigation(tab: tab, navigator: navigator))
+    }
+}
+
+struct PerformTabBarNavigation: ViewModifier {
+    
+    private typealias AnyRoute = any Hashable
+    
+    @Dependency(\.hapticManager) private var hapticManager
+    
+    @Environment(\.navigationPathWithRoutes) private var routesNavigationPath
+    
+    @Environment(\.tabSelectionHashValue) private var selectedTabHashValue
+    @Environment(\.tabNavigationSelectionHashValue) private var selectedNavigationTabHashValue
+
+    private var navigationPath: [AnyRoute] {
+        guard let selectedTabHashValue else {
+            return []
+        }
+        guard selectedTabHashValue.hashValue != TabSelection._tabBarNavigation.hashValue else {
+            assertionFailure()
+            return []
+        }
+        return routesNavigationPath.wrappedValue
+    }
+    
+    let tab: TabSelection
+    let navigator: Navigation
+    
+    func body(content: Content) -> some View {
+        content.onChange(of: selectedNavigationTabHashValue) { newValue in
+            if newValue == tab.hashValue {
+                hapticManager.play(haptic: .gentleInfo, priority: .high)
+                // Customization based  on user preference should occur here, for example:
+                // performSystemPopToRootBehaviour()
+                // noOp()
+                // performDimsissOnly()
+                performDismissAfterAuxiliary()
+            }
+        }
+    }
+    
+    /// Runs all auxiliary actions before calling system dismiss action.
+    private func performDismissAfterAuxiliary() {
+        #if DEBUG
+        print("perform action on path index -> \(navigationPath.count)")
+        #endif
+        guard let pathAction = navigator.pathActions[navigationPath.count] else {
+            #if DEBUG
+            print("path action not found at index -> \(navigationPath.count)")
+            #endif
+            return
+        }
+        
+        if let auxiliaryAction = pathAction.auxiliaryAction {
+            let performed = auxiliaryAction()
+            if !performed, let dismiss = pathAction.dismiss {
+                #if DEBUG
+                print("found auxiliary action, but that logic has been exhausted...perform standard dismiss action")
+                print("perform tab navigation on \(tab) tab")
+                #endif
+                dismiss()
+            } else {
+                #if DEBUG
+                print("performed auxiliary action")
+                #endif
+            }
+        } else if let dismiss = pathAction.dismiss {
+            #if DEBUG
+            print("perform dismiss action via tab navigation on \(tab) tab")
+            #endif
+            dismiss()
+        } else {
+            #if DEBUG
+            print("attempted tab navigation -> action(s) not found")
+            #endif
+        }
+    }
+}

--- a/Mlem/Navigation/README.md
+++ b/Mlem/Navigation/README.md
@@ -1,0 +1,82 @@
+# Navigation
+
+Date Created: Nov. 23, 2023
+
+### Tab Bar Navigation
+
+**Initial Setup: Tab Root View**
+1. Add the following properties to your tab's root view:
+```
+@StateObject private var tabNavigationPath: AnyNavigationPath<AppRoute> = .init()
+@StateObject private var navigation: Navigation = .init()
+```
+2. In your tab's root view (this should also be where a NavigationStack is declared), pass in an `AnyNavigationPath<Path>` binding as that stack's path.
+3. On the NavigationStack itself, pass in the following environment values:
+```
+.environment(\.navigationPathWithRoutes, $tabNavigationPath.path)
+.environmentObject(navigation)
+```
+4. Pass in the navigation path to `handleLemmyLinkResolution(...)`:
+```
+.handleLemmyLinkResolution(navigationPath: .constant(tabNavigationPath))
+```
+5. On the outer-most view *inside* your NavigationStack, do the following:
+- 5a. Pass in the following environment values:
+```
+.environmentObject(tabNavigationPath)
+```
+- 5b. On that same outer-most view, apply the following view modifiers:
+```
+.tabBarNavigationEnabled(.settings, navigation)
+AND either of the following (read the function's documentation for explanation):
+.hoistNavigation(
+    _ primaryAction: .dismiss,
+    auxiliaryAction: nil
+)
+OR:
+.hoistNavigation(
+    dismiss: dismiss,
+    auxiliaryAction: {
+        withAnimation {
+            proxy.scrollTo(scrollToTop, anchor: .bottom)
+        }
+        return true
+    }
+)
+```
+6. And now you're done configuring the tab's root view! See `Tap to Dismiss` section to enable/customize tab navigation behaviour.
+
+**Tap to Dismiss: Enabling Behaviour**
+On each view, including the tab's 'root view:
+1. Add the `@Environment(\.dismiss)` action to view.
+2. On the outer-most view in that view's 'body, apply the `.hoistNavigation(...)` view modifier, optionally passing in an `auxiliaryAction`. For example:
+```
+.hoistNavigation(
+    _ primaryAction: .dismiss,
+    auxiliaryAction: nil
+)
+OR:
+.hoistNavigation(
+    dismiss: dismiss,
+    auxiliaryAction: {
+    /// Example auxiliary action: Scroll to top before performing the dismiss action.
+        withAnimation {
+            proxy.scrollTo(scrollToTop, anchor: .bottom)
+        }
+        return true
+    }
+)
+```
+3. That's it =)
+
+**Tab Navigation: Auxiliary Action**
+Tab navigation is configured such that the auxiliary action is always performed until no more actions can be found. After which, the navigator will perform the dismiss action.
+- In the auxiliary action closure, return `true` to indicate that all auxiliary actions have been performed.
+- You may wish to perform multiple auxiliary actions in a view. For example, you may wish to have the `ExpandedPost` view travel up each parent comment when user taps on tab. In this scenario, continue returning `false` until that view reaches the top. 
+
+**Tab Navigation: Scroll to Top**
+For ease of use, you may wish to declare a `ScrollViewReader` near or at the top of your tab's root view, and then propagate that proxy via the `@Environment(\.scrollViewProxy)` environment value. If you do so, that reader must be wrapped outside of NavigationStack, otherwise environment values won't propagate to views pushed onto the stack. 
+
+## FAQ
+Q: Why can't I rapidly tap the tab bar to trigger multiple navigation actions at once?
+A: Technically, this is possible by programmatically manipulating a navigation path, but doing so will cause SwiftUI's navigation state to become corrupt (on iOS 16/17) such that the navigation data state and UI state become desynced. Our workaround uses the system environment's dismiss action to perform dismissal, which correctly coordinates the data/UI states, but that dismiss action requires a view to become fully dismissed before the previous view's dismiss action can be triggered.

--- a/Mlem/Views/Shared/Accounts/Accounts Page.swift
+++ b/Mlem/Views/Shared/Accounts/Accounts Page.swift
@@ -71,6 +71,7 @@ struct AccountsPage: View {
                 }
             }
         }
+        .hoistNavigation(.dismiss)
         .sheet(isPresented: $isShowingInstanceAdditionSheet) {
             AddSavedInstanceView(onboarding: false)
         }

--- a/Mlem/Views/Shared/DocumentView.swift
+++ b/Mlem/Views/Shared/DocumentView.swift
@@ -18,5 +18,6 @@ struct DocumentView: View {
                 .padding()
         }
         .fancyTabScrollCompatible()
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -70,6 +70,9 @@ struct ExpandedPost: View {
     @State var commentSortingType: CommentSortType = .appStorageValue()
     @State private var postLayoutMode: LargePost.LayoutMode = .maximize
     
+    @State private var scrollToTopAppeared = false
+    @Namespace var scrollToTop
+    
     var body: some View {
         contentView
             .environmentObject(commentTracker)
@@ -91,6 +94,9 @@ struct ExpandedPost: View {
         GeometryReader { proxy in
             ScrollViewReader { (scrollProxy: ScrollViewProxy) in
                 ScrollView {
+                    ScrollToView(appeared: $scrollToTopAppeared)
+                        .id(scrollToTop)
+
                     VStack(spacing: 0) {
                         postView
                             .id(0)
@@ -126,6 +132,16 @@ struct ExpandedPost: View {
                 }
                 .onPreferenceChange(AnchorsKey.self) { anchors in
                     topVisibleCommentId = topCommentRow(of: anchors, in: proxy)
+                }
+                .hoistNavigation {
+                    if scrollToTopAppeared {
+                        return false
+                    } else {
+                        withAnimation {
+                            scrollProxy.scrollTo(scrollToTop)
+                        }
+                        return true
+                    }
                 }
             }
         }

--- a/Mlem/Views/Shared/Posts/Lazy Load Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Lazy Load Expanded Post.swift
@@ -38,6 +38,7 @@ struct LazyLoadExpandedPost: View {
                 progressView
             }
         }
+        .hoistNavigation()
     }
     
     private var progressView: some View {

--- a/Mlem/Views/Shared/ScrollToView.swift
+++ b/Mlem/Views/Shared/ScrollToView.swift
@@ -1,0 +1,56 @@
+//
+//  ScrollToView.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-09-12.
+//
+
+import SwiftUI
+
+/// To enable scroll to behaviour: Assign a @Namespace id, and place this view inside a scroll view in the desired position.
+///
+/// This view is not visible to users.
+/// - Note: Use `ListScrollToView` in `List`.
+/// - Warning: Do not set this view to hidden.
+struct ScrollToView: View {
+    
+    @Binding var appeared: Bool
+    
+    var body: some View {
+        /// We don't have any horizontal scroll views yet, but this may need to be a LazyHStack if we do. [2023.09]
+        LazyVStack(spacing: 0) {
+            HStack(spacing: 0) {
+                EmptyView()
+            }
+            .frame(height: 1)
+            .onAppear {
+                appeared = true
+            }
+            .onDisappear {
+                appeared = false
+            }
+        }
+    }
+}
+
+/// For use inside `List`.
+///
+/// See also: `ScrollToView`.
+struct ListScrollToView: View {
+    
+    @Binding var appeared: Bool
+    
+    var body: some View {
+        /// We don't have any horizontal scroll views yet, but this may need to be a LazyHStack if we do. [2023.09]
+        LazyVStack(spacing: 0) {
+            EmptyView()
+                .frame(height: 1)
+                .onAppear {
+                    appeared = true
+                }
+                .onDisappear {
+                    appeared = false
+                }
+        }
+    }
+}

--- a/Mlem/Views/Tabs/Feeds/Community List/Community List View.swift
+++ b/Mlem/Views/Tabs/Feeds/Community List/Community List View.swift
@@ -21,6 +21,9 @@ struct CommunityListView: View {
     
     @Binding var selectedCommunity: CommunityLinkWithContext?
     
+    /// Set to `false` on disappear.
+    @State private var appeared: Bool = false
+    
     init(selectedCommunity: Binding<CommunityLinkWithContext?>) {
         self._selectedCommunity = selectedCommunity
     }
@@ -72,8 +75,22 @@ struct CommunityListView: View {
                 .navigationBarColor()
                 .listStyle(PlainListStyle())
                 .scrollIndicators(.hidden)
+                .onAppear {
+                    appeared = true
+                }
+                .onDisappear {
+                    appeared = false
+                }
                 
                 SectionIndexTitles(proxy: scrollProxy, communitySections: model.allSections())
+            }
+            .reselectAction(tab: .feeds) {
+                guard appeared else {
+                    return
+                }
+                withAnimation {
+                    scrollProxy.scrollTo("top", anchor: .bottom)
+                }
             }
         }
         .refreshable {

--- a/Mlem/Views/Tabs/Feeds/Components/Sidebar View.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/Sidebar View.swift
@@ -23,6 +23,7 @@ struct CommunitySidebarView: View {
         Section { view }
         .navigationTitle("Sidebar")
         .navigationBarTitleDisplayMode(.inline)
+        .hoistNavigation()
         .task(priority: .userInitiated) {
             // Load community details if they weren't provided already
             if community.moderators == nil {

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -36,7 +36,7 @@ struct FeedRoot: View {
                     .environmentObject(appState)
                     .environmentObject(feedTabNavigation)
                     .handleLemmyViews()
-                    .tabBarNavigationEnabled(.settings, navigation)
+                    .tabBarNavigationEnabled(.feeds, navigation)
                 }
                 .id(rootDetails.id)
                 .environment(\.navigationPathWithRoutes, $feedTabNavigation.path)

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -34,6 +34,8 @@ struct FeedRoot: View {
                     .handleLemmyViews()
                 }
                 .id(rootDetails.id)
+                .environment(\.navigationPathWithRoutes, $feedTabNavigation.path)
+                .environmentObject(navigation)
             } else {
                 Text("Please select a community")
             }

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -16,7 +16,8 @@ struct FeedRoot: View {
     @AppStorage("defaultFeed") var defaultFeed: FeedType = .subscribed
 
     @StateObject private var feedTabNavigation: AnyNavigationPath<AppRoute> = .init()
-
+    @StateObject private var navigation: Navigation = .init()
+    
     @State var rootDetails: CommunityLinkWithContext?
 
     var body: some View {

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -31,7 +31,9 @@ struct FeedRoot: View {
                         feedType: rootDetails.feedType
                     )
                     .environmentObject(appState)
+                    .environmentObject(feedTabNavigation)
                     .handleLemmyViews()
+                    .tabBarNavigationEnabled(.settings, navigation)
                 }
                 .id(rootDetails.id)
                 .environment(\.navigationPathWithRoutes, $feedTabNavigation.path)

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -28,7 +28,7 @@ struct FeedRoot: View {
          - For tab bar navigation (scroll to top) to work, ScrollViewReader must wrap the entire `NavigationSplitView`. Furthermore, the proxy must be passed into the environment on the split view. Attempting to do so on a column view doesn't work. [2023.09]
          */
         ScrollViewReader { scrollProxy in
-            NavigationSplitView {
+            NavigationSplitView(columnVisibility: $columnVisibility) {
                 CommunityListView(selectedCommunity: $rootDetails)
             } detail: {
                 NavigationStack(path: $feedTabNavigation.path) {

--- a/Mlem/Views/Tabs/Feeds/Feed Root.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Root.swift
@@ -19,6 +19,7 @@ struct FeedRoot: View {
     @StateObject private var navigation: Navigation = .init()
     
     @State var rootDetails: CommunityLinkWithContext?
+    @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
 
     var body: some View {
         NavigationSplitView {
@@ -28,7 +29,9 @@ struct FeedRoot: View {
                 NavigationStack(path: $feedTabNavigation.path) {
                     FeedView(
                         community: rootDetails.community,
-                        feedType: rootDetails.feedType
+                        feedType: rootDetails.feedType,
+                        rootDetails: $rootDetails,
+                        splitViewColumnVisibility: $columnVisibility
                     )
                     .environmentObject(appState)
                     .environmentObject(feedTabNavigation)

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -217,16 +217,18 @@ struct FeedView: View {
     private var contentView: some View {
         ScrollView {
             if !postTracker.items.isEmpty {
-                ScrollToView(appeared: $scrollToTopAppeared)
-                    .id(scrollToTop)
-                
-                // note: using .uid here because .id causes swipe actions to break--state changes still seem to properly trigger rerenders this way 🤔
-                ForEach(postTracker.items, id: \.uid) { post in
-                    feedPost(for: post)
+                LazyVStack(spacing: 0) {
+                    ScrollToView(appeared: $scrollToTopAppeared)
+                        .id(scrollToTop)
+                    
+                    // note: using .uid here because .id causes swipe actions to break--state changes still seem to properly trigger rerenders this way 🤔
+                    ForEach(postTracker.items, id: \.uid) { post in
+                        feedPost(for: post)
+                    }
+                    
+                    // TODO: update to use proper LoadingState
+                    EndOfFeedView(loadingState: isLoading && postTracker.page > 1 ? .loading : .done, viewType: .hobbit)
                 }
-                
-                // TODO: update to use proper LoadingState
-                EndOfFeedView(loadingState: isLoading && postTracker.page > 1 ? .loading : .done, viewType: .hobbit)
             }
         }
         .frame(maxWidth: .infinity)

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -179,13 +179,6 @@ struct FeedView: View {
                     noPostsView()
                 }
             }
-            .reselectAction(tab: TabSelection.feeds) {
-                // TODO: SwiftUI doesn't seem to natively support customizing this animation
-                // https://stackoverflow.com/questions/62535553/swiftui-customize-animation-for-scrollto-using-scrollviewreader
-                withAnimation {
-                    scrollProxy.scrollTo("top")
-                }
-            }
             .fancyTabScrollCompatible()
         }
     }

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -26,6 +26,8 @@ struct FeedView: View {
     @AppStorage("postSize") var postSize: PostSize = .large
     @AppStorage("showReadPosts") var showReadPosts: Bool = true
     
+    @Environment(\.navigationPathWithRoutes) private var navigationPath
+    @Environment(\.scrollViewProxy) private var scrollViewProxy
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var filtersTracker: FiltersTracker
     @EnvironmentObject var editorTracker: EditorTracker
@@ -34,12 +36,17 @@ struct FeedView: View {
     
     @State var community: CommunityModel?
     @State var feedType: FeedType
+    @Binding var rootDetails: CommunityLinkWithContext?
+    /// Applicable when presented as root view in a column of NavigationSplitView.
+    @Binding var splitViewColumnVisibility: NavigationSplitViewVisibility
     
     @State var errorDetails: ErrorDetails?
     
     init(
         community: CommunityModel?,
-        feedType: FeedType
+        feedType: FeedType,
+        rootDetails: Binding<CommunityLinkWithContext?>? = nil,
+        splitViewColumnVisibility: Binding<NavigationSplitViewVisibility>? = nil
     ) {
         // need to grab some stuff from app storage to initialize post tracker with
         @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
@@ -52,6 +59,8 @@ struct FeedView: View {
             upvoteOnSave: upvoteOnSave
         ))
         
+        self._rootDetails = rootDetails ?? .constant(nil)
+        self._splitViewColumnVisibility = splitViewColumnVisibility ?? .constant(.automatic)
         self._community = State(initialValue: community)
         
         @AppStorage("fallbackDefaultPostSorting") var fallbackDefaultPostSorting: PostSortType = .hot
@@ -79,6 +88,14 @@ struct FeedView: View {
         isPresentingConfirmDestructive = true
     }
     
+    @Namespace var scrollToTop
+    @State private var scrollToTopAppeared = false
+    private var scrollToTopId: Int? {
+        postTracker.items.first?.id
+    }
+    
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    
     // MARK: - Main Views
     
     var body: some View {
@@ -93,6 +110,47 @@ struct FeedView: View {
             .navigationBarTitleDisplayMode(.inline)
             /// [2023.08] Set to `.visible` to workaround bug where navigation bar background may disappear on certain devices when device rotates.
             .navigationBarColor(visibility: .visible)
+            .hoistNavigation {
+                if navigationPath.isEmpty {
+                    /// Need to check `scrollToTopAppeared` because we want to scroll to top before popping back to sidebar. [2023.09]
+                    if scrollToTopAppeared {
+                        if horizontalSizeClass == .regular {
+                            print("show/hide sidebar in regular size class")
+                            splitViewColumnVisibility = {
+                                if splitViewColumnVisibility == .all {
+                                    return .automatic
+                                } else {
+                                    return .all
+                                }
+                            }()
+                            return true
+                        } else {
+                            print("show/hide sidebar in compact size class")
+                            // This seems a lot more reliable than dismiss action for some reason. [2023.09]
+                            rootDetails = nil
+                            return true
+                            //                                // Return `false` to use dismiss action to go back to sidebar. Not sure
+                            //                                return false
+                        }
+                    } else {
+                        print("scroll to top")
+                        withAnimation {
+                            scrollViewProxy?.scrollTo(scrollToTop, anchor: .top)
+                        }
+                        return true
+                    }
+                } else {
+                    if scrollToTopAppeared {
+                        print("exhausted auxiliary actions, perform dismiss action instead...")
+                        return false
+                    } else {
+                        withAnimation {
+                            scrollViewProxy?.scrollTo(scrollToTop, anchor: .top)
+                        }
+                        return true
+                    }
+                }
+            }
             .environmentObject(postTracker)
             .task {
                 // hack to load if task below fails
@@ -157,30 +215,27 @@ struct FeedView: View {
     
     @ViewBuilder
     private var contentView: some View {
-        ScrollViewReader { scrollProxy in
-            ScrollView {
-                if !postTracker.items.isEmpty {
-                    LazyVStack(spacing: 0) {
-                        EmptyView().id("top")
-                        
-                        // note: using .uid here because .id causes swipe actions to break--state changes still seem to properly trigger rerenders this way 🤔
-                        ForEach(postTracker.items, id: \.uid) { post in
-                            feedPost(for: post)
-                        }
-                        
-                        // TODO: update to use proper LoadingState
-                        EndOfFeedView(loadingState: isLoading && postTracker.page > 1 ? .loading : .done, viewType: .hobbit)
-                    }
+        ScrollView {
+            if !postTracker.items.isEmpty {
+                ScrollToView(appeared: $scrollToTopAppeared)
+                    .id(scrollToTop)
+                
+                // note: using .uid here because .id causes swipe actions to break--state changes still seem to properly trigger rerenders this way 🤔
+                ForEach(postTracker.items, id: \.uid) { post in
+                    feedPost(for: post)
                 }
+                
+                // TODO: update to use proper LoadingState
+                EndOfFeedView(loadingState: isLoading && postTracker.page > 1 ? .loading : .done, viewType: .hobbit)
             }
-            .frame(maxWidth: .infinity)
-            .overlay {
-                if postTracker.items.isEmpty {
-                    noPostsView()
-                }
-            }
-            .fancyTabScrollCompatible()
         }
+        .frame(maxWidth: .infinity)
+        .overlay {
+            if postTracker.items.isEmpty {
+                noPostsView()
+            }
+        }
+        .fancyTabScrollCompatible()
     }
     
     @ViewBuilder

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -149,12 +149,6 @@ struct InboxView: View {
                         }
                     }
                 }
-                .reselectAction(tab: .inbox) {
-                    withAnimation {
-                        // note that the actual "top" views live within the tabs themselves so they get placed correctly within the LazyVStacks
-                        scrollProxy.scrollTo("top")
-                    }
-                }
                 .fancyTabScrollCompatible()
                 .refreshable {
                     // wrapping in task so view redraws don't cancel

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -123,7 +123,7 @@ struct InboxView: View {
                         await handleShouldFilterReadChange(newShouldFilterRead: newValue)
                     }
                 }
-                .tabBarNavigationEnabled(.settings, navigation)
+                .tabBarNavigationEnabled(.inbox, navigation)
         }
         .handleLemmyLinkResolution(navigationPath: .constant(inboxTabNavigation))
         .environment(\.navigationPathWithRoutes, $inboxTabNavigation.path)

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -120,6 +120,7 @@ struct InboxView: View {
                     }
                 }
         }
+        .handleLemmyLinkResolution(navigationPath: .constant(inboxTabNavigation))
         .environment(\.navigationPathWithRoutes, $inboxTabNavigation.path)
         .environmentObject(navigation)
     }

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -99,6 +99,7 @@ struct InboxView: View {
     
     // utility
     @StateObject private var inboxTabNavigation: AnyNavigationPath<AppRoute> = .init()
+    @StateObject private var navigation: Navigation = .init()
     
     var body: some View {
         // NOTE: there appears to be a SwiftUI issue with segmented pickers stacked on top of ScrollViews which causes the tab bar to appear fully transparent. The internet suggests that this may be a bug that only manifests in dev mode, so, unless this pops up in a build, don't worry about it. If it does manifest, we can either put the Picker *in* the ScrollView (bad because then you can't access it without scrolling to the top) or put a Divider() at the bottom of the VStack (bad because then the material tab bar doesn't show)

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -120,6 +120,8 @@ struct InboxView: View {
                     }
                 }
         }
+        .environment(\.navigationPathWithRoutes, $inboxTabNavigation.path)
+        .environmentObject(navigation)
     }
     
     @ViewBuilder var contentView: some View {

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -28,6 +28,9 @@ struct InboxView: View {
     @Dependency(\.personRepository) var personRepository
     
     // MARK: Global
+    
+    @Namespace var scrollToTop
+    @State private var scrollToTopAppeared = false
 
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var editorTracker: EditorTracker
@@ -139,6 +142,9 @@ struct InboxView: View {
             .padding(.top, AppConstants.postAndCommentSpacing)
             
             ScrollViewReader { scrollProxy in
+                ScrollToView(appeared: $scrollToTopAppeared)
+                    .id(scrollToTop)
+
                 ScrollView {
                     if errorOccurred {
                         errorView()
@@ -162,6 +168,12 @@ struct InboxView: View {
                     await Task {
                         await refresh()
                     }.value
+                }
+                .hoistNavigation {
+                    withAnimation {
+                        scrollProxy.scrollTo(scrollToTop)
+                    }
+                    return true
                 }
             }
         }

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -113,12 +113,14 @@ struct InboxView: View {
                 }
                 .listStyle(PlainListStyle())
                 .handleLemmyViews()
+                .environmentObject(inboxTabNavigation)
                 .environmentObject(inboxTracker)
                 .onChange(of: shouldFilterRead) { newValue in
                     Task(priority: .userInitiated) {
                         await handleShouldFilterReadChange(newShouldFilterRead: newValue)
                     }
                 }
+                .tabBarNavigationEnabled(.settings, navigation)
         }
         .handleLemmyLinkResolution(navigationPath: .constant(inboxTabNavigation))
         .environment(\.navigationPathWithRoutes, $inboxTabNavigation.path)

--- a/Mlem/Views/Tabs/Profile/Profile View.swift
+++ b/Mlem/Views/Tabs/Profile/Profile View.swift
@@ -18,14 +18,17 @@ struct ProfileView: View {
     @StateObject private var navigation: Navigation = .init()
     
     var body: some View {
-        NavigationStack(path: $profileTabNavigation.path) {
-            UserView(userID: userID)
-                .handleLemmyViews()
-                .environmentObject(profileTabNavigation)
-                .tabBarNavigationEnabled(.profile, navigation)
+        ScrollViewReader { proxy in
+            NavigationStack(path: $profileTabNavigation.path) {
+                UserView(userID: userID)
+                    .handleLemmyViews()
+                    .environmentObject(profileTabNavigation)
+                    .tabBarNavigationEnabled(.profile, navigation)
+            }
+            .handleLemmyLinkResolution(navigationPath: .constant(profileTabNavigation))
+            .environment(\.navigationPathWithRoutes, $profileTabNavigation.path)
+            .environment(\.scrollViewProxy, proxy)
+            .environmentObject(navigation)
         }
-        .handleLemmyLinkResolution(navigationPath: .constant(profileTabNavigation))
-        .environment(\.navigationPathWithRoutes, $profileTabNavigation.path)
-        .environmentObject(navigation)
     }
 }

--- a/Mlem/Views/Tabs/Profile/Profile View.swift
+++ b/Mlem/Views/Tabs/Profile/Profile View.swift
@@ -22,7 +22,7 @@ struct ProfileView: View {
             UserView(userID: userID)
                 .handleLemmyViews()
                 .environmentObject(profileTabNavigation)
-                .tabBarNavigationEnabled(.settings, navigation)
+                .tabBarNavigationEnabled(.profile, navigation)
         }
         .handleLemmyLinkResolution(navigationPath: .constant(profileTabNavigation))
         .environment(\.navigationPathWithRoutes, $profileTabNavigation.path)

--- a/Mlem/Views/Tabs/Profile/Profile View.swift
+++ b/Mlem/Views/Tabs/Profile/Profile View.swift
@@ -23,5 +23,7 @@ struct ProfileView: View {
                 .handleLemmyViews()
         }
         .handleLemmyLinkResolution(navigationPath: .constant(profileTabNavigation))
+        .environment(\.navigationPathWithRoutes, $profileTabNavigation.path)
+        .environmentObject(navigation)
     }
 }

--- a/Mlem/Views/Tabs/Profile/Profile View.swift
+++ b/Mlem/Views/Tabs/Profile/Profile View.swift
@@ -15,6 +15,7 @@ struct ProfileView: View {
     let userID: Int
 
     @StateObject private var profileTabNavigation: AnyNavigationPath<AppRoute> = .init()
+    @StateObject private var navigation: Navigation = .init()
     
     var body: some View {
         NavigationStack(path: $profileTabNavigation.path) {

--- a/Mlem/Views/Tabs/Profile/Profile View.swift
+++ b/Mlem/Views/Tabs/Profile/Profile View.swift
@@ -21,6 +21,8 @@ struct ProfileView: View {
         NavigationStack(path: $profileTabNavigation.path) {
             UserView(userID: userID)
                 .handleLemmyViews()
+                .environmentObject(profileTabNavigation)
+                .tabBarNavigationEnabled(.settings, navigation)
         }
         .handleLemmyLinkResolution(navigationPath: .constant(profileTabNavigation))
         .environment(\.navigationPathWithRoutes, $profileTabNavigation.path)

--- a/Mlem/Views/Tabs/Profile/User Moderator View.swift
+++ b/Mlem/Views/Tabs/Profile/User Moderator View.swift
@@ -25,6 +25,7 @@ struct UserModeratorView: View {
         .navigationTitle("Moderator Details")
         .navigationBarColor()
         .navigationBarTitleDisplayMode(.inline)
+        .hoistNavigation()
         .headerProminence(.standard)
         .listStyle(.plain)
     }

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -161,11 +161,6 @@ struct UserView: View {
                     moderatorButton
                 }
             }
-            .reselectAction(tab: .profile) {
-                withAnimation {
-                    scrollProxy.scrollTo("top")
-                }
-            }
         }
     }
     

--- a/Mlem/Views/Tabs/Search/SearchRoot.swift
+++ b/Mlem/Views/Tabs/Search/SearchRoot.swift
@@ -15,9 +15,6 @@ struct SearchRoot: View {
             SearchView()
         }
         .handleLemmyLinkResolution(navigationPath: .constant(searchRouter))
-        .reselectAction(tab: TabSelection.search) {
-            print("re-selected search")
-        }
     }
 }
 

--- a/Mlem/Views/Tabs/Search/SearchRoot.swift
+++ b/Mlem/Views/Tabs/Search/SearchRoot.swift
@@ -14,6 +14,8 @@ struct SearchRoot: View {
     var body: some View {
         NavigationStack(path: $searchRouter.path) {
             SearchView()
+                .environmentObject(searchRouter)
+                .tabBarNavigationEnabled(.settings, navigation)
         }
         .handleLemmyLinkResolution(navigationPath: .constant(searchRouter))
         .environment(\.navigationPathWithRoutes, $searchRouter.path)

--- a/Mlem/Views/Tabs/Search/SearchRoot.swift
+++ b/Mlem/Views/Tabs/Search/SearchRoot.swift
@@ -16,6 +16,8 @@ struct SearchRoot: View {
             SearchView()
         }
         .handleLemmyLinkResolution(navigationPath: .constant(searchRouter))
+        .environment(\.navigationPathWithRoutes, $searchRouter.path)
+        .environmentObject(navigation)
     }
 }
 

--- a/Mlem/Views/Tabs/Search/SearchRoot.swift
+++ b/Mlem/Views/Tabs/Search/SearchRoot.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SearchRoot: View {
     @StateObject private var searchRouter: AnyNavigationPath<AppRoute> = .init()
+    @StateObject private var navigation: Navigation = .init()
     
     var body: some View {
         NavigationStack(path: $searchRouter.path) {

--- a/Mlem/Views/Tabs/Search/SearchRoot.swift
+++ b/Mlem/Views/Tabs/Search/SearchRoot.swift
@@ -12,14 +12,17 @@ struct SearchRoot: View {
     @StateObject private var navigation: Navigation = .init()
     
     var body: some View {
-        NavigationStack(path: $searchRouter.path) {
-            SearchView()
-                .environmentObject(searchRouter)
-                .tabBarNavigationEnabled(.settings, navigation)
+        ScrollViewReader { proxy in
+            NavigationStack(path: $searchRouter.path) {
+                SearchView()
+                    .environmentObject(searchRouter)
+                    .tabBarNavigationEnabled(.search, navigation)
+            }
+            .environment(\.scrollViewProxy, proxy)
+            .environment(\.navigationPathWithRoutes, $searchRouter.path)
+            .environmentObject(navigation)
+            .handleLemmyLinkResolution(navigationPath: .constant(searchRouter))
         }
-        .handleLemmyLinkResolution(navigationPath: .constant(searchRouter))
-        .environment(\.navigationPathWithRoutes, $searchRouter.path)
-        .environmentObject(navigation)
     }
 }
 

--- a/Mlem/Views/Tabs/Search/SearchView.swift
+++ b/Mlem/Views/Tabs/Search/SearchView.swift
@@ -27,6 +27,7 @@ struct SearchView: View {
     }
     
     // environment
+    @Environment(\.scrollViewProxy) private var scrollProxy
     @EnvironmentObject var appState: AppState
     @EnvironmentObject private var recentSearchesTracker: RecentSearchesTracker
     @StateObject var searchModel: SearchModel
@@ -36,6 +37,9 @@ struct SearchView: View {
     
     @State var isSearching: Bool = false
     @State var page: Page = .home
+    
+    @Namespace var scrollToTop
+    @State private var scrollToTopAppeared = false
     
     @State private var recentsScrollToTopSignal: Int = .min
     @State private var resultsScrollToTopSignal: Int = .min
@@ -89,6 +93,9 @@ struct SearchView: View {
         ScrollViewReader { proxy in
             ZStack {
                 ScrollView {
+                    ScrollToView(appeared: $scrollToTopAppeared)
+                        .id(scrollToTop)
+
                     SearchHomeView()
                         .environmentObject(homeSearchModel)
                         .environmentObject(homeContentTracker)
@@ -141,6 +148,23 @@ struct SearchView: View {
                     }
                 }
             }
+            .hoistNavigation {
+                withAnimation {
+                    scrollToTop(page: page)
+                }
+                return true
+            }
+        }
+    }
+    
+    private func scrollToTop(page: Page) {
+        switch page {
+        case .home:
+            scrollProxy?.scrollTo(scrollToTop, anchor: .bottom)
+        case .recents:
+            scrollProxy?.scrollTo(recentsScrollToTop, anchor: .bottom)
+        case .results:
+            scrollProxy?.scrollTo(resultsScrollToTop, anchor: .bottom)
         }
     }
 }

--- a/Mlem/Views/Tabs/Search/SearchView.swift
+++ b/Mlem/Views/Tabs/Search/SearchView.swift
@@ -90,70 +90,68 @@ struct SearchView: View {
     
     @ViewBuilder
     private var content: some View {
-        ScrollViewReader { proxy in
-            ZStack {
-                ScrollView {
-                    ScrollToView(appeared: $scrollToTopAppeared)
-                        .id(scrollToTop)
-
-                    SearchHomeView()
-                        .environmentObject(homeSearchModel)
-                        .environmentObject(homeContentTracker)
-                }
-                .fancyTabScrollCompatible()
-                .scrollDismissesKeyboard(.immediately)
-                ._opacity(page == .home ? 1 : 0, speed: page == .home ? 1 : 0)
-                .zIndex(page == .home ? 1 : 0)
+        ZStack {
+            ScrollView {
+                ScrollToView(appeared: $scrollToTopAppeared)
+                    .id(scrollToTop)
                 
-                ScrollView {
-                    HStack { EmptyView() }
-                        .id(recentsScrollToTop)
-                    RecentSearchesView()
-                }
-                .fancyTabScrollCompatible()
-                .scrollDismissesKeyboard(.immediately)
-                ._opacity(page == .recents ? 1 : 0, speed: page == .recents ? 1 : 0)
-                .zIndex(page == .recents ? 1 : 0)
-                .onChange(of: recentsScrollToTopSignal) { _ in
-                    proxy.scrollTo(recentsScrollToTop)
-                }
-                
-                ScrollView {
-                    HStack { EmptyView() }
-                        .id(resultsScrollToTop)
-                    SearchResultsView()
-                        .environmentObject(searchModel)
-                }
-                .fancyTabScrollCompatible()
-                .scrollDismissesKeyboard(.immediately)
-                ._opacity(page == .results ? 1 : 0, speed: page == .results ? 1 : 0)
-                .zIndex(page == .results ? 1 : 0)
-                .onChange(of: resultsScrollToTopSignal) { _ in
-                    proxy.scrollTo(resultsScrollToTop)
-                }
+                SearchHomeView()
+                    .environmentObject(homeSearchModel)
+                    .environmentObject(homeContentTracker)
             }
-            .animation(.default, value: page)
-            .transition(.opacity)
-            .onChange(of: isSearching) { newValue in
-                if newValue, searchModel.searchText.isEmpty {
+            .fancyTabScrollCompatible()
+            .scrollDismissesKeyboard(.immediately)
+            ._opacity(page == .home ? 1 : 0, speed: page == .home ? 1 : 0)
+            .zIndex(page == .home ? 1 : 0)
+            
+            ScrollView {
+                HStack { EmptyView() }
+                    .id(recentsScrollToTop)
+                RecentSearchesView()
+            }
+            .fancyTabScrollCompatible()
+            .scrollDismissesKeyboard(.immediately)
+            ._opacity(page == .recents ? 1 : 0, speed: page == .recents ? 1 : 0)
+            .zIndex(page == .recents ? 1 : 0)
+            .onChange(of: recentsScrollToTopSignal) { _ in
+                scrollProxy?.scrollTo(recentsScrollToTop)
+            }
+            
+            ScrollView {
+                HStack { EmptyView() }
+                    .id(resultsScrollToTop)
+                SearchResultsView()
+                    .environmentObject(searchModel)
+            }
+            .fancyTabScrollCompatible()
+            .scrollDismissesKeyboard(.immediately)
+            ._opacity(page == .results ? 1 : 0, speed: page == .results ? 1 : 0)
+            .zIndex(page == .results ? 1 : 0)
+            .onChange(of: resultsScrollToTopSignal) { _ in
+                scrollProxy?.scrollTo(resultsScrollToTop)
+            }
+        }
+        .animation(.default, value: page)
+        .transition(.opacity)
+        .onChange(of: isSearching) { newValue in
+            if newValue, searchModel.searchText.isEmpty {
+                page = .recents
+            }
+        }
+        .onChange(of: searchModel.searchText) { newValue in
+            if page != .home {
+                if newValue.isEmpty {
                     page = .recents
+                } else {
+                    page = .results
                 }
             }
-            .onChange(of: searchModel.searchText) { newValue in
-                if page != .home {
-                    if newValue.isEmpty {
-                        page = .recents
-                    } else {
-                        page = .results
-                    }
-                }
+        }
+        .hoistNavigation {
+            withAnimation {
+                scrollToTop(page: page)
             }
-            .hoistNavigation {
-                withAnimation {
-                    scrollToTop(page: page)
-                }
-                return true
-            }
+            return true
         }
     }
     

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -117,9 +117,6 @@ struct SettingsView: View {
                         }
                     }
                 }
-                .reselectAction(tab: TabSelection.settings) {
-                    print("re-selected settings")
-                }
             }
             .environmentObject(settingsTabNavigation)
             .fancyTabScrollCompatible()

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -15,7 +15,8 @@ struct SettingsView: View {
     @EnvironmentObject var layoutWidgetTracker: LayoutWidgetTracker
 
     @StateObject private var settingsTabNavigation: AnyNavigationPath<AppRoute> = .init()
-
+    @StateObject private var navigation: Navigation = .init()
+    
     @Environment(\.openURL) private var openURL
 
     @Namespace var scrollToTop

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -127,5 +127,7 @@ struct SettingsView: View {
             .navigationBarColor()
         }
         .handleLemmyLinkResolution(navigationPath: .constant(settingsTabNavigation))
+        .environment(\.navigationPathWithRoutes, $settingsTabNavigation.path)
+        .environmentObject(navigation)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -13,17 +13,17 @@ struct SettingsView: View {
     
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var layoutWidgetTracker: LayoutWidgetTracker
-
+    
     @StateObject private var settingsTabNavigation: AnyNavigationPath<AppRoute> = .init()
     @StateObject private var navigation: Navigation = .init()
     
     @Environment(\.openURL) private var openURL
-
+    
     @Namespace var scrollToTop
     
     var body: some View {
-        NavigationStack(path: $settingsTabNavigation.path) {
-            ScrollViewReader { _ in
+        ScrollViewReader { proxy in
+            NavigationStack(path: $settingsTabNavigation.path) {
                 List {
                     Section {
                         NavigationLink(.settings(.currentAccount)) {
@@ -34,10 +34,10 @@ struct SettingsView: View {
                                     avatarSize: 54,
                                     iconResolution: .unrestricted
                                 )
-                                    .padding(.vertical, -6)
-                                    .padding(.leading, 3)
+                                .padding(.vertical, -6)
+                                .padding(.leading, 3)
                                 if let account = appState.currentActiveAccount {
-
+                                    
                                     VStack(alignment: .leading, spacing: 3) {
                                         Text(account.nickname)
                                             .font(.title2)
@@ -126,6 +126,12 @@ struct SettingsView: View {
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarColor()
             .tabBarNavigationEnabled(.settings, navigation)
+            .hoistNavigation {
+                withAnimation {
+                    proxy.scrollTo(scrollToTop, anchor: .bottom)
+                }
+                return true
+            }
         }
         .handleLemmyLinkResolution(navigationPath: .constant(settingsTabNavigation))
         .environment(\.navigationPathWithRoutes, $settingsTabNavigation.path)

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -125,6 +125,7 @@ struct SettingsView: View {
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarColor()
+            .tabBarNavigationEnabled(.settings, navigation)
         }
         .handleLemmyLinkResolution(navigationPath: .constant(settingsTabNavigation))
         .environment(\.navigationPathWithRoutes, $settingsTabNavigation.path)

--- a/Mlem/Views/Tabs/Settings/Components/Settings View.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Settings View.swift
@@ -118,23 +118,23 @@ struct SettingsView: View {
                         }
                     }
                 }
-            }
-            .environmentObject(settingsTabNavigation)
-            .fancyTabScrollCompatible()
-            .handleLemmyViews()
-            .navigationTitle("Settings")
-            .navigationBarTitleDisplayMode(.inline)
-            .navigationBarColor()
-            .tabBarNavigationEnabled(.settings, navigation)
-            .hoistNavigation {
-                withAnimation {
-                    proxy.scrollTo(scrollToTop, anchor: .bottom)
+                .environmentObject(settingsTabNavigation)
+                .fancyTabScrollCompatible()
+                .handleLemmyViews()
+                .navigationTitle("Settings")
+                .navigationBarTitleDisplayMode(.inline)
+                .navigationBarColor()
+                .tabBarNavigationEnabled(.settings, navigation)
+                .hoistNavigation {
+                    withAnimation {
+                        proxy.scrollTo(scrollToTop, anchor: .bottom)
+                    }
+                    return true
                 }
-                return true
             }
+            .handleLemmyLinkResolution(navigationPath: .constant(settingsTabNavigation))
+            .environment(\.navigationPathWithRoutes, $settingsTabNavigation.path)
+            .environmentObject(navigation)
         }
-        .handleLemmyLinkResolution(navigationPath: .constant(settingsTabNavigation))
-        .environment(\.navigationPathWithRoutes, $settingsTabNavigation.path)
-        .environmentObject(navigation)
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/AboutView.swift
@@ -62,6 +62,7 @@ struct AboutView: View {
         }
         .navigationTitle("About")
         .navigationBarColor()
+        .hoistNavigation()
     }
 
     var versionString: String {

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/ContributorsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/ContributorsView.swift
@@ -73,5 +73,6 @@ struct ContributorsView: View {
         .fancyTabScrollCompatible()
         .navigationTitle("Contributors")
         .navigationBarColor()
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/About/LicensesView.swift
@@ -50,5 +50,6 @@ struct LicensesView: View {
         }
         .navigationTitle("Licenses")
         .navigationBarColor()
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -92,5 +92,6 @@ struct AccessibilitySettingsView: View {
         .fancyTabScrollCompatible()
         .navigationTitle("Accessibility")
         .navigationBarColor()
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Advanced/AdvancedSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Advanced/AdvancedSettingsView.swift
@@ -53,5 +53,6 @@ struct AdvancedSettingsView: View {
         }
         .navigationTitle("Advanced")
         .navigationBarColor()
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/AppearanceSettingsView.swift
@@ -71,5 +71,6 @@ struct AppearanceSettingsView: View {
         .navigationTitle("Appearance")
         .navigationBarColor()
         .navigationBarTitleDisplayMode(.inline)
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Comment/CommentSettingsView.swift
@@ -127,5 +127,6 @@ struct CommentSettingsView: View {
         .navigationTitle("Comments")
         .navigationBarColor()
         .navigationBarTitleDisplayMode(.inline)
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Community/CommunitySettingsView.swift
@@ -24,5 +24,6 @@ struct CommunitySettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Communities")
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -180,5 +180,6 @@ struct PostSettingsView: View {
         .navigationTitle("Posts")
         .navigationBarColor()
         .navigationBarTitleDisplayMode(.inline)
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Shared/LayoutWidgetEditView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Shared/LayoutWidgetEditView.swift
@@ -115,6 +115,7 @@ struct LayoutWidgetEditView: View {
         }
         .navigationTitle("Widgets")
         .navigationBarColor()
+        .hoistNavigation()
     }
     
     var infoText: some View {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/TabBar/TabBarSettingsView.swift
@@ -102,5 +102,6 @@ struct TabBarSettingsView: View {
             print("new nickname: \(nickname)")
             textFieldEntry = nickname
         }
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Theme/ThemeSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Theme/ThemeSettingsView.swift
@@ -72,5 +72,6 @@ struct ThemeSettingsView: View {
         .fancyTabScrollCompatible()
         .navigationTitle("Theme")
         .navigationBarColor()
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/User/UserSettingsView.swift
@@ -26,5 +26,6 @@ struct UserSettingsView: View {
         }
         .fancyTabScrollCompatible()
         .navigationTitle("Users")
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Filters/FiltersSettingsView.swift
@@ -151,6 +151,7 @@ struct FiltersSettingsView: View {
         .navigationTitle("Filters")
         .navigationBarColor()
         .navigationBarTitleDisplayMode(.inline)
+        .hoistNavigation()
         .toolbar {
             ToolbarItem(placement: .automatic) {
                 EditButton()

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -153,5 +153,6 @@ struct GeneralSettingsView: View {
         .fancyTabScrollCompatible()
         .navigationTitle("General")
         .navigationBarColor()
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Sorting/SortingSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Sorting/SortingSettingsView.swift
@@ -62,5 +62,6 @@ struct SortingSettingsView: View {
         .fancyTabScrollCompatible()
         .navigationTitle("Sorting")
         .navigationBarColor()
+        .hoistNavigation()
     }
 }


### PR DESCRIPTION
# Pull Request Information

## About this Pull Request
### Tab Bar Navigation
- Tapping on tab now causes view to scroll to top (except for some document views in Settings).
- Tapping again causes the view to be removed ("popped") from its navigation stack.

### Overview
- Tab re-selection can now be configured to perform a dismiss action and, optionally, auxiliary action(s).
- If configured, the auxiliary action(s) is performed first, before the dismiss action is called.
- The auxiliary action can be configured to run multiple times.
- Views have to opt-in to this system (see `README` for more info).

### Auxiliary Action(s)
- In this PR, the auxiliary action is primarily used to scroll to top.
- Auxiliary actions can be run multiple times until the view decides it's had enough.
- Auxiliary actions can be configured to do pretty much anything, for example:
-- In root views that have a search bar, the auxiliary action can be set to scroll to top first, and then focus on a search bar.
-- Or it can be configured to scroll up to each parent comment.

### Dismiss Action
- This is the primary action, and causes the current view to be removed ("popped") from the navigation stack.
- The only exception is in `FeedView`, where it uses the `rootDetails` binding to pop to sidebar (the system dismiss action was not very reliable in this scenario for some reason). In this corner case setup, the auxiliary action causes `FeedView` to be removed ("popped").

### iPad:
- In `FeedView`, tapping on tab causes sidebar to switch between visible and hidden.

### What's Missing:
- Tap search tab to focus search field.
- In `DocumentView` in Settings, tapping tab never causes view to scroll to top (didn't seem particularly useful).

## Screenshots and Videos

https://github.com/mlemgroup/mlem/assets/2549615/62db20f9-e4df-4c2f-9e61-d4ad6282d366

## Additional Context
- See `README` in `/Navigation` directory for more details.
- This PR removes the current tap to scroll to top logic.
- This branch was re-created from `tab-bar-navigation-2` by following the instructions in the `README` file.
