### PR TITLE
Matrix ID Settings Bug Fixes & UI Tweaks

### DIFF
--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/MatrixLinkView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/MatrixLinkView.swift
@@ -73,7 +73,6 @@ struct MatrixLinkView: View {
                     }
                 }
             } footer: {
-                // swiftlint:disable:next line_length
                 Text("Everyone will be able to see your Matrix ID.")
             }
             Link("What is matrix?", destination: URL(string: "https://matrix.org/")!)

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/MatrixLinkView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/MatrixLinkView.swift
@@ -74,7 +74,7 @@ struct MatrixLinkView: View {
                 }
             } footer: {
                 // swiftlint:disable:next line_length
-                Text("Everyone will be able to see your matrix ID, and will be able to send you messages through Lemmy or another matrix client.")
+                Text("Everyone will be able to see your Matrix ID.")
             }
             Link("What is matrix?", destination: URL(string: "https://matrix.org/")!)
         }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/MatrixLinkView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/MatrixLinkView.swift
@@ -13,11 +13,17 @@ struct MatrixLinkView: View {
     @Dependency(\.apiClient) var apiClient: APIClient
     @Dependency(\.errorHandler) var errorHandler: ErrorHandler
     
-    @State var matrixUserId: String = ""
+    @State var matrixUserId: String
     
     @State var hasEdited: UserSettingsEditState = .unedited
     
     let matrixIdRegex = /@.+\:.+\..+/
+    
+    init() {
+        @Dependency(\.siteInformation) var siteInformation: SiteInformationTracker
+        let user = siteInformation.myUserInfo?.localUserView
+        _matrixUserId = State(wrappedValue: user?.person.matrixUserId ?? "")
+    }
     
     var matrixIdValid: Bool {
         if matrixUserId.isEmpty {
@@ -51,7 +57,7 @@ struct MatrixLinkView: View {
                 .autocorrectionDisabled()
                 .textInputAutocapitalization(.never)
                 .onChange(of: matrixUserId) { newValue in
-                    if newValue != siteInformation.myUserInfo?.localUserView.person.matrixUserId {
+                    if newValue != siteInformation.myUserInfo?.localUserView.person.matrixUserId ?? "" {
                         hasEdited = .edited
                     }
                 }

--- a/Mlem/Views/Tabs/Settings/Components/Views/Account/ProfileSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Account/ProfileSettingsView.swift
@@ -17,8 +17,8 @@ struct ProfileSettingsView: View {
     @Dependency(\.apiClient) var apiClient: APIClient
     @Dependency(\.errorHandler) var errorHandler: ErrorHandler
     
-    @State var displayName: String = ""
-    @State var bio: String = ""
+    @State var displayName: String
+    @State var bio: String
     
     @StateObject var avatarAttachmentModel: LinkAttachmentModel
     @StateObject var bannerAttachmentModel: LinkAttachmentModel
@@ -155,9 +155,19 @@ struct ProfileSettingsView: View {
                 }
           }
             NavigationLink(.settings(.linkMatrixAccount)) {
-                Label("Link Matrix Account", image: "logo.matrix").labelStyle(SquircleLabelStyle(color: .black))
-                    .disabled(hasEdited != .unedited)
+                let user = siteInformation.myUserInfo?.localUserView
+                if let user, let matrixId = user.person.matrixUserId {
+                    HStack {
+                        Label("Matrix ID", image: "logo.matrix").labelStyle(SquircleLabelStyle(color: .black))
+                        Spacer()
+                        Text(matrixId)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Label("Link Matrix Account", image: "logo.matrix").labelStyle(SquircleLabelStyle(color: .black))
+                }
             }
+            .disabled(hasEdited != .unedited)
         }
         .scrollDismissesKeyboard(.interactively)
         .navigationTitle("My Profile")


### PR DESCRIPTION
A couple of bug fixes related to the Matrix ID page:

- Matrix ID input field always showed `""` when opening the page, not your existing Matrix ID.
- Pressing "cancel" the first time wouldn't do anything - you'd have to press it twice for the cancel to take effect.

I changed the description text (it seems Lemmy messaging doesn't go through Matrix as I previously thought) and also tweaked the appearance of the navigation link to show your matrix ID if you have one.

This is shown if you have a matrix ID:

![IMG_9900](https://github.com/mlemgroup/mlem/assets/78750526/cc60ddff-07c5-4a9f-a3d6-d7ebb4ceeabc)

This is shown if you don't:

![IMG_9901](https://github.com/mlemgroup/mlem/assets/78750526/2aa8023e-78ec-4161-9010-045120f78f1c)
