### PR TITLE
Added subscribe indicator to community

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 		CD8C55342A95515C0060B75B /* Onboarding Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8C55332A95515C0060B75B /* Onboarding Text.swift */; };
 		CD8CF2092AF3F131009FFC23 /* Firm Info.ahap in Resources */ = {isa = PBXBuildFile; fileRef = CD8CF2082AF3F131009FFC23 /* Firm Info.ahap */; };
 		CD9A03C62B34D20500C16276 /* EnvironmentValues+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9A03C52B34D20500C16276 /* EnvironmentValues+Navigation.swift */; };
+		CD9A03C82B389F7000C16276 /* EnvironmentValues+FeedType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9A03C72B389F7000C16276 /* EnvironmentValues+FeedType.swift */; };
 		CD9A49D12B045B64001E18A0 /* ZoomableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9A49D02B045B64001E18A0 /* ZoomableContainer.swift */; };
 		CD9A49D32B045B81001E18A0 /* ZoomableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9A49D22B045B81001E18A0 /* ZoomableImageView.swift */; };
 		CD9A49D52B0587F1001E18A0 /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9A49D42B0587F1001E18A0 /* ImageDetailView.swift */; };
@@ -969,6 +970,7 @@
 		CD8C55332A95515C0060B75B /* Onboarding Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Onboarding Text.swift"; sourceTree = "<group>"; };
 		CD8CF2082AF3F131009FFC23 /* Firm Info.ahap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Firm Info.ahap"; sourceTree = "<group>"; };
 		CD9A03C52B34D20500C16276 /* EnvironmentValues+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+Navigation.swift"; sourceTree = "<group>"; };
+		CD9A03C72B389F7000C16276 /* EnvironmentValues+FeedType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+FeedType.swift"; sourceTree = "<group>"; };
 		CD9A49D02B045B64001E18A0 /* ZoomableContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableContainer.swift; sourceTree = "<group>"; };
 		CD9A49D22B045B81001E18A0 /* ZoomableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableImageView.swift; sourceTree = "<group>"; };
 		CD9A49D42B0587F1001E18A0 /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
@@ -2304,6 +2306,7 @@
 				CD46C1F52B0D0A5700065953 /* EnvironmentValues+TabReselectionHashValue.swift */,
 				CDDCF6462A663849003DA3AC /* EnvironmentValues+TabSelectionHashValue.swift */,
 				CD9A03C52B34D20500C16276 /* EnvironmentValues+Navigation.swift */,
+				CD9A03C72B389F7000C16276 /* EnvironmentValues+FeedType.swift */,
 			);
 			path = EnvironmentValues;
 			sourceTree = "<group>";
@@ -3246,6 +3249,7 @@
 				CD863FBC2A6B026400A31ED9 /* DocumentView.swift in Sources */,
 				CD8461662A96F9EB0026A627 /* Website Indicator View.swift in Sources */,
 				038A16E92A7A9C640087987E /* LayoutWidget.swift in Sources */,
+				CD9A03C82B389F7000C16276 /* EnvironmentValues+FeedType.swift in Sources */,
 				50811B2E2A92046D006BA3F2 /* URL+Mock.swift in Sources */,
 				E409E16E2AFEFB8C0026FDC2 /* ImageDetailSheetState.swift in Sources */,
 				CD3FBCE52A4A89B900B2063F /* Mentions Feed View.swift in Sources */,

--- a/Mlem/API/Models/Community/APISubscribedStatus.swift
+++ b/Mlem/API/Models/Community/APISubscribedStatus.swift
@@ -12,4 +12,13 @@ enum APISubscribedStatus: String, Decodable {
     case subscribed = "Subscribed"
     case pending = "Pending"
     case notSubscribed = "NotSubscribed"
+    
+    var isSubscribed: Bool {
+        switch self {
+        case .subscribed:
+            true
+        default:
+            false
+        }
+    }
 }

--- a/Mlem/Extensions/EnvironmentValues/EnvironmentValues+FeedType.swift
+++ b/Mlem/Extensions/EnvironmentValues/EnvironmentValues+FeedType.swift
@@ -1,0 +1,20 @@
+//
+//  EnvironmentValues+FeedType.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-12-24.
+//
+
+import Foundation
+import SwiftUI
+
+private struct FeedTypeEnvironmentKey: EnvironmentKey {
+    static let defaultValue: FeedType? = nil
+}
+
+extension EnvironmentValues {
+    var feedType: FeedType? {
+        get { self[FeedTypeEnvironmentKey.self] }
+        set { self[FeedTypeEnvironmentKey.self] = newValue }
+    }
+}

