### PR TITLE
Accounts tab navigation

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -504,6 +504,7 @@
 		E40E018E2AABFBDE00410B2C /* AnyNavigationPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40E018D2AABFBDE00410B2C /* AnyNavigationPath.swift */; };
 		E40E01902AABFC9300410B2C /* AnyNavigablePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40E018F2AABFC9300410B2C /* AnyNavigablePath.swift */; };
 		E42D9B5A2AD6802B0087693C /* OnboardingRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42D9B592AD6802B0087693C /* OnboardingRoutes.swift */; };
+		E449C5912B2AA8A300E3BCF4 /* AccountDiscussionLanguagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E449C5902B2AA8A300E3BCF4 /* AccountDiscussionLanguagesView.swift */; };
 		E453477E2A9DE37300D1B46F /* Array+SafeIndexing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E453477D2A9DE37300D1B46F /* Array+SafeIndexing.swift */; };
 		E453A1D02A81C2140004BB8A /* QuickLookPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */; };
 		E46AF98E2B29A4AA0087FDF3 /* DismissAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46AF98D2B29A4AA0087FDF3 /* DismissAction.swift */; };
@@ -1035,6 +1036,7 @@
 		E40E018D2AABFBDE00410B2C /* AnyNavigationPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyNavigationPath.swift; sourceTree = "<group>"; };
 		E40E018F2AABFC9300410B2C /* AnyNavigablePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyNavigablePath.swift; sourceTree = "<group>"; };
 		E42D9B592AD6802B0087693C /* OnboardingRoutes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingRoutes.swift; sourceTree = "<group>"; };
+		E449C5902B2AA8A300E3BCF4 /* AccountDiscussionLanguagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDiscussionLanguagesView.swift; sourceTree = "<group>"; };
 		E453477D2A9DE37300D1B46F /* Array+SafeIndexing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeIndexing.swift"; sourceTree = "<group>"; };
 		E453A1CF2A81C2140004BB8A /* QuickLookPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewController.swift; sourceTree = "<group>"; };
 		E46AF98D2B29A4AA0087FDF3 /* DismissAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DismissAction.swift; sourceTree = "<group>"; };
@@ -1097,6 +1099,7 @@
 				031A617D2B1CE90F00ABF23B /* ChangePasswordView.swift */,
 				03F4DC9C2B193F4C00556C67 /* MatrixLinkView.swift */,
 				03F4DCA22B1A8B0400556C67 /* AccountGeneralSettingsView.swift */,
+				E449C5902B2AA8A300E3BCF4 /* AccountDiscussionLanguagesView.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -3259,6 +3262,7 @@
 				030AC0522A64666C00037155 /* UserSettingsView.swift in Sources */,
 				CDA2C5262A705D6000649D5A /* PostEditor.swift in Sources */,
 				03A40DAD2AD5EA11005F019F /* NoPostsView.swift in Sources */,
+				E449C5912B2AA8A300E3BCF4 /* AccountDiscussionLanguagesView.swift in Sources */,
 				6372184A2A3A2AAD008C4816 /* APIPost.swift in Sources */,
 				6D693A3E2A5113DF009E2D76 /* CreatePostReport.swift in Sources */,
 				E46AF9922B29AA350087FDF3 /* ScrollToView.swift in Sources */,

