### PR TITLE
fixed account quick switcher not appearing until settings toggled

### DIFF
--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -199,9 +199,11 @@ struct ContentView: View {
     var accountSwitchLongPress: some Gesture {
         LongPressGesture()
             .onEnded { _ in
+                @AppStorage("allowQuickSwitcherLongPressGesture") var allowQuickSwitcherLongPressGesture: Bool = true
+                
                 // disable long press in accessibility mode to prevent conflict with HUD
                 if !accessibilityFont {
-                    if UserDefaults.standard.bool(forKey: "allowQuickSwitcherLongPressGesture") {
+                    if allowQuickSwitcherLongPressGesture {
                         hapticManager.play(haptic: .rigidInfo, priority: .high)
                         if accountsTracker.savedAccounts.count == 2 {
                             hapticManager.play(haptic: .rigidInfo, priority: .high)


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
  - Closes #913 

# Pull Request Information

Fixes an issue where the account switcher long press gesture wasn't appearing properly when updating from 1.1.2.
