### PR TITLE
Search Reselection

### DIFF
--- a/Mlem/Views/Shared/Search Bar/SearchBar.swift
+++ b/Mlem/Views/Shared/Search Bar/SearchBar.swift
@@ -133,19 +133,34 @@ import SwiftUI
             (uiView as? _UISearchBar)?.isFirstResponderBinding = isFocused
 
             do {
-                if let uiView = uiView as? _UISearchBar, environment.isEnabled {
-                    DispatchQueue.main.async {
-                        if let isFocused, uiView.window != nil {
-                            uiView.isFirstResponderBinding = isFocused
-
-                            if isFocused.wrappedValue, !uiView.isFirstResponder {
-                                uiView.becomeFirstResponder()
-                            } else if !isFocused.wrappedValue, uiView.isFirstResponder {
-                                uiView.resignFirstResponder()
-                            }
+                // version of below with no responder binding. it's not a pretty hack but it does work
+                // note that switching tabs with search selected will result in search still displaying "search for communities and users,"
+                // but since the keyboard hides the tab bar that probably won't come up for 99% of users
+                if let isFocused, environment.isEnabled {
+                    if isFocused.wrappedValue, !uiView.isFirstResponder {
+                        DispatchQueue.main.async {
+                            uiView.becomeFirstResponder()
+                        }
+                    } else if !isFocused.wrappedValue, uiView.isFirstResponder {
+                        DispatchQueue.main.async {
+                            uiView.resignFirstResponder()
                         }
                     }
                 }
+                
+//                if let uiView = uiView as? _UISearchBar, environment.isEnabled {
+//                    DispatchQueue.main.async {
+//                        if let isFocused, uiView.window != nil {
+//                            uiView.isFirstResponderBinding = isFocused
+//
+//                            if isFocused.wrappedValue, !uiView.isFirstResponder {
+//                                uiView.becomeFirstResponder()
+//                            } else if !isFocused.wrappedValue, uiView.isFirstResponder {
+//                                uiView.resignFirstResponder()
+//                            }
+//                        }
+//                    }
+//                }
             }
         }
     


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #246 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

This PR enables re-selecting the search tab to focus the search bar, provided that the feed is already scrolled to the top. I needed to do some slightly unsightly things to the SwiftUIX search bar to make the reselection work, as `let uiView = uiView as? _UISearchBar` never seems to execute and so the stock `.focused` doesn't work--the hack I've written doesn't have binding support, so *de-*selecting search requires some manual work, but since navigating off of the search tab usually requires dismissing the keyboard and therefore unfocusing search I don't think that's a huge problem.

https://github.com/mlemgroup/mlem/assets/44140166/60acbcc4-3b9a-4d53-acd5-6359d55a798c

https://github.com/mlemgroup/mlem/assets/44140166/8f904f4c-e4a2-45ec-9183-d9ab0c33d432