### PR TITLE
fixed dupes in profile feed

### DIFF
--- a/Mlem/Views/Tabs/Profile/UserView+Logic.swift
+++ b/Mlem/Views/Tabs/Profile/UserView+Logic.swift
@@ -47,31 +47,12 @@ extension UserView {
             
             communityTracker.replaceAll(with: user.moderatedCommunities ?? [])
             
-            var savedContentData: GetPersonDetailsResponse?
-            if isOwnProfile {
-                savedContentData = try await personRepository.loadUserDetails(
-                    for: user.userId,
-                    limit: internetSpeed.pageSize,
-                    savedOnly: true
-                )
-            }
-            
             // accumulate comments and posts so we don't update state more than we need to
             var newComments = authoredContent.comments
                 .sorted(by: { $0.comment.published > $1.comment.published })
                 .map { HierarchicalComment(comment: $0, children: [], parentCollapsed: false, collapsed: false) }
             
             var newPosts = authoredContent.posts.map { PostModel(from: $0) }
-            
-            // add saved content, if present
-            if let savedContent = savedContentData {
-                newComments.append(contentsOf:
-                    savedContent.comments
-                        .sorted(by: { $0.comment.published > $1.comment.published })
-                        .map { HierarchicalComment(comment: $0, children: [], parentCollapsed: false, collapsed: false) })
-                
-                newPosts.append(contentsOf: savedContent.posts.map { PostModel(from: $0) })
-            }
             
             privateCommentTracker.comments = newComments
             await privatePostTracker.reset(with: newPosts)


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #919 

# Pull Request Information

This PR fixes a regression introduced by #874 where saved posts would appear twice in the feed. Saved posts were still being loaded and added to the tracker, but the feed itself was no longer filtering them out in the Posts or Overview tab.