### PR TITLE
Rearrange Menu Functions

### DIFF
--- a/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
@@ -24,7 +24,7 @@ extension PostModel {
     ) -> [MenuFunction] {
         var functions: [MenuFunction] = .init()
         
-        functions.append(.controlGroup(topRowMenuFunctions(editorTracker: editorTracker)))
+        functions.append(.controlGroupMenuFunction(children: topRowMenuFunctions(editorTracker: editorTracker)))
         
         if creator.isActiveAccount {
             // Edit
@@ -106,7 +106,7 @@ extension PostModel {
     ) -> [MenuFunction] {
         var functions: [MenuFunction] = .init()
         
-        functions.append(.controlGroup(pinLockMenuFunctions()))
+        functions.append(.controlGroupMenuFunction(children: pinLockMenuFunctions()))
         
         if creator.userId != siteInformation.userId {
             functions.append(MenuFunction.toggleableMenuFunction(

--- a/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
@@ -200,7 +200,7 @@ extension PostModel {
         // Save
         functions.append(MenuFunction.standardMenuFunction(
             text: saved ? "Unsave" : "Save",
-            imageName: saved ? Icons.unsave : Icons.save,
+            imageName: saved ? Icons.saveFill : Icons.save,
             enabled: true
         ) {
             Task(priority: .userInitiated) {

--- a/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Post/PostModel+MenuFunctions.swift
@@ -17,6 +17,7 @@ extension PostModel {
     ///   - modToolTracker: optional ModToolTracker. If this and community are present, moderator functions will be included in the menu.
     ///   - Returns: menu functions for this post
     @MainActor func menuFunctions(
+        isExpanded: Bool = false,
         editorTracker: EditorTracker,
         postTracker: StandardPostTracker?,
         community: CommunityModel?,
@@ -80,6 +81,7 @@ extension PostModel {
             functions.append(.divider)
             functions.append(
                 contentsOf: modMenuFunctions(
+                    isExpanded: isExpanded,
                     community: community,
                     modToolTracker: modToolTracker,
                     postTracker: postTracker
@@ -103,37 +105,40 @@ extension PostModel {
     }
 
     private func modMenuFunctions(
+        isExpanded: Bool,
         community: CommunityModel,
         modToolTracker: ModToolTracker,
         postTracker: StandardPostTracker?
     ) -> [MenuFunction] {
         var functions: [MenuFunction] = .init()
         
-        functions.append(MenuFunction.toggleableMenuFunction(
-            toggle: post.featuredCommunity,
-            trueText: "Unpin",
-            trueImageName: Icons.unpin,
-            falseText: "Pin",
-            falseImageName: Icons.pin
-        ) {
-            Task {
-                await self.toggleFeatured(featureType: .community)
-                await self.notifier.add(.success("\(self.post.featuredCommunity ? "P" : "Unp")inned post"))
-            }
-        })
-        
-        functions.append(MenuFunction.toggleableMenuFunction(
-            toggle: post.locked,
-            trueText: "Unlock",
-            trueImageName: Icons.unlock,
-            falseText: "Lock",
-            falseImageName: Icons.lock
-        ) {
-            Task {
-                await self.toggleLocked()
-                await self.notifier.add(.success("\(self.post.locked ? "L" : "Unl")ocked post"))
-            }
-        })
+        if isExpanded {
+            functions.append(MenuFunction.toggleableMenuFunction(
+                toggle: post.featuredCommunity,
+                trueText: "Unpin",
+                trueImageName: Icons.unpin,
+                falseText: "Pin",
+                falseImageName: Icons.pin
+            ) {
+                Task {
+                    await self.toggleFeatured(featureType: .community)
+                    await self.notifier.add(.success("\(self.post.featuredCommunity ? "P" : "Unp")inned post"))
+                }
+            })
+            
+            functions.append(MenuFunction.toggleableMenuFunction(
+                toggle: post.locked,
+                trueText: "Unlock",
+                trueImageName: Icons.unlock,
+                falseText: "Lock",
+                falseImageName: Icons.lock
+            ) {
+                Task {
+                    await self.toggleLocked()
+                    await self.notifier.add(.success("\(self.post.locked ? "L" : "Unl")ocked post"))
+                }
+            })
+        }
         
         if creator.userId != siteInformation.userId {
             functions.append(MenuFunction.toggleableMenuFunction(

--- a/Mlem/Models/Menu Function.swift
+++ b/Mlem/Models/Menu Function.swift
@@ -21,8 +21,8 @@ enum MenuFunction: Identifiable {
             return navigationMenuFunction.id
         case let .disclosureGroup(groupMenuFunction):
             return groupMenuFunction.id
-        case let .controlGroup(groups):
-            return groups.reduce("CONTROL") { $0 + $1.id }
+        case let .controlGroup(groupMenuFunction):
+            return groupMenuFunction.id
         case .divider:
             return UUID().uuidString
         }
@@ -120,7 +120,7 @@ extension MenuFunction {
     }
     
         static func controlGroupMenuFunction(
-            children: [MenuFunction],
+            children: [MenuFunction]
         ) -> MenuFunction {
             MenuFunction.controlGroup(ControlGroupMenuFunction(children: children))
         }

--- a/Mlem/Models/Menu Function.swift
+++ b/Mlem/Models/Menu Function.swift
@@ -19,8 +19,10 @@ enum MenuFunction: Identifiable {
             return shareImageFunction.id
         case let .navigation(navigationMenuFunction):
             return navigationMenuFunction.id
-        case let .group(groupMenuFunction):
+        case let .disclosureGroup(groupMenuFunction):
             return groupMenuFunction.id
+        case let .controlGroup(groups):
+            return groups.reduce("CONTROL") { $0 + $1.id }
         case .divider:
             return UUID().uuidString
         }
@@ -31,10 +33,8 @@ enum MenuFunction: Identifiable {
     case shareUrl(ShareMenuFunction)
     case shareImage(ShareImageFunction)
     case navigation(NavigationMenuFunction)
-    /// - Parameter titleKey: User-facing title label for menu.
-    /// - Parameter children: Menu items for this child menu.
-    /// - Note: Destructive confirmation is not supported at this time.
-    case group(GroupMenuFunction)
+    case disclosureGroup(DisclosureGroupMenuFunction)
+    case controlGroup(ControlGroupMenuFunction)
 }
 
 struct MenuFunctionPopup {
@@ -112,13 +112,19 @@ extension MenuFunction {
         imageName: String,
         children: [MenuFunction]
     ) -> MenuFunction {
-        MenuFunction.group(GroupMenuFunction(
+        MenuFunction.disclosureGroup(DisclosureGroupMenuFunction(
             text: text,
             imageName: imageName,
             children: children
         ))
     }
     
+        static func controlGroupMenuFunction(
+            children: [MenuFunction],
+        ) -> MenuFunction {
+            MenuFunction.controlGroup(ControlGroupMenuFunction(children: children))
+        }
+
     // swiftlint:disable:next function_parameter_count
     static func toggleableMenuFunction(
         toggle: Bool,
@@ -198,10 +204,15 @@ struct StandardMenuFunction: Identifiable {
     let enabled: Bool
 }
 
-struct GroupMenuFunction: Identifiable {
+struct DisclosureGroupMenuFunction: Identifiable {
     var id: String { text }
     let text: String
     let imageName: String
+    var children: [MenuFunction]
+}
+
+struct ControlGroupMenuFunction: Identifiable {
+    var id: String { children.reduce("CONTROL") { $0 + $1.id } }
     var children: [MenuFunction]
 }
 

--- a/Mlem/Views/Shared/Comments/Comment Item Logic.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item Logic.swift
@@ -230,7 +230,7 @@ extension CommentItem {
             replyToComment()
         })
         
-        ret.append(.controlGroup(topRowFunctions))
+        ret.append(.controlGroupMenuFunction(children: topRowFunctions))
         
         let isOwnComment = appState.isCurrentAccountId(hierarchicalComment.commentView.creator.id)
         

--- a/Mlem/Views/Shared/Comments/Comment Item Logic.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item Logic.swift
@@ -211,7 +211,7 @@ extension CommentItem {
                 
         // save
         let (saveText, saveImg) = hierarchicalComment.commentView.saved ?
-        ("Unsave", Icons.unsave) :
+        ("Unsave", Icons.saveFill) :
         ("Save", Icons.save)
         topRowFunctions.append(MenuFunction.standardMenuFunction(
             text: saveText,

--- a/Mlem/Views/Shared/Comments/Comment Item Logic.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item Logic.swift
@@ -182,12 +182,12 @@ extension CommentItem {
     func genMenuFunctions() -> [MenuFunction] {
         var ret: [MenuFunction] = .init()
         
-        var topRowFunctions: [MenuFunction] = .init()
+        var mainFunctions: [MenuFunction] = .init()
         // upvote
         let (upvoteText, upvoteImg) = hierarchicalComment.commentView.myVote == .upvote ?
         ("Undo Upvote", Icons.upvoteSquareFill) :
         ("Upvote", Icons.upvoteSquare)
-        topRowFunctions.append(MenuFunction.standardMenuFunction(
+        mainFunctions.append(MenuFunction.standardMenuFunction(
             text: upvoteText,
             imageName: upvoteImg
         ) {
@@ -200,7 +200,7 @@ extension CommentItem {
         let (downvoteText, downvoteImg) = hierarchicalComment.commentView.myVote == .downvote ?
         ("Undo Downvote", Icons.downvoteSquareFill) :
         ("Downvote", Icons.downvoteSquare)
-        topRowFunctions.append(MenuFunction.standardMenuFunction(
+        mainFunctions.append(MenuFunction.standardMenuFunction(
             text: downvoteText,
             imageName: downvoteImg
         ) {
@@ -213,7 +213,7 @@ extension CommentItem {
         let (saveText, saveImg) = hierarchicalComment.commentView.saved ?
         ("Unsave", Icons.saveFill) :
         ("Save", Icons.save)
-        topRowFunctions.append(MenuFunction.standardMenuFunction(
+        mainFunctions.append(MenuFunction.standardMenuFunction(
             text: saveText,
             imageName: saveImg
         ) {
@@ -223,20 +223,18 @@ extension CommentItem {
         })
 
         // reply
-        topRowFunctions.append(MenuFunction.standardMenuFunction(
+        mainFunctions.append(MenuFunction.standardMenuFunction(
             text: "Reply",
             imageName: Icons.reply
         ) {
             replyToComment()
         })
         
-        ret.append(.controlGroupMenuFunction(children: topRowFunctions))
-        
         let isOwnComment = appState.isCurrentAccountId(hierarchicalComment.commentView.creator.id)
         
         if isOwnComment {
             // edit
-            ret.append(MenuFunction.standardMenuFunction(
+            mainFunctions.append(MenuFunction.standardMenuFunction(
                 text: "Edit",
                 imageName: Icons.edit
             ) {
@@ -244,7 +242,7 @@ extension CommentItem {
             })
         
             // delete
-            ret.append(MenuFunction.standardMenuFunction(
+            mainFunctions.append(MenuFunction.standardMenuFunction(
                 text: "Delete",
                 imageName: Icons.delete,
                 confirmationPrompt: "Are you sure you want to delete this comment?  This cannot be undone.",
@@ -258,12 +256,12 @@ extension CommentItem {
                 
         // share
         if let url = URL(string: hierarchicalComment.commentView.comment.apId) {
-            ret.append(MenuFunction.shareMenuFunction(url: url))
+            mainFunctions.append(MenuFunction.shareMenuFunction(url: url))
         }
         
         if !isOwnComment {
             // report
-            ret.append(MenuFunction.standardMenuFunction(
+            mainFunctions.append(MenuFunction.standardMenuFunction(
                 text: "Report",
                 imageName: Icons.moderationReport,
                 confirmationPrompt: AppConstants.reportCommentPrompt
@@ -275,7 +273,7 @@ extension CommentItem {
             })
             
             // block
-            ret.append(MenuFunction.standardMenuFunction(
+            mainFunctions.append(MenuFunction.standardMenuFunction(
                 text: "Block User",
                 imageName: Icons.hide,
                 confirmationPrompt: AppConstants.blockUserPrompt
@@ -285,6 +283,8 @@ extension CommentItem {
                 }
             })
         }
+        
+        ret.append(.controlGroupMenuFunction(children: mainFunctions))
                    
         return ret
     }

--- a/Mlem/Views/Shared/Comments/Comment Item.swift
+++ b/Mlem/Views/Shared/Comments/Comment Item.swift
@@ -30,7 +30,6 @@ struct CommentItem: View {
     @AppStorage("shouldShowTimeInCommentBar") var shouldShowTimeInCommentBar: Bool = true
     @AppStorage("shouldShowSavedInCommentBar") var shouldShowSavedInCommentBar: Bool = false
     @AppStorage("shouldShowRepliesInCommentBar") var shouldShowRepliesInCommentBar: Bool = true
-    @AppStorage("showExtraContextMenuActions") var showExtraContextMenuActions: Bool = false
     @AppStorage("compactComments") var compactComments: Bool = false
     @AppStorage("collapseChildComments") var collapseComments: Bool = false
     @AppStorage("tapCommentToCollapse") var tapCommentToCollapse: Bool = true

--- a/Mlem/Views/Shared/Components/Components/Menu Button.swift
+++ b/Mlem/Views/Shared/Components/Components/Menu Button.swift
@@ -36,7 +36,21 @@ struct MenuButton: View {
             NavigationLink(navigationMenuFunction.destination) {
                 Label(navigationMenuFunction.text, systemImage: navigationMenuFunction.imageName)
             }
-        case let .group(groupMenuFunction):
+        case let .controlGroup(groupMenuFunction):
+            
+            if #available(iOS 16.4, *) {
+                ControlGroup {
+                    ForEach(groupMenuFunction.children) { child in
+                        MenuButton(menuFunction: child, menuFunctionPopup: $menuFunctionPopup)
+                    }
+                }
+                .controlGroupStyle(.compactMenu)
+            } else {
+                ForEach(groupMenuFunction.children) { child in
+                    MenuButton(menuFunction: child, menuFunctionPopup: $menuFunctionPopup)
+                }
+            }
+        case let .disclosureGroup(groupMenuFunction):
             Menu {
                 ForEach(groupMenuFunction.children) { child in
                     MenuButton(menuFunction: child, menuFunctionPopup: $menuFunctionPopup)

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -88,6 +88,7 @@ struct ExpandedPost: View {
                 ToolbarItemGroup(placement: .secondaryAction) {
                     let isMod = siteInformation.moderatedCommunities.contains(post.community.communityId)
                     let menuFunctions = post.menuFunctions(
+                        isExpanded: true,
                         editorTracker: editorTracker,
                         postTracker: postTracker,
                         community: isMod ? post.community : nil,

--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -50,7 +50,6 @@ struct ExpandedPost: View {
     
     @AppStorage("showCommentJumpButton") var showCommentJumpButton: Bool = true
     @AppStorage("commentJumpButtonSide") var commentJumpButtonSide: JumpButtonLocation = .bottomTrailing
-    @AppStorage("showExtraContextMenuActions") var showExtraContextMenuActions: Bool = false
 
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var editorTracker: EditorTracker
@@ -237,8 +236,6 @@ struct ExpandedPost: View {
                     
                     let menuFunctions = post.menuFunctions(
                         editorTracker: editorTracker,
-                        showExtraContextMenuActions: showExtraContextMenuActions,
-                        widgetTracker: layoutWidgetTracker,
                         postTracker: postTracker,
                         community: isMod ? post.community : nil,
                         modToolTracker: isMod ? modToolTracker : nil

--- a/Mlem/Views/Shared/Posts/Feed Post.swift
+++ b/Mlem/Views/Shared/Posts/Feed Post.swift
@@ -37,7 +37,6 @@ struct FeedPost: View {
     @AppStorage("shouldShowTimeInPostBar") var shouldShowTimeInPostBar: Bool = true
     @AppStorage("shouldShowSavedInPostBar") var shouldShowSavedInPostBar: Bool = false
     @AppStorage("shouldShowRepliesInPostBar") var shouldShowRepliesInPostBar: Bool = true
-    @AppStorage("showExtraContextMenuActions") var showExtraContextMenuActions: Bool = false
     
     @AppStorage("reakMarkStyle") var readMarkStyle: ReadMarkStyle = .bar
     @AppStorage("readBarThickness") var readBarThickness: Int = 3
@@ -94,8 +93,6 @@ struct FeedPost: View {
         
         return postModel.menuFunctions(
             editorTracker: editorTracker,
-            showExtraContextMenuActions: showExtraContextMenuActions || postSize == .compact,
-            widgetTracker: layoutWidgetTracker,
             postTracker: postTracker,
             community: isMod ? postModel.community : nil,
             modToolTracker: isMod ? modToolTracker : nil

--- a/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Accessibility/AccessibilitySettingsView.swift
@@ -13,7 +13,6 @@ struct AccessibilitySettingsView: View {
     @AppStorage("readBarThickness") var readBarThickness: Int = 3
     @AppStorage("hasTranslucentInsets") var hasTranslucentInsets: Bool = true
     @AppStorage("showSettingsIcons") var showSettingsIcons: Bool = true
-    @AppStorage("showExtraContextMenuActions") var showExtraContextMenuActions: Bool = false
     
     @State private var readBarThicknessSlider: CGFloat = 3.0
     
@@ -88,16 +87,6 @@ struct AccessibilitySettingsView: View {
                 )
             } header: {
                 Text("Icons")
-            }
-            Section {
-                SwitchableSettingsItem(
-                    settingPictureSystemName: Icons.copy,
-                    settingName: "Show Duplicate Context Menu Actions",
-                    isTicked: $showExtraContextMenuActions
-                )
-            } footer: {
-                // swiftlint:disable:next line_length
-                Text("Show context menu actions such as Upvote and Save even when those actions are available via buttons below the post or comment.")
             }
         }
         .fancyTabScrollCompatible()


### PR DESCRIPTION
Moved upvote/downvote/save/reply onto one row. Also moved the ellipsis menu of an expanded post to the toolbar. Pin and Lock are only shown in the expanded post.