### PR TITLE
Add developer menu to post model context menu and ellipsis menu.

### DIFF
--- a/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
@@ -164,7 +164,7 @@ extension PostModel {
             children: [
                 .standardMenuFunction(
                     text: "Toggle Read State",
-                    imageName: "",
+                    imageName: "book.and.wrench",
                     destructiveActionPrompt: nil,
                     enabled: true,
                     callback: {

--- a/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
@@ -141,7 +141,41 @@ extension PostModel {
             }
         }
 
+#if DEBUG
+        functions.append(
+            buildDeveloperMenu(
+                editorTracker: editorTracker,
+                postTracker: postTracker
+            )
+        )
+#endif
+        
         return functions
     }
     // swiftlint:enable function_body_length
+    
+#if DEBUG
+    private func buildDeveloperMenu(
+        editorTracker: EditorTracker,
+        postTracker: StandardPostTracker?
+    ) -> MenuFunction {
+        MenuFunction.childMenu(
+            titleKey: "Developer Menu",
+            children: [
+                .standardMenuFunction(
+                    text: "Toggle Read State",
+                    imageName: "",
+                    destructiveActionPrompt: nil,
+                    enabled: true,
+                    callback: {
+                        Task {
+                            let newState = !self.read
+                            await self.markRead(newState)
+                        }
+                    }
+                )
+            ]
+        )
+    }
+#endif
 }

--- a/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
@@ -160,7 +160,6 @@ extension PostModel {
                 .standardMenuFunction(
                     text: "Toggle Read State",
                     imageName: "book.and.wrench",
-                    destructiveActionPrompt: nil,
                     enabled: true,
                     callback: {
                         Task {

--- a/Mlem/Models/Menu Function.swift
+++ b/Mlem/Models/Menu Function.swift
@@ -19,6 +19,8 @@ enum MenuFunction: Identifiable {
             return shareImageFunction.id
         case let .navigation(navigationMenuFunction):
             return navigationMenuFunction.id
+        case .childMenu:
+            return UUID().uuidString
         }
     }
     
@@ -26,6 +28,10 @@ enum MenuFunction: Identifiable {
     case shareUrl(ShareMenuFunction)
     case shareImage(ShareImageFunction)
     case navigation(NavigationMenuFunction)
+    /// - Parameter titleKey: User-facing title label for menu.
+    /// - Parameter children: Menu items for this child menu.
+    /// - Note: Destructive confirmation is not supported at this time.
+    case childMenu(titleKey: String, children: [MenuFunction])
 }
 
 // some convenience initializers because MenuFunction.standard(StandardMenuFunction...) is ugly

--- a/Mlem/Views/Shared/Components/Components/Menu Button.swift
+++ b/Mlem/Views/Shared/Components/Components/Menu Button.swift
@@ -34,6 +34,12 @@ struct MenuButton: View {
             NavigationLink(navigationMenuFunction.destination) {
                 Label(navigationMenuFunction.text, systemImage: navigationMenuFunction.imageName)
             }
+        case let .childMenu(titleKey, children):
+            Menu(titleKey) {
+                ForEach(children) { child in
+                    MenuButton(menuFunction: child, confirmDestructive: nil)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Pull Request Information

## About this Pull Request
1. Adds a "Developer Menu" to `PostModel` context menu and ellipsis menu (this only ever builds when `DEBUG` flag is enabled).
2. Adds `Toggle Read State` to developer menu.
3. Adds ability to build child menus using existing MenuButton and MenuFunction infrastructure.

## Screenshots and Videos
<img src="https://github.com/mlemgroup/mlem/assets/2549615/83ac4eb9-8d0a-4fa4-a007-663a37a8a89e" width="360">
<img src="https://github.com/mlemgroup/mlem/assets/2549615/7978a0c0-b618-4e08-ae16-842c1a36c3ca" width="360">
