### PR TITLE
Tab navigation custom behaviours

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 		CD4DBC032A6F803C001A1E61 /* ReplyToPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4DBC022A6F803C001A1E61 /* ReplyToPost.swift */; };
 		CD525F652A4B6D8F00BCA794 /* CommunityLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD525F642A4B6D8F00BCA794 /* CommunityLinkView.swift */; };
 		CD59E8A52A72C943005757F4 /* MarkAllAsReadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD59E8A42A72C943005757F4 /* MarkAllAsReadRequest.swift */; };
+		CD5F76BC2B75BE700013A827 /* MarkReadBatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5F76BB2B75BE700013A827 /* MarkReadBatcher.swift */; };
 		CD6483302A38D31C00EE6CA3 /* UpvoteCounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD64832F2A38D31C00EE6CA3 /* UpvoteCounterView.swift */; };
 		CD6483322A38D3A600EE6CA3 /* ScoreCounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6483312A38D3A600EE6CA3 /* ScoreCounterView.swift */; };
 		CD6483362A39F20800EE6CA3 /* Post Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6483352A39F20800EE6CA3 /* Post Type.swift */; };
@@ -442,6 +443,7 @@
 		CD8461662A96F9EB0026A627 /* Website Indicator View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8461652A96F9EB0026A627 /* Website Indicator View.swift */; };
 		CD863FBA2A6AEB5900A31ED9 /* View+FancyTabScrollCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD863FB92A6AEB5900A31ED9 /* View+FancyTabScrollCompatible.swift */; };
 		CD863FBC2A6B026400A31ED9 /* DocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD863FBB2A6B026400A31ED9 /* DocumentView.swift */; };
+		CD876EC72B7736370075DC15 /* MarkReadBatcher+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD876EC62B7736370075DC15 /* MarkReadBatcher+Dependency.swift */; };
 		CD8C55342A95515C0060B75B /* Onboarding Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8C55332A95515C0060B75B /* Onboarding Text.swift */; };
 		CD8CF2092AF3F131009FFC23 /* Firm Info.ahap in Resources */ = {isa = PBXBuildFile; fileRef = CD8CF2082AF3F131009FFC23 /* Firm Info.ahap */; };
 		CD963FCB2B5F0388002352FD /* DefaultFeedType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD963FCA2B5F0388002352FD /* DefaultFeedType.swift */; };
@@ -980,6 +982,7 @@
 		CD4DBC022A6F803C001A1E61 /* ReplyToPost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplyToPost.swift; sourceTree = "<group>"; };
 		CD525F642A4B6D8F00BCA794 /* CommunityLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityLinkView.swift; sourceTree = "<group>"; };
 		CD59E8A42A72C943005757F4 /* MarkAllAsReadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkAllAsReadRequest.swift; sourceTree = "<group>"; };
+		CD5F76BB2B75BE700013A827 /* MarkReadBatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkReadBatcher.swift; sourceTree = "<group>"; };
 		CD64832F2A38D31C00EE6CA3 /* UpvoteCounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpvoteCounterView.swift; sourceTree = "<group>"; };
 		CD6483312A38D3A600EE6CA3 /* ScoreCounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreCounterView.swift; sourceTree = "<group>"; };
 		CD6483352A39F20800EE6CA3 /* Post Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post Type.swift"; sourceTree = "<group>"; };
@@ -1008,6 +1011,7 @@
 		CD8461652A96F9EB0026A627 /* Website Indicator View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Website Indicator View.swift"; sourceTree = "<group>"; };
 		CD863FB92A6AEB5900A31ED9 /* View+FancyTabScrollCompatible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+FancyTabScrollCompatible.swift"; sourceTree = "<group>"; };
 		CD863FBB2A6B026400A31ED9 /* DocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentView.swift; sourceTree = "<group>"; };
+		CD876EC62B7736370075DC15 /* MarkReadBatcher+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarkReadBatcher+Dependency.swift"; sourceTree = "<group>"; };
 		CD8C55332A95515C0060B75B /* Onboarding Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Onboarding Text.swift"; sourceTree = "<group>"; };
 		CD8CF2082AF3F131009FFC23 /* Firm Info.ahap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Firm Info.ahap"; sourceTree = "<group>"; };
 		CD963FCA2B5F0388002352FD /* DefaultFeedType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeedType.swift; sourceTree = "<group>"; };
@@ -1536,6 +1540,7 @@
 				5064D03E2A6DE0DB00B22EE3 /* Notifier+Dependency.swift */,
 				50785F722A98E03F00117245 /* SiteInformationTracker+Dependency.swift */,
 				CD4368CD2AE242C900BD8BD1 /* InboxRepository+Dependency.swift */,
+				CD876EC62B7736370075DC15 /* MarkReadBatcher+Dependency.swift */,
 			);
 			path = Dependency;
 			sourceTree = "<group>";
@@ -1616,6 +1621,7 @@
 		6318EDC427EE4E0500BFCAE8 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				CD5F76BA2B75B8290013A827 /* Batchers */,
 				CDEBC3262A9A57E900518D9D /* Content */,
 				CDA2C5242A705D3100649D5A /* Composers */,
 				B14E93BE2A45CA1A00D6DA93 /* Navigation Contexts */,
@@ -2567,6 +2573,14 @@
 			path = Links;
 			sourceTree = "<group>";
 		};
+		CD5F76BA2B75B8290013A827 /* Batchers */ = {
+			isa = PBXGroup;
+			children = (
+				CD5F76BB2B75BE700013A827 /* MarkReadBatcher.swift */,
+			);
+			path = Batchers;
+			sourceTree = "<group>";
+		};
 		CD62D12D2B5ED48000395BD9 /* Community List */ = {
 			isa = PBXGroup;
 			children = (
@@ -3419,6 +3433,7 @@
 				6322A5D027F8629700135D4F /* UserLinkView.swift in Sources */,
 				030E864C2AC7037F000283A6 /* SearchBarExtensions.swift in Sources */,
 				6372184B2A3A2AAD008C4816 /* APIPostAggregates.swift in Sources */,
+				CD876EC72B7736370075DC15 /* MarkReadBatcher+Dependency.swift in Sources */,
 				50A8812C2A72D727003E3661 /* CommunityRepository+Dependency.swift in Sources */,
 				0394398F2A98EB2300463032 /* APIComment+Mock.swift in Sources */,
 				E453477E2A9DE37300D1B46F /* Array+SafeIndexing.swift in Sources */,
@@ -3581,6 +3596,7 @@
 				63F0C7A62A05225100A18C5D /* Saved Account.swift in Sources */,
 				637218462A3A2AAD008C4816 /* APIComment.swift in Sources */,
 				CDCBD7282A8D6B7700387A2C /* Instance Picker View Logic.swift in Sources */,
+				CD5F76BC2B75BE700013A827 /* MarkReadBatcher.swift in Sources */,
 				637457102A18CB6600B69C03 /* Custom Text Field.swift in Sources */,
 				038A16E12A75AA880087987E /* LayoutWidgetModel.swift in Sources */,
 				63344C4F2A07BD2A001BC616 /* Filters Tracker.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		03A276792AFD903600C0D66B /* CommunityModel+MenuFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A276782AFD903600C0D66B /* CommunityModel+MenuFunctions.swift */; };
 		03A2767B2AFE560000C0D66B /* CommunityModel+SwipeActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A2767A2AFE560000C0D66B /* CommunityModel+SwipeActions.swift */; };
 		03A2767D2AFE656700C0D66B /* UserModel+MenuFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A2767C2AFE656700C0D66B /* UserModel+MenuFunctions.swift */; };
+		03A4330F2B7186C20004E743 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A4330E2B7186C20004E743 /* WebView.swift */; };
 		03A54C322B5331F30064CCDE /* InstanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A54C312B5331F30064CCDE /* InstanceView.swift */; };
 		03A54C352B533BC50064CCDE /* InstanceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A54C342B533BC50064CCDE /* InstanceModel.swift */; };
 		03A54C372B545A430064CCDE /* InstanceModel+MenuFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A54C362B545A430064CCDE /* InstanceModel+MenuFunctions.swift */; };
@@ -635,6 +636,7 @@
 		03A276782AFD903600C0D66B /* CommunityModel+MenuFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommunityModel+MenuFunctions.swift"; sourceTree = "<group>"; };
 		03A2767A2AFE560000C0D66B /* CommunityModel+SwipeActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommunityModel+SwipeActions.swift"; sourceTree = "<group>"; };
 		03A2767C2AFE656700C0D66B /* UserModel+MenuFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserModel+MenuFunctions.swift"; sourceTree = "<group>"; };
+		03A4330E2B7186C20004E743 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		03A54C312B5331F30064CCDE /* InstanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceView.swift; sourceTree = "<group>"; };
 		03A54C342B533BC50064CCDE /* InstanceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceModel.swift; sourceTree = "<group>"; };
 		03A54C362B545A430064CCDE /* InstanceModel+MenuFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InstanceModel+MenuFunctions.swift"; sourceTree = "<group>"; };
@@ -2100,6 +2102,7 @@
 				E453A1CE2A81C1F20004BB8A /* Quick Look */,
 				63A09B68285F53E9004F0032 /* Error View.swift */,
 				6322A5CA27F77A4D00135D4F /* Loading View.swift */,
+				03A4330E2B7186C20004E743 /* WebView.swift */,
 				6386E03F2A045723006B3C1D /* Website Icon Complex.swift */,
 				63D24EDD2A169F2A005CCA81 /* Markdown View.swift */,
 				03B15BEC2B55CBBB00E7C30A /* MarkdownTheme.swift */,
@@ -3161,6 +3164,7 @@
 				6372185E2A3A2AAD008C4816 /* APICommunityModeratorView.swift in Sources */,
 				CD18DC732A522A7C002C56BC /* CreatePrivateMessageRequest.swift in Sources */,
 				CD525F652A4B6D8F00BCA794 /* CommunityLinkView.swift in Sources */,
+				03A4330F2B7186C20004E743 /* WebView.swift in Sources */,
 				637218592A3A2AAD008C4816 /* APISiteAggregates.swift in Sources */,
 				50A881262A71A511003E3661 /* PersistenceRepository+Dependency.swift in Sources */,
 				032C1E062B5DBDB100FB4F23 /* LocalAccountSettingsView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -88,6 +88,9 @@
 		03C905CA2B3C834C00B9082F /* AvatarBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C905C92B3C834C00B9082F /* AvatarBannerView.swift */; };
 		03C905CC2B3C88F700B9082F /* SearchTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C905CB2B3C88F700B9082F /* SearchTab.swift */; };
 		03C905CE2B3C8DC400B9082F /* UserView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C905CD2B3C8DC400B9082F /* UserView+Logic.swift */; };
+		03C942922B6457B4002068A4 /* BanUserEditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C942912B6457B4002068A4 /* BanUserEditorModel.swift */; };
+		03C942942B64596B002068A4 /* BanUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C942932B64596B002068A4 /* BanUserView.swift */; };
+		03C942962B648252002068A4 /* BanPerson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C942952B648252002068A4 /* BanPerson.swift */; };
 		03CB329E2A6D8E910021EF27 /* PostComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CB329D2A6D8E910021EF27 /* PostComposerView.swift */; };
 		03E0B9C82A61F0F400FED265 /* AdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9C72A61F0F400FED265 /* AdvancedSettingsView.swift */; };
 		03E0B9CA2A62B4A400FED265 /* ContributorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9C92A62B4A400FED265 /* ContributorsView.swift */; };
@@ -657,6 +660,9 @@
 		03C905C92B3C834C00B9082F /* AvatarBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarBannerView.swift; sourceTree = "<group>"; };
 		03C905CB2B3C88F700B9082F /* SearchTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTab.swift; sourceTree = "<group>"; };
 		03C905CD2B3C8DC400B9082F /* UserView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserView+Logic.swift"; sourceTree = "<group>"; };
+		03C942912B6457B4002068A4 /* BanUserEditorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BanUserEditorModel.swift; sourceTree = "<group>"; };
+		03C942932B64596B002068A4 /* BanUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BanUserView.swift; sourceTree = "<group>"; };
+		03C942952B648252002068A4 /* BanPerson.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BanPerson.swift; sourceTree = "<group>"; };
 		03CB329D2A6D8E910021EF27 /* PostComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostComposerView.swift; sourceTree = "<group>"; };
 		03E0B9C72A61F0F400FED265 /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
 		03E0B9C92A62B4A400FED265 /* ContributorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorsView.swift; sourceTree = "<group>"; };
@@ -1411,6 +1417,14 @@
 			path = TabBar;
 			sourceTree = "<group>";
 		};
+		03C942902B6457A3002068A4 /* Administration */ = {
+			isa = PBXGroup;
+			children = (
+				03C942912B6457B4002068A4 /* BanUserEditorModel.swift */,
+			);
+			path = Administration;
+			sourceTree = "<group>";
+		};
 		03E79F3D2AE3E6FF0006700D /* Sorting */ = {
 			isa = PBXGroup;
 			children = (
@@ -2024,6 +2038,7 @@
 		6372182E2A3A2AAD008C4816 /* Person */ = {
 			isa = PBXGroup;
 			children = (
+				03C942952B648252002068A4 /* BanPerson.swift */,
 				6372182F2A3A2AAD008C4816 /* GetPersonDetails.swift */,
 				CDF842632A49EAFA00723DA0 /* GetPersonMentions.swift */,
 				CD3FBCDC2A4A6F0600B2063F /* GetReplies.swift */,
@@ -2215,6 +2230,7 @@
 			isa = PBXGroup;
 			children = (
 				CD391F952A535F5400E213B5 /* ResponseEditorView.swift */,
+				03C942932B64596B002068A4 /* BanUserView.swift */,
 				03CB329D2A6D8E910021EF27 /* PostComposerView.swift */,
 				03EA79C32AC0D92C00BCDC91 /* PostComposerView+Logic.swift */,
 			);
@@ -2652,6 +2668,7 @@
 		CDA2C5242A705D3100649D5A /* Composers */ = {
 			isa = PBXGroup;
 			children = (
+				03C942902B6457A3002068A4 /* Administration */,
 				CD391F922A533B6C00E213B5 /* Response Composers */,
 				CDA2C5252A705D6000649D5A /* PostEditor.swift */,
 			);
@@ -3155,6 +3172,7 @@
 				637218442A3A2AAD008C4816 /* HierarchicalComment.swift in Sources */,
 				CDDCF6472A663849003DA3AC /* EnvironmentValues+TabSelectionHashValue.swift in Sources */,
 				63D24EDE2A169F2A005CCA81 /* Markdown View.swift in Sources */,
+				03C942962B648252002068A4 /* BanPerson.swift in Sources */,
 				E453A1D02A81C2140004BB8A /* QuickLookPreviewController.swift in Sources */,
 				B104A6E02A59C19400B3E725 /* OperationQueue+ConvenienceInit.swift in Sources */,
 				CD2053122ACB72190000AA38 /* AccountTransitionView.swift in Sources */,
@@ -3397,6 +3415,7 @@
 				030D00882AD1BB2600953B1D /* UserModel+ContentModel.swift in Sources */,
 				CD82A24C2A70A26900111034 /* View+CustomBadge.swift in Sources */,
 				B1CB6E752A4C729D00DA9675 /* Bundle+IconFileName.swift in Sources */,
+				03C942922B6457B4002068A4 /* BanUserEditorModel.swift in Sources */,
 				030D4AE82AA1278400A3393D /* ErrorDetails+Mock.swift in Sources */,
 				CD4368C62AE240BF00BD8BD1 /* MessageModel.swift in Sources */,
 				6363D60427EE20A200E34822 /* Expanded Post.swift in Sources */,
@@ -3475,6 +3494,7 @@
 				637218622A3A2AAD008C4816 /* DeletePost.swift in Sources */,
 				505240E32A86916500EA4558 /* FavoriteCommunitiesTracker+Dependency.swift in Sources */,
 				6332FDC327EFCB5F0009A98A /* Color+Colors.swift in Sources */,
+				03C942942B64596B002068A4 /* BanUserView.swift in Sources */,
 				E46AF9942B29AB270087FDF3 /* EnvironmentValues+ScrollViewReaderProxy.swift in Sources */,
 				637218432A3A2AAD008C4816 /* APIClient.swift in Sources */,
 				CD82A2572A716D7C00111034 /* PersonRepository+Dependency.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -95,6 +95,9 @@
 		03E0B9C82A61F0F400FED265 /* AdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9C72A61F0F400FED265 /* AdvancedSettingsView.swift */; };
 		03E0B9CA2A62B4A400FED265 /* ContributorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9C92A62B4A400FED265 /* ContributorsView.swift */; };
 		03E0B9CC2A62CD5800FED265 /* ThemeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E0B9CB2A62CD5800FED265 /* ThemeSettingsView.swift */; };
+		03E47AEB2B66BADC00A3E4DB /* UptimeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E47AEA2B66BADC00A3E4DB /* UptimeData.swift */; };
+		03E47AED2B66BC0000A3E4DB /* InstanceUptimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E47AEC2B66BC0000A3E4DB /* InstanceUptimeView.swift */; };
+		03E47AEF2B66BD3C00A3E4DB /* InstanceModel+Uptime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E47AEE2B66BD3C00A3E4DB /* InstanceModel+Uptime.swift */; };
 		03E79F3F2AE3E7100006700D /* SortingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E79F3E2AE3E7100006700D /* SortingSettingsView.swift */; };
 		03E90FB12B3703ED00E5A802 /* AccountSortMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E90FB02B3703ED00E5A802 /* AccountSortMode.swift */; };
 		03EA79C42AC0D92C00BCDC91 /* PostComposerView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EA79C32AC0D92C00BCDC91 /* PostComposerView+Logic.swift */; };