--- a/Mlem/Models/Content/Community/CommunityModel.swift
+++ b/Mlem/Models/Content/Community/CommunityModel.swift
@@ -76,11 +76,11 @@ struct CommunityModel {
     init(from communityView: APICommunityView) {
         self.init(from: communityView.community)
         self.subscriberCount = communityView.counts.subscribers
-        self.subscribed = communityView.subscribed != .notSubscribed ? true : false
+        self.subscribed = communityView.subscribed.isSubscribed
         self.blocked = communityView.blocked
     }
     
-    init(from community: APICommunity) {
+    init(from community: APICommunity, subscribed: Bool? = nil) {
         self.community = community
         
         self.communityId = community.id
@@ -104,6 +104,8 @@ struct CommunityModel {
         self.updatedDate = community.updated
         
         self.communityUrl = community.actorId
+        
+        self.subscribed = subscribed
     }
     
     mutating func toggleSubscribe(_ callback: @escaping (_ item: Self) -> Void = { _ in }) async throws {
@@ -168,7 +170,7 @@ extension CommunityModel: Identifiable {
 
 extension CommunityModel: Hashable {
     static func == (lhs: CommunityModel, rhs: CommunityModel) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        lhs.hashValue == rhs.hashValue
     }
     
     /// Hashes all fields for which state changes should trigger view updates.
@@ -177,6 +179,6 @@ extension CommunityModel: Hashable {
         hasher.combine(subscribed)
         hasher.combine(subscriberCount)
         hasher.combine(blocked)
-        hasher.combine(moderators?.map { $0.moderator.id } ?? [])
+        hasher.combine(moderators?.map(\.moderator.id) ?? [])
     }
 }

--- a/Mlem/Models/Content/Post Model.swift
+++ b/Mlem/Models/Content/Post Model.swift
@@ -30,7 +30,7 @@ struct PostModel {
         self.postId = apiPostView.post.id
         self.post = apiPostView.post
         self.creator = UserModel(from: apiPostView.creator)
-        self.community = CommunityModel(from: apiPostView.community)
+        self.community = CommunityModel(from: apiPostView.community, subscribed: apiPostView.subscribed.isSubscribed)
         self.votes = VotesModel(from: apiPostView.counts, myVote: apiPostView.myVote)
         self.numReplies = apiPostView.counts.comments
         self.saved = apiPostView.saved

--- a/Mlem/Views/Shared/Links/Community/CommunityLabelView.swift
+++ b/Mlem/Views/Shared/Links/Community/CommunityLabelView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 struct CommunityLabelView: View {
     // settings
     @AppStorage("shouldShowCommunityIcons") var shouldShowCommunityIcons: Bool = true
+    @AppStorage("shouldShowSubscribedStatus") var shouldShowSubscribedStatus: Bool = true
+    
+    @Environment(\.feedType) var feedType
 
     // parameters
     let community: CommunityModel
@@ -27,6 +30,15 @@ struct CommunityLabelView: View {
         } else {
             return shouldShowCommunityIcons
         }
+    }
+    
+    var showSubscribed: Bool {
+        if let feedType, feedType != .subscribed {
+            return shouldShowSubscribedStatus &&
+                !(overrideShowSubscribed ?? false) &&
+                community.subscribed ?? false
+        }
+        return false
     }
     
     @available(*, deprecated, message: "Provide a CommunityModel rather than an APICommunity.")
@@ -92,13 +104,20 @@ struct CommunityLabelView: View {
     @ViewBuilder
     private var communityName: some View {
         HStack(spacing: 4) {
+            if showSubscribed, serverInstanceLocation != .bottom {
+                Image(systemName: Icons.present)
+                    .font(.system(size: 8.0))
+                    .imageScale(.small)
+                    .foregroundColor(.secondary)
+            }
+            
             Text(community.name)
                 .dynamicTypeSize(.small ... .accessibility1)
                 .font(.footnote)
                 .bold()
                 .foregroundColor(.secondary)
             
-            if community.subscribed ?? false {
+            if showSubscribed, serverInstanceLocation == .bottom {
                 Image(systemName: Icons.present)
                     .font(.system(size: 8.0))
                     .imageScale(.small)

--- a/Mlem/Views/Shared/Links/Community/CommunityLabelView.swift
+++ b/Mlem/Views/Shared/Links/Community/CommunityLabelView.swift
@@ -14,6 +14,7 @@ struct CommunityLabelView: View {
     let community: CommunityModel
     let serverInstanceLocation: ServerInstanceLocation
     let overrideShowAvatar: Bool? // if present, shows or hides the avatar according to value; otherwise uses system setting
+    let overrideShowSubscribed: Bool? // if present, shows or hides the subscribed status according to the value
     
     var avatarSize: CGFloat { serverInstanceLocation == .bottom
         ? AppConstants.largeAvatarSize
@@ -44,11 +45,13 @@ struct CommunityLabelView: View {
     init(
         community: CommunityModel,
         serverInstanceLocation: ServerInstanceLocation,
-        overrideShowAvatar: Bool? = nil
+        overrideShowAvatar: Bool? = nil,
+        overrideShowSubscribed: Bool? = nil
     ) {
         self.community = community
         self.serverInstanceLocation = serverInstanceLocation
         self.overrideShowAvatar = overrideShowAvatar
+        self.overrideShowSubscribed = overrideShowSubscribed
     }
 
     var body: some View {
@@ -58,34 +61,50 @@ struct CommunityLabelView: View {
                     AvatarView(community: community, avatarSize: avatarSize)
                         .accessibilityHidden(true)
                 }
-
-                switch serverInstanceLocation {
-                case .disabled:
-                    communityName
-                case .trailing:
-                    HStack(spacing: 0) {
-                        communityName
-                        communityInstance
-                    }
-                    .foregroundColor(.secondary)
-                case .bottom:
-                    VStack(alignment: .leading) {
-                        communityName
-                        communityInstance
-                    }
-                }
+                
+                communityLabel
             }
             .accessibilityElement(children: .combine)
+        }
+    }
+    
+    @ViewBuilder
+    private var communityLabel: some View {
+        HStack(spacing: 4) {
+            switch serverInstanceLocation {
+            case .disabled:
+                communityName
+            case .trailing:
+                HStack(spacing: 0) {
+                    communityName
+                    communityInstance
+                }
+                .foregroundColor(.secondary)
+            case .bottom:
+                VStack(alignment: .leading) {
+                    communityName
+                    communityInstance
+                }
+            }
         }
     }
 
     @ViewBuilder
     private var communityName: some View {
-        Text(community.name)
-            .dynamicTypeSize(.small ... .accessibility1)
-            .font(.footnote)
-            .bold()
-            .foregroundColor(.secondary)
+        HStack(spacing: 4) {
+            Text(community.name)
+                .dynamicTypeSize(.small ... .accessibility1)
+                .font(.footnote)
+                .bold()
+                .foregroundColor(.secondary)
+            
+            if community.subscribed ?? false {
+                Image(systemName: Icons.present)
+                    .font(.system(size: 8.0))
+                    .imageScale(.small)
+                    .foregroundColor(.secondary)
+            }
+        }
     }
 
     @ViewBuilder
@@ -101,5 +120,4 @@ struct CommunityLabelView: View {
             EmptyView()
         }
     }
-
 }

--- a/Mlem/Views/Shared/Links/Community/CommunityLabelView.swift
+++ b/Mlem/Views/Shared/Links/Community/CommunityLabelView.swift
@@ -17,7 +17,6 @@ struct CommunityLabelView: View {
     let community: CommunityModel
     let serverInstanceLocation: ServerInstanceLocation
     let overrideShowAvatar: Bool? // if present, shows or hides the avatar according to value; otherwise uses system setting
-    let overrideShowSubscribed: Bool? // if present, shows or hides the subscribed status according to the value
     
     var avatarSize: CGFloat { serverInstanceLocation == .bottom
         ? AppConstants.largeAvatarSize
@@ -35,7 +34,6 @@ struct CommunityLabelView: View {
     var showSubscribed: Bool {
         if let feedType, feedType != .subscribed {
             return shouldShowSubscribedStatus &&
-                !(overrideShowSubscribed ?? false) &&
                 community.subscribed ?? false
         }
         return false
@@ -57,13 +55,11 @@ struct CommunityLabelView: View {
     init(
         community: CommunityModel,
         serverInstanceLocation: ServerInstanceLocation,
-        overrideShowAvatar: Bool? = nil,
-        overrideShowSubscribed: Bool? = nil
+        overrideShowAvatar: Bool? = nil
     ) {
         self.community = community
         self.serverInstanceLocation = serverInstanceLocation
         self.overrideShowAvatar = overrideShowAvatar
-        self.overrideShowSubscribed = overrideShowSubscribed
     }
 
     var body: some View {

--- a/Mlem/Views/Tabs/Feeds/Feed View.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed View.swift
@@ -152,6 +152,7 @@ struct FeedView: View {
                 }
             }
             .environmentObject(postTracker)
+            .environment(\.feedType, feedType)
             .task {
                 // hack to load if task below fails
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -21,6 +21,7 @@ struct PostSettingsView: View {
     
     // Community
     @AppStorage("shouldShowCommunityServerInPost") var shouldShowCommunityServerInPost: Bool = true
+    @AppStorage("shouldShowSubscribedStatus") var shouldShowSubscribedStatus: Bool = true
     
     // Author
     @AppStorage("shouldShowPostCreator") var shouldShowPostCreator: Bool = true
@@ -80,6 +81,12 @@ struct PostSettingsView: View {
                     settingPictureSystemName: Icons.instance,
                     settingName: "Show Community Server Instance",
                     isTicked: $shouldShowCommunityServerInPost
+                )
+                
+                SwitchableSettingsItem(
+                    settingPictureSystemName: Icons.subscribed,
+                    settingName: "Show Subscribed Status",
+                    isTicked: $shouldShowSubscribedStatus
                 )
                 
                 SwitchableSettingsItem(


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - From community
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR adds a subscription status indicator to the community label and a toggle in settings to enable/disable it. To support this, it adds logic to enrich the `CommunityModel` created within a `PostModel` with the subscription status.
 
<img width="395" alt="Screenshot 2023-12-24 at 1 10 33 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/ddc7506f-c528-49b0-8b8d-2f2652b479f2">

<img width="403" alt="Screenshot 2023-12-24 at 1 14 14 PM" src="https://github.com/mlemgroup/mlem/assets/44140166/1001c51f-82e3-497d-bc61-a75fdc6272f0">