--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -112,6 +112,8 @@ struct HandleLemmyLinksDisplay: ViewModifier {
             AccountGeneralSettingsView()
         case .accountAdvanced:
             AdvancedAccountSettingsView()
+        case .accountDiscussionLanguages:
+            AccountDiscussionLanguagesView()
         case .linkMatrixAccount:
             MatrixLinkView()
         case .accounts:

--- a/Mlem/Navigation/Destination Values/SettingsValues.swift
+++ b/Mlem/Navigation/Destination Values/SettingsValues.swift
@@ -13,6 +13,7 @@ enum SettingsPage: DestinationValue {
     case signInAndSecurity
     case accountGeneral
     case accountAdvanced
+    case accountDiscussionLanguages
     case linkMatrixAccount
     case accounts
     case general

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/AccountDiscussionLanguagesView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/AccountDiscussionLanguagesView.swift
@@ -1,0 +1,84 @@
+//
+//  AccountDiscussionLanguagesView.swift
+//  Mlem
+//
+//  Created by Bosco Ho on 2023-12-13.
+//
+
+import SwiftUI
+import Dependencies
+
+struct AccountDiscussionLanguagesView: View {
+    
+    @Dependency(\.siteInformation) var siteInformation: SiteInformationTracker
+    @Dependency(\.apiClient) var apiClient: APIClient
+    @Dependency(\.errorHandler) var errorHandler: ErrorHandler
+
+    @State private var discussionLanguages: Set<Int> = .init()
+    
+    init() {
+        if let info = siteInformation.myUserInfo {
+            _discussionLanguages = .init(wrappedValue: Set(info.discussionLanguages))
+        }
+    }
+    
+    var body: some View {
+        Form {
+            Section {
+                Toggle(isOn: Binding(
+                    get: { discussionLanguages.contains(0) },
+                    set: { selected in
+                        if selected {
+                            discussionLanguages.insert(0)
+                        } else {
+                            discussionLanguages.remove(0)
+                        }
+                        saveDiscussionLanguages()
+                    }
+                )) {
+                    Text("Undetermined")
+                }
+            } footer: {
+                Text("If you deselect Undetermined, you won't see most content.")
+            }
+            Section {
+                ForEach(siteInformation.allLanguages.dropFirst(), id: \.self) { language in
+                    Toggle(isOn: Binding(
+                        get: { discussionLanguages.contains(language.id) },
+                        set: { selected in
+                            if selected {
+                                discussionLanguages.insert(language.id)
+                            } else {
+                                discussionLanguages.remove(language.id)
+                            }
+                            saveDiscussionLanguages()
+                        }
+                    )) {
+                        Text(language.name)
+                    }
+                }
+            }
+        }
+        .fancyTabScrollCompatible()
+        .hoistNavigation()
+    }
+    
+    private func saveDiscussionLanguages() {
+        let newValue = Array(discussionLanguages).sorted()
+        if newValue != siteInformation.myUserInfo?.discussionLanguages {
+            let oldValues = siteInformation.myUserInfo?.discussionLanguages ?? []
+            siteInformation.myUserInfo?.discussionLanguages = newValue
+            Task {
+                if let info = siteInformation.myUserInfo {
+                    do {
+                        try await apiClient.saveUserSettings(myUserInfo: info)
+                    } catch {
+                        discussionLanguages = Set(oldValues)
+                        siteInformation.myUserInfo?.discussionLanguages = oldValues
+                        errorHandler.handle(error)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/AccountGeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/AccountGeneralSettingsView.swift
@@ -17,39 +17,15 @@ struct AccountGeneralSettingsView: View {
     @State var showBotAccounts: Bool = false
     @State var sendNotificationsToEmail: Bool = false
     
-    @State var discussionLanguages: Set<Int> = .init()
-    
     init() {
         if let info = siteInformation.myUserInfo {
             _showNsfw = State(wrappedValue: info.localUserView.localUser.showNsfw)
             _showBotAccounts = State(wrappedValue: info.localUserView.localUser.showBotAccounts)
             _sendNotificationsToEmail = State(wrappedValue: info.localUserView.localUser.sendNotificationsToEmail)
-            _discussionLanguages = State(wrappedValue: Set(info.discussionLanguages))
-        }
-        
-    }
-    
-    func saveDiscussionLanguages() {
-        let newValue = Array(discussionLanguages).sorted()
-        if newValue != siteInformation.myUserInfo?.discussionLanguages {
-            let oldValues = siteInformation.myUserInfo?.discussionLanguages ?? []
-            siteInformation.myUserInfo?.discussionLanguages = newValue
-            Task {
-                if let info = siteInformation.myUserInfo {
-                    do {
-                        try await apiClient.saveUserSettings(myUserInfo: info)
-                    } catch {
-                        discussionLanguages = Set(oldValues)
-                        siteInformation.myUserInfo?.discussionLanguages = oldValues
-                        errorHandler.handle(error)
-                    }
-                }
-            }
         }
     }
     
     var body: some View {
-
         Form {
             Section {
                 SwitchableSettingsItem(
@@ -100,46 +76,9 @@ struct AccountGeneralSettingsView: View {
                 }
             }
             Section {
-                NavigationLink("Discussion Languages") {
-                    Form {
-                        Section {
-                            Toggle(isOn: Binding(
-                                get: { discussionLanguages.contains(0) },
-                                set: { selected in
-                                    if selected {
-                                        discussionLanguages.insert(0)
-                                    } else {
-                                        discussionLanguages.remove(0)
-                                    }
-                                    saveDiscussionLanguages()
-                                }
-                            )) {
-                                Text("Undetermined")
-                            }
-                        } footer: {
-                            Text("If you deselect Undetermined, you won't see most content.")
-                        }
-                        Section {
-                            ForEach(siteInformation.allLanguages.dropFirst(), id: \.self) { language in
-                                Toggle(isOn: Binding(
-                                    get: { discussionLanguages.contains(language.id) },
-                                    set: { selected in
-                                        if selected {
-                                            discussionLanguages.insert(language.id)
-                                        } else {
-                                            discussionLanguages.remove(language.id)
-                                        }
-                                        saveDiscussionLanguages()
-                                    }
-                                )) {
-                                    Text(language.name)
-                                }
-                            }
-                        }
-                    }
-                    .fancyTabScrollCompatible()
+                NavigationLink(.settings(.accountDiscussionLanguages)) {
+                    Text("Discussion Languages")
                 }
-                
             }
             Section {
                 SwitchableSettingsItem(

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/AccountGeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/AccountGeneralSettingsView.swift
@@ -173,5 +173,6 @@ struct AccountGeneralSettingsView: View {
             }
         }
         .navigationTitle("Content & Notifications")
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/AccountSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/AccountSettingsView.swift
@@ -127,6 +127,7 @@ struct AccountSettingsView: View {
         }
         .navigationTitle("Account Settings")
         .fancyTabScrollCompatible()
+        .hoistNavigation()
         .sheet(item: $accountForDeletion) { account in
             DeleteAccountView(account: account)
         }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/AdvancedAccountSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/AdvancedAccountSettingsView.swift
@@ -48,5 +48,6 @@ struct AdvancedAccountSettingsView: View {
             }
         }
         .navigationTitle("Advanced")
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/MatrixLinkView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/MatrixLinkView.swift
@@ -110,5 +110,6 @@ struct MatrixLinkView: View {
                 }
             }
         }
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/ProfileSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/ProfileSettingsView.swift
@@ -106,5 +106,6 @@ struct ProfileSettingsView: View {
             }
         }
         .fancyTabScrollCompatible()
+        .hoistNavigation()
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/SignInAndSecuritySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/SignInAndSecuritySettingsView.swift
@@ -127,5 +127,6 @@ struct SignInAndSecuritySettingsView: View {
             }
         }
         .fancyTabScrollCompatible()
+        .hoistNavigation()
     }
 }


### PR DESCRIPTION
# Pull Request Information

## About this Pull Request
+ Opts in the new accounts views into tab bar navigation (only dismiss, no scroll to top).
+ Moves account discussion languages view into separate view, instead of nesting it inside NavigationLink. This is necessary because SwiftUI has trouble figuring out which dismiss action to get when there are two full-screen views inside a single view definition.