### PR TITLE
Auto-Reader Mode

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0300F2C62B9C7D4B0022F7C4 /* CloseButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0300F2C52B9C7D4B0022F7C4 /* CloseButtonView.swift */; };
+		030245CA2BA70F5200D07747 /* LinksSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030245C92BA70F5200D07747 /* LinksSettingsView.swift */; };
 		0304F58A2B44AF5B00537BFA /* CollapsibleSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0304F5892B44AF5B00537BFA /* CollapsibleSection.swift */; };
 		0308E1142B0EA32A000CA955 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0308E1132B0EA32A000CA955 /* AccountSettingsView.swift */; };
 		0308E1162B0EA42B000CA955 /* APILocalUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0308E1152B0EA42B000CA955 /* APILocalUserView.swift */; };
@@ -628,6 +629,7 @@
 
 /* Begin PBXFileReference section */
 		0300F2C52B9C7D4B0022F7C4 /* CloseButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseButtonView.swift; sourceTree = "<group>"; };
+		030245C92BA70F5200D07747 /* LinksSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinksSettingsView.swift; sourceTree = "<group>"; };
 		0304F5892B44AF5B00537BFA /* CollapsibleSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleSection.swift; sourceTree = "<group>"; };
 		0308E1132B0EA32A000CA955 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
 		0308E1152B0EA42B000CA955 /* APILocalUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APILocalUserView.swift; sourceTree = "<group>"; };
@@ -1260,6 +1262,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		030245CB2BA70F5F00D07747 /* Links */ = {
+			isa = PBXGroup;
+			children = (
+				030245C92BA70F5200D07747 /* LinksSettingsView.swift */,
+			);
+			path = Links;
+			sourceTree = "<group>";
+		};
 		0308E1122B0EA31F000CA955 /* Account */ = {
 			isa = PBXGroup;
 			children = (
@@ -1871,6 +1881,7 @@
 				032C1E022B5D7D9C00FB4F23 /* AccountList */,
 				0308E1122B0EA31F000CA955 /* Account */,
 				030AC0432A62F82B00037155 /* General */,
+				030245CB2BA70F5F00D07747 /* Links */,
 				03E79F3D2AE3E6FF0006700D /* Sorting */,
 				030AC0442A62F83100037155 /* Filters */,
 				CDC1C93D2A7AB8B400072E3D /* Accessibility */,
@@ -3682,6 +3693,7 @@
 				CD876EC72B7736370075DC15 /* MarkReadBatcher+Dependency.swift in Sources */,
 				50A8812C2A72D727003E3661 /* CommunityRepository+Dependency.swift in Sources */,
 				0394398F2A98EB2300463032 /* APIComment+Mock.swift in Sources */,
+				030245CA2BA70F5200D07747 /* LinksSettingsView.swift in Sources */,
 				E453477E2A9DE37300D1B46F /* Array+SafeIndexing.swift in Sources */,
 				CD4368BE2AE23FA600BD8BD1 /* LoadingState.swift in Sources */,
 				CD9DD8852A62302A0044EA8E /* ConcreteEditorModel.swift in Sources */,

--- a/Mlem/Extensions/View Modifiers/View+HandleLemmyLinks.swift
+++ b/Mlem/Extensions/View Modifiers/View+HandleLemmyLinks.swift
@@ -92,6 +92,8 @@ struct HandleLemmyLinksDisplay: ViewModifier {
             QuickSwitcherSettingsView()
         case .general:
             GeneralSettingsView()
+        case .links:
+            LinksSettingsView()
         case .sorting:
             SortingSettingsView()
         case .contentFilters:

--- a/Mlem/Logic/URLHandler.swift
+++ b/Mlem/Logic/URLHandler.swift
@@ -48,7 +48,7 @@ extension SFSafariViewController.Configuration {
     /// The default settings used in this application
     static var `default`: Self {
         let configuration = Self()
-        configuration.entersReaderIfAvailable = false
+        configuration.entersReaderIfAvailable = UserDefaults.standard.bool(forKey: "openLinksInReaderMode")
         return configuration
     }
 }

--- a/Mlem/Navigation/Destination Values/SettingsValues.swift
+++ b/Mlem/Navigation/Destination Values/SettingsValues.swift
@@ -19,6 +19,7 @@ enum SettingsPage: DestinationValue {
     case accounts
     case quickSwitcher
     case general
+    case links
     case sorting
     case contentFilters
     case accessibility

--- a/Mlem/Views/Tabs/Settings/Components/SettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/SettingsView.swift
@@ -87,7 +87,9 @@ struct SettingsView: View {
                         NavigationLink(.settings(.general)) {
                             Label("General", systemImage: "gear").labelStyle(SquircleLabelStyle(color: .gray))
                         }
-                        
+                        NavigationLink(.settings(.links)) {
+                            Label("Links", systemImage: "link").labelStyle(SquircleLabelStyle(color: .teal))
+                        }
                         NavigationLink(.settings(.sorting)) {
                             Label("Sorting", systemImage: "arrow.up.and.down.text.horizontal")
                                 .labelStyle(SquircleLabelStyle(color: .indigo))

--- a/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/General/GeneralSettingsView.swift
@@ -16,15 +16,12 @@ struct GeneralSettingsView: View {
     @AppStorage("internetSpeed") var internetSpeed: InternetSpeed = .fast
     @AppStorage("appLock") var appLock: AppLock = .disabled
     @AppStorage("tapCommentToCollapse") var tapCommentToCollapse: Bool = true
-    @AppStorage("easyTapLinkDisplayMode") var easyTapLinkDisplayMode: EasyTapLinkDisplayMode = .contextual
     @AppStorage("markReadOnScroll") var markReadOnScroll: Bool = false
     
     @AppStorage("defaultFeed") var defaultFeed: DefaultFeedType = .subscribed
     
     @AppStorage("hapticLevel") var hapticLevel: HapticPriority = .low
     @AppStorage("upvoteOnSave") var upvoteOnSave: Bool = false
-    
-    @AppStorage("openLinksInBrowser") var openLinksInBrowser: Bool = false
 
     @EnvironmentObject var appState: AppState
 
@@ -33,11 +30,6 @@ struct GeneralSettingsView: View {
     var body: some View {
         List {
             Section {
-                SwitchableSettingsItem(
-                    settingPictureSystemName: Icons.browser,
-                    settingName: "Open Links in Browser",
-                    isTicked: $openLinksInBrowser
-                )
                 SelectableSettingsItem(
                     settingIconSystemName: Icons.haptics,
                     settingName: "Haptic Level",
@@ -53,12 +45,6 @@ struct GeneralSettingsView: View {
                     settingPictureSystemName: Icons.upvoteOnSave,
                     settingName: "Upvote on Save",
                     isTicked: $upvoteOnSave
-                )
-                SelectableSettingsItem(
-                    settingIconSystemName: Icons.websiteAddress,
-                    settingName: "Tappable Links",
-                    currentValue: $easyTapLinkDisplayMode,
-                    options: EasyTapLinkDisplayMode.allCases
                 )
                 SwitchableSettingsItem(
                     settingPictureSystemName: Icons.read,

--- a/Mlem/Views/Tabs/Settings/Components/Views/Links/LinksSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Links/LinksSettingsView.swift
@@ -1,0 +1,57 @@
+//
+//  LinksSettingsView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 17/03/2024.
+//
+
+import SwiftUI
+
+struct LinksSettingsView: View {
+    @AppStorage("openLinksInBrowser") var openLinksInBrowser: Bool = false
+    @AppStorage("openLinksInReaderMode") var openLinksInReaderMode: Bool = false
+    @AppStorage("easyTapLinkDisplayMode") var easyTapLinkDisplayMode: EasyTapLinkDisplayMode = .contextual
+    
+    var body: some View {
+        Form {
+            Section("Open External Links") {
+                Picker("Open External Links", selection: $openLinksInBrowser) {
+                    Text("In-App").tag(false)
+                    Text("In Default Browser").tag(true)
+                }
+                .pickerStyle(.inline)
+                .labelsHidden()
+            }
+            
+            Section {
+                SwitchableSettingsItem(
+                    settingPictureSystemName: "doc.plaintext",
+                    settingName: "Open in Reader Mode",
+                    isTicked: Binding(
+                        get: {
+                            !openLinksInBrowser && openLinksInReaderMode
+                        },
+                        set: { newValue in
+                            openLinksInReaderMode = newValue
+                        }
+                    )
+                )
+                .disabled(openLinksInBrowser)
+            } footer: {
+                Text("Automatically enable Reader Mode for supported webpages.")
+            }
+            Section {
+                SelectableSettingsItem(
+                    settingIconSystemName: Icons.websiteAddress,
+                    settingName: "Tappable Links",
+                    currentValue: $easyTapLinkDisplayMode,
+                    options: EasyTapLinkDisplayMode.allCases
+                )
+            }
+        }
+        .fancyTabScrollCompatible()
+        .navigationTitle("Links")
+        .navigationBarColor()
+        .hoistNavigation()
+    }
+}

--- a/Mlem/Views/Tabs/Settings/Components/Views/Links/LinksSettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/Views/Links/LinksSettingsView.swift
@@ -26,7 +26,7 @@ struct LinksSettingsView: View {
             Section {
                 SwitchableSettingsItem(
                     settingPictureSystemName: "doc.plaintext",
-                    settingName: "Open in Reader Mode",
+                    settingName: "Open in Reader",
                     isTicked: Binding(
                         get: {
                             !openLinksInBrowser && openLinksInReaderMode
@@ -38,7 +38,7 @@ struct LinksSettingsView: View {
                 )
                 .disabled(openLinksInBrowser)
             } footer: {
-                Text("Automatically enable Reader Mode for supported webpages.")
+                Text("Automatically enable Reader for supported webpages. You can only enable this when using the in-app browser.")
             }
             Section {
                 SelectableSettingsItem(


### PR DESCRIPTION
Adds an "Open in Reader" option that opens webpages in Safari's Reader Mode when available. 

I've moved all of the link-related settings from General into a new Links page. In future, we'll have even more link-related settings (see #639) so I think having a separate page for links is justified.

Closes #949

<img src="https://github.com/mlemgroup/mlem/assets/78750526/a4e82bad-4041-4c07-b796-ca9f06dd68db" width=40%>

<img src="https://github.com/mlemgroup/mlem/assets/78750526/16b3e57d-29e1-4e2f-b8cf-37f0fd24c1f3" width=40%>