### PR TITLE
Fix toggling "hide read" not immediately updating

### DIFF
--- a/Mlem/Views/Tabs/Feeds/PostFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/PostFeedView.swift
@@ -112,6 +112,7 @@ struct PostFeedView: View {
         }
         .onChange(of: showReadPosts) { _ in
             Task(priority: .userInitiated) {
+                postTracker.filter = self.filter
                 await postTracker.refresh(clearBeforeFetch: true)
             }
         }


### PR DESCRIPTION
Toggling "Hide Read" via the ellipsis menu in a feed wouldn't immediately work - you'd have to exit and re-enter the feed to see changes. Now, the feed refreshes immediately with the new setting applied. 

I don't really know why this fixes it, but it works 🤔 