### PR TITLE
Saved feed comment interaction crash fix

### DIFF
--- a/Mlem/API/Internal/HierarchicalComment.swift
+++ b/Mlem/API/Internal/HierarchicalComment.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// A model which represents a comment and it's child relationships
 class HierarchicalComment: ObservableObject {
-    let commentView: APICommentView
+    var commentView: APICommentView
     var children: [HierarchicalComment]
     /// Indicates comment's position in a post's parent/child comment thread.
     /// Values range from `0...Int.max`, where 0 indicates the parent comment.

--- a/Mlem/API/Internal/HierarchicalComment.swift
+++ b/Mlem/API/Internal/HierarchicalComment.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// A model which represents a comment and it's child relationships
 class HierarchicalComment: ObservableObject {
-    var commentView: APICommentView
+    @Published var commentView: APICommentView
     var children: [HierarchicalComment]
     /// Indicates comment's position in a post's parent/child comment thread.
     /// Values range from `0...Int.max`, where 0 indicates the parent comment.

--- a/Mlem/Views/Shared/Comments/Comment Item Logic.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item Logic.swift
@@ -16,7 +16,7 @@ extension CommentItem {
                 id: hierarchicalComment.commentView.id,
                 vote: operation
             )
-            commentTracker.comments.update(with: updatedComment)
+            hierarchicalComment.commentView = updatedComment
         } catch {
             errorHandler.handle(error)
         }
@@ -31,7 +31,7 @@ extension CommentItem {
                 // TODO: the UI for this only allows delete, but the operation can be undone it appears...
                 shouldDelete: true
             )
-            commentTracker.comments.update(with: updatedComment.commentView)
+            hierarchicalComment.commentView = updatedComment.commentView
         } catch {
             errorHandler.handle(error)
         }
@@ -139,7 +139,7 @@ extension CommentItem {
             // Perhaps we want an explict flag for this in the future?
             if collapseComments, !isCommentReplyHidden, pageContext == .posts {
                 toggleTopLevelCommentCollapse(isCollapsed: !hierarchicalComment.isCollapsed)
-            } else if !showPostContext {
+            } else if !showPostContext, let commentTracker {
                 commentTracker.setCollapsed(!hierarchicalComment.isCollapsed, comment: hierarchicalComment)
             }
         }
@@ -147,10 +147,12 @@ extension CommentItem {
     
     /// Uncollapses HierarchicalComment and children at depth level 1
     func uncollapseComment() {
-        commentTracker.setCollapsed(false, comment: hierarchicalComment)
-        
-        for comment in hierarchicalComment.children where comment.depth == 1 {
-            commentTracker.setCollapsed(false, comment: comment)
+        if let commentTracker {
+            commentTracker.setCollapsed(false, comment: hierarchicalComment)
+            
+            for comment in hierarchicalComment.children where comment.depth == 1 {
+                commentTracker.setCollapsed(false, comment: comment)
+            }
         }
     }
     
@@ -166,9 +168,11 @@ extension CommentItem {
     
     /// Collapses HierarchicalComment and children at depth level 1
     func collapseComment() {
-        for comment in hierarchicalComment.children where comment.depth == 1 {
-            commentTracker.setCollapsed(true, comment: comment)
-            comment.isParentCollapsed = true
+        if let commentTracker {
+            for comment in hierarchicalComment.children where comment.depth == 1 {
+                commentTracker.setCollapsed(true, comment: comment)
+                comment.isParentCollapsed = true
+            }
         }
     }
     
@@ -300,8 +304,11 @@ extension CommentItem {
             
             if response.blocked {
                 await notifier.add(.success("Blocked user"))
-                commentTracker.filter { comment in
-                    comment.commentView.creator.id != userId
+                
+                if let commentTracker {
+                    commentTracker.filter { comment in
+                        comment.commentView.creator.id != userId
+                    }
                 }
             }
         } catch {

--- a/Mlem/Views/Shared/Comments/Comment Item Logic.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item Logic.swift
@@ -128,7 +128,7 @@ extension CommentItem {
                 shouldSave: dirtySaved
             )
             
-            commentTracker.comments.update(with: response.commentView)
+            hierarchicalComment.commentView = response.commentView
         } catch {
             errorHandler.handle(error)
         }

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -53,7 +53,6 @@ struct CommentItem: View {
     
     // MARK: Environment
 
-    @EnvironmentObject var commentTracker: CommentTracker
     @EnvironmentObject var editorTracker: EditorTracker
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var layoutWidgetTracker: LayoutWidgetTracker
@@ -65,6 +64,7 @@ struct CommentItem: View {
 
     // MARK: Parameters
 
+    let commentTracker: CommentTracker?
     @ObservedObject var hierarchicalComment: HierarchicalComment
     let postContext: PostModel? // TODO: redundant with comment.post?
     let indentBehaviour: IndentBehaviour
@@ -104,6 +104,7 @@ struct CommentItem: View {
 
     // init needed to get dirty and clean aligned
     init(
+        commentTracker: CommentTracker?,
         hierarchicalComment: HierarchicalComment,
         postContext: PostModel?,
         indentBehaviour: IndentBehaviour = .standard,
@@ -112,6 +113,7 @@ struct CommentItem: View {
         enableSwipeActions: Bool = true,
         pageContext: PageContext = .posts
     ) {
+        self.commentTracker = commentTracker
         self.hierarchicalComment = hierarchicalComment
         self.postContext = postContext
         self.indentBehaviour = indentBehaviour

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -299,6 +299,7 @@ struct ExpandedPost: View {
         LazyVStack(alignment: .leading, spacing: 0) {
             ForEach(commentTracker.commentsView, id: \.commentView.comment.id) { comment in
                 CommentItem(
+                    commentTracker: commentTracker,
                     hierarchicalComment: comment,
                     postContext: post,
                     showPostContext: false,

--- a/Mlem/Views/Tabs/Feeds/Components/UserContentFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/UserContentFeedView.swift
@@ -93,6 +93,7 @@ struct UserContentFeedView: View {
                 scrollTarget: hierarchicalComment.id
             ))) {
                 CommentItem(
+                    commentTracker: nil,
                     hierarchicalComment: hierarchicalComment,
                     postContext: nil,
                     indentBehaviour: .never,

--- a/Mlem/Views/Tabs/Profile/UserFeedView.swift
+++ b/Mlem/Views/Tabs/Profile/UserFeedView.swift
@@ -113,6 +113,7 @@ struct UserFeedView: View {
     private func commentEntry(for comment: HierarchicalComment) -> some View {
         VStack(spacing: 0) {
             CommentItem(
+                commentTracker: privateCommentTracker,
                 hierarchicalComment: comment,
                 postContext: nil,
                 indentBehaviour: .never,


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #892 

# Pull Request Information

Fixes an issue where comment items in the user feed view would crash when updated due to no comment tracker being present in the environment. Comment tracker is now passed into the comment item directly as an optional, and all actions that require a comment tracker to updated are now guarded against its existence.

Longer term, comment voting logic needs to be moved into a `CommentModel` class that replaces `APICommentView`, but that's out of scope for 1.2.