### PR TITLE
Cursor pagination hotfix

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3439,7 +3439,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -3480,7 +3480,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Mlem/API/Requests/Post/GetPosts.swift
+++ b/Mlem/API/Requests/Post/GetPosts.swift
@@ -39,8 +39,10 @@ struct GetPostsRequest: APIGetRequest {
         
         let paginationParameter: URLQueryItem
         if let cursor {
-            paginationParameter = .init(name: "page_v2", value: cursor)
+            print("adding page cursor")
+            paginationParameter = .init(name: "page_cursor", value: cursor)
         } else {
+            print("adding raw page")
             paginationParameter = .init(name: "page", value: "\(page)")
         }
         

--- a/Mlem/API/Requests/Post/GetPosts.swift
+++ b/Mlem/API/Requests/Post/GetPosts.swift
@@ -39,10 +39,8 @@ struct GetPostsRequest: APIGetRequest {
         
         let paginationParameter: URLQueryItem
         if let cursor {
-            print("adding page cursor")
             paginationParameter = .init(name: "page_cursor", value: cursor)
         } else {
-            print("adding raw page")
             paginationParameter = .init(name: "page", value: "\(page)")
         }
         

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -90,7 +90,6 @@ class PostTracker: ObservableObject {
             if newPosts.isEmpty {
                 hasReachedEnd = true
             } else if let currentCursor, cursor == currentCursor {
-                print("cursor has reached end")
                 hasReachedEnd = true
             } else {
                 await add(newPosts, filtering: filtering)

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -76,7 +76,6 @@ class PostTracker: ObservableObject {
         var newPosts: [PostModel] = .init()
         let numItems = items.count
         repeat {
-            print("[DEBUG] current cursor: \(currentCursor)")
             let (posts, cursor) = try await postRepository.loadPage(
                 communityId: communityId,
                 page: page,
@@ -88,11 +87,10 @@ class PostTracker: ObservableObject {
             
             newPosts = posts
             
-            print("[DEBUG] got \(newPosts.count) new posts")
-            
             if newPosts.isEmpty {
                 hasReachedEnd = true
             } else if let currentCursor, cursor == currentCursor {
+                print("cursor has reached end")
                 hasReachedEnd = true
             } else {
                 await add(newPosts, filtering: filtering)
@@ -206,7 +204,7 @@ class PostTracker: ObservableObject {
         let thresholdIndex = max(0, items.index(items.endIndex, offsetBy: AppConstants.infiniteLoadThresholdOffset))
         if thresholdIndex >= 0,
            let itemIndex = items.firstIndex(where: { $0.uid == item.uid }),
-           itemIndex >= thresholdIndex {
+           itemIndex == thresholdIndex {
             return true
         }
 

--- a/Mlem/Models/Trackers/Post Tracker.swift
+++ b/Mlem/Models/Trackers/Post Tracker.swift
@@ -76,6 +76,7 @@ class PostTracker: ObservableObject {
         var newPosts: [PostModel] = .init()
         let numItems = items.count
         repeat {
+            print("[DEBUG] current cursor: \(currentCursor)")
             let (posts, cursor) = try await postRepository.loadPage(
                 communityId: communityId,
                 page: page,
@@ -86,6 +87,8 @@ class PostTracker: ObservableObject {
             )
             
             newPosts = posts
+            
+            print("[DEBUG] got \(newPosts.count) new posts")
             
             if newPosts.isEmpty {
                 hasReachedEnd = true


### PR DESCRIPTION
Hotfix to address prod issue where 0.19 instances are unable to properly paginate, resulting in "end of feed" after one page.

Tested on lemmy.ca and lemmy.ml.

- Updates the pagination cursor from `page_v2` to the correct `page_cursor`
- Updates `shouldLoadContentAfter` to only return true once per page of posts, which avoids a multithreading issue where multiple concurrent load calls triggered an erroneous "end of feed" status due to a race condition on `currentCursor`. Note that this should properly be handled by migrating PostTracker to be based on StandardTracker.