### PR TITLE
Accout Switch error bug fix

### DIFF
--- a/Mlem/Views/Tabs/Settings/Components/AccountButtonView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/AccountButtonView.swift
@@ -15,6 +15,7 @@ struct AccountButtonView: View {
     @Environment(\.setAppFlow) private var setFlow
     
     @State var showingSignOutConfirmation: Bool = false
+    @Binding var isSwitching: Bool
     
     enum CaptionState {
         case instanceOnly, timeOnly, instanceAndTime
@@ -23,9 +24,10 @@ struct AccountButtonView: View {
     let account: SavedAccount
     let caption: CaptionState
     
-    init(account: SavedAccount, caption: CaptionState = .instanceAndTime) {
+    init(account: SavedAccount, caption: CaptionState = .instanceAndTime, isSwitching: Binding<Bool>) {
         self.account = account
         self.caption = caption
+        self._isSwitching = isSwitching
     }
     
     var timeText: String? {
@@ -126,6 +128,7 @@ struct AccountButtonView: View {
     
     private func setFlow(using account: SavedAccount?) {
         if let account {
+            isSwitching = true
             setFlow(.account(account))
             return
         }

--- a/Mlem/Views/Tabs/Settings/Components/AccountListView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/AccountListView.swift
@@ -31,6 +31,8 @@ struct AccountListView: View {
     
     @State private var isShowingInstanceAdditionSheet: Bool = false
     
+    @State var isSwitching: Bool = false
+    
     struct AccountGroup {
         let header: String
         let accounts: [SavedAccount]
@@ -47,37 +49,40 @@ struct AccountListView: View {
     
     var body: some View {
         Group {
-            if accountsTracker.savedAccounts.count > 3 && groupAccountSort {
-                ForEach(Array(accountGroups.enumerated()), id: \.offset) { offset, group in
-                    Section {
-                        ForEach(group.accounts, id: \.self) { account in
-                            AccountButtonView(
-                                account: account,
-                                caption: accountSort != .instance || group.header == "Other" ? .instanceAndTime : .timeOnly
-                            )
+            if !isSwitching {
+                if accountsTracker.savedAccounts.count > 3 && groupAccountSort {
+                    ForEach(Array(accountGroups.enumerated()), id: \.offset) { offset, group in
+                        Section {
+                            ForEach(group.accounts, id: \.self) { account in
+                                AccountButtonView(
+                                    account: account,
+                                    caption: accountSort != .instance || group.header == "Other" ? .instanceAndTime : .timeOnly,
+                                    isSwitching: $isSwitching
+                                )
+                            }
+                        } header: {
+                            if offset == 0 {
+                                topHeader(text: group.header)
+                            } else {
+                                Text(group.header)
+                            }
                         }
-                    } header: {
-                        if offset == 0 {
-                            topHeader(text: group.header)
-                        } else {
-                            Text(group.header)
+                    }
+                } else {
+                    Section(header: topHeader()) {
+                        ForEach(accounts, id: \.self) { account in
+                            AccountButtonView(account: account, isSwitching: $isSwitching)
                         }
                     }
                 }
-            } else {
-                Section(header: topHeader()) {
-                    ForEach(accounts, id: \.self) { account in
-                        AccountButtonView(account: account)
+                Section {
+                    Button {
+                        isShowingInstanceAdditionSheet = true
+                    } label: {
+                        Label("Add Account", systemImage: "plus")
                     }
+                    .accessibilityLabel("Add a new account.")
                 }
-            }
-            Section {
-                Button {
-                    isShowingInstanceAdditionSheet = true
-                } label: {
-                    Label("Add Account", systemImage: "plus")
-                }
-                .accessibilityLabel("Add a new account.")
             }
         }
         .sheet(isPresented: $isShowingInstanceAdditionSheet) {


### PR DESCRIPTION
When switching accounts, there was a chance of a `fatalError` occurring. The `fatalError` did not have a line number, and had the following message:

```
Fatal Error: Duplicate keys of type 'SavedAccount' were found in a dictionary.
```

This occurred when switching accounts using the quick-switcher, settings page or profile switcher. I was able to reproduce the problem roughly every 5-10 account switches via the quick switcher. I was logged into 3 accounts, if that makes any difference.

To be honest, I'm not exactly sure what was causing this. We don't have a dictionary with `SavedAccount` keys anywhere in the program, so maybe it's an internal SwiftUI issue? I did some testing, and discovered that it didn't occur if I switched accounts not via the quick switcher view (I added a temporary button that switched to a different account to test this). I also added debug `print` statements to find that the issue didn't occur anywhere in the `flowDidChange` logic. So I reckon it's probably something to do with SwiftUI.

I've "fixed" the bug by immediately hiding the accounts list as soon as one of the buttons is clicked, which seems to fix the issue. Since the bug happens seemingly randomly, there's a chance I just haven't encountered it yet and it's still there haha, but I've tried a good 100 or so times and haven't got it again thus far. So I'm hoping this is a working fix