### PR TITLE
Fix "Show n replies" button tap area

### DIFF
--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -203,17 +203,17 @@ struct CommentItem: View {
                    hierarchicalComment.children.count > 0,
                    !isCommentReplyHidden {
                     Divider()
-                    HStack {
                         CollapsedCommentReplies(numberOfReplies: .constant(hierarchicalComment.commentView.counts.childCount))
-                            .onTapGesture {
-                                isCommentReplyHidden = true
-                                uncollapseComment()
-                            }
-                    }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(.rect)
+                        .onTapGesture {
+                            isCommentReplyHidden = true
+                            uncollapseComment()
+                        }
                 }
             }
         }
-        .contentShape(Rectangle()) // allow taps in blank space to register
+        .contentShape(.rect) // allow taps in blank space to register
         .onTapGesture {
             if tapCommentToCollapse {
                 toggleCollapsed()


### PR DESCRIPTION
Previously you had to tap on the "show n replies" text to expand the replies, and tapping elsewhere on the button wouldn't work. Now, you can tap anywhere on the "show n replies" button to expand