### PR TITLE
Link Resolution Fix

### DIFF
--- a/Mlem/Extensions/View Modifiers/View+HandleLemmyLinks.swift
+++ b/Mlem/Extensions/View Modifiers/View+HandleLemmyLinks.swift
@@ -193,7 +193,7 @@ struct HandleLemmyLinkResolution<Path: AnyNavigablePath>: ViewModifier {
                     var altLookup: String?
                     
                     // anything with an @ gets parsed to mailto: by Markdown
-                    if lookup.starts(with: /mailto:|\/c\/|\/u\//) {
+                    if lookup.starts(with: "mailto:") {
                         // SUS I think this might be a community or user link
                         let processedLookup = lookup
                             .replacing(/.*\/c\//, with: "")
@@ -203,6 +203,12 @@ struct HandleLemmyLinkResolution<Path: AnyNavigablePath>: ViewModifier {
                         // the mailto: strips the ! and @, so we have to try both
                         lookup = "!\(processedLookup)" // community
                         altLookup = "@\(processedLookup)" // user
+                        
+                    } else if lookup.starts(with: "/u/") {
+                        lookup = "@\(lookup.trimmingPrefix("/u/"))"
+                        
+                    } else if lookup.starts(with: "/c/") {
+                        lookup = "!\(lookup.trimmingPrefix("/c/"))"
                     }
                     
                     print("lookup: \(lookup), altLookup: \(String(describing: altLookup)) (original: \(url.absoluteString))")


### PR DESCRIPTION
Adds support for the following link formats:

```
/u/user@lemmy.ml
/c/community@lemmy.ml
```

Bug was reported on mlemapp [here](https://lemmy.ml/comment/7989503). These are used frequently in the [!trendingcommunities@feddit.nl](https://feddit.nl/post/10189096) community.

Also, I removed the `"couldnt_find_object"` notification and made it just open in the browser instead in this case.