### PR TITLE
Fix changing avatar externally failing to update `SavedAccount`

### DIFF
--- a/Mlem/Models/Trackers/SiteInformationTracker.swift
+++ b/Mlem/Models/Trackers/SiteInformationTracker.swift
@@ -28,8 +28,8 @@ class SiteInformationTracker: ObservableObject {
                 instance = .init(from: response)
                 enableDownvotes = response.siteView.localSite.enableDownvotes
                 version = SiteVersion(response.version)
-                if version != account.siteVersion {
-                    let avatarUrl = response.myUser?.localUserView.person.avatarUrl
+                let avatarUrl = response.myUser?.localUserView.person.avatarUrl
+                if version != account.siteVersion || avatarUrl != account.avatarUrl {
                     DispatchQueue.main.async {
                         self.accountsTracker.update(with: .init(from: account, avatarUrl: avatarUrl, siteVersion: self.version))
                     }


### PR DESCRIPTION
Fixed a bug where changing your avatar from outside of Mlem wouldn't update the avatar in Mlem's account switcher. Now, switching accounts causes the avatar to update