### PR TITLE
Fix Sort Mode Labelling Inconsistency

### DIFF
--- a/Mlem/Enums/Settings/PostSortType.swift
+++ b/Mlem/Enums/Settings/PostSortType.swift
@@ -85,9 +85,9 @@ enum PostSortType: String, Codable, CaseIterable, Identifiable {
         case .topHour:
             return "Top of the last hour"
         case .topSixHour:
-            return "Top of the last six hours"
+            return "Top of the last 6 hours"
         case .topTwelveHour:
-            return "Top of the last twelve hours"
+            return "Top of the last 12 hours"
         case .topDay:
             return "Top of today"
         case .topWeek:
@@ -164,9 +164,9 @@ extension PostSortType: SettingsOptions {
         case .topHour:
             return "Hour"
         case .topSixHour:
-            return "Six Hours"
+            return "6 Hours"
         case .topTwelveHour:
-            return "Twelve Hours"
+            return "12 Hours"
         case .topDay:
             return "Day"
         case .topWeek:

--- a/Mlem/Views/Shared/Comments/Comment Item Logic.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item Logic.swift
@@ -151,7 +151,7 @@ extension CommentItem {
         
         // upvote
         let (upvoteText, upvoteImg) = hierarchicalComment.commentView.myVote == .upvote ?
-            ("Undo upvote", Icons.upvoteSquareFill) :
+            ("Undo Upvote", Icons.upvoteSquareFill) :
             ("Upvote", Icons.upvoteSquare)
         ret.append(MenuFunction.standardMenuFunction(
             text: upvoteText,
@@ -166,7 +166,7 @@ extension CommentItem {
         
         // downvote
         let (downvoteText, downvoteImg) = hierarchicalComment.commentView.myVote == .downvote ?
-            ("Undo downvote", Icons.downvoteSquareFill) :
+            ("Undo Downvote", Icons.downvoteSquareFill) :
             ("Downvote", Icons.downvoteSquare)
         ret.append(MenuFunction.standardMenuFunction(
             text: downvoteText,


### PR DESCRIPTION
The labels of the "Six Hours" and "6 Months" sort modes used inconsistent naming schemes. I changed the labels so that they all use numerals ("6") instead of words ("Six"). If you prefer they all use "Six", lmk and I'll change it. We should keep it consistent either way.

Also fixed a casing inconsistency with comment context menu actions. I changed "Undo upvote" to "Undo Upvote".