@@ -667,6 +670,9 @@
 		03E0B9C72A61F0F400FED265 /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
 		03E0B9C92A62B4A400FED265 /* ContributorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorsView.swift; sourceTree = "<group>"; };
 		03E0B9CB2A62CD5800FED265 /* ThemeSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsView.swift; sourceTree = "<group>"; };
+		03E47AEA2B66BADC00A3E4DB /* UptimeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UptimeData.swift; sourceTree = "<group>"; };
+		03E47AEC2B66BC0000A3E4DB /* InstanceUptimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceUptimeView.swift; sourceTree = "<group>"; };
+		03E47AEE2B66BD3C00A3E4DB /* InstanceModel+Uptime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InstanceModel+Uptime.swift"; sourceTree = "<group>"; };
 		03E79F3E2AE3E7100006700D /* SortingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortingSettingsView.swift; sourceTree = "<group>"; };
 		03E90FB02B3703ED00E5A802 /* AccountSortMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSortMode.swift; sourceTree = "<group>"; };
 		03EA79C32AC0D92C00BCDC91 /* PostComposerView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostComposerView+Logic.swift"; sourceTree = "<group>"; };
@@ -1393,6 +1399,8 @@
 			isa = PBXGroup;
 			children = (
 				03A54C312B5331F30064CCDE /* InstanceView.swift */,
+				03E47AEC2B66BC0000A3E4DB /* InstanceUptimeView.swift */,
+				03E47AEA2B66BADC00A3E4DB /* UptimeData.swift */,
 				031F95562B5C7FF20069C244 /* InstanceDetailsView.swift */,
 			);
 			path = Instance;
@@ -1402,6 +1410,7 @@
 			isa = PBXGroup;
 			children = (
 				03A54C342B533BC50064CCDE /* InstanceModel.swift */,
+				03E47AEE2B66BD3C00A3E4DB /* InstanceModel+Uptime.swift */,
 				0355DA4E2B5EB63600CDF5A5 /* InstanceStub.swift */,
 				0355DA4C2B5EB51900CDF5A5 /* InstanceModel+ContentModel.swift */,
 				03A54C362B545A430064CCDE /* InstanceModel+MenuFunctions.swift */,
@@ -3244,6 +3253,7 @@
 				039C8DBB2B35B2EB0096BAAF /* AccountListView.swift in Sources */,
 				CD1446252A5B357900610EF1 /* Document.swift in Sources */,
 				CDEBC32C2A9A582500518D9D /* Votes Model.swift in Sources */,
+				03E47AED2B66BC0000A3E4DB /* InstanceUptimeView.swift in Sources */,
 				CDEBC3282A9A57F200518D9D /* Content Model Identifier.swift in Sources */,
 				6FF17D012B685C16007E1814 /* AppLockView.swift in Sources */,
 				B1955A1D2A606B950056CF99 /* Easter Rewards.swift in Sources */,
@@ -3363,10 +3373,12 @@
 				039439912A98FA6100463032 /* UserFeedView.swift in Sources */,
 				03EA79C42AC0D92C00BCDC91 /* PostComposerView+Logic.swift in Sources */,
 				03A18CBF2B1252BD00BA69D2 /* ListingType.swift in Sources */,
+				03E47AEF2B66BD3C00A3E4DB /* InstanceModel+Uptime.swift in Sources */,
 				637218482A3A2AAD008C4816 /* APICommentReply.swift in Sources */,
 				CD3720EC2B2E8F96004D7103 /* AlternativeIconCell.swift in Sources */,
 				032109472AA7C3FC00912DFC /* CommunityLabelView.swift in Sources */,
 				637218502A3A2AAD008C4816 /* APIPersonAggregates.swift in Sources */,
+				03E47AEB2B66BADC00A3E4DB /* UptimeData.swift in Sources */,
 				CD4368D72AE2464D00BD8BD1 /* ReplyModel+InboxItem.swift in Sources */,
 				6D693A422A5114DF009E2D76 /* APIPostReport.swift in Sources */,
 				5064D03F2A6DE0DB00B22EE3 /* Notifier+Dependency.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3831,7 +3831,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -3873,7 +3873,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Mlem/API/APIClient/APIClient+Post.swift
+++ b/Mlem/API/APIClient/APIClient+Post.swift
@@ -43,6 +43,13 @@ extension APIClient {
         return SuccessResponse(from: compatibilityResponse)
     }
     
+    func markPostsAsRead(for postIds: [Int], read: Bool) async throws -> SuccessResponse {
+        let request = try MarkPostReadRequest(session: session, postIds: postIds, read: read)
+        // TODO: 0.18 deprecation simply return result of perform
+        let compatibilityResponse = try await perform(request: request)
+        return SuccessResponse(from: compatibilityResponse)
+    }
+    
     func loadPost(id: Int, commentId: Int? = nil) async throws -> APIPostView {
         let request = try GetPostRequest(session: session, id: id, commentId: commentId)
         return try await perform(request: request).postView

--- a/Mlem/API/APIClient/APIClient.swift
+++ b/Mlem/API/APIClient/APIClient.swift
@@ -256,6 +256,18 @@ extension APIClient {
         return try await perform(request: request)
     }
     
+    func banPerson(id: Int, shouldBan: Bool, expires: Int?, reason: String?, removeData: Bool) async throws -> BanPersonResponse {
+        let request = try BanPersonRequest(
+            session: session,
+            personId: id,
+            ban: shouldBan,
+            expires: expires,
+            reason: reason,
+            removeData: removeData
+        )
+        return try await perform(request: request)
+    }
+    
     func markPersonMentionAsRead(mentionId: Int, isRead: Bool) async throws -> APIPersonMentionView {
         let request = try MarkPersonMentionAsRead(session: session, personMentionId: mentionId, read: isRead)
         return try await perform(request: request).personMentionView

--- a/Mlem/API/Models/Common/SuccessResponse.swift
+++ b/Mlem/API/Models/Common/SuccessResponse.swift
@@ -29,8 +29,8 @@ struct SuccessResponse: Decodable {
 }
 
 struct MarkReadCompatibilityResponse: Decodable {
-    let success: Bool?
-    let postView: APIPostView?
+    let success: Bool? // 0.19+ response
+    let postView: APIPostView? // 0.18- response
 }
 
 struct SaveUserSettingsCompatibilityResponse: Decodable {

--- a/Mlem/API/Requests/Person/BanPerson.swift
+++ b/Mlem/API/Requests/Person/BanPerson.swift
@@ -1,0 +1,50 @@
+//
+//  BanPerson.swift
+//  Mlem
+//
+//  Created by Sjmarf on 27/01/2024.
+//
+
+import Foundation
+
+struct BanPersonRequest: APIPostRequest {
+    typealias Response = BanPersonResponse
+
+    let instanceURL: URL
+    let path = "user/ban"
+    let body: Body
+
+    struct Body: Encodable {
+        let personId: Int
+        let ban: Bool
+        let expires: Int?
+        let reason: String?
+        let removeData: Bool
+        let auth: String
+    }
+
+    init(
+        session: APISession,
+        personId: Int,
+        ban: Bool,
+        expires: Int?,
+        reason: String?,
+        removeData: Bool
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+
+        self.body = .init(
+            personId: personId,
+            ban: ban,
+            expires: expires,
+            reason: reason,
+            removeData: removeData,
+            auth: try session.token
+        )
+    }
+}
+
+struct BanPersonResponse: Decodable {
+    let banned: Bool
+    let personView: APIPersonView
+}

--- a/Mlem/API/Requests/Post/MarkPostRead.swift
+++ b/Mlem/API/Requests/Post/MarkPostRead.swift
@@ -15,12 +15,13 @@ struct MarkPostReadRequest: APIPostRequest {
     let body: Body
 
     struct Body: Encodable {
-        let post_id: Int
+        let post_id: Int?
+        let post_ids: [Int]?
         let read: Bool
         let auth: String
-        // TODO: 0.19 support add post_ids? field
     }
 
+    /// Create a request to mark a single post as read
     init(
         session: APISession,
         postId: Int,
@@ -30,6 +31,23 @@ struct MarkPostReadRequest: APIPostRequest {
 
         self.body = try .init(
             post_id: postId,
+            post_ids: nil,
+            read: read,
+            auth: session.token
+        )
+    }
+    
+    /// Create a request to mark multiple posts as read
+    init(
+        session: APISession,
+        postIds: [Int],
+        read: Bool
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        
+        self.body = try .init(
+            post_id: nil,
+            post_ids: postIds,
             read: read,
             auth: session.token
         )

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -153,6 +153,14 @@ struct ContentView: View {
             .presentationDragIndicator(.hidden)
             ._presentationBackgroundInteraction(enabledUpThrough: .medium)
         }
+        .sheet(item: $editorTracker.banUser) { editing in
+            NavigationStack {
+                BanUserView(editModel: editing)
+            }
+            .presentationDetents([.medium, .large], selection: .constant(.large))
+            .presentationDragIndicator(.hidden)
+            ._presentationBackgroundInteraction(enabledUpThrough: .medium)
+        }
         .sheet(item: $quickLookState.url) { url in
             NavigationStack {
                 ImageDetailView(url: url)

--- a/Mlem/Dependency/MarkReadBatcher+Dependency.swift
+++ b/Mlem/Dependency/MarkReadBatcher+Dependency.swift
@@ -1,0 +1,20 @@
+//
+//  MarkReadBatcher+Dependency.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-09.
+//
+
+import Dependencies
+import Foundation
+
+extension MarkReadBatcher: DependencyKey {
+    static let liveValue = MarkReadBatcher()
+}
+
+extension DependencyValues {
+    var markReadBatcher: MarkReadBatcher {
+        get { self[MarkReadBatcher.self] }
+        set { self[MarkReadBatcher.self] = newValue }
+    }
+}

--- a/Mlem/Enums/Settings/PostSize.swift
+++ b/Mlem/Enums/Settings/PostSize.swift
@@ -17,6 +17,14 @@ extension PostSize: SettingsOptions {
     }
     
     var id: Self { self }
+    
+    var markReadThreshold: Int {
+        switch self {
+        case .compact: 4
+        case .headline: 2
+        case .large: 1
+        }
+    }
 }
 
 extension PostSize: AssociatedIcon {

--- a/Mlem/Extensions/View Modifiers/View+DestructiveConfirmation.swift
+++ b/Mlem/Extensions/View Modifiers/View+DestructiveConfirmation.swift
@@ -23,8 +23,8 @@ struct DestructiveConfirmation: ViewModifier {
                     }
                 }
             } message: {
-                if let destructivePrompt = confirmationMenuFunction?.destructiveActionPrompt {
-                    Text(destructivePrompt)
+                if case let .destructive(prompt: prompt) = confirmationMenuFunction?.role, let prompt {
+                    Text(prompt)
                 }
             }
     }

--- a/Mlem/Extensions/View Modifiers/View+HandleLemmyLinks.swift
+++ b/Mlem/Extensions/View Modifiers/View+HandleLemmyLinks.swift
@@ -36,8 +36,8 @@ struct HandleLemmyLinksDisplay: ViewModifier {
                     UserView(user: user, communityContext: communityContext)
                         .environmentObject(appState)
                         .environmentObject(quickLookState)
-                case let .instance(domainName, instance):
-                    InstanceView(domainName: domainName, instance: instance)
+                case let .instance(instance):
+                    InstanceView(instance: instance)
                 case let .postLinkWithContext(postLink):
                     ExpandedPost(post: postLink.post, community: postLink.community, scrollTarget: postLink.scrollTarget)
                         .environmentObject(postLink.postTracker)

--- a/Mlem/Icons.swift
+++ b/Mlem/Icons.swift
@@ -52,7 +52,7 @@ enum Icons {
     static let titleOnlyPost: String = "character.bubble"
     static let pinned: String = "pin.fill"
     static let websiteIcon: String = "globe"
-    static let hideRead: String = "book"
+    static let read: String = "book"
     
     // post sizes
     static let postSizeSetting: String = "rectangle.expand.vertical"

--- a/Mlem/Icons.swift
+++ b/Mlem/Icons.swift
@@ -149,6 +149,11 @@ enum Icons {
     static let close: String = "multiply"
     static let cakeDay: String = "birthday.cake"
     
+    // uptime
+    static let uptimeOffline: String = "xmark.circle.fill"
+    static let uptimeOnline: String = "checkmark.circle.fill"
+    static let uptimeOutage: String = "exclamationmark.circle.fill"
+    
     // end of feed
     static let endOfFeedHobbit: String = "figure.climbing"
     static let endOfFeedCartoon: String = "figure.wave"

--- a/Mlem/Icons.swift
+++ b/Mlem/Icons.swift
@@ -190,6 +190,7 @@ enum Icons {
     static let limitImageHeightSetting: String = "rectangle.compress.vertical"
     static let appLockSettings: String = "lock.app.dashed"
     static let collapseComments: String = "arrow.down.and.line.horizontal.and.arrow.up"
+    static let ban: String = "xmark.circle"
     
     // misc
     static let `private`: String = "lock"

--- a/Mlem/Logic/BiometricUnlock.swift
+++ b/Mlem/Logic/BiometricUnlock.swift
@@ -36,7 +36,7 @@ class BiometricUnlock: ObservableObject {
             let reason = "Please authenticate to unlock app."
             
             context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, _ in
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     if success {
                         self.isUnlocked = true
                         onComplete(.success(()))

--- a/Mlem/Models/Batchers/MarkReadBatcher.swift
+++ b/Mlem/Models/Batchers/MarkReadBatcher.swift
@@ -1,0 +1,75 @@
+//
+//  MarkReadBatcher.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-08.
+//
+
+import Dependencies
+import Foundation
+import Semaphore
+
+class MarkReadBatcher {
+    @Dependency(\.notifier) var notifier
+    @Dependency(\.errorHandler) var errorHandler
+    @Dependency(\.postRepository) var postRepository
+    
+    private let loadingSemaphore: AsyncSemaphore = .init(value: 1)
+    
+    private(set) var enabled: Bool = false
+    private var pending: [Int] = .init()
+    private var sending: [Int] = .init()
+    
+    func resolveSiteVersion(to siteVersion: SiteVersion) {
+        enabled = siteVersion >= .init("0.19.0")
+    }
+    
+    func flush() async {
+        // only one thread may execute this function at a time to avoid duplicate requests
+        await loadingSemaphore.wait()
+        defer { loadingSemaphore.signal() }
+        
+        sending = pending
+        pending = .init()
+        
+        // perform this on background thread to return ASAP
+        Task {
+            await dispatchSending()
+        }
+    }
+    
+    func dispatchSending() async {
+        guard sending.count > 0 else {
+            return
+        }
+        
+        do {
+            try await postRepository.markRead(postIds: sending, read: true)
+        } catch {
+            errorHandler.handle(error)
+        }
+        
+        sending = .init()
+    }
+  
+    func add(_ postId: Int) async {
+        // FUTURE DEV: wouldn't it be nicer to pass in a PostModel and perform the mark read state fake here?
+        // PAST DEV: no, that causes nasty little memory errors in fringe cases thanks to pass-by-reference. Trust in the safety of pass-by-value, future dev.
+        
+        guard enabled else {
+            assertionFailure("Cannot add to disabled batcher!")
+            return
+        }
+        
+        if pending.count >= 50 {
+            await flush()
+        }
+        
+        // This call is deliberately placed *after* the flush check to avoid the potential data race:
+        // - Threads 0 and 1 call add() at the same time
+        // - Thread 0 calls flush() and performs sending = pending
+        // - Thread 1 adds its id to pending
+        // - Thread 0 performs pending = .init(), and thread 1's id is lost forever!
+        pending.append(postId)
+    }
+}

--- a/Mlem/Models/Composers/Administration/BanUserEditorModel.swift
+++ b/Mlem/Models/Composers/Administration/BanUserEditorModel.swift
@@ -1,0 +1,18 @@
+//
+//  BanUser.swift
+//  Mlem
+//
+//  Created by Sjmarf on 26/01/2024.
+//
+
+import Dependencies
+import Foundation
+import SwiftUI
+
+struct BanUserEditorModel: Identifiable {
+    @Dependency(\.commentRepository) var commentRepository
+    
+    let user: UserModel
+    var callback: (_ item: UserModel) -> Void = { _ in }
+    var id: Int { user.userId }
+}

--- a/Mlem/Models/Content/Community/CommunityModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Community/CommunityModel+MenuFunctions.swift
@@ -10,17 +10,17 @@ import SwiftUI
 
 extension CommunityModel {
     func newPostMenuFunction(editorTracker: EditorTracker, postTracker: StandardPostTracker? = nil) -> MenuFunction {
-        .standardMenuFunction(
-            text: "New Post",
-            imageName: Icons.sendFill,
-            destructiveActionPrompt: nil,
-            enabled: true
-        ) {
-            editorTracker.openEditor(with: PostEditorModel(
-                community: self,
-                postTracker: postTracker
-            ))
-        }
+        return .standardMenuFunction(
+                text: "New Post",
+                imageName: Icons.sendFill,
+                role: nil,
+                enabled: true
+            ) {
+                editorTracker.openEditor(with: PostEditorModel(
+                    community: self,
+                    postTracker: postTracker
+                ))
+            }
     }
     
     func subscribeMenuFunction(_ callback: @escaping (_ item: Self) -> Void = { _ in }) throws -> StandardMenuFunction {
@@ -30,7 +30,7 @@ extension CommunityModel {
         return .init(
             text: subscribed ? "Unsubscribe" : "Subscribe",
             imageName: subscribed ? Icons.unsubscribe : Icons.subscribe,
-            destructiveActionPrompt: subscribed ? "Are you sure you want to unsubscribe from \(name!)?" : nil,
+            role: subscribed ? .destructive(prompt: "Are you sure you want to unsubscribe from \(name!)?") : nil,
             enabled: true,
             callback: {
                 Task {
@@ -48,7 +48,7 @@ extension CommunityModel {
         .init(
             text: favorited ? "Unfavorite" : "Favorite",
             imageName: favorited ? Icons.unfavorite : Icons.favorite,
-            destructiveActionPrompt: favorited ? "Really unfavorite \(name ?? "this community")?" : nil,
+            role: favorited ? .destructive(prompt: "Really unfavorite \(name ?? "this community")?") : nil,
             enabled: true
         ) {
             Task {
@@ -68,7 +68,7 @@ extension CommunityModel {
         return .standardMenuFunction(
             text: blocked ? "Unblock" : "Block",
             imageName: blocked ? Icons.show : Icons.hide,
-            destructiveActionPrompt: blocked ? nil : AppConstants.blockCommunityPrompt,
+            role: blocked ? nil : .destructive(prompt: AppConstants.blockCommunityPrompt),
             enabled: true,
             callback: {
                 Task {
@@ -114,7 +114,7 @@ extension CommunityModel {
             .standardMenuFunction(
                 text: "Copy Name",
                 imageName: Icons.copy,
-                destructiveActionPrompt: nil,
+                role: nil,
                 enabled: true,
                 callback: copyFullyQualifiedName
             )

--- a/Mlem/Models/Content/Community/CommunityModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Community/CommunityModel+MenuFunctions.swift
@@ -95,20 +95,24 @@ extension CommunityModel {
             functions.append(.standard(function))
             functions.append(.standard(favoriteMenuFunction(callback)))
         }
-        if let instanceHost = communityUrl.host() {
-            let instance: InstanceModel?
-            if let site {
-                instance = .init(from: site)
-            } else {
-                instance = nil
-            }
-            functions.append(
-                .navigationMenuFunction(
-                    text: instanceHost,
-                    imageName: Icons.instance,
-                    destination: .instance(instanceHost, instance)
+        do {
+            if let instanceHost = self.communityUrl.host() {
+                let instance: InstanceModel
+                if let site {
+                    instance = .init(from: site)
+                } else {
+                    instance = try .init(domainName: instanceHost)
+                }
+                functions.append(
+                    .navigationMenuFunction(
+                        text: instanceHost,
+                        imageName: Icons.instance,
+                        destination: .instance(instance)
+                    )
                 )
-            )
+            }
+        } catch {
+            print("Failed to add instance menu function!")
         }
         functions.append(
             .standardMenuFunction(

--- a/Mlem/Models/Content/Inbox/MentionModel.swift
+++ b/Mlem/Models/Content/Inbox/MentionModel.swift
@@ -240,7 +240,7 @@ extension MentionModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: votes.myVote == .upvote ? "Undo Upvote" : "Upvote",
             imageName: votes.myVote == .upvote ? Icons.upvoteSquareFill : Icons.upvoteSquare,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -252,7 +252,7 @@ extension MentionModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: votes.myVote == .downvote ? "Undo Downvote" : "Downvote",
             imageName: votes.myVote == .downvote ? Icons.downvoteSquareFill : Icons.downvoteSquare,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -264,7 +264,7 @@ extension MentionModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: personMention.read ? "Mark Unread" : "Mark Read",
             imageName: personMention.read ? Icons.markUnread : Icons.markRead,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -276,7 +276,7 @@ extension MentionModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Reply",
             imageName: Icons.reply,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -288,7 +288,7 @@ extension MentionModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Report",
             imageName: Icons.moderationReport,
-            destructiveActionPrompt: AppConstants.reportCommentPrompt,
+            role: .destructive(prompt: AppConstants.reportCommentPrompt),
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -300,7 +300,7 @@ extension MentionModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Block",
             imageName: Icons.userBlock,
-            destructiveActionPrompt: AppConstants.blockUserPrompt,
+            role: .destructive(prompt: AppConstants.blockUserPrompt),
             enabled: true
         ) {
             Task(priority: .userInitiated) {

--- a/Mlem/Models/Content/Inbox/MessageModel.swift
+++ b/Mlem/Models/Content/Inbox/MessageModel.swift
@@ -123,7 +123,7 @@ class MessageModel: ContentIdentifiable, ObservableObject {
         ret.append(MenuFunction.standardMenuFunction(
             text: privateMessage.read ? "Mark unread" : "Mark read",
             imageName: privateMessage.read ? Icons.markUnread : Icons.markRead,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -135,7 +135,7 @@ class MessageModel: ContentIdentifiable, ObservableObject {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Reply",
             imageName: Icons.reply,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -147,7 +147,7 @@ class MessageModel: ContentIdentifiable, ObservableObject {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Report",
             imageName: Icons.moderationReport,
-            destructiveActionPrompt: AppConstants.reportMessagePrompt,
+            role: .destructive(prompt: AppConstants.reportMessagePrompt),
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -159,7 +159,7 @@ class MessageModel: ContentIdentifiable, ObservableObject {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Block User",
             imageName: Icons.userBlock,
-            destructiveActionPrompt: AppConstants.blockUserPrompt,
+            role: .destructive(prompt: AppConstants.blockUserPrompt),
             enabled: true
         ) {
             Task(priority: .userInitiated) {

--- a/Mlem/Models/Content/Inbox/ReplyModel.swift
+++ b/Mlem/Models/Content/Inbox/ReplyModel.swift
@@ -235,7 +235,7 @@ extension ReplyModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: votes.myVote == .upvote ? "Undo Upvote" : "Upvote",
             imageName: votes.myVote == .upvote ? Icons.upvoteSquareFill : Icons.upvoteSquare,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -247,7 +247,7 @@ extension ReplyModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: votes.myVote == .downvote ? "Undo Downvote" : "Downvote",
             imageName: votes.myVote == .downvote ? Icons.downvoteSquareFill : Icons.downvoteSquare,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -259,7 +259,7 @@ extension ReplyModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: commentReply.read ? "Mark Unread" : "Mark Read",
             imageName: commentReply.read ? Icons.markUnread : Icons.markRead,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -271,7 +271,7 @@ extension ReplyModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Reply",
             imageName: Icons.reply,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -283,7 +283,7 @@ extension ReplyModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Report",
             imageName: Icons.moderationReport,
-            destructiveActionPrompt: AppConstants.reportCommentPrompt,
+            role: .destructive(prompt: AppConstants.reportCommentPrompt),
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -295,7 +295,7 @@ extension ReplyModel {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Block",
             imageName: Icons.userBlock,
-            destructiveActionPrompt: AppConstants.blockUserPrompt,
+            role: .destructive(prompt: AppConstants.blockUserPrompt),
             enabled: true
         ) {
             Task(priority: .userInitiated) {

--- a/Mlem/Models/Content/Instance/InstanceModel+Uptime.swift
+++ b/Mlem/Models/Content/Instance/InstanceModel+Uptime.swift
@@ -1,0 +1,59 @@
+//
+//  InstanceModel+Uptime.swift
+//  Mlem
+//
+//  Created by Sjmarf on 28/01/2024.
+//
+
+import SwiftUI
+
+extension InstanceModel {
+    
+    // Instances watched by lemmy-status.org
+    static let uptimeSupportedInstances: [String] = [
+        "aussie.zone",
+        "beehaw.org",
+        "discuss.online",
+        "discuss.tchncs.de",
+        "dubvee.org",
+        "feddit.de",
+        "feddit.dk",
+        "hexbear.net",
+        "infosec.pub",
+        "jlai.lu",
+        "lemdro.id",
+        "lemm.ee",
+        "lemmings.world",
+        "lemmy.blahaj.zone",
+        "lemmy.ca",
+        "lemmy.dbzer0.com",
+        "lemmy.eco.br",
+        "lemmy.ml",
+        "lemmy.myserv.one",
+        "lemmy.nz",
+        "lemmy.world",
+        "lemmy.zip",
+        "literature.cafe",
+        "mander.xyz",
+        "midwest.social",
+        "programming.dev",
+        "sh.itjust.works",
+        "slrpnk.net",
+        "sopuli.xyz",
+        "startrek.website"
+    ]
+    
+    var canFetchUptime: Bool { InstanceModel.uptimeSupportedInstances.contains(name) }
+
+    var uptimeDataUrl: URL? {
+        guard canFetchUptime else { return nil }
+        let name = "_\(name.replacingOccurrences(of: ".", with: "-"))"
+        return URL(string: "https://lemmy-status.org/api/v1/endpoints/\(name)/statuses?page=1")
+    }
+    
+    var uptimeFrontendUrl: URL? {
+        guard canFetchUptime else { return nil }
+        let name = "_\(name.replacingOccurrences(of: ".", with: "-"))"
+        return URL(string: "https://lemmy-status.org/endpoints/\(name)")
+    }
+}

--- a/Mlem/Models/Content/Instance/InstanceModel.swift
+++ b/Mlem/Models/Content/Instance/InstanceModel.swift
@@ -8,6 +8,11 @@
 import SwiftUI
 
 struct InstanceModel {
+    
+    enum InstanceError: Error {
+        case invalidUrl
+    }
+    
     var displayName: String!
     var description: String?
     var avatar: URL?
@@ -40,6 +45,18 @@ struct InstanceModel {
     var hideModlogModNames: Bool?
     var applicationsEmailAdmins: Bool?
     var reportsEmailAdmins: Bool?
+    
+    init(domainName: String) throws {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = domainName
+        if let url = components.url {
+            self.url = url
+            displayName = name
+        } else {
+            throw InstanceError.invalidUrl
+        }
+    }
     
     init(from response: SiteResponse) {
         update(with: response)

--- a/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
@@ -16,7 +16,6 @@ extension PostModel {
         functions.append(MenuFunction.standardMenuFunction(
             text: votes.myVote == .upvote ? "Undo Upvote" : "Upvote",
             imageName: votes.myVote == .upvote ? Icons.upvoteSquareFill : Icons.upvoteSquare,
-            destructiveActionPrompt: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -28,7 +27,6 @@ extension PostModel {
         functions.append(MenuFunction.standardMenuFunction(
             text: votes.myVote == .downvote ? "Undo Downvote" : "Downvote",
             imageName: votes.myVote == .downvote ? Icons.downvoteSquareFill : Icons.downvoteSquare,
-            destructiveActionPrompt: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -40,7 +38,6 @@ extension PostModel {
         functions.append(MenuFunction.standardMenuFunction(
             text: saved ? "Unsave" : "Save",
             imageName: saved ? Icons.unsave : Icons.save,
-            destructiveActionPrompt: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -52,7 +49,6 @@ extension PostModel {
         functions.append(MenuFunction.standardMenuFunction(
             text: "Reply",
             imageName: Icons.reply,
-            destructiveActionPrompt: nil,
             enabled: true
         ) {
             editorTracker.openEditor(
@@ -65,7 +61,6 @@ extension PostModel {
             functions.append(MenuFunction.standardMenuFunction(
                 text: "Edit",
                 imageName: Icons.edit,
-                destructiveActionPrompt: nil,
                 enabled: true
             ) {
                 editorTracker.openEditor(with: PostEditorModel(post: self))
@@ -75,7 +70,7 @@ extension PostModel {
             functions.append(MenuFunction.standardMenuFunction(
                 text: "Delete",
                 imageName: Icons.delete,
-                destructiveActionPrompt: "Are you sure you want to delete this post? This cannot be undone.",
+                role: .destructive(prompt: "Are you sure you want to delete this post? This cannot be undone."),
                 enabled: !post.deleted
             ) {
                 Task(priority: .userInitiated) {
@@ -94,7 +89,7 @@ extension PostModel {
             functions.append(MenuFunction.standardMenuFunction(
                 text: "Report",
                 imageName: Icons.moderationReport,
-                destructiveActionPrompt: AppConstants.reportPostPrompt,
+                role: .destructive(prompt: AppConstants.reportPostPrompt),
                 enabled: true
             ) {
                 editorTracker.openEditor(
@@ -107,7 +102,7 @@ extension PostModel {
                 functions.append(MenuFunction.standardMenuFunction(
                     text: "Block User",
                     imageName: Icons.userBlock,
-                    destructiveActionPrompt: AppConstants.blockUserPrompt,
+                    role: .destructive(prompt: AppConstants.blockUserPrompt),
                     enabled: true
                 ) {
                     Task(priority: .userInitiated) {
@@ -125,7 +120,7 @@ extension PostModel {
                 functions.append(MenuFunction.standardMenuFunction(
                     text: "Block Community",
                     imageName: Icons.hide,
-                    destructiveActionPrompt: AppConstants.blockCommunityPrompt,
+                    role: .destructive(prompt: AppConstants.blockCommunityPrompt),
                     enabled: true
                 ) {
                     Task(priority: .userInitiated) {

--- a/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
@@ -136,7 +136,40 @@ extension PostModel {
             }
         }
 
+#if DEBUG
+        functions.append(
+            buildDeveloperMenu(
+                editorTracker: editorTracker,
+                postTracker: postTracker
+            )
+        )
+#endif
+        
         return functions
     }
     // swiftlint:enable function_body_length
+    
+#if DEBUG
+    private func buildDeveloperMenu(
+        editorTracker: EditorTracker,
+        postTracker: StandardPostTracker?
+    ) -> MenuFunction {
+        MenuFunction.childMenu(
+            titleKey: "Developer Menu",
+            children: [
+                .standardMenuFunction(
+                    text: "Toggle Read State",
+                    imageName: "book.and.wrench",
+                    enabled: true,
+                    callback: {
+                        Task {
+                            let newState = !self.read
+                            await self.markRead(newState)
+                        }
+                    }
+                )
+            ]
+        )
+    }
+#endif
 }

--- a/Mlem/Models/Content/User/UserModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/User/UserModel+MenuFunctions.swift
@@ -48,20 +48,24 @@ extension UserModel {
         editorTracker: EditorTracker? = nil
     ) -> [MenuFunction] {
         var functions: [MenuFunction] = .init()
-        if let instanceHost = profileUrl.host() {
-            let instance: InstanceModel?
-            if let site {
-                instance = .init(from: site)
-            } else {
-                instance = nil
-            }
-            functions.append(
-                .navigationMenuFunction(
-                    text: instanceHost,
-                    imageName: Icons.instance,
-                    destination: .instance(instanceHost, instance)
+        do {
+            if let instanceHost = self.profileUrl.host() {
+                let instance: InstanceModel
+                if let site {
+                    instance = .init(from: site)
+                } else {
+                    instance = try .init(domainName: instanceHost)
+                }
+                functions.append(
+                    .navigationMenuFunction(
+                        text: instanceHost,
+                        imageName: Icons.instance,
+                        destination: .instance(instance)
+                    )
                 )
-            )
+            }
+        } catch {
+            print("Failed to add instance menu function!")
         }
         functions.append(
             .standardMenuFunction(

--- a/Mlem/Models/Content/User/UserModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/User/UserModel+MenuFunctions.swift
@@ -12,8 +12,7 @@ extension UserModel {
         .standardMenuFunction(
             text: blocked ? "Unblock" : "Block",
             imageName: blocked ? Icons.show : Icons.hide,
-            destructiveActionPrompt: blocked ? nil : AppConstants.blockUserPrompt,
-            enabled: true,
+            role: blocked ? nil : .destructive(prompt: AppConstants.blockUserPrompt),
             callback: {
                 Task {
                     var new = self
@@ -23,7 +22,31 @@ extension UserModel {
         )
     }
     
-    func menuFunctions(_ callback: @escaping (_ item: Self) -> Void = { _ in }) -> [MenuFunction] {
+    func banMenuFunction(
+        _ callback: @escaping (_ item: Self) -> Void = { _ in },
+        editorTracker: EditorTracker
+    ) -> MenuFunction {
+        return .standardMenuFunction(
+            text: banned ? "Unban" : "Ban",
+            imageName: Icons.bannedFlair,
+            role: .destructive(prompt: banned ? "Really unban this user?" : nil),
+            callback: {
+                if banned {
+                    Task {
+                        var new = self
+                        await new.toggleBan(callback)
+                    }
+                } else {
+                    editorTracker.banUser = BanUserEditorModel(user: self, callback: callback)
+                }
+            }
+        )
+    }
+    
+    func menuFunctions(
+        _ callback: @escaping (_ item: Self) -> Void = { _ in },
+        editorTracker: EditorTracker? = nil
+    ) -> [MenuFunction] {
         var functions: [MenuFunction] = .init()
         if let instanceHost = profileUrl.host() {
             let instance: InstanceModel?
@@ -44,14 +67,18 @@ extension UserModel {
             .standardMenuFunction(
                 text: "Copy Username",
                 imageName: Icons.copy,
-                destructiveActionPrompt: nil,
-                enabled: true,
                 callback: copyFullyQualifiedUsername
             )
         )
         functions.append(.shareMenuFunction(url: profileUrl))
-        if siteInformation.myUserInfo?.localUserView.person.id != userId {
+        
+        let isOwnUser = (siteInformation.myUser?.userId ?? -1) == self.userId
+        
+        if !isOwnUser {
             functions.append(blockMenuFunction(callback))
+            if siteInformation.myUser?.isAdmin ?? false, !(isAdmin ?? false), let editorTracker {
+                functions.append(banMenuFunction(callback, editorTracker: editorTracker))
+            }
         }
         return functions
     }

--- a/Mlem/Models/Menu Function.swift
+++ b/Mlem/Models/Menu Function.swift
@@ -28,19 +28,23 @@ enum MenuFunction: Identifiable {
     case navigation(NavigationMenuFunction)
 }
 
+enum MenuFunctionRole {
+    case destructive(prompt: String?)
+}
+
 // some convenience initializers because MenuFunction.standard(StandardMenuFunction...) is ugly
 extension MenuFunction {
     static func standardMenuFunction(
         text: String,
         imageName: String,
-        destructiveActionPrompt: String?,
-        enabled: Bool,
+        role: MenuFunctionRole? = nil,
+        enabled: Bool = true,
         callback: @escaping () -> Void
     ) -> MenuFunction {
         MenuFunction.standard(StandardMenuFunction(
             text: text,
             imageName: imageName,
-            destructiveActionPrompt: destructiveActionPrompt,
+            role: role,
             enabled: enabled,
             callback: callback
         ))
@@ -90,7 +94,7 @@ struct StandardMenuFunction: Identifiable {
     
     let text: String
     let imageName: String
-    let destructiveActionPrompt: String?
+    var role: MenuFunctionRole?
     let enabled: Bool
     let callback: () -> Void
 }

--- a/Mlem/Models/Menu Function.swift
+++ b/Mlem/Models/Menu Function.swift
@@ -19,6 +19,8 @@ enum MenuFunction: Identifiable {
             return shareImageFunction.id
         case let .navigation(navigationMenuFunction):
             return navigationMenuFunction.id
+        case .childMenu:
+            return UUID().uuidString
         }
     }
     
@@ -26,6 +28,10 @@ enum MenuFunction: Identifiable {
     case shareUrl(ShareMenuFunction)
     case shareImage(ShareImageFunction)
     case navigation(NavigationMenuFunction)
+    /// - Parameter titleKey: User-facing title label for menu.
+    /// - Parameter children: Menu items for this child menu.
+    /// - Note: Destructive confirmation is not supported at this time.
+    case childMenu(titleKey: String, children: [MenuFunction])
 }
 
 enum MenuFunctionRole {

--- a/Mlem/Models/Trackers/Editor Tracker.swift
+++ b/Mlem/Models/Trackers/Editor Tracker.swift
@@ -9,6 +9,7 @@ import Foundation
 class EditorTracker: ObservableObject {
     @Published var editResponse: ConcreteEditorModel?
     @Published var editPost: PostEditorModel?
+    @Published var banUser: BanUserEditorModel?
 
     func openEditor(with editResponse: ConcreteEditorModel) {
         self.editResponse = editResponse

--- a/Mlem/Models/Trackers/SiteInformationTracker.swift
+++ b/Mlem/Models/Trackers/SiteInformationTracker.swift
@@ -13,6 +13,7 @@ class SiteInformationTracker: ObservableObject {
     @Dependency(\.apiClient) var apiClient
     @Dependency(\.errorHandler) var errorHandler
     @Dependency(\.accountsTracker) var accountsTracker
+    @Dependency(\.markReadBatcher) var markReadBatcher
     
     @Published private(set) var instance: InstanceModel?
     @Published private(set) var enableDownvotes = true
@@ -36,7 +37,9 @@ class SiteInformationTracker: ObservableObject {
                 }
                 myUserInfo = response.myUser
                 allLanguages = response.allLanguages
-                
+                if let version {
+                    markReadBatcher.resolveSiteVersion(to: version)
+                }
             } catch {
                 errorHandler.handle(error)
             }

--- a/Mlem/Models/Trackers/SiteInformationTracker.swift
+++ b/Mlem/Models/Trackers/SiteInformationTracker.swift
@@ -20,6 +20,7 @@ class SiteInformationTracker: ObservableObject {
     @Published var version: SiteVersion?
     @Published private(set) var allLanguages: [APILanguage] = .init()
     @Published var myUserInfo: APIMyUserInfo?
+    @Published var myUser: UserModel?
     
     func load(account: SavedAccount) {
         version = account.siteVersion
@@ -37,6 +38,11 @@ class SiteInformationTracker: ObservableObject {
                 }
                 myUserInfo = response.myUser
                 allLanguages = response.allLanguages
+                if let userInfo = response.myUser {
+                    myUser = UserModel(from: userInfo.localUserView.person)
+                    myUser?.isAdmin = response.admins.contains { $0.person.id == myUser?.userId }
+                }
+                
                 if let version {
                     markReadBatcher.resolveSiteVersion(to: version)
                 }

--- a/Mlem/Navigation/DismissAction.swift
+++ b/Mlem/Navigation/DismissAction.swift
@@ -20,7 +20,7 @@ final class Navigation: ObservableObject {
     typealias AuxiliaryAction = () -> Bool
     
     /// Specify behaviour to use when user triggers a navigation action.
-    var behaviour: Behaviour = .primaryAuxiliary
+    var behaviour: Behaviour = .system
     
     /// Actions associated with specific locations along a navigation path.
     var pathActions: [Int: (dismiss: DismissAction?, auxiliaryAction: AuxiliaryAction?)] = [:]
@@ -229,17 +229,45 @@ struct PerformTabBarNavigation: ViewModifier {
         // Customization based on user preference should occur here, for example:
         switch behaviour {
         case .system:
-            // performSystemPopToRootBehaviour()
-            break
+             performSystemPopToRoot()
         case .primary:
-            // performDimsissOnly()
-            break
+             performPrimaryOnly()
         case .primaryAuxiliary:
             performDismissAfterAuxiliary()
         case .none:
             // noOp()
             break
         }
+    }
+    
+    private func performSystemPopToRoot() {
+        if navigationPath.isEmpty {
+            guard let pathAction = navigator.pathActions[0] else {
+#if DEBUG
+                print(#function, "path action not found after popping to root")
+#endif
+                return
+            }
+            
+            let performed = pathAction.auxiliaryAction?() ?? false
+            if !performed, let dismiss = pathAction.dismiss {
+#if DEBUG
+                print("found auxiliary action, but that logic has been exhausted...perform standard dismiss action")
+                print("perform tab navigation on \(tab) tab")
+#endif
+                dismiss()
+            } else {
+#if DEBUG
+                print("performed auxiliary action")
+#endif
+            }
+        } else {
+            routesNavigationPath.wrappedValue = []
+        }
+    }
+    
+    private func performPrimaryOnly() {
+        
     }
     
     /// Runs all auxiliary actions before calling system dismiss action.

--- a/Mlem/Navigation/DismissAction.swift
+++ b/Mlem/Navigation/DismissAction.swift
@@ -19,6 +19,10 @@ final class Navigation: ObservableObject {
     /// Return `true` to indicate that an auxiliary action was performed.
     typealias AuxiliaryAction = () -> Bool
     
+    /// Specify behaviour to use when user triggers a navigation action.
+    var behaviour: Behaviour = .primaryAuxiliary
+    
+    /// Actions associated with specific locations along a navigation path.
     var pathActions: [Int: (dismiss: DismissAction?, auxiliaryAction: AuxiliaryAction?)] = [:]
     
     /// Navigation always performs dismiss action (if available), but may choose to perform an auxiliary action first.
@@ -34,6 +38,7 @@ final class Navigation: ObservableObject {
 // MARK: - Navigation Behaviour
 
 extension Navigation {
+    ///
     enum Behaviour {
         /// Mimics Apple platforms tab bar navigation behaviour (i.e. pop to root regardless of navigation stack size, then scroll to top).
         case system
@@ -41,6 +46,8 @@ extension Navigation {
         case primary
         /// Perform the auxiliary action(s) first, if specified, before proceeding with the primary action.
         case primaryAuxiliary
+        /// Do nothing, tyvm =)
+        case none
     }
 }
 
@@ -212,13 +219,26 @@ struct PerformTabBarNavigation: ViewModifier {
     func body(content: Content) -> some View {
         content.onChange(of: selectedNavigationTabHashValue) { newValue in
             if newValue == tab.hashValue {
-                hapticManager.play(haptic: .gentleInfo, priority: .high)
-                // Customization based  on user preference should occur here, for example:
-                // performSystemPopToRootBehaviour()
-                // noOp()
-                // performDimsissOnly()
-                performDismissAfterAuxiliary()
+                hapticManager.play(haptic: .gentleInfo, priority: .low)
+                performNavigation(behaviour: navigator.behaviour)
             }
+        }
+    }
+    
+    private func performNavigation(behaviour: Navigation.Behaviour) {
+        // Customization based on user preference should occur here, for example:
+        switch behaviour {
+        case .system:
+            // performSystemPopToRootBehaviour()
+            break
+        case .primary:
+            // performDimsissOnly()
+            break
+        case .primaryAuxiliary:
+            performDismissAfterAuxiliary()
+        case .none:
+            // noOp()
+            break
         }
     }
     

--- a/Mlem/Navigation/DismissAction.swift
+++ b/Mlem/Navigation/DismissAction.swift
@@ -341,13 +341,13 @@ extension Navigation.Behaviour: CustomStringConvertible, CustomDebugStringConver
     var description: String {
         switch self {
         case .system:
-            "System"
+            "Return to first page..."
         case .primary:
-            "Dismiss"
+            "Return to previous page..."
         case .primaryAuxiliary:
-            "Dismiss after Scroll"
+            "Scroll to top..."
         case .none:
-            "none"
+            "Do nothing"
         }
     }
     
@@ -366,14 +366,28 @@ extension Navigation.Behaviour: CustomStringConvertible, CustomDebugStringConver
 }
 
 extension Navigation.Behaviour {
+    
+    var systemImage: String {
+        switch self {
+        case .system:
+            "arrow.backward.to.line.circle"
+        case .primary:
+            "arrow.backward.circle"
+        case .primaryAuxiliary:
+            "arrow.up.to.line.circle"
+        case .none:
+            "circle.slash"
+        }
+    }
+    
     var explanation: String {
         switch self {
         case .system:
-            "Go back to the first page, then scroll to top."
+            "Return to first page, then scroll to top."
         case .primary:
-            "Go back to previous page until the first page, then scroll to top."
+            "Return to previous page until the first page, then scroll to top."
         case .primaryAuxiliary:
-            "Always scroll to top before going back to previous page."
+            "Always scroll to top before returning to previous page."
         case .none:
             ""
         }
@@ -381,6 +395,6 @@ extension Navigation.Behaviour {
 }
 
 extension Navigation.Behaviour: SettingsOptions {
-    var label: String { description.capitalized }
+    var label: String { description }
     var id: Self { self }
 }

--- a/Mlem/Navigation/DismissAction.swift
+++ b/Mlem/Navigation/DismissAction.swift
@@ -20,7 +20,7 @@ final class Navigation: ObservableObject {
     typealias AuxiliaryAction = () -> Bool
     
     /// Specify behaviour to use when user triggers a navigation action.
-    var behaviour: Behaviour = .system
+    var behaviour: Behaviour = .primary
     
     /// Actions associated with specific locations along a navigation path.
     var pathActions: [Int: (dismiss: DismissAction?, auxiliaryAction: AuxiliaryAction?)] = [:]
@@ -267,7 +267,35 @@ struct PerformTabBarNavigation: ViewModifier {
     }
     
     private func performPrimaryOnly() {
+#if DEBUG
+        print("perform action on path index -> \(navigationPath.count)")
+#endif
+        guard let pathAction = navigator.pathActions[navigationPath.count] else {
+#if DEBUG
+            print("path action not found at index -> \(navigationPath.count)")
+#endif
+            return
+        }
         
+        if navigationPath.isEmpty {
+            /// Users most likely expect scroll-to-top action:
+            /// Perform auxiliary action first, then perform dismiss.
+            let performed = pathAction.auxiliaryAction?() ?? false
+            if !performed, let dismiss = pathAction.dismiss {
+                dismiss()
+            }
+        } else {
+            if let dismiss = pathAction.dismiss {
+#if DEBUG
+                print("perform dismiss action via tab navigation on \(tab) tab")
+#endif
+                dismiss()
+            } else {
+#if DEBUG
+                print("attempted tab navigation -> action(s) not found")
+#endif
+            }
+        }
     }
     
     /// Runs all auxiliary actions before calling system dismiss action.

--- a/Mlem/Navigation/DismissAction.swift
+++ b/Mlem/Navigation/DismissAction.swift
@@ -20,6 +20,7 @@ final class Navigation: ObservableObject {
     typealias AuxiliaryAction = () -> Bool
     
     /// Specify behaviour to use when user triggers a navigation action.
+    @AppStorage("tabBarActionBehaviour") 
     var behaviour: Behaviour = .primary
     
     /// Actions associated with specific locations along a navigation path.
@@ -39,7 +40,7 @@ final class Navigation: ObservableObject {
 
 extension Navigation {
     ///
-    enum Behaviour {
+    enum Behaviour: Int, CaseIterable {
         /// Mimics Apple platforms tab bar navigation behaviour (i.e. pop to root regardless of navigation stack size, then scroll to top).
         case system
         /// Only perform the primary action for navigation (this defaults to dismiss action).
@@ -334,4 +335,24 @@ struct PerformTabBarNavigation: ViewModifier {
             #endif
         }
     }
+}
+
+extension Navigation.Behaviour: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .system:
+            "system"
+        case .primary:
+            "primary"
+        case .primaryAuxiliary:
+            "primary auxiliary"
+        case .none:
+            "none"
+        }
+    }
+}
+
+extension Navigation.Behaviour: SettingsOptions {
+    var label: String { description.capitalized }
+    var id: Self { self }
 }

--- a/Mlem/Navigation/Routes/AppRoutes.swift
+++ b/Mlem/Navigation/Routes/AppRoutes.swift
@@ -13,7 +13,7 @@ import Foundation
 ///
 enum AppRoute: Routable {
     case community(CommunityModel)
-    case instance(String? = nil, InstanceModel? = nil)
+    case instance(InstanceModel)
     
     case userProfile(UserModel, communityContext: CommunityModel? = nil)
     

--- a/Mlem/Repositories/PostRepository.swift
+++ b/Mlem/Repositories/PostRepository.swift
@@ -8,6 +8,10 @@
 import Dependencies
 import Foundation
 
+enum PostError: Error {
+    case failure
+}
+
 class PostRepository {
     @Dependency(\.apiClient) private var apiClient
     
@@ -54,6 +58,17 @@ class PostRepository {
     func markRead(post: PostModel, read: Bool) async throws -> PostModel {
         let success = try await apiClient.markPostAsRead(for: post.postId, read: read).success
         return PostModel(from: post, read: success ? read : post.read)
+    }
+    
+    /// Attempts to mark the given posts as read.
+    /// - Parameters:
+    ///   - postIds: postIds to mark as read
+    ///   - read: Intended read state of the posts (true to mark read, false to mark unread)
+    func markRead(postIds: [Int], read: Bool) async throws {
+        let success = try await apiClient.markPostsAsRead(for: postIds, read: read).success
+        if !success {
+            throw PostError.failure
+        }
     }
 
     /// Rates a given post. Does not care what the current vote state is; sends the given request no matter what (i.e., calling this with operation `.upvote` on an already upvoted post will not send a `.resetVote`, but will instead send a second idempotent `.upvote`)

--- a/Mlem/Temp Image Viewer/ZoomableImageView.swift
+++ b/Mlem/Temp Image Viewer/ZoomableImageView.swift
@@ -79,7 +79,7 @@ struct ZoomableImageView: View {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Details",
             imageName: Icons.imageDetails,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -90,7 +90,7 @@ struct ZoomableImageView: View {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Save",
             imageName: Icons.import,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {

--- a/Mlem/Views/Shared/Cached Image.swift
+++ b/Mlem/Views/Shared/Cached Image.swift
@@ -5,6 +5,7 @@
 //  Created by tht7 on 26/06/2023.
 //
 
+import Dependencies
 import Foundation
 import MarkdownUI
 import Nuke
@@ -13,11 +14,14 @@ import QuickLook
 import SwiftUI
 
 struct CachedImage: View {
+    @Dependency(\.notifier) var notifier
     let url: URL?
     let shouldExpand: Bool
+    let hasContextMenu: Bool
     
     // state vars to track the current image size and whether that size needs to be recomputed when the image actually loads. Combined with the image size cache, this produces good scrolling behavior except in the case where we scroll past an image and it derenders before it ever gets a chance to load, in which case that image will cause a slight hiccup on the way back up. That's kind of an unsolvable problem, since we can't know the size before we load the image at all, but that's fine because it shouldn't really happen during normal use. If we really want to guarantee smooth feed scrolling we can squish any image with no cached size into a square, but that feels like squishing a lot of images for the sake of a fringe case.
     @State var size: CGSize
+    let fixedSize: CGSize?
     @State var shouldRecomputeSize: Bool
     
     @EnvironmentObject private var imageDetailSheetState: ImageDetailSheetState
@@ -37,6 +41,7 @@ struct CachedImage: View {
     init(
         url: URL?,
         shouldExpand: Bool = true,
+        hasContextMenu: Bool = false,
         maxHeight: CGFloat = .infinity,
         fixedSize: CGSize? = nil,
         imageNotFound: @escaping () -> AnyView = imageNotFoundDefault,
@@ -48,6 +53,7 @@ struct CachedImage: View {
     ) {
         self.url = url
         self.shouldExpand = shouldExpand
+        self.hasContextMenu = hasContextMenu
         self.maxHeight = maxHeight
         self.imageNotFound = imageNotFound
         self.errorBackgroundColor = errorBackgroundColor
@@ -58,6 +64,7 @@ struct CachedImage: View {
         
         self.screenWidth = UIScreen.main.bounds.width - (AppConstants.postAndCommentSpacing * 2)
         
+        self.fixedSize = fixedSize
         // determine the size of the image
         if let fixedSize {
             // if we're given a size, just use it and to hell with the cache
@@ -86,40 +93,26 @@ struct CachedImage: View {
     var body: some View {
         LazyImage(url: url) { state in
             if let imageContainer = state.imageContainer {
-                let imageView = Image(uiImage: imageContainer.image)
-                    .resizable()
-                    .aspectRatio(contentMode: contentMode)
-                    .cornerRadius(cornerRadius)
-                    .frame(idealWidth: size.width, maxHeight: size.height)
-                    .blur(radius: blurRadius)
-                    .clipped()
-                    .allowsHitTesting(false)
-                    .overlay(alignment: .top) {
-                        // weeps in janky hack but this lets us tap the image only in the area we want
-                        Rectangle()
-                            .frame(maxHeight: size.height)
-                            .opacity(0.00000000001)
-                    }
-                    .onAppear {
-                        // if the image appears and its size isn't cached, compute its size and cache it
-                        if shouldRecomputeSize {
-                            let ratio = screenWidth / imageContainer.image.size.width
-                            size = CGSize(
-                                width: screenWidth,
-                                height: min(maxHeight, imageContainer.image.size.height * ratio)
-                            )
-                            cacheImageSize()
-                            shouldRecomputeSize = false
-                        }
-                    }
-                if shouldExpand {
-                    imageView
-                        .onTapGesture {
-                            imageDetailSheetState.url = url // show image detail
-                            onTapCallback?()
+                let baseImage = Image(uiImage: imageContainer.image)
+                let coreImage = coreImage(baseImage: baseImage, containerSize: imageContainer.image.size)
+                
+                if fixedSize == nil {
+                    imageWithTapGestures(image: coreImage)
+                        .contextMenu {
+                            if hasContextMenu {
+                                contextMenuActions(image: Image(uiImage: imageContainer.image))
+                            }
                         }
                 } else {
-                    imageView
+                    imageWithTapGestures(image: coreImage)
+                        .contextMenu {
+                            if hasContextMenu {
+                                contextMenuActions(image: Image(uiImage: imageContainer.image))
+                            }
+                        } preview: {
+                            baseImage
+                                .resizable()
+                        }
                 }
             } else if state.error != nil {
                 // Indicates an error
@@ -150,6 +143,69 @@ struct CachedImage: View {
         }
     }
     
+    @ViewBuilder func coreImage(baseImage: Image, containerSize: CGSize) -> some View {
+        baseImage
+            .resizable()
+            .aspectRatio(contentMode: contentMode)
+            .cornerRadius(cornerRadius)
+            .frame(idealWidth: size.width, maxHeight: size.height)
+            .fixSize(fixedSize: fixedSize, fallbackSize: size)
+            .blur(radius: blurRadius)
+            .clipped()
+            .allowsHitTesting(false)
+            .overlay(alignment: .top) {
+                // weeps in janky hack but this lets us tap the image only in the area we want
+                Rectangle()
+                    .frame(maxHeight: size.height)
+                    .opacity(0.00000000001)
+            }
+            .onAppear {
+                // if the image appears and its size isn't cached, compute its size and cache it
+                if shouldRecomputeSize {
+                    let ratio = screenWidth / containerSize.width
+                    size = CGSize(
+                        width: screenWidth,
+                        height: min(maxHeight, containerSize.height * ratio)
+                    )
+                    cacheImageSize()
+                    shouldRecomputeSize = false
+                }
+            }
+    }
+    
+    @ViewBuilder func imageWithTapGestures(image: some View) -> some View {
+        if shouldExpand {
+            image
+                .onTapGesture {
+                    if shouldExpand {
+                        imageDetailSheetState.url = url // show image detail
+                        onTapCallback?()
+                    }
+                }
+        } else {
+            image
+        }
+    }
+    
+    @ViewBuilder
+    func contextMenuActions(image: Image) -> some View {
+        if hasContextMenu, let url {
+            Button("Save", systemImage: Icons.import) {
+                Task {
+                    do {
+                        let (data, _) = try await ImagePipeline.shared.data(for: url)
+                        let imageSaver = ImageSaver()
+                        imageSaver.writeToPhotoAlbum(imageData: data)
+                        await notifier.add(.success("Image saved"))
+                    } catch {
+                        print(String(describing: error))
+                    }
+                }
+            }
+        }
+        ShareLink(item: image, preview: .init("photo", image: image))
+    }
+    
     static func imageNotFoundDefault() -> AnyView {
         AnyView(Image(systemName: Icons.missing)
             .resizable()
@@ -166,5 +222,24 @@ struct CachedImage: View {
         if let url {
             AppConstants.imageSizeCache.setObject(ImageSize(size: size), forKey: NSString(string: url.description))
         }
+    }
+}
+
+private struct OptionalFixedSizeImage: ViewModifier {
+    let fixedSize: CGSize?
+    let fallbackSize: CGSize
+    
+    func body(content: Content) -> some View {
+        if let fixedSize {
+            content.frame(width: fixedSize.width, height: fixedSize.height)
+        } else {
+            content.frame(idealWidth: fallbackSize.width, maxHeight: fallbackSize.height)
+        }
+    }
+}
+
+private extension View {
+    func fixSize(fixedSize: CGSize?, fallbackSize: CGSize) -> some View {
+        modifier(OptionalFixedSizeImage(fixedSize: fixedSize, fallbackSize: fallbackSize))
     }
 }

--- a/Mlem/Views/Shared/Comments/Comment Item Logic.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item Logic.swift
@@ -189,7 +189,7 @@ extension CommentItem {
         ret.append(MenuFunction.standardMenuFunction(
             text: upvoteText,
             imageName: upvoteImg,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -204,7 +204,7 @@ extension CommentItem {
         ret.append(MenuFunction.standardMenuFunction(
             text: downvoteText,
             imageName: downvoteImg,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -219,7 +219,7 @@ extension CommentItem {
         ret.append(MenuFunction.standardMenuFunction(
             text: saveText,
             imageName: saveImg,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {
@@ -231,7 +231,7 @@ extension CommentItem {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Reply",
             imageName: Icons.reply,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             replyToComment()
@@ -242,7 +242,7 @@ extension CommentItem {
             ret.append(MenuFunction.standardMenuFunction(
                 text: "Edit",
                 imageName: Icons.edit,
-                destructiveActionPrompt: nil,
+                role: nil,
                 enabled: true
             ) {
                 editComment()
@@ -254,7 +254,7 @@ extension CommentItem {
             ret.append(MenuFunction.standardMenuFunction(
                 text: "Delete",
                 imageName: Icons.delete,
-                destructiveActionPrompt: "Are you sure you want to delete this comment?  This cannot be undone.",
+                role: .destructive(prompt: "Are you sure you want to delete this comment?  This cannot be undone."),
                 enabled: !hierarchicalComment.commentView.comment.deleted
             ) {
                 Task(priority: .userInitiated) {
@@ -272,7 +272,7 @@ extension CommentItem {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Report",
             imageName: Icons.moderationReport,
-            destructiveActionPrompt: "Really report?",
+            role: .destructive(prompt: "Really report?"),
             enabled: true
         ) {
             editorTracker.openEditor(with: ConcreteEditorModel(
@@ -285,7 +285,7 @@ extension CommentItem {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Block User",
             imageName: Icons.userBlock,
-            destructiveActionPrompt: AppConstants.blockUserPrompt,
+            role: .destructive(prompt: AppConstants.blockUserPrompt),
             enabled: true
         ) {
             Task(priority: .userInitiated) {

--- a/Mlem/Views/Shared/Components/Components/Menu Button.swift
+++ b/Mlem/Views/Shared/Components/Components/Menu Button.swift
@@ -19,9 +19,9 @@ struct MenuButton: View {
         case let .shareImage(shareImageFunction):
             ShareLink(item: shareImageFunction.image, preview: .init("photo", image: shareImageFunction.image))
         case let .standard(standardMenuFunction):
-            let role: ButtonRole? = standardMenuFunction.destructiveActionPrompt != nil ? .destructive : nil
+            let role: ButtonRole? = standardMenuFunction.role != nil ? .destructive : nil
             Button(role: role) {
-                if standardMenuFunction.destructiveActionPrompt != nil, let confirmDestructive {
+                if case let .destructive(prompt: prompt) = standardMenuFunction.role, prompt != nil, let confirmDestructive {
                     confirmDestructive(standardMenuFunction)
                 } else {
                     standardMenuFunction.callback()

--- a/Mlem/Views/Shared/Components/Components/Menu Button.swift
+++ b/Mlem/Views/Shared/Components/Components/Menu Button.swift
@@ -34,6 +34,12 @@ struct MenuButton: View {
             NavigationLink(navigationMenuFunction.destination) {
                 Label(navigationMenuFunction.text, systemImage: navigationMenuFunction.imageName)
             }
+        case let .childMenu(titleKey, children):
+            Menu(titleKey) {
+                ForEach(children) { child in
+                    MenuButton(menuFunction: child, confirmDestructive: nil)
+                }
+            }
         }
     }
 }

--- a/Mlem/Views/Shared/Components/EasyTapLinkView.swift
+++ b/Mlem/Views/Shared/Components/EasyTapLinkView.swift
@@ -74,6 +74,13 @@ extension LinkType: Hashable, Identifiable {
     }
     
     var id: Int { hashValue }
+    
+    var isWebsite: Bool {
+        if case .website = self {
+            return true
+        }
+        return false
+    }
 }
 
 enum EasyTapLinkDisplayMode: String, SettingsOptions {
@@ -112,14 +119,19 @@ struct EasyTapLinkView: View {
         }
         .padding(AppConstants.postAndCommentSpacing)
         .background(RoundedRectangle(cornerRadius: AppConstants.largeItemCornerRadius)
-            .foregroundColor(Color(UIColor.secondarySystemBackground)))
+        .foregroundColor(Color(UIColor.secondarySystemBackground)))
         .contextMenu {
-            Button("Copy", systemImage: Icons.copy) {
-                let pasteboard = UIPasteboard.general
-                pasteboard.url = linkType.url
+            if linkType.isWebsite {
+                Button("Open", systemImage: Icons.browser) {
+                    openURL(linkType.url)
+                }
+                Button("Copy", systemImage: Icons.copy) {
+                    let pasteboard = UIPasteboard.general
+                    pasteboard.url = linkType.url
+                }
+                ShareLink(item: linkType.url)
             }
-            ShareLink(item: linkType.url)
-        }
+        } preview: { WebView(url: linkType.url) }
     }
     
     @ViewBuilder

--- a/Mlem/Views/Shared/Composer/BanUserView.swift
+++ b/Mlem/Views/Shared/Composer/BanUserView.swift
@@ -1,0 +1,212 @@
+//
+//  BanUserView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 26/01/2024.
+//
+
+import SwiftUI
+import Dependencies
+
+private struct BanFormButton: ButtonStyle {
+    
+    let selected: Bool
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.callout)
+            .foregroundStyle(selected ? .white : .primary)
+            .padding(.vertical, 4)
+            .frame(maxWidth: 150)
+            .background {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(selected ? .blue : Color(uiColor: .systemGroupedBackground))
+            }
+    }
+}
+
+struct BanUserView: View {
+    @Dependency(\.siteInformation) var siteInformation
+    @Dependency(\.hapticManager) var hapticManager
+    @Dependency(\.apiClient) var apiClient
+    @Dependency(\.errorHandler) var errorHandler
+    @Dependency(\.notifier) var notifier
+    
+    @Environment(\.dismiss) var dismiss
+    
+    let editModel: BanUserEditorModel
+    
+    @State var reason: String = ""
+    @State var days: Int = 1
+    @State var isPermanent: Bool = true
+    @State var removeContent: Bool = false
+    @State var isWaiting: Bool = false
+    
+    enum FocusedField {
+        case reason, days
+    }
+    
+    @FocusState var focusedField: FocusedField?
+    
+    var body: some View {
+        Form {
+            Section("Reason") {
+                TextField("Optional", text: $reason, axis: .vertical)
+                    .lineLimit(8)
+                    .focused($focusedField, equals: .reason)
+                    .overlay(alignment: .trailing) {
+                        if reason.isNotEmpty, focusedField != .reason {
+                            Button("Clear", systemImage: "xmark.circle.fill") { reason = "" }
+                                .foregroundStyle(.secondary.opacity(0.8))
+                                .labelStyle(.iconOnly)
+                        }
+                    }
+                HStack {
+                    if reason == "Rule #" {
+                        ForEach(1..<9) { value in
+                            Button(String(value)) {
+                                reason = "Rule \(value)"
+                                hapticManager.play(haptic: .gentleInfo, priority: .low)
+                            }
+                            .buttonStyle(BanFormButton(selected: false))
+                        }
+                    } else {
+                        Button("Rule #") {
+                            reason = "Rule #"
+                            hapticManager.play(haptic: .gentleInfo, priority: .low)
+                        }
+                        .buttonStyle(BanFormButton(selected: reason.hasPrefix("Rule")))
+                        reasonPresetButton("Spam")
+                        reasonPresetButton("Troll")
+                        reasonPresetButton("Abuse")
+                    }
+                }
+                .padding(.horizontal, -8)
+            }
+            Section {
+                Toggle("Permanent", isOn: $isPermanent)
+                    .tint(.red)
+            }
+            Section("Ban Duration") {
+                HStack {
+                    Text("Days:")
+                        .onTapGesture {
+                            focusedField = .days
+                        }
+                    TextField("", value: Binding(
+                        get: { days },
+                        set: { newValue in
+                            days = newValue > 1 ? newValue : 0
+                        }
+                    ), format: .number)
+                        .keyboardType(.numberPad)
+                        .focused($focusedField, equals: .days)
+                }
+                DatePicker(
+                    "Expiration Date:",
+                    selection: Binding(
+                        get: {
+                            return .now.advanced(by: .days(Double(days)))
+                        },
+                        set: { newValue in
+                            days = Int(newValue.timeIntervalSince(.now) / (60 * 60 * 24))
+                        }
+                    ),
+                    in: Date.now.advanced(by: .days(1))...,
+                    displayedComponents: [.date]
+                )
+                HStack {
+                    daysPresetButton("1d", value: 1)
+                    daysPresetButton("3d", value: 3)
+                    daysPresetButton("7d", value: 7)
+                    daysPresetButton("30d", value: 30)
+                    daysPresetButton("60d", value: 60)
+                    daysPresetButton("90d", value: 90)
+                    daysPresetButton("1y", value: 365)
+                }
+                .padding(.horizontal, -8)
+            }
+            .opacity(isPermanent ? 0.5 : 1)
+            .disabled(isPermanent)
+            
+            Section {
+                Toggle("Remove Content", isOn: $removeContent)
+                    .tint(.red)
+            } footer: {
+                let posts = editModel.user.postCount ?? 0
+                let comments = editModel.user.commentCount ?? 0
+                Text("Remove all \(posts) posts and \(comments) comments created by this user.")
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .keyboard) {
+                HStack {
+                    Spacer()
+                    Button("Done") { focusedField = nil }
+                }
+            }
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .tint(.red)
+                .disabled(isWaiting)
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                if isWaiting {
+                    ProgressView()
+                } else {
+                    Button("Confirm", systemImage: Icons.send, action: confirm)
+                }
+            }
+        }
+        .navigationTitle("Ban \(editModel.user.displayName)")
+        .navigationBarTitleDisplayMode(.inline)
+        .allowsHitTesting(!isWaiting)
+        .opacity(isWaiting ? 0.5 : 1)
+        .interactiveDismissDisabled(isWaiting)
+    }
+    
+    @ViewBuilder
+    func reasonPresetButton(_ label: String) -> some View {
+        Button(label) {
+            reason = reason == label ? "" : label
+            hapticManager.play(haptic: .gentleInfo, priority: .low)
+        }
+        .buttonStyle(BanFormButton(selected: reason == label))
+    }
+    
+    @ViewBuilder
+    func daysPresetButton(_ label: String, value: Int) -> some View {
+        Button(label) {
+            days = value
+            hapticManager.play(haptic: .gentleInfo, priority: .low)
+        }
+        .buttonStyle(BanFormButton(selected: days == value && !isPermanent))
+    }
+    
+    func confirm() {
+        isWaiting = true
+        Task {
+            let expires: Date? = isPermanent ? nil : .now.advanced(by: .days(Double(days)))
+            let reason = reason.isEmpty ? nil : reason
+            var user = editModel.user
+            await user.toggleBan(expires: expires, reason: reason, removeData: removeContent) { editModel.callback($0) }
+            DispatchQueue.main.async {
+                isWaiting = false
+            }
+            if user.banned {
+                await notifier.add(.success("Banned"))
+                DispatchQueue.main.async {
+                    dismiss()
+                }
+            } else {
+                await notifier.add(.failure("Failed to ban user"))
+            }
+        }
+    }
+}
+
+#Preview {
+    BanUserView(editModel: .init(user: .mock()))
+}

--- a/Mlem/Views/Shared/Instance/InstanceUptimeView.swift
+++ b/Mlem/Views/Shared/Instance/InstanceUptimeView.swift
@@ -1,0 +1,263 @@
+//
+//  InstanceUptimeView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 28/01/2024.
+//
+
+import SwiftUI
+import Charts
+import Dependencies
+import Foundation
+
+struct InstanceUptimeView: View {
+    @Dependency(\.errorHandler) var errorHandler
+    
+    @Environment(\.accessibilityDifferentiateWithoutColor) var diffWithoutColor: Bool
+    @Environment(\.colorScheme) var colorScheme
+    
+    @State var showingExactTime: Bool = false
+    @State var showingAllDowntimes: Bool = false
+    
+    let instance: InstanceModel
+    let uptimeData: UptimeData
+    
+    @ViewBuilder
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            section { summary }
+            .padding(.top, 16)
+            .padding(.bottom, 10)
+            section("Recent Checks") {
+                recentChecks
+                    .padding(.horizontal)
+                    .padding(.vertical, 15)
+            }
+            .padding(.top, 20)
+            footnote("Mlem will refresh this automatically every 30 seconds.")
+            .padding(.top, 8)
+            .padding(.leading, 6)
+            .padding(.bottom, 30)
+            section("Response Time") {
+                VStack(alignment: .leading, spacing: 4) {
+                    responseTimeChart
+                        .padding(.horizontal, 20)
+                    footnote("Average: \(uptimeData.results.map(\.durationMs).reduce(0, +) / uptimeData.results.count)ms")
+                        .padding(.leading, 20)
+                }
+                .padding(.top, 17)
+                .padding(.bottom, 8)
+            }
+            subHeading("Incidents")
+                .padding(.top, 30)
+                .padding(.bottom, 3)
+            let todayDowntimes = uptimeData.downtimes.filter { abs($0.endTime.timeIntervalSinceNow) < 60 * 60 * 24 }
+            
+            Text(
+                todayDowntimes.count == 0
+                ? "There were no recorded incidents today."
+                : "There ^[were \(todayDowntimes.count)](inflect: true) recorded incidents today."
+            )
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .padding(.leading, 6)
+            .padding(.bottom, 7)
+            
+            let displayedIncidents = showingAllDowntimes ? uptimeData.downtimes : todayDowntimes
+            if !displayedIncidents.isEmpty {
+                section(spacing: 0) {
+                    ForEach(displayedIncidents) { event in
+                        if event.id != uptimeData.downtimes.first?.id {
+                            Divider()
+                        }
+                        IncidentRow(event: event, showingExactTime: showingExactTime)
+                            .padding(.vertical, 10)
+                            .padding(.leading)
+                    }
+                    .onTapGesture {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            showingExactTime.toggle()
+                        }
+                    }
+                }
+                .padding(.bottom, 30)
+            }
+            Button {
+                withAnimation {
+                    showingAllDowntimes.toggle()
+                }
+            } label: {
+                Text("\(showingAllDowntimes ? "Hide" : "Show") Older Incidents")
+                    .foregroundStyle(.blue)
+                    .padding(.leading, 12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: AppConstants.largeItemCornerRadius)
+                            .fill(Color(uiColor: .secondarySystemGroupedBackground))
+                    )
+            }
+            .buttonStyle(EmptyButtonStyle())
+            
+            if let url = instance.uptimeFrontendUrl {
+                Text("Uptime data fetched from [lemmy-status.org](\(url))")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
+                    .padding(.leading, 6)
+            }
+            if colorScheme == .light {
+                Divider()
+            }
+        }
+        .padding(.horizontal, 16)
+        .background(Color(uiColor: .systemGroupedBackground))
+    }
+    
+    @ViewBuilder
+    var summary: some View {
+        VStack(alignment: .leading) {
+            if let mostRecentOutage = uptimeData.downtimes.first {
+                if uptimeData.results.filter(\.success).count < 15 {
+                    summaryHeader(statusText: "unhealthy", systemImage: Icons.uptimeOutage, color: .red)
+                    footnote("\(instance.name) has been unresponsive recently.")
+                } else {
+                    summaryHeader(statusText: "online", systemImage: Icons.uptimeOnline, color: .green)
+                    let relTime = mostRecentOutage.relativeTimeCaption
+                    let length = mostRecentOutage.differenceTitle(unitsStyle: .full)
+                    footnote("The most recent outage was \(relTime), and lasted for \(length).")
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 10)
+        .padding(.horizontal)
+    }
+    
+    @ViewBuilder
+    func summaryHeader(statusText: String, systemImage: String, color: Color) -> some View {
+        HStack(spacing: 5) {
+            (Text("\(instance.name) is ") + Text(statusText).foregroundColor(color))
+                .font(.title2)
+                .fontWeight(.semibold)
+            Image(systemName: systemImage)
+                .foregroundStyle(color)
+        }
+    }
+    
+    @ViewBuilder
+    var recentChecks: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 3) {
+                ForEach(uptimeData.results) { result in
+                    if diffWithoutColor {
+                        Image(systemName: result.success ? Icons.uptimeOnline : Icons.uptimeOffline)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .foregroundStyle(result.success ? .green : .red)
+                            .frame(maxWidth: 20)
+                            .frame(maxWidth: 25)
+                    } else {
+                        Circle()
+                            .fill(result.success ? .green : .red)
+                            .frame(maxWidth: 20)
+                            .frame(maxWidth: 25)
+                    }
+                }
+            }
+            HStack {
+                footnote(timeOnlyFormatter.string(from: uptimeData.results.first?.timestamp ?? .now))
+                Spacer()
+                footnote(timeOnlyFormatter.string(from: uptimeData.results.last?.timestamp ?? .now))
+            }
+            .frame(maxWidth: CGFloat(uptimeData.results.count*25 + (uptimeData.results.count-1)*3))
+            .padding(.top, 4)
+        }
+    }
+    
+    @ViewBuilder
+    var responseTimeChart: some View {
+        Chart {
+            ForEach(uptimeData.results) { node in
+                let time = Int(node.durationMs)
+                LineMark(
+                    x: .value("Time", node.timestamp),
+                    y: .value("Response Time", time)
+                )
+            }
+        }
+        .frame(height: 200)
+        .chartXAxis {
+            let marks = [uptimeData.results.first?.timestamp ?? .distantPast, uptimeData.results.last?.timestamp ?? .distantFuture]
+            AxisMarks(format: .dateTime.hour(.defaultDigits(amPM: .abbreviated)).minute(.twoDigits), values: marks)
+        }
+        .chartYScale(domain: [0, max(1000, (uptimeData.results.map(\.durationMs).max() ?? 0) + 100)])
+        .chartYAxis {
+            AxisMarks(values: .automatic) { value in
+                AxisGridLine()
+                AxisValueLabel {
+                    if let intValue = value.as(Int.self) {
+                        Text("\(intValue)ms")
+                    }
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder func section(_ title: String? = nil, spacing: CGFloat = 5, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            if let title {
+                subHeading(title)
+            }
+            VStack(alignment: .leading, spacing: spacing) {
+                content()
+            }
+            .frame(maxWidth: .infinity)
+            .background(Color(uiColor: .secondarySystemGroupedBackground))
+            .cornerRadius(AppConstants.largeItemCornerRadius)
+        }
+    }
+    
+    @ViewBuilder
+    func subHeading(_ title: String) -> some View {
+        Text(title)
+            .font(.title2)
+            .fontWeight(.semibold)
+            .padding(.leading, 6)
+    }
+    
+    @ViewBuilder
+    func footnote(_ title: String) -> some View {
+        Text(title)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+    }
+    
+    var timeOnlyFormatter: DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeStyle = .short
+        dateFormatter.dateStyle = .none
+        return dateFormatter
+    }
+}
+
+private struct IncidentRow: View {
+    let event: DowntimePeriod
+    let showingExactTime: Bool
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Image(systemName: Icons.uptimeOutage)
+                    .foregroundStyle(event.severityColor)
+                    .foregroundStyle(.secondary)
+                Text("Unhealthy for \(event.differenceTitle())")
+            }
+            Text(showingExactTime ? event.differenceCaption : event.relativeTimeCaption)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(.rect)
+    }
+}

--- a/Mlem/Views/Shared/Instance/InstanceView.swift
+++ b/Mlem/Views/Shared/Instance/InstanceView.swift
@@ -34,8 +34,13 @@ struct InstanceView: View {
     @Environment(\.navigationPathWithRoutes) private var navigationPath
     @Environment(\.scrollViewProxy) private var scrollViewProxy
     
-    @State var domainName: String
-    @State var instance: InstanceModel?
+    enum UptimeDataStatus {
+        case success(UptimeData)
+        case failure(Error)
+    }
+    
+    @State var instance: InstanceModel
+    @State var uptimeData: UptimeDataStatus?
     @State var errorDetails: ErrorDetails?
     
     @Namespace var scrollToTop
@@ -43,21 +48,32 @@ struct InstanceView: View {
     
     @State var selectedTab: InstanceViewTab = .about
     
-    init(domainName: String? = nil, instance: InstanceModel? = nil) {
-        _domainName = State(wrappedValue: domainName ?? instance?.name ?? "")
+    var uptimeRefreshTimer = Timer.publish(every: 30, tolerance: 0.5, on: .main, in: .common)
+        .autoconnect()
+    
+    init(instance: InstanceModel) {
         var instance = instance
-        if domainName == siteInformation.instance?.url.host() {
+        @Dependency(\.siteInformation) var siteInformation
+        if instance.name == siteInformation.instance?.url.host() {
             instance = siteInformation.instance ?? instance
         }
         _instance = State(wrappedValue: instance)
     }
     
     var subtitleText: String {
-        if let version = instance?.version {
-            "\(domainName) • \(String(describing: version))"
+        if let version = instance.version {
+            "\(instance.name) • \(String(describing: version))"
         } else {
-            domainName
+            instance.name
         }
+    }
+    
+    var availableTabs: [InstanceViewTab] {
+        var tabs: [InstanceViewTab] = [.about, .administrators, .details]
+        if instance.canFetchUptime {
+            tabs.append(.uptime)
+        }
+        return tabs
     }
     
     var body: some View {
@@ -70,19 +86,20 @@ struct InstanceView: View {
                     .padding(.top, 10)
                 VStack(spacing: 5) {
                     if errorDetails == nil {
-                        if let instance {
-                            Text(instance.displayName)
-                                .font(.title)
-                                .fontWeight(.semibold)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.01)
-
-                            Text(subtitleText)
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
+                        Text(instance.displayName)
+                            .font(.title)
+                            .fontWeight(.semibold)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.01)
+                            .transition(.opacity)
+                            .id("Title" + instance.displayName) // https://stackoverflow.com/a/60136737/17629371
+                        Text(subtitleText)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .transition(.opacity)
+                            .id("Subtitle" + subtitleText)
                     } else {
-                        Text(domainName)
+                        Text(instance.name)
                             .font(.title)
                             .fontWeight(.semibold)
                             .lineLimit(1)
@@ -91,14 +108,34 @@ struct InstanceView: View {
                         Divider()
                     }
                 }
-                .padding(.bottom, 5)
                 if let errorDetails {
-                    ErrorView(errorDetails)
-                } else if let instance, instance.creationDate != nil {
+                    if instance.canFetchUptime {
+                        switch uptimeData {
+                        case .success(let uptimeData):
+                            VStack(alignment: .leading, spacing: 0) {
+                                Text("We couldn't connect to \(instance.name). Perhaps the instance is offline?")
+                                    .foregroundStyle(.secondary)
+                                    .padding(.horizontal, 16)
+                                    .padding(.bottom, AppConstants.postAndCommentSpacing)
+                                Divider()
+                                InstanceUptimeView(instance: instance, uptimeData: uptimeData)
+                            }
+                        case .failure:
+                            ErrorView(errorDetails)
+                                .padding(.top, 5)
+                        default:
+                            ProgressView()
+                                .padding(.top, 30)
+                        }
+                    } else {
+                        ErrorView(errorDetails)
+                            .padding(.top, 5)
+                    }
+                } else if instance.creationDate != nil {
                     VStack(spacing: 0) {
                         VStack(spacing: 4) {
                             Divider()
-                            BubblePicker([.about, .administrators, .details], selected: $selectedTab) { tab in
+                            BubblePicker(availableTabs, selected: $selectedTab) { tab in
                                 Text(tab.label)
                             }
                             Divider()
@@ -122,7 +159,7 @@ struct InstanceView: View {
                                 }
                             } else {
                                 ProgressView()
-                                    .padding(.top)
+                                    .padding(.top, 30)
                             }
                         case .details:
                             if instance.userCount != nil {
@@ -136,46 +173,53 @@ struct InstanceView: View {
                                 }
                             } else {
                                 ProgressView()
-                                    .padding(.top)
+                                    .padding(.top, 30)
                             }
+                        case .uptime:
+                            VStack {
+                                switch uptimeData {
+                                case .success(let uptimeData):
+                                    InstanceUptimeView(instance: instance, uptimeData: uptimeData)
+                                case .failure(let error):
+                                    ErrorView(.init(error: error))
+                                default:
+                                    ProgressView()
+                                        .padding(.top, 30)
+                                }
+                            }
+                            .onAppear(perform: attemptToLoadUptimeData)
+                            .onReceive(uptimeRefreshTimer) { _ in attemptToLoadUptimeData() }
                         default:
                             EmptyView()
                         }
                         Spacer()
                             .frame(height: 100)
                     }
-                    
+                    .padding(.top, 5)
                 } else {
                     LoadingView(whatIsLoading: .instanceDetails)
                 }
             }
         }
         .toolbar {
-            if let instance {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Link(destination: instance.url) {
-                        Label("Open in Browser", systemImage: Icons.browser)
-                    }
+            ToolbarItem(placement: .topBarTrailing) {
+                Link(destination: instance.url) {
+                    Label("Open in Browser", systemImage: Icons.browser)
                 }
             }
         }
         .task {
-            if instance?.administrators == nil {
+            if instance.administrators == nil {
                 do {
-                    if let url = URL(string: "https://\(domainName)") {
+                    if let url = URL(string: "https://\(instance.name)") {
                         let info = try await apiClient.loadSiteInformation(instanceURL: url)
                         DispatchQueue.main.async {
                             withAnimation(.easeOut(duration: 0.2)) {
-                                if var instance {
-                                    instance.update(with: info)
-                                    self.instance = instance
-                                } else {
-                                    instance = InstanceModel(from: info)
-                                }
+                                instance.update(with: info)
                             }
                         }
                     } else {
-                        errorDetails = ErrorDetails(title: "\"\(domainName)\" is an invalid URL.")
+                        errorDetails = ErrorDetails(title: "\"\(instance.name)\" is an invalid URL.")
                     }
                 } catch let APIClientError.decoding(data, error) {
                     withAnimation(.easeOut(duration: 0.2)) {
@@ -216,7 +260,29 @@ struct InstanceView: View {
             }
         }
         .navigationBarColor()
-        .navigationTitle(instance?.displayName ?? domainName)
+        .navigationTitle(instance.displayName ?? instance.name)
         .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: errorDetails == nil) { _ in
+            attemptToLoadUptimeData()
+        }
+    }
+    
+    func attemptToLoadUptimeData() {
+        print("Fetching uptime data...")
+        if let url = instance.uptimeDataUrl {
+            Task {
+                do {
+                    let data = try await URLSession.shared.data(from: url).0
+                    let uptimeData = try JSONDecoder.defaultDecoder.decode(UptimeData.self, from: data)
+                    DispatchQueue.main.async {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            self.uptimeData = .success(uptimeData)
+                        }
+                    }
+                } catch {
+                    errorHandler.handle(error)
+                }
+            }
+        }
     }
 }

--- a/Mlem/Views/Shared/Instance/UptimeData.swift
+++ b/Mlem/Views/Shared/Instance/UptimeData.swift
@@ -1,0 +1,115 @@
+//
+//  UptimeData.swift
+//  Mlem
+//
+//  Created by Sjmarf on 28/01/2024.
+//
+
+import Foundation
+import SwiftUI
+
+struct UptimeData: Codable {
+    let results: [UptimeResponseTime]
+    let events: [UptimeEvent]
+    
+    var downtimes: [DowntimePeriod] {
+        var ret: [DowntimePeriod] = []
+        var previous: UptimeEvent?
+        for event in events {
+            if event.type == .healthy {
+                if let previous {
+                    ret.append(.init(startTime: previous.timestamp, endTime: event.timestamp))
+                }
+            }
+            previous = event
+        }
+        return ret.reversed()
+    }
+}
+
+struct UptimeResponseTime: Codable, Identifiable {
+    let success: Bool
+    let duration: Int
+    let timestamp: Date
+    
+    var durationMs: Int {
+        duration / 1000000
+    }
+    
+    var id: Int { Int(timestamp.timeIntervalSince1970) }
+}
+
+struct UptimeEvent: Codable, Identifiable {
+    enum EventType: String, Codable {
+        case healthy = "HEALTHY"
+        case unhealthy = "UNHEALTHY"
+    }
+    
+    let type: EventType
+    let timestamp: Date
+    
+    var id: Int { Int(timestamp.timeIntervalSince1970) }
+}
+
+struct DowntimePeriod: Codable, Identifiable {
+    let startTime: Date
+    let endTime: Date
+    
+    var id: Int { Int(startTime.timeIntervalSince1970) }
+    
+    var duration: TimeInterval {
+        endTime.timeIntervalSince(startTime)
+    }
+    
+    var severityColor: Color {
+        if duration < 60 * 5 {
+            .secondary
+        } else if duration < 60 * 30 {
+            .orange
+        } else {
+            .red
+        }
+    }
+    
+    func differenceTitle(unitsStyle: DateComponentsFormatter.UnitsStyle = .short) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = unitsStyle
+        formatter.maximumUnitCount = 2
+        return formatter.string(from: duration) ?? "Unknown"
+    }
+    
+    var relativeTimeCaption: String {
+        endTime.getRelativeTime()
+    }
+    
+    private var timeOnlyFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return formatter
+    }
+    
+    private var dateAndTimeFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter
+    }
+    
+    var differenceCaption: String {
+        if duration < 60 {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .short
+            formatter.timeStyle = .short
+            return formatter.string(from: startTime)
+        }
+        
+        let onSameDay = Calendar.current.isDate(startTime, equalTo: endTime, toGranularity: .day)
+        
+        if onSameDay {
+            return "\(dateAndTimeFormatter.string(from: startTime)) to \(timeOnlyFormatter.string(from: endTime))"
+        }
+        
+        return "\(dateAndTimeFormatter.string(from: startTime)) to \(dateAndTimeFormatter.string(from: endTime))"
+    }
+}

--- a/Mlem/Views/Shared/Markdown View.swift
+++ b/Mlem/Views/Shared/Markdown View.swift
@@ -101,8 +101,13 @@ struct MarkdownView: View {
                     )
                 } else {
                     return AnyView(
-                        CachedImage(url: url, shouldExpand: shouldExpand, cornerRadius: AppConstants.largeItemCornerRadius)
-                            .applyNsfwOverlay(isNsfw)
+                        CachedImage(
+                            url: url,
+                            shouldExpand: shouldExpand,
+                            hasContextMenu: true,
+                            cornerRadius: AppConstants.largeItemCornerRadius
+                        )
+                        .applyNsfwOverlay(isNsfw)
                     )
                 }
             }

--- a/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
+++ b/Mlem/Views/Shared/Posts/ExpandedPostLogic.swift
@@ -25,6 +25,8 @@ extension ExpandedPost {
             operation: CommentOperation.replyToComment
         ))
     }
+    
+    // MARK: Helper functions
 
     @discardableResult
     func loadComments() async -> Bool {

--- a/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
+++ b/Mlem/Views/Shared/Posts/Post Sizes/Large Post.swift
@@ -202,6 +202,7 @@ struct LargePost: View {
                 if layoutMode != .minimize {
                     CachedImage(
                         url: url,
+                        hasContextMenu: true,
                         maxHeight: layoutMode.getMaxHeight(limitHeight),
                         onTapCallback: markPostAsRead,
                         cornerRadius: AppConstants.largeItemCornerRadius

--- a/Mlem/Views/Shared/WebView.swift
+++ b/Mlem/Views/Shared/WebView.swift
@@ -1,0 +1,23 @@
+//
+//  WebView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 05/02/2024.
+//
+
+import SwiftUI
+import WebKit
+
+struct WebView: UIViewRepresentable {
+    let url: URL
+    
+    func makeUIView(context: Context) -> WKWebView {
+        let wkwebView = WKWebView()
+        let request = URLRequest(url: url)
+        wkwebView.load(request)
+        return wkwebView
+    }
+    
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+    }
+}

--- a/Mlem/Views/Shared/Website Icon Complex.swift
+++ b/Mlem/Views/Shared/Website Icon Complex.swift
@@ -63,6 +63,24 @@ struct WebsiteIconComplex: View {
     var imageHeight: CGFloat { horizontalSizeClass == .regular ? 400 : screenWidth * 0.66 }
 
     var body: some View {
+        if let url = post.linkUrl {
+            content
+                .contextMenu {
+                    Button("Open", systemImage: Icons.browser) {
+                        openURL(url)
+                    }
+                    Button("Copy", systemImage: Icons.copy) {
+                        let pasteboard = UIPasteboard.general
+                        pasteboard.url = url
+                    }
+                    ShareLink(item: url)
+                } preview: { WebView(url: url) }
+        } else {
+            content
+        }
+    }
+    
+    var content: some View {
         LazyVStack(spacing: 0) {
             if shouldShowWebsitePreviews, let thumbnailURL = post.thumbnailImageUrl {
                 CachedImage(
@@ -119,15 +137,6 @@ struct WebsiteIconComplex: View {
                 if let onTapActions {
                     onTapActions()
                 }
-            }
-        }
-        .contextMenu {
-            if let url = post.linkUrl {
-                Button("Copy", systemImage: Icons.copy) {
-                    let pasteboard = UIPasteboard.general
-                    pasteboard.url = url
-                }
-                ShareLink(item: url)
             }
         }
     }

--- a/Mlem/Views/Tabs/Feeds/Components/PostFeedView+MenuFunctions.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/PostFeedView+MenuFunctions.swift
@@ -15,7 +15,7 @@ extension PostFeedView {
             return MenuFunction.standardMenuFunction(
                 text: type.label,
                 imageName: imageName,
-                destructiveActionPrompt: nil,
+                role: nil,
                 enabled: !isSelected
             ) {
                 postSortType = type
@@ -29,7 +29,7 @@ extension PostFeedView {
             return MenuFunction.standardMenuFunction(
                 text: type.label,
                 imageName: isSelected ? Icons.timeSortFill : Icons.timeSort,
-                destructiveActionPrompt: nil,
+                role: nil,
                 enabled: !isSelected
             ) {
                 postSortType = type
@@ -44,7 +44,6 @@ extension PostFeedView {
         ret.append(MenuFunction.standardMenuFunction(
             text: blurNsfwText,
             imageName: Icons.blurNsfw,
-            destructiveActionPrompt: nil,
             enabled: true
         ) {
             shouldBlurNsfw.toggle()
@@ -54,7 +53,6 @@ extension PostFeedView {
         ret.append(MenuFunction.standardMenuFunction(
             text: showReadPostsText,
             imageName: "book",
-            destructiveActionPrompt: nil,
             enabled: true
         ) {
             showReadPosts.toggle()
@@ -72,7 +70,7 @@ extension PostFeedView {
             return MenuFunction.standardMenuFunction(
                 text: size.label,
                 imageName: imageName,
-                destructiveActionPrompt: nil,
+                role: nil,
                 enabled: enabled,
                 callback: { postSize = size }
             )

--- a/Mlem/Views/Tabs/Feeds/Components/UserContentFeedView+Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/UserContentFeedView+Logic.swift
@@ -15,7 +15,6 @@ extension UserContentFeedView {
         ret.append(MenuFunction.standardMenuFunction(
             text: blurNsfwText,
             imageName: Icons.blurNsfw,
-            destructiveActionPrompt: nil,
             enabled: true
         ) {
             shouldBlurNsfw.toggle()
@@ -33,7 +32,6 @@ extension UserContentFeedView {
             return MenuFunction.standardMenuFunction(
                 text: size.label,
                 imageName: imageName,
-                destructiveActionPrompt: nil,
                 enabled: enabled,
                 callback: { postSize = size }
             )

--- a/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView+Logic.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView+Logic.swift
@@ -17,7 +17,7 @@ extension AggregateFeedView {
             ret.append(MenuFunction.standardMenuFunction(
                 text: type.label,
                 imageName: imageName,
-                destructiveActionPrompt: nil,
+                role: nil,
                 enabled: enabled,
                 callback: {
                     // when switching back from the saved feed, stale items are sometimes present in the post tracker; this ensures that those are not displayed

--- a/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 /// View for post feeds aggregating multiple communities (all, local, subscribed, saved)
 struct AggregateFeedView: View {
     @Dependency(\.errorHandler) var errorHandler
+    @Dependency(\.markReadBatcher) var markReadBatcher
     
     @Environment(\.dismiss) var dismiss
     @Environment(\.scrollViewProxy) var scrollProxy
@@ -82,6 +83,7 @@ struct AggregateFeedView: View {
                 if let selectedFeed {
                     switch selectedFeed {
                     case .all, .local, .subscribed:
+                        await markReadBatcher.flush()
                         await postTracker.changeFeedType(to: selectedFeed)
                         postTracker.isStale = false
                     default:
@@ -94,6 +96,7 @@ struct AggregateFeedView: View {
                     do {
                         switch selectedFeed {
                         case .all, .local, .subscribed:
+                            await markReadBatcher.flush()
                             _ = try await postTracker.refresh(clearBeforeRefresh: false)
                         case .saved:
                             _ = try await savedContentTracker.refresh(clearBeforeRefresh: false)

--- a/Mlem/Views/Tabs/Inbox/InboxView+Logic.swift
+++ b/Mlem/Views/Tabs/Inbox/InboxView+Logic.swift
@@ -55,7 +55,7 @@ extension InboxView {
         ret.append(MenuFunction.standardMenuFunction(
             text: filterReadText,
             imageName: filterReadSymbol,
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             toggleFilterRead()
@@ -64,7 +64,7 @@ extension InboxView {
         ret.append(MenuFunction.standardMenuFunction(
             text: "Mark All as Read",
             imageName: "envelope.open",
-            destructiveActionPrompt: nil,
+            role: nil,
             enabled: true
         ) {
             Task(priority: .userInitiated) {

--- a/Mlem/Views/Tabs/Profile/UserView.swift
+++ b/Mlem/Views/Tabs/Profile/UserView.swift
@@ -18,6 +18,8 @@ struct UserView: View {
     @Environment(\.navigationPathWithRoutes) private var navigationPath
     @Environment(\.scrollViewProxy) private var scrollViewProxy
     
+    @EnvironmentObject var editorTracker: EditorTracker
+    
     let internetSpeed: InternetSpeed
     let communityContext: CommunityModel?
     
@@ -151,7 +153,7 @@ struct UserView: View {
         )
         .toolbar {
             ToolbarItemGroup(placement: .secondaryAction) {
-                let functions = user.menuFunctions { user = $0 }
+                let functions = user.menuFunctions({ user = $0 }, editorTracker: editorTracker)
                 ForEach(functions) { item in
                     MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
                 }

--- a/Mlem/Views/Tabs/Search/Results/InstanceResultView.swift
+++ b/Mlem/Views/Tabs/Search/Results/InstanceResultView.swift
@@ -47,7 +47,7 @@ struct InstanceResultView: View {
     }
     
     var body: some View {
-        NavigationLink(value: AppRoute.instance(instance.url.host(), instance)) {
+        NavigationLink(value: AppRoute.instance(instance)) {
             HStack(spacing: 10) {
                 AvatarView(instance: instance, avatarSize: 48, iconResolution: .fixed(128))
                 

--- a/Mlem/Views/Tabs/Search/Results/UserResultView.swift
+++ b/Mlem/Views/Tabs/Search/Results/UserResultView.swift
@@ -31,6 +31,8 @@ struct UserResultView: View {
     @State private var isPresentingConfirmDestructive: Bool = false
     @State private var confirmationMenuFunction: StandardMenuFunction?
     
+    @EnvironmentObject var editorTracker: EditorTracker
+    
     init(
         _ user: UserModel,
         complications: [UserComplication] = .withoutTypeLabel,
@@ -130,7 +132,7 @@ struct UserResultView: View {
         )
         .addSwipeyActions(swipeActions ?? .init())
         .contextMenu {
-            ForEach(user.menuFunctions(trackerCallback)) { item in
+            ForEach(user.menuFunctions(trackerCallback, editorTracker: editorTracker)) { item in
                 MenuButton(menuFunction: item, confirmDestructive: confirmDestructive)
             }
         }

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -142,14 +142,22 @@ struct GeneralSettingsView: View {
             }
             
             Section {
-                SelectableSettingsItem(
-                    settingIconSystemName: Icons.tabBarNavigation,
-                    settingName: "Behaviour",
-                    currentValue: $tabBarActionBehaviour,
-                    options: Navigation.Behaviour.allCases
-                )
+                Picker(selection: $tabBarActionBehaviour) {
+                    ForEach(Navigation.Behaviour.allCases) { value in
+                        Label {
+                            Text(value.label)
+                        } icon: {
+                            Image(systemName: value.systemImage)
+                                .foregroundColor(.pink)
+                        }
+                    }
+                } label: {
+                    EmptyView()
+                }
+                .pickerStyle(.inline)
+                .accentColor(.pink)
             } header: {
-                Text("Tab Bar Actions")
+                Text("Tap tab bar icon to...")
             } footer: {
                 Text(tabBarActionBehaviour.explanation)
             }

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -25,6 +25,8 @@ struct GeneralSettingsView: View {
     
     @AppStorage("openLinksInBrowser") var openLinksInBrowser: Bool = false
 
+    @AppStorage("tabBarActionBehaviour") private var tabBarActionBehaviour: Navigation.Behaviour = .primary
+
     @EnvironmentObject var appState: AppState
 
     @State var showErrorAlert: Bool = false
@@ -126,6 +128,14 @@ struct GeneralSettingsView: View {
                 )
             } header: {
                 Text("Privacy")
+            }
+            
+            Section {
+                Picker("Tab Bar Action", selection: $tabBarActionBehaviour) {
+                    ForEach(Navigation.Behaviour.allCases) { behaviour in
+                        Text(behaviour.label).tag(behaviour.id)
+                    }
+                }
             }
         }
         .fancyTabScrollCompatible()

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -17,6 +17,7 @@ struct GeneralSettingsView: View {
     @AppStorage("appLock") var appLock: AppLock = .disabled
     @AppStorage("tapCommentToCollapse") var tapCommentToCollapse: Bool = true
     @AppStorage("easyTapLinkDisplayMode") var easyTapLinkDisplayMode: EasyTapLinkDisplayMode = .contextual
+    @AppStorage("markReadOnScroll") var markReadOnScroll: Bool = false
     
     @AppStorage("defaultFeed") var defaultFeed: DefaultFeedType = .subscribed
     
@@ -59,6 +60,16 @@ struct GeneralSettingsView: View {
                     currentValue: $easyTapLinkDisplayMode,
                     options: EasyTapLinkDisplayMode.allCases
                 )
+                SwitchableSettingsItem(
+                    settingPictureSystemName: Icons.read,
+                    settingName: "Mark Read on Scroll",
+                    isTicked: $markReadOnScroll
+                )
+                .disabled(siteInformation.version ?? .infinity <= .init("0.19.0"))
+            } footer: {
+                if siteInformation.version ?? .infinity <= .init("0.19.0") {
+                    Text("Mark read on scroll is only available on instances running v0.19.0 or greater.")
+                }
             }
             
             Section {

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -26,6 +26,8 @@ struct GeneralSettingsView: View {
     
     @AppStorage("openLinksInBrowser") var openLinksInBrowser: Bool = false
 
+    @AppStorage("tabBarActionBehaviour") private var tabBarActionBehaviour: Navigation.Behaviour = .primary
+
     @EnvironmentObject var appState: AppState
 
     @State var showErrorAlert: Bool = false
@@ -137,6 +139,14 @@ struct GeneralSettingsView: View {
                 )
             } header: {
                 Text("Privacy")
+            }
+            
+            Section {
+                Picker("Tab Bar Action", selection: $tabBarActionBehaviour) {
+                    ForEach(Navigation.Behaviour.allCases) { behaviour in
+                        Text(behaviour.label).tag(behaviour.id)
+                    }
+                }
             }
         }
         .fancyTabScrollCompatible()

--- a/Mlem/Window.swift
+++ b/Mlem/Window.swift
@@ -15,6 +15,7 @@ struct Window: View {
     @Dependency(\.notifier) var notifier
     @Dependency(\.hapticManager) var hapticManager
     @Dependency(\.siteInformation) var siteInformation
+    @Dependency(\.markReadBatcher) var markReadBatcher
 
     @StateObject var easterFlagsTracker: EasterFlagsTracker = .init()
     @StateObject var filtersTracker: FiltersTracker = .init()
@@ -91,6 +92,11 @@ struct Window: View {
     
     private func setFlow(_ flow: AppFlow) {
         transition(flow)
+        DispatchQueue.main.async {
+            Task {
+                await markReadBatcher.flush()
+            }
+        }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             self.flow = flow
         }


### PR DESCRIPTION
# Pull Request Information

## About this Pull Request
Allows users to customize tab bar actions behaviour:
- System: Pop to root, then scroll to top (and pop back to sidebar, if available).
- Dismiss: Go back to previous page until root page, then scroll to top (and pop back to sidebar, if available).
- Dismiss after Scroll: Always scroll-to-top before going back to previous page (and pop back to sidebar, if available).

Appreciate any input on behaviour naming and explanation text.

## Screenshots and Videos

<img src="https://github.com/mlemgroup/mlem/assets/2549615/7a6c3ca7-e4c0-4d30-b4b1-a45dc56a54bb" width="320">
<img src="https://github.com/mlemgroup/mlem/assets/2549615/e3281501-2f66-4ed7-95fb-94eb1dfdb3f8" width="320">
