### PR TITLE
Fix community "Favorite" action being shown when it shouldn't

### DIFF
--- a/Mlem/Models/Content/Community/CommunityModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Community/CommunityModel+MenuFunctions.swift
@@ -96,8 +96,8 @@ extension CommunityModel {
         }
         if let function = try? subscribeMenuFunction(callback) {
             functions.append(.standard(function))
+            functions.append(.standard(favoriteMenuFunction(callback)))
         }
-        functions.append(.standard(favoriteMenuFunction(callback)))
         functions.append(
             .standardMenuFunction(
                 text: "Copy Name",

--- a/Mlem/Models/Content/Community/CommunityModel+SwipeActions.swift
+++ b/Mlem/Models/Content/Community/CommunityModel+SwipeActions.swift
@@ -78,8 +78,8 @@ extension CommunityModel {
         
         if let subscribeAction {
             trailingActions.append(subscribeAction)
+            trailingActions.append(favoriteAction)
         }
-        trailingActions.append(favoriteAction)
        
         return SwipeConfiguration(leadingActions: [], trailingActions: trailingActions)
     }


### PR DESCRIPTION
When the `subscribed` property of `CommunityModel` is `nil`, it won't show the "Subscribe" action in context menus or swipe actions. This occurs when the `CommunityModel` was created from an `APICommunity` and not an `APICommunityView`, such as in the moderated communities list on a user profile. 

This PR fixes a bug where the "Favorite" action was still shown even when the "Subscribed" action was hidden. Now, both actions are hidden if the `subscribed` property is `nil`.