### PR TITLE
Fix "Show score in info" setting default value inconsistency

### DIFF
--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -21,7 +21,7 @@ struct CommentItem: View {
     @Dependency(\.hapticManager) var hapticManager
     
     // appstorage
-    @AppStorage("shouldShowScoreInCommentBar") var shouldShowScoreInCommentBar: Bool = true
+    @AppStorage("shouldShowScoreInCommentBar") var shouldShowScoreInCommentBar: Bool = false
     @AppStorage("showCommentDownvotesSeparately") var showCommentDownvotesSeparately: Bool = false
     @AppStorage("shouldShowTimeInCommentBar") var shouldShowTimeInCommentBar: Bool = true
     @AppStorage("shouldShowSavedInCommentBar") var shouldShowSavedInCommentBar: Bool = false

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -38,7 +38,7 @@ struct ExpandedPost: View {
     @AppStorage("shouldShowCommunityServerInPost") var shouldShowCommunityServerInPost: Bool = false
     @AppStorage("shouldShowUserAvatars") var shouldShowUserAvatars: Bool = false
     
-    @AppStorage("shouldShowScoreInPostBar") var shouldShowScoreInPostBar: Bool = true
+    @AppStorage("shouldShowScoreInPostBar") var shouldShowScoreInPostBar: Bool = false
     @AppStorage("showDownvotesSeparately") var showPostDownvotesSeparately: Bool = false
     @AppStorage("shouldShowTimeInPostBar") var shouldShowTimeInPostBar: Bool = true
     @AppStorage("shouldShowSavedInPostBar") var shouldShowSavedInPostBar: Bool = false

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -33,7 +33,7 @@ struct FeedPost: View {
     @AppStorage("shouldShowCommunityServerInPost") var shouldShowCommunityServerInPost: Bool = true
     @AppStorage("shouldShowUserServerInPost") var shouldShowUserServerInPost: Bool = true
     
-    @AppStorage("shouldShowScoreInPostBar") var shouldShowScoreInPostBar: Bool = true
+    @AppStorage("shouldShowScoreInPostBar") var shouldShowScoreInPostBar: Bool = false
     @AppStorage("showDownvotesSeparately") var showPostDownvotesSeparately: Bool = false
     @AppStorage("shouldShowTimeInPostBar") var shouldShowTimeInPostBar: Bool = true
     @AppStorage("shouldShowSavedInPostBar") var shouldShowSavedInPostBar: Bool = false

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -137,9 +137,8 @@ struct PostSettingsView: View {
             } header: {
                 Text("Interactions and Info")
             } footer: {
-                Text(
-                    "Choose which information is shown when using Large or Headline mode. In Compact mode, all info stack widgets are shown."
-                )
+                // swiftlint:disable:next line_length
+                Text("Choose which information is shown when using Large or Headline mode. In Compact mode, all info stack widgets are shown.")
             }
             
             Section("Website Previews") {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -108,7 +108,7 @@ struct PostSettingsView: View {
                 )
             }
             
-            Section("Interactions and Info") {
+            Section {
                 SwitchableSettingsItem(
                     settingPictureSystemName: Icons.upvoteSquare,
                     settingName: "Show Score In Info",
@@ -134,6 +134,10 @@ struct PostSettingsView: View {
                     settingName: "Show Replies In Info",
                     isTicked: $shouldShowRepliesInPostBar
                 )
+            } header: {
+                Text("Interactions and Info")
+            } footer: {
+                Text("Choose which information is shown when using Large or Headline mode. In Compact mode, all info stack widgets are shown.")
             }
             
             Section("Website Previews") {

--- a/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Appearance/Post/PostSettingsView.swift
@@ -137,7 +137,9 @@ struct PostSettingsView: View {
             } header: {
                 Text("Interactions and Info")
             } footer: {
-                Text("Choose which information is shown when using Large or Headline mode. In Compact mode, all info stack widgets are shown.")
+                Text(
+                    "Choose which information is shown when using Large or Headline mode. In Compact mode, all info stack widgets are shown."
+                )
             }
             
             Section("Website Previews") {


### PR DESCRIPTION
The default value for this was inconsistent. I've set it to `false` everywhere, since the score is already shown in the Upvote/downvote widget.

Also added a footer to the "Interactions and info" section in post appearance settings to clarify that the settings only apply to Large & Headline posts. For Compact posts, the user's preferences are ignored and all of the info is shown.