### PR TITLE
Fix Community/User instance caption app startup inconsistency

### DIFF
--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -34,8 +34,8 @@ struct ExpandedPost: View {
     @Dependency(\.postRepository) var postRepository
     
     // appstorage
-    @AppStorage("shouldShowUserServerInPost") var shouldShowUserServerInPost: Bool = false
-    @AppStorage("shouldShowCommunityServerInPost") var shouldShowCommunityServerInPost: Bool = false
+    @AppStorage("shouldShowUserServerInPost") var shouldShowUserServerInPost: Bool = true
+    @AppStorage("shouldShowCommunityServerInPost") var shouldShowCommunityServerInPost: Bool = true
     @AppStorage("shouldShowUserAvatars") var shouldShowUserAvatars: Bool = false
     
     @AppStorage("shouldShowScoreInPostBar") var shouldShowScoreInPostBar: Bool = false


### PR DESCRIPTION
On first app startup, the community and user instance captions on `CommunityLink` and `UserLink` were enabled, but not shown in `ExpandedPost` until the settings were toggled off and on again.