### PR TITLE
fixed ipad sidebar navigation problems

### DIFF
--- a/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
@@ -81,7 +81,7 @@ struct AggregateFeedView: View {
             .task(id: selectedFeed) {
                 if let selectedFeed {
                     switch selectedFeed {
-                    case .all, .local:
+                    case .all, .local, .subscribed:
                         await postTracker.changeFeedType(to: selectedFeed)
                         postTracker.isStale = false
                     default:

--- a/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
@@ -79,9 +79,14 @@ struct AggregateFeedView: View {
                 }
             }
             .task(id: selectedFeed) {
-                if let selectedFeed, selectedFeed != .saved {
-                    await postTracker.changeFeedType(to: selectedFeed)
-                    postTracker.isStale = false
+                if let selectedFeed {
+                    switch selectedFeed {
+                    case .all, .local:
+                        await postTracker.changeFeedType(to: selectedFeed)
+                        postTracker.isStale = false
+                    default:
+                        return
+                    }
                 }
             }
             .refreshable {
@@ -148,7 +153,7 @@ struct AggregateFeedView: View {
                 MenuButton(menuFunction: menuFunction, confirmDestructive: nil)
             }
         } label: {
-            if let selectedFeed {
+            if let selectedFeed, FeedType.allAggregateFeedCases.contains(selectedFeed) {
                 FeedHeaderView(feedType: selectedFeed)
             } else {
                 EmptyView() // shouldn't be possible

--- a/Mlem/Views/Tabs/Feeds/Feed Types/CommunityFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/CommunityFeedView.swift
@@ -64,7 +64,6 @@ struct CommunityFeedView: View {
     }
     
     init(communityModel: CommunityModel) {
-        print("DEBUG initializing with \(communityModel.name)")
         // need to grab some stuff from app storage to initialize post tracker with
         @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
         @AppStorage("upvoteOnSave") var upvoteOnSave = false

--- a/Mlem/Views/Tabs/Feeds/Feed Types/CommunityFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/CommunityFeedView.swift
@@ -64,6 +64,7 @@ struct CommunityFeedView: View {
     }
     
     init(communityModel: CommunityModel) {
+        print("DEBUG initializing with \(communityModel.name)")
         // need to grab some stuff from app storage to initialize post tracker with
         @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
         @AppStorage("upvoteOnSave") var upvoteOnSave = false

--- a/Mlem/Views/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/Views/Tabs/Feeds/FeedsView.swift
@@ -117,6 +117,7 @@ struct FeedsView: View {
             AggregateFeedView(selectedFeed: $selectedFeed)
         case let .community(communityModel):
             CommunityFeedView(communityModel: communityModel)
+                .id(communityModel.uid) // explicit id forces redraw on change of community model
         case .none:
             Text("Please select a feed")
         }


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #903

This PR addresses some issues relating to sidebar navigation on iPad:
- Navigating between communities not working: addressed by giving the `CommunityFeedView` inside the navigation switch an explicit `id` so it redraws when the community changes
- Assertion failures on `FeedHeaderView` when navigating from an aggregate feed to a community: addressed by not drawing the header if selected feed isn't aggregate. 

Also adds some logic in `AggregateFeedView` to avoid superfluous post tracker refreshes when navigating to a community view.