### PR TITLE
Remove/Purge Community

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		0300F2C62B9C7D4B0022F7C4 /* CloseButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0300F2C52B9C7D4B0022F7C4 /* CloseButtonView.swift */; };
+		030245C02BA607EA00D07747 /* FeedToolbarContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030245BF2BA607EA00D07747 /* FeedToolbarContent.swift */; };
+		030245C22BA60A2600D07747 /* ToolbarEllipsisMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030245C12BA60A2600D07747 /* ToolbarEllipsisMenu.swift */; };
+		030245C42BA6123A00D07747 /* RemoveCommunityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030245C32BA6123A00D07747 /* RemoveCommunityView.swift */; };
+		030245C62BA6138100D07747 /* RemoveCommunityRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030245C52BA6138100D07747 /* RemoveCommunityRequest.swift */; };
+		030245C82BA617FE00D07747 /* PurgeCommunityRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030245C72BA617FE00D07747 /* PurgeCommunityRequest.swift */; };
 		0304F58A2B44AF5B00537BFA /* CollapsibleSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0304F5892B44AF5B00537BFA /* CollapsibleSection.swift */; };
 		0308E1142B0EA32A000CA955 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0308E1132B0EA32A000CA955 /* AccountSettingsView.swift */; };
 		0308E1162B0EA42B000CA955 /* APILocalUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0308E1152B0EA42B000CA955 /* APILocalUserView.swift */; };
@@ -628,6 +633,11 @@
 
 /* Begin PBXFileReference section */
 		0300F2C52B9C7D4B0022F7C4 /* CloseButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseButtonView.swift; sourceTree = "<group>"; };
+		030245BF2BA607EA00D07747 /* FeedToolbarContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedToolbarContent.swift; sourceTree = "<group>"; };
+		030245C12BA60A2600D07747 /* ToolbarEllipsisMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarEllipsisMenu.swift; sourceTree = "<group>"; };
+		030245C32BA6123A00D07747 /* RemoveCommunityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveCommunityView.swift; sourceTree = "<group>"; };
+		030245C52BA6138100D07747 /* RemoveCommunityRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveCommunityRequest.swift; sourceTree = "<group>"; };
+		030245C72BA617FE00D07747 /* PurgeCommunityRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurgeCommunityRequest.swift; sourceTree = "<group>"; };
 		0304F5892B44AF5B00537BFA /* CollapsibleSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleSection.swift; sourceTree = "<group>"; };
 		0308E1132B0EA32A000CA955 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
 		0308E1152B0EA42B000CA955 /* APILocalUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APILocalUserView.swift; sourceTree = "<group>"; };
@@ -2209,6 +2219,8 @@
 				6372183D2A3A2AAD008C4816 /* HideCommunity.swift */,
 				6372183E2A3A2AAD008C4816 /* FollowCommunity.swift */,
 				6372183F2A3A2AAD008C4816 /* ListCommunities.swift */,
+				030245C72BA617FE00D07747 /* PurgeCommunityRequest.swift */,
+				030245C52BA6138100D07747 /* RemoveCommunityRequest.swift */,
 				637218402A3A2AAD008C4816 /* GetCommunity.swift */,
 				637218412A3A2AAD008C4816 /* BlockCommunity.swift */,
 				CDD0EFAC2B7EA73000CA3504 /* BanFromCommunity.swift */,
@@ -2247,6 +2259,7 @@
 				6FF17D002B685C16007E1814 /* AppLockView.swift */,
 				03F6D4BA2B952738008235A0 /* SelectTextView.swift */,
 				0300F2C52B9C7D4B0022F7C4 /* CloseButtonView.swift */,
+				030245C12BA60A2600D07747 /* ToolbarEllipsisMenu.swift */,
 				CD2053152ACBBB490000AA38 /* Avatars */,
 				CD2E147B2A6B2891004198DE /* Components */,
 				6332FDCD27EFDD0A0009A98A /* Accounts */,
@@ -2370,6 +2383,7 @@
 				03F6D4BC2B966D53008235A0 /* BodyEditorView.swift */,
 				03CB329D2A6D8E910021EF27 /* PostComposerView.swift */,
 				CD0D5A442B8EC5D9005E3365 /* RemovePostView.swift */,
+				030245C32BA6123A00D07747 /* RemoveCommunityView.swift */,
 			);
 			path = Composer;
 			sourceTree = "<group>";
@@ -3053,6 +3067,7 @@
 			children = (
 				CDEC95112B5B318B004BA288 /* CommunityFeedView.swift */,
 				CD4BAD422B507F2B00A1E726 /* AggregateFeedView.swift */,
+				030245BF2BA607EA00D07747 /* FeedToolbarContent.swift */,
 				CDEC95132B5CBC42004BA288 /* AggregateFeedView+Logic.swift */,
 			);
 			path = "Feed Types";
@@ -3356,6 +3371,7 @@
 				6372185C2A3A2AAD008C4816 /* APICommunity.swift in Sources */,
 				CDA1E84F2B93FF83007953EF /* RemovedTag.swift in Sources */,
 				CD268C112B9A3CB30074DBEE /* SimpleCommunitySearchView.swift in Sources */,
+				030245C62BA6138100D07747 /* RemoveCommunityRequest.swift in Sources */,
 				6372185D2A3A2AAD008C4816 /* APICommunityAggregates.swift in Sources */,
 				03B7AAF52ABEFA7A00068B23 /* UserListRow.swift in Sources */,
 				E47478152AAC3C19001CB1AC /* NavigationContext.swift in Sources */,
@@ -3631,6 +3647,7 @@
 				CDB652572B8EAE15007B7797 /* APIPostResponse.swift in Sources */,
 				CD268C142B9A3DD80074DBEE /* CommunityListRowBody.swift in Sources */,
 				CD18DC6B2A5202D4002C56BC /* MarkPersonMentionAsReadRequest.swift in Sources */,
+				030245C22BA60A2600D07747 /* ToolbarEllipsisMenu.swift in Sources */,
 				CD16A06A2B670ABE000312D2 /* UserContentFeedView+Logic.swift in Sources */,
 				CD4BAD3B2B4C6C3200A1E726 /* FeedRowView.swift in Sources */,
 				CD1824402AA8E24100D9BEB5 /* View+DestructiveConfirmation.swift in Sources */,
@@ -3648,6 +3665,7 @@
 				CD69F55B2A400D820028D4F7 /* App Theme.swift in Sources */,
 				CDEBC3392A9ADE6C00518D9D /* APIClient+Post.swift in Sources */,
 				E4A7BFD12B35912500B95F56 /* InboxMessageView.swift in Sources */,
+				030245C02BA607EA00D07747 /* FeedToolbarContent.swift in Sources */,
 				CDF9EF332AB2845C003F885B /* Icons.swift in Sources */,
 				B14E93C22A45D3B300D6DA93 /* Community Link.swift in Sources */,
 				637218712A3A2AAD008C4816 /* GetSite.swift in Sources */,
@@ -3753,6 +3771,7 @@
 				038A16E72A7A9C430087987E /* LayoutWidgetCollection.swift in Sources */,
 				6322A5D227F88CFD00135D4F /* Time Parser.swift in Sources */,
 				AD1B0D352A5F63F60006F554 /* AboutView.swift in Sources */,
+				030245C82BA617FE00D07747 /* PurgeCommunityRequest.swift in Sources */,
 				50811B442A920945006BA3F2 /* APIPost+Mock.swift in Sources */,
 				030E86462AC6FC1B000283A6 /* DefaultTextInputType.swift in Sources */,
 				50811B3A2A920569006BA3F2 /* APIPerson+Mock.swift in Sources */,
@@ -3793,6 +3812,7 @@
 				CDF842642A49EAFA00723DA0 /* GetPersonMentions.swift in Sources */,
 				CD6A2A792B1A553500003E23 /* SuccessResponse.swift in Sources */,
 				031A61802B1CEA7300ABF23B /* ChangePassword.swift in Sources */,
+				030245C42BA6123A00D07747 /* RemoveCommunityView.swift in Sources */,
 				CDB652552B8EAC3E007B7797 /* APIPostFeatureType.swift in Sources */,
 				CD4368B42AE23F3500BD8BD1 /* ChildTrackerProtocol.swift in Sources */,
 				03AFBEA32B6EA86B00F01F3C /* SiteResponse+Mock.swift in Sources */,

--- a/Mlem/API/APIClient/APIClient+Community.swift
+++ b/Mlem/API/APIClient/APIClient+Community.swift
@@ -90,6 +90,16 @@ extension APIClient {
         return response.banned
     }
     
+    func removeCommunity(id: Int, shouldRemove: Bool, reason: String?) async throws -> CommunityResponse {
+        let request = try RemoveCommunityRequest(session: session, communityId: id, removed: shouldRemove, reason: reason)
+        return try await perform(request: request)
+    }
+    
+    func purgeCommunity(id: Int, reason: String?) async throws -> SuccessResponse {
+        let request = try PurgeCommunityRequest(session: session, communityId: id, reason: reason)
+        return try await perform(request: request)
+    }
+    
     /// Adds or removes the given user from the mod list of the given community
     /// - Parameters:
     ///   - of: id of user to add/remove

--- a/Mlem/API/Requests/Community/PurgeCommunityRequest.swift
+++ b/Mlem/API/Requests/Community/PurgeCommunityRequest.swift
@@ -1,0 +1,33 @@
+//
+//  PurgePostRequest.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-27
+//
+
+import Foundation
+
+struct PurgeCommunityRequest: APIPostRequest {
+    typealias Response = SuccessResponse
+
+    var instanceURL: URL
+    let path = "admin/purge/community"
+    let body: Body
+    
+    struct Body: Codable {
+        let community_id: Int
+        let reason: String?
+    }
+
+    init(
+        session: APISession,
+        communityId: Int,
+        reason: String?
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = .init(
+            community_id: communityId,
+            reason: reason
+      )
+    }
+}

--- a/Mlem/API/Requests/Community/RemoveCommunityRequest.swift
+++ b/Mlem/API/Requests/Community/RemoveCommunityRequest.swift
@@ -1,0 +1,36 @@
+//
+//  RemoveCommunityRequest.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-27
+//
+
+import Foundation
+
+struct RemoveCommunityRequest: APIPostRequest {
+    typealias Response = CommunityResponse
+    
+    struct Body: Codable {
+        let community_id: Int
+        let removed: Bool
+        let reason: String?
+    }
+
+    let instanceURL: URL
+    let path = "community/remove"
+    let body: Body
+
+    init(
+        session: APISession,
+        communityId: Int,
+        removed: Bool,
+        reason: String?
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = .init(
+          community_id: communityId,
+          removed: removed,
+          reason: reason
+        )
+    }
+}

--- a/Mlem/Models/Content/Community/CommunityModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Community/CommunityModel+MenuFunctions.swift
@@ -102,9 +102,11 @@ extension CommunityModel {
         )
     }
     
+    // swiftlint:disable:next function_body_length
     func menuFunctions(
         editorTracker: EditorTracker? = nil,
         postTracker: StandardPostTracker? = nil,
+        modToolTracker: ModToolTracker? = nil,
         _ callback: @escaping (_ item: Self) -> Void = { _ in }
     ) -> [MenuFunction] {
         var functions: [MenuFunction] = .init()
@@ -144,6 +146,23 @@ extension CommunityModel {
         functions.append(.shareMenuFunction(url: communityUrl))
         if let function = try? blockMenuFunction(callback) {
             functions.append(function)
+        }
+        
+        if siteInformation.myUser?.isAdmin ?? false, let modToolTracker {
+            functions.append(.divider)
+            functions.append(
+                .toggleableMenuFunction(
+                    toggle: removed,
+                    trueText: "Restore",
+                    trueImageName: Icons.restore,
+                    falseText: "Remove",
+                    falseImageName: Icons.remove,
+                    isDestructive: .always,
+                    callback: {
+                        modToolTracker.removeCommunity(self, shouldRemove: !removed)
+                    }
+                )
+            )
         }
         
         return functions

--- a/Mlem/Models/Trackers/ModToolTracker.swift
+++ b/Mlem/Models/Trackers/ModToolTracker.swift
@@ -11,6 +11,7 @@ import SwiftUI
 enum ModTool: Hashable, Identifiable {
     // community
     case editCommunity(CommunityModel) // community to edit
+    case removeCommunity(CommunityModel, Bool) // community to remove, should remove
 
     case communityBan(UserModel, CommunityModel, Bool, Bool, StandardPostTracker?)
     // user to ban, community to ban from, is banned from community, should ban
@@ -52,6 +53,10 @@ enum ModTool: Hashable, Identifiable {
             hasher.combine("removePost")
             hasher.combine(post.uid)
             hasher.combine(shouldRemove)
+        case let .removeCommunity(community, shouldRemove):
+            hasher.combine("removeCommunity")
+            hasher.combine(community.uid)
+            hasher.combine(shouldRemove)
         }
     }
 }
@@ -84,5 +89,9 @@ class ModToolTracker: ObservableObject {
     
     func removePost(_ post: PostModel, shouldRemove: Bool) {
         openTool = .removePost(post, shouldRemove)
+    }
+    
+    func removeCommunity(_ community: CommunityModel, shouldRemove: Bool) {
+        openTool = .removeCommunity(community, shouldRemove)
     }
 }

--- a/Mlem/Views/Shared/CommunityList/CommunityListRow.swift
+++ b/Mlem/Views/Shared/CommunityList/CommunityListRow.swift
@@ -31,6 +31,7 @@ struct CommunityListRow: View {
     @State private var menuFunctionPopup: MenuFunctionPopup?
     
     @EnvironmentObject var editorTracker: EditorTracker
+    @EnvironmentObject var modToolTracker: ModToolTracker
     
     init(
         _ community: CommunityModel,
@@ -67,6 +68,7 @@ struct CommunityListRow: View {
                 ForEach(
                     community.menuFunctions(
                         editorTracker: editorTracker,
+                        modToolTracker: modToolTracker,
                         trackerCallback
                     )
                 ) { item in

--- a/Mlem/Views/Shared/Composer/RemoveCommunityView.swift
+++ b/Mlem/Views/Shared/Composer/RemoveCommunityView.swift
@@ -1,0 +1,117 @@
+//
+//  RemoveCommunityView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/03/2024.
+//
+
+import Dependencies
+import Foundation
+import SwiftUI
+
+struct RemoveCommunityView: View {
+    @Dependency(\.apiClient) var apiClient
+    @Dependency(\.notifier) var notifier
+    @Dependency(\.errorHandler) var errorHandler
+    @Dependency(\.siteInformation) var siteInformation
+    
+    @Environment(\.dismiss) var dismiss
+    
+    @State var reason: String = ""
+    @FocusState var reasonFocused: FocusedField?
+    @State var isWaiting: Bool = false
+    @State var shouldPurge: Bool = false
+    
+    let community: CommunityModel
+    let shouldRemove: Bool
+    
+    var verb: String { shouldRemove ? "Remove" : "Restore" }
+    
+    var body: some View {
+        form
+            .onAppear {
+                reasonFocused = .reason
+            }
+            .toolbar {
+                ToolbarItem(placement: .keyboard) {
+                    HStack {
+                        Spacer()
+                        Button("Done") { reasonFocused = nil }
+                    }
+                }
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .tint(.red)
+                    .disabled(isWaiting)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    if isWaiting {
+                        ProgressView()
+                    } else {
+                        Button("Confirm", systemImage: Icons.send, action: confirm)
+                    }
+                }
+            }
+            .allowsHitTesting(!isWaiting)
+            .opacity(isWaiting ? 0.5 : 1)
+            .interactiveDismissDisabled(isWaiting)
+            .navigationTitle("\(verb) Community")
+            .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    var form: some View {
+        Form {
+            ReasonView(reason: $reason, focusedField: $reasonFocused, showReason: shouldRemove)
+            if shouldRemove {
+                Section {
+                    Toggle("Purge", isOn: $shouldPurge)
+                        .tint(.red)
+                } footer: {
+                    // swiftlint:disable:next line_length
+                    Text("Permanently remove this community, its posts, comments, attachments and any other related data from the database. This cannot be undone.")
+                }
+            }
+        }
+    }
+    
+    private func confirm() {
+        isWaiting = true
+        
+        Task {
+            if shouldPurge {
+                let outcome = await community.purge(reason: reason.isEmpty ? nil: reason)
+                if outcome {
+                    await notifier.add(.success("purged community"))
+                    DispatchQueue.main.async {
+                        dismiss()
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        isWaiting = false
+                    }
+                }
+            } else {
+                await community.toggleRemove(reason: reason.isEmpty ? nil : reason) { community in
+                    Task {
+                        if community.removed == shouldRemove {
+                            await notifier.add(.success("\(verb)d community"))
+                            DispatchQueue.main.async {
+                                dismiss()
+                            }
+                        } else {
+                            DispatchQueue.main.async {
+                                isWaiting = false
+                            }
+                        }
+                    }
+                } onFailure: {
+                    DispatchQueue.main.async {
+                        isWaiting = false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Mlem/Views/Shared/Moderation/ModToolSheet.swift
+++ b/Mlem/Views/Shared/Moderation/ModToolSheet.swift
@@ -34,6 +34,8 @@ struct ModToolSheet: View {
             ) // TODO: add post tracker support
         case let .removePost(post, shouldRemove):
             RemovePostView(post: post, shouldRemove: shouldRemove)
+        case let .removeCommunity(community, shouldRemove):
+            RemoveCommunityView(community: community, shouldRemove: shouldRemove)
         }
     }
 }

--- a/Mlem/Views/Shared/ToolbarEllipsisMenu.swift
+++ b/Mlem/Views/Shared/ToolbarEllipsisMenu.swift
@@ -1,0 +1,26 @@
+//
+//  ToolbarEllipsisMenu.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/03/2024.
+//
+
+import SwiftUI
+
+struct ToolbarEllipsisMenu<Content: View>: View {
+    let content: Content
+    
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+    
+    var body: some View {
+        Menu {
+            content
+        } label: {
+            Label("More", systemImage: Icons.menuCircle)
+                .frame(height: AppConstants.barIconHitbox)
+                .contentShape(Rectangle())
+        }
+    }
+}

--- a/Mlem/Views/Shared/UserList/UserListRow.swift
+++ b/Mlem/Views/Shared/UserList/UserListRow.swift
@@ -22,6 +22,8 @@ struct UserListRow: View {
     @Dependency(\.apiClient) private var apiClient
     @Dependency(\.hapticManager) var hapticManager
     
+    @EnvironmentObject var modToolTracker: ModToolTracker
+    
     let user: UserModel
     let communityContext: CommunityModel?
     let trackerCallback: (_ item: UserModel) -> Void
@@ -64,7 +66,7 @@ struct UserListRow: View {
             .destructiveConfirmation(menuFunctionPopup: $menuFunctionPopup)
             .addSwipeyActions(swipeActions ?? .init())
             .contextMenu {
-                ForEach(user.menuFunctions(trackerCallback)) { item in
+                ForEach(user.menuFunctions(trackerCallback, modToolTracker: modToolTracker)) { item in
                     MenuButton(menuFunction: item, menuFunctionPopup: $menuFunctionPopup)
                 }
             }

--- a/Mlem/Views/Tabs/Feeds/Components/PostFeedView+MenuFunctions.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/PostFeedView+MenuFunctions.swift
@@ -34,43 +34,4 @@ extension PostFeedView {
             }
         }
     }
-    
-    func genEllipsisMenuFunctions() -> [MenuFunction] {
-        var ret: [MenuFunction] = .init()
-        
-        let blurNsfwText = shouldBlurNsfw ? "Unblur NSFW" : "Blur NSFW"
-        ret.append(MenuFunction.standardMenuFunction(
-            text: blurNsfwText,
-            imageName: Icons.blurNsfw,
-            enabled: true
-        ) {
-            shouldBlurNsfw.toggle()
-        })
-        
-        let showReadPostsText = showReadPosts ? "Hide Read" : "Show Read"
-        ret.append(MenuFunction.standardMenuFunction(
-            text: showReadPostsText,
-            imageName: "book",
-            enabled: true
-        ) {
-            showReadPosts.toggle()
-        })
-        
-        return ret
-    }
-    
-    func genPostSizeSwitchingFunctions() -> [MenuFunction] {
-        PostSize.allCases.map { size in
-            let (imageName, enabled) = size != postSize
-                ? (size.iconName, true)
-                : (size.iconNameFill, false)
-            
-            return MenuFunction.standardMenuFunction(
-                text: size.label,
-                imageName: imageName,
-                enabled: enabled,
-                callback: { postSize = size }
-            )
-        }
-    }
 }

--- a/Mlem/Views/Tabs/Feeds/Components/PostFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/PostFeedView.swift
@@ -80,20 +80,7 @@ struct PostFeedView: View {
             }
             .toolbar {
                 if versionSafePostSort != nil {
-                    ToolbarItem(placement: .primaryAction) { sortMenu }
-                    
-                    ToolbarItemGroup(placement: .secondaryAction) {
-                        ForEach(genEllipsisMenuFunctions()) { menuFunction in
-                            MenuButton(menuFunction: menuFunction, menuFunctionPopup: .constant(nil))
-                        }
-                        Menu {
-                            ForEach(genPostSizeSwitchingFunctions()) { menuFunction in
-                                MenuButton(menuFunction: menuFunction, menuFunctionPopup: .constant(nil))
-                            }
-                        } label: {
-                            Label("Post Size", systemImage: Icons.postSizeSetting)
-                        }
-                    }
+                    ToolbarItem(placement: .topBarTrailing) { sortMenu }
                 }
             }
     }

--- a/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
@@ -118,6 +118,11 @@ struct AggregateFeedView: View {
                         .opacity(scrollToTopAppeared ? 0 : 1)
                         .animation(.easeOut(duration: 0.2), value: scrollToTopAppeared)
                 }
+                ToolbarItem(placement: .primaryAction) {
+                    ToolbarEllipsisMenu {
+                        FeedToolbarContent()
+                    }
+                }
             }
             .hoistNavigation {
                 if let scrollProxy {

--- a/Mlem/Views/Tabs/Feeds/Feed Types/CommunityFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/CommunityFeedView.swift
@@ -32,6 +32,7 @@ struct CommunityFeedView: View {
     
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject var editorTracker: EditorTracker
+    @EnvironmentObject var modToolTracker: ModToolTracker
     
     @StateObject var postTracker: StandardPostTracker
     
@@ -108,14 +109,19 @@ struct CommunityFeedView: View {
                         .animation(.easeOut(duration: 0.2), value: scrollToTopAppeared)
                 }
                 
-                ToolbarItemGroup(placement: .secondaryAction) {
-                    ForEach(
-                        communityModel.menuFunctions(
-                            editorTracker: editorTracker,
-                            postTracker: postTracker
-                        ) { communityModel = $0 }
-                    ) { item in
-                        MenuButton(menuFunction: item, menuFunctionPopup: $menuFunctionPopup)
+                ToolbarItemGroup(placement: .primaryAction) {
+                    ToolbarEllipsisMenu {
+                        ForEach(
+                            communityModel.menuFunctions(
+                                editorTracker: editorTracker,
+                                postTracker: postTracker,
+                                modToolTracker: modToolTracker
+                            ) { communityModel = $0 }
+                        ) { item in
+                            MenuButton(menuFunction: item, menuFunctionPopup: $menuFunctionPopup)
+                        }
+                        Divider()
+                        FeedToolbarContent()
                     }
                 }
             }

--- a/Mlem/Views/Tabs/Feeds/Feed Types/FeedToolbarContent.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/FeedToolbarContent.swift
@@ -1,0 +1,85 @@
+//
+//  FeedToolbarContent.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/03/2024.
+//
+
+import Dependencies
+import SwiftUI
+
+struct FeedToolbarContent: View {
+    @Dependency(\.siteInformation) var siteInformation
+    @AppStorage("showReadPosts") var showReadPosts: Bool = true
+    @AppStorage("shouldBlurNsfw") var shouldBlurNsfw: Bool = true
+    @AppStorage("postSize") var postSize: PostSize = .large
+    
+    var body: some View {
+        ForEach(genEllipsisMenuFunctions()) { menuFunction in
+            MenuButton(menuFunction: menuFunction, menuFunctionPopup: .constant(nil))
+        }
+        Menu {
+            ForEach(genPostSizeSwitchingFunctions()) { menuFunction in
+                MenuButton(menuFunction: menuFunction, menuFunctionPopup: .constant(nil))
+            }
+        } label: {
+            Label("Post Size", systemImage: Icons.postSizeSetting)
+        }
+    }
+    
+    func genEllipsisMenuFunctions() -> [MenuFunction] {
+        var body: some ToolbarContent {
+            ToolbarItemGroup(placement: .secondaryAction) {
+                ForEach(genEllipsisMenuFunctions()) { menuFunction in
+                    MenuButton(menuFunction: menuFunction, menuFunctionPopup: .constant(nil))
+                }
+                Menu {
+                    ForEach(genPostSizeSwitchingFunctions()) { menuFunction in
+                        MenuButton(menuFunction: menuFunction, menuFunctionPopup: .constant(nil))
+                    }
+                } label: {
+                    Label("Post Size", systemImage: Icons.postSizeSetting)
+                }
+            }
+        }
+        
+        var ret: [MenuFunction] = .init()
+        
+        if siteInformation.myUserInfo?.localUserView.localUser.showNsfw ?? true {
+            let blurNsfwText = shouldBlurNsfw ? "Unblur NSFW" : "Blur NSFW"
+            ret.append(MenuFunction.standardMenuFunction(
+                text: blurNsfwText,
+                imageName: Icons.blurNsfw,
+                enabled: true
+            ) {
+                shouldBlurNsfw.toggle()
+            })
+        }
+        
+        let showReadPostsText = showReadPosts ? "Hide Read" : "Show Read"
+        ret.append(MenuFunction.standardMenuFunction(
+            text: showReadPostsText,
+            imageName: "book",
+            enabled: true
+        ) {
+            showReadPosts.toggle()
+        })
+        
+        return ret
+    }
+    
+    func genPostSizeSwitchingFunctions() -> [MenuFunction] {
+        PostSize.allCases.map { size in
+            let (imageName, enabled) = size != postSize
+                ? (size.iconName, true)
+                : (size.iconNameFill, false)
+            
+            return MenuFunction.standardMenuFunction(
+                text: size.label,
+                imageName: imageName,
+                enabled: enabled,
+                callback: { postSize = size }
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #973. 

- You can remove a community from the `CommunityFeedView` context menu or from the `CommunityListRow` context menu.
- Added the divider between community and feed options in the `CommunityFeedView` ellipsis menu back in (we had this before 1.2, but it got removed).
- "Blur NSFW" will no longer be shown in the `CommunityFeedView` ellipsis menu if you've disabled NSFW content entirely.

<img width="385" alt="Screenshot 2024-03-16 at 19 32 41" src="https://github.com/mlemgroup/mlem/assets/78750526/dcdbb6c6-7880-4f45-8ddf-882b426170b1">

This doesn't state-fake at all (CommunityModel is still a struct, making it difficult to handle in all cases). Ideally, we would:
- State-fake community removal in both communities and in search results
- Remove the result from search results if you purge it
- Pop the `CommunityFeedView` from the navigation stack when you purge it

All of these would be much easier to do in 2.0, so I think we should leave them out for now.