### PR TITLE
Updated search bar prompt

### DIFF
--- a/Mlem/Views/Tabs/Search/RecentSearchesView.swift
+++ b/Mlem/Views/Tabs/Search/RecentSearchesView.swift
@@ -112,7 +112,7 @@ struct RecentSearchesView: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 100)
                 .fontWeight(.thin)
-            Text("Search for communities and users.")
+            Text("Search for communities, users and instances.")
                 .multilineTextAlignment(.center)
         }
         .foregroundStyle(.secondary)

--- a/Mlem/Views/Tabs/Search/SearchView.swift
+++ b/Mlem/Views/Tabs/Search/SearchView.swift
@@ -63,7 +63,7 @@ struct SearchView: View {
             .navigationBarColor()
             .navigationTitle("Search")
             .navigationSearchBar {
-                SearchBar("Search for communities & users", text: $searchModel.searchText, isEditing: $isSearching)
+                SearchBar("Communities, Users & Instances", text: $searchModel.searchText, isEditing: $isSearching)
                     .showsCancelButton(page != .home)
                     .onCancel {
                         page = .home


### PR DESCRIPTION
We now support searching instances, so I changed the search bar prompt from "Search Communities & Users" to "Communities, Users & Instances".

When we add post/comment searching, the prompt obviously wouldn't fit anymore. We'd have to go the Apple Music Route and write "Communities, Posts & More"