### PR TITLE
Embedded Post Link Multiline Fix

### DIFF
--- a/Mlem/Views/Shared/Comments/Components/Embedded Post.swift
+++ b/Mlem/Views/Shared/Comments/Components/Embedded Post.swift
@@ -42,6 +42,7 @@ struct EmbeddedPost: View {
     private func postLinkButton() -> some View {
         VStack(alignment: .leading, spacing: 5) {
             Text(post.embedTitle ?? post.name)
+                .multilineTextAlignment(.leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .foregroundColor(.secondary)
                 .font(.subheadline)


### PR DESCRIPTION
Fixed the embedded post link title alignment so that it's aligned to the leading edge rather than the center.

Before:

<img src="https://github.com/mlemgroup/mlem/assets/78750526/53d2fd9b-af7f-4d79-ae53-fa703dcbb6de" width=50%>
<br/>
After:
<br/>
<img src="https://github.com/mlemgroup/mlem/assets/78750526/fabf80fb-8742-4c0d-9934-ec4b93ec5996" width=50%>

