### PR TITLE
Eric/inbox header

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -495,6 +495,7 @@
 		CD4BAD3D2B4C6C8E00A1E726 /* PostFeedType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD3C2B4C6C8E00A1E726 /* PostFeedType.swift */; };
 		CD4BAD432B507F2B00A1E726 /* AggregateFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD422B507F2B00A1E726 /* AggregateFeedView.swift */; };
 		CD4DBC032A6F803C001A1E61 /* ReplyToPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4DBC022A6F803C001A1E61 /* ReplyToPost.swift */; };
+		CD4DD9DA2BABABB000085D41 /* InboxRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4DD9D92BABABB000085D41 /* InboxRoot.swift */; };
 		CD50504D2B80065300632C56 /* Date+DaysFromNow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD50504C2B80065300632C56 /* Date+DaysFromNow.swift */; };
 		CD5050542B807BF800632C56 /* AddModToCommunity.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5050532B807BF800632C56 /* AddModToCommunity.swift */; };
 		CD525F652A4B6D8F00BCA794 /* CommunityLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD525F642A4B6D8F00BCA794 /* CommunityLinkView.swift */; };
@@ -1162,6 +1163,7 @@
 		CD4BAD3C2B4C6C8E00A1E726 /* PostFeedType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostFeedType.swift; sourceTree = "<group>"; };
 		CD4BAD422B507F2B00A1E726 /* AggregateFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregateFeedView.swift; sourceTree = "<group>"; };
 		CD4DBC022A6F803C001A1E61 /* ReplyToPost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplyToPost.swift; sourceTree = "<group>"; };
+		CD4DD9D92BABABB000085D41 /* InboxRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxRoot.swift; sourceTree = "<group>"; };
 		CD50504C2B80065300632C56 /* Date+DaysFromNow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+DaysFromNow.swift"; sourceTree = "<group>"; };
 		CD5050532B807BF800632C56 /* AddModToCommunity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddModToCommunity.swift; sourceTree = "<group>"; };
 		CD525F642A4B6D8F00BCA794 /* CommunityLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityLinkView.swift; sourceTree = "<group>"; };
@@ -2460,6 +2462,7 @@
 				CDE6A80E2A4908200062D161 /* Feed */,
 				6DFF50422A48DED3001E648D /* Inbox View.swift */,
 				CD4368DC2AE24E1A00BD8BD1 /* InboxView+Logic.swift */,
+				CD4DD9D92BABABB000085D41 /* InboxRoot.swift */,
 			);
 			path = Inbox;
 			sourceTree = "<group>";
@@ -3647,6 +3650,7 @@
 				6FF17D012B685C16007E1814 /* AppLockView.swift in Sources */,
 				B1955A1D2A606B950056CF99 /* Easter Rewards.swift in Sources */,
 				CD16A0642B66F81A000312D2 /* UserContentModel+TrackerItem.swift in Sources */,
+				CD4DD9DA2BABABB000085D41 /* InboxRoot.swift in Sources */,
 				CDB0117F2A6F70A000D043EB /* Editor Tracker.swift in Sources */,
 				03ED5D5F2B6560FE005C245B /* PostModel+MenuFunctions.swift in Sources */,
 				030E86482AC6FD1D000283A6 /* _assignIfNotEqual.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -492,7 +492,7 @@
 		CD46C1F82B0D0A8A00065953 /* View+ReselectAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD46C1F72B0D0A8A00065953 /* View+ReselectAction.swift */; };
 		CD4BAD352B4B2C0B00A1E726 /* FeedsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD342B4B2C0B00A1E726 /* FeedsView.swift */; };
 		CD4BAD3B2B4C6C3200A1E726 /* FeedRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD3A2B4C6C3200A1E726 /* FeedRowView.swift */; };
-		CD4BAD3D2B4C6C8E00A1E726 /* FeedType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD3C2B4C6C8E00A1E726 /* FeedType.swift */; };
+		CD4BAD3D2B4C6C8E00A1E726 /* PostFeedType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD3C2B4C6C8E00A1E726 /* PostFeedType.swift */; };
 		CD4BAD432B507F2B00A1E726 /* AggregateFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD422B507F2B00A1E726 /* AggregateFeedView.swift */; };
 		CD4DBC032A6F803C001A1E61 /* ReplyToPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4DBC022A6F803C001A1E61 /* ReplyToPost.swift */; };
 		CD50504D2B80065300632C56 /* Date+DaysFromNow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD50504C2B80065300632C56 /* Date+DaysFromNow.swift */; };
@@ -1159,7 +1159,7 @@
 		CD46C1F72B0D0A8A00065953 /* View+ReselectAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ReselectAction.swift"; sourceTree = "<group>"; };
 		CD4BAD342B4B2C0B00A1E726 /* FeedsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedsView.swift; sourceTree = "<group>"; };
 		CD4BAD3A2B4C6C3200A1E726 /* FeedRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRowView.swift; sourceTree = "<group>"; };
-		CD4BAD3C2B4C6C8E00A1E726 /* FeedType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedType.swift; sourceTree = "<group>"; };
+		CD4BAD3C2B4C6C8E00A1E726 /* PostFeedType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostFeedType.swift; sourceTree = "<group>"; };
 		CD4BAD422B507F2B00A1E726 /* AggregateFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregateFeedView.swift; sourceTree = "<group>"; };
 		CD4DBC022A6F803C001A1E61 /* ReplyToPost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplyToPost.swift; sourceTree = "<group>"; };
 		CD50504C2B80065300632C56 /* Date+DaysFromNow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+DaysFromNow.swift"; sourceTree = "<group>"; };
@@ -2412,7 +2412,7 @@
 				CD2053132ACBAF150000AA38 /* AvatarType.swift */,
 				CD4368BD2AE23FA600BD8BD1 /* LoadingState.swift */,
 				CD4368C92AE2428C00BD8BD1 /* ContentIdentifiable.swift */,
-				CD4BAD3C2B4C6C8E00A1E726 /* FeedType.swift */,
+				CD4BAD3C2B4C6C8E00A1E726 /* PostFeedType.swift */,
 				CDB652542B8EAC3E007B7797 /* APIPostFeatureType.swift */,
 			);
 			path = Enums;
@@ -3617,7 +3617,7 @@
 				ADDC9E3A2A5CEAA100383D58 /* BlockPerson.swift in Sources */,
 				CD6F29A82A77FF1700F20B6B /* MarkPostRead.swift in Sources */,
 				031A617E2B1CE90F00ABF23B /* ChangePasswordView.swift in Sources */,
-				CD4BAD3D2B4C6C8E00A1E726 /* FeedType.swift in Sources */,
+				CD4BAD3D2B4C6C8E00A1E726 /* PostFeedType.swift in Sources */,
 				6372186B2A3A2AAD008C4816 /* GetComments.swift in Sources */,
 				B1DD00BD2A62DDEC002A7B39 /* RecognizedLemmyInstances.swift in Sources */,
 				6DA61F892A575DF1001EA633 /* URL+WithIconSize.swift in Sources */,

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -65,7 +65,7 @@ struct ContentView: View {
                 // but when guest mode arrives we'll either omit these entirely, or replace them with a
                 // guest mode specific tab for sign in / change instance screen.
                 if appState.currentActiveAccount != nil {
-                    InboxView()
+                    InboxRoot()
                         .fancyTabItem(tag: TabSelection.inbox) {
                             FancyTabBarLabel(
                                 tag: TabSelection.inbox,
@@ -141,14 +141,14 @@ struct ContentView: View {
         }
         .sheet(item: $editorTracker.editResponse) { editing in
             ResponseEditorView(concreteEditorModel: editing)
-            .presentationDetents([.medium, .large], selection: .constant(.large))
-            ._presentationBackgroundInteraction(enabledUpThrough: .medium)
+                .presentationDetents([.medium, .large], selection: .constant(.large))
+                ._presentationBackgroundInteraction(enabledUpThrough: .medium)
         }
         .sheet(item: $editorTracker.selectText) { selectText in
             SelectTextView(text: selectText.text)
-            .presentationDetents([.medium])
-            ._presentationCornerRadius(20)
-            ._presentationBackgroundInteraction(enabledUpThrough: .medium)
+                .presentationDetents([.medium])
+                ._presentationCornerRadius(20)
+                ._presentationBackgroundInteraction(enabledUpThrough: .medium)
         }
         .sheet(item: $editorTracker.editPost) { editing in
             NavigationStack {

--- a/Mlem/Enums/PostFeedType.swift
+++ b/Mlem/Enums/PostFeedType.swift
@@ -5,15 +5,17 @@
 //  Created by Eric Andrews on 2024-01-08.
 //
 
+import Dependencies
 import Foundation
 import SwiftUI
 
-enum FeedType {
+// maybe a slight misnomer because .saved can include comments?
+enum PostFeedType: FeedType {
     case all, local, subscribed, moderated, saved
     case community(CommunityModel)
     
-    static var allShortcutFeedCases: [FeedType] = [.all, .local, .subscribed, .saved]
-    static var allAggregateFeedCases: [FeedType] = [.all, .local, .subscribed, .moderated, .saved]
+    static var allShortcutFeedCases: [PostFeedType] = [.all, .local, .subscribed, .saved]
+    static var allAggregateFeedCases: [PostFeedType] = [.all, .local, .subscribed, .moderated, .saved]
     
     var label: String {
         switch self {
@@ -23,6 +25,25 @@ enum FeedType {
         case .moderated: "Moderated"
         case .saved: "Saved"
         case let .community(communityModel): communityModel.name
+        }
+    }
+    
+    var subtitle: String {
+        @Dependency(\.siteInformation) var siteInformation
+        switch self {
+        case .all:
+            return "Posts from all federated instances"
+        case .local:
+            return "Posts from \(siteInformation.instance?.url.host() ?? "your instance's") communities"
+        case .subscribed:
+            return "Posts from all subscribed communities"
+        case .moderated:
+            return "Posts from communities you moderate"
+        case .saved:
+            return "Your saved posts and comments"
+        default:
+            assertionFailure("We shouldn't be here...")
+            return ""
         }
     }
     
@@ -50,7 +71,7 @@ enum FeedType {
         }
     }
     
-    static func fromShortcutString(shortcut: String?) -> FeedType? {
+    static func fromShortcutString(shortcut: String?) -> PostFeedType? {
         switch shortcut {
         case "All":
             return .all
@@ -75,7 +96,7 @@ enum FeedType {
     }
 }
 
-extension FeedType: Hashable, Identifiable {
+extension PostFeedType: Hashable, Identifiable {
     func hash(into hasher: inout Hasher) {
         switch self {
         case .all:
@@ -97,7 +118,7 @@ extension FeedType: Hashable, Identifiable {
     var id: Int { hashValue }
 }
 
-extension FeedType: AssociatedIcon {
+extension PostFeedType: AssociatedIcon {
     var iconName: String {
         switch self {
         case .all: Icons.federatedFeed
@@ -150,7 +171,7 @@ extension FeedType: AssociatedIcon {
     }
 }
 
-extension FeedType: AssociatedColor {
+extension PostFeedType: AssociatedColor {
     var color: Color? {
         switch self {
         case .all: .blue

--- a/Mlem/Enums/Settings/DefaultFeedType.swift
+++ b/Mlem/Enums/Settings/DefaultFeedType.swift
@@ -21,7 +21,7 @@ enum DefaultFeedType: String, SettingsOptions, CaseIterable {
         }
     }
     
-    var toFeedType: FeedType {
+    var toFeedType: PostFeedType {
         switch self {
         case .all: .all
         case .local: .local

--- a/Mlem/Extensions/EnvironmentValues/EnvironmentValues+FeedType.swift
+++ b/Mlem/Extensions/EnvironmentValues/EnvironmentValues+FeedType.swift
@@ -9,11 +9,11 @@ import Foundation
 import SwiftUI
 
 private struct FeedTypeEnvironmentKey: EnvironmentKey {
-    static let defaultValue: FeedType? = nil
+    static let defaultValue: PostFeedType? = nil
 }
 
 extension EnvironmentValues {
-    var feedType: FeedType? {
+    var feedType: PostFeedType? {
         get { self[FeedTypeEnvironmentKey.self] }
         set { self[FeedTypeEnvironmentKey.self] = newValue }
     }

--- a/Mlem/MlemApp.swift
+++ b/Mlem/MlemApp.swift
@@ -73,7 +73,7 @@ struct MlemApp: App {
     private func setupAppShortcuts() {
         guard accountsTracker.savedAccounts.first != nil else { return }
         
-        UIApplication.shared.shortcutItems = FeedType.allShortcutFeedCases.map { feedType in
+        UIApplication.shared.shortcutItems = PostFeedType.allShortcutFeedCases.map { feedType in
             let icon = UIApplicationShortcutIcon(systemImageName: feedType.iconName)
             return UIApplicationShortcutItem(
                 type: feedType.toShortcutString,

--- a/Mlem/Models/Trackers/Feeds/StandardPostTracker.swift
+++ b/Mlem/Models/Trackers/Feeds/StandardPostTracker.swift
@@ -50,7 +50,7 @@ class StandardPostTracker: StandardTracker<PostModel> {
     // TODO: ERIC keyword filters could be more elegant
     var filteredKeywords: [String]
     
-    var feedType: FeedType
+    var feedType: PostFeedType
     private(set) var postSortType: PostSortType
     private var filters: [PostFilter: Int]
     
@@ -64,7 +64,7 @@ class StandardPostTracker: StandardTracker<PostModel> {
         maxConcurrentRequestCount: 40
     )
     
-    init(internetSpeed: InternetSpeed, sortType: PostSortType, showReadPosts: Bool, feedType: FeedType) {
+    init(internetSpeed: InternetSpeed, sortType: PostSortType, showReadPosts: Bool, feedType: PostFeedType) {
         @Dependency(\.persistenceRepository) var persistenceRepository
         
         assert(feedType != .saved, "Cannot create StandardPostTracker for saved feed!")
@@ -136,7 +136,7 @@ class StandardPostTracker: StandardTracker<PostModel> {
     }
     
     @MainActor
-    func changeFeedType(to newFeedType: FeedType) async {
+    func changeFeedType(to newFeedType: PostFeedType) async {
         // don't do anything if feed type not changed
         guard feedType != newFeedType else {
             return

--- a/Mlem/Models/Trackers/SiteInformationTracker.swift
+++ b/Mlem/Models/Trackers/SiteInformationTracker.swift
@@ -46,7 +46,7 @@ class SiteInformationTracker: ObservableObject {
         myUser?.isAdmin ?? false
     }
     
-    var feeds: [FeedType] {
+    var feeds: [PostFeedType] {
         if moderatorFeedAvailable {
             [.all, .local, .subscribed, .moderated, .saved]
         } else {

--- a/Mlem/Views/Shared/Instance/InstanceView.swift
+++ b/Mlem/Views/Shared/Instance/InstanceView.swift
@@ -83,16 +83,15 @@ struct InstanceView: View {
         ScrollView {
             ScrollToView(appeared: $scrollToTopAppeared)
                 .id(scrollToTop)
-            VStack(spacing: AppConstants.postAndCommentSpacing) {
+            VStack(spacing: AppConstants.standardSpacing) {
                 headerView
+                    .padding(.bottom, AppConstants.halfSpacing)
+                
                 VStack(spacing: 0) {
-                    VStack(spacing: 4) {
-                        Divider()
-                        BubblePicker(availableTabs, selected: $selectedTab) { tab in
-                            Text(tab.label)
-                        }
-                        Divider()
+                    BubblePicker(availableTabs, selected: $selectedTab, withDividers: [.top, .bottom]) { tab in
+                        Text(tab.label)
                     }
+                    
                     if let errorDetails, [.about, .administration, .details].contains(selectedTab) {
                         ErrorView(errorDetails)
                     } else {
@@ -170,7 +169,6 @@ struct InstanceView: View {
                             .frame(height: 100)
                     }
                 }
-                .padding(.top, 5)
             }
         }
         .toolbar {

--- a/Mlem/Views/Tabs/Feeds/Components/FeedHeaderView.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/FeedHeaderView.swift
@@ -55,7 +55,7 @@ struct FeedHeaderView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             .padding(.vertical, 5)
-            .padding(.bottom, 3)
+            .padding(.bottom, 5)
             
             Divider()
         }

--- a/Mlem/Views/Tabs/Feeds/Components/FeedHeaderView.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/FeedHeaderView.swift
@@ -20,11 +20,11 @@ struct FeedHeaderView: View {
     @EnvironmentObject var appState: AppState
     
     let feedType: any FeedType
-    let suppressDropdownIndicator: Bool
+    let showDropdownIndicator: Bool
     
-    init(feedType: any FeedType, suppressDropdownIndicator: Bool = false) {
+    init(feedType: any FeedType, showDropdownIndicator: Bool = true) {
         self.feedType = feedType
-        self.suppressDropdownIndicator = suppressDropdownIndicator
+        self.showDropdownIndicator = showDropdownIndicator
     }
     
     var body: some View {
@@ -40,7 +40,7 @@ struct FeedHeaderView: View {
                             .minimumScaleFactor(0.01)
                             .fontWeight(.semibold)
                         
-                        if !suppressDropdownIndicator {
+                        if showDropdownIndicator {
                             Image(systemName: Icons.dropdown)
                                 .foregroundStyle(.secondary)
                         }

--- a/Mlem/Views/Tabs/Feeds/Components/FeedHeaderView.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/FeedHeaderView.swift
@@ -8,27 +8,23 @@
 import Foundation
 import SwiftUI
 
+protocol FeedType {
+    var label: String { get }
+    var subtitle: String { get }
+    var color: Color? { get }
+    var iconNameFill: String { get }
+    var iconScaleFactor: CGFloat { get }
+}
+
 struct FeedHeaderView: View {
     @EnvironmentObject var appState: AppState
     
-    let feedType: FeedType
+    let feedType: any FeedType
+    let suppressDropdownIndicator: Bool
     
-    var subtitle: String {
-        switch feedType {
-        case .all:
-            return "Posts from all federated instances"
-        case .local:
-            return "Posts from \(appState.currentActiveAccount?.instanceLink.host() ?? "your instance's") communities"
-        case .subscribed:
-            return "Posts from all subscribed communities"
-        case .moderated:
-            return "Posts from communities you moderate"
-        case .saved:
-            return "Your saved posts and comments"
-        default:
-            assertionFailure("We shouldn't be here...")
-            return ""
-        }
+    init(feedType: any FeedType, suppressDropdownIndicator: Bool = false) {
+        self.feedType = feedType
+        self.suppressDropdownIndicator = suppressDropdownIndicator
     }
     
     var body: some View {
@@ -43,12 +39,15 @@ struct FeedHeaderView: View {
                             .lineLimit(1)
                             .minimumScaleFactor(0.01)
                             .fontWeight(.semibold)
-                        Image(systemName: Icons.dropdown)
-                            .foregroundStyle(.secondary)
+                        
+                        if !suppressDropdownIndicator {
+                            Image(systemName: Icons.dropdown)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                     .font(.title2)
                         
-                    Text(subtitle)
+                    Text(feedType.subtitle)
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }

--- a/Mlem/Views/Tabs/Feeds/Components/FeedRowView.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/FeedRowView.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftUI
 
 struct FeedRowView: View {
-    let feedType: FeedType
+    let feedType: PostFeedType
     
     var body: some View {
         HStack {
@@ -21,7 +21,7 @@ struct FeedRowView: View {
 }
 
 struct FeedIconView: View {
-    let feedType: FeedType
+    let feedType: any FeedType
     let size: CGFloat
     
     var body: some View {
@@ -34,7 +34,6 @@ struct FeedIconView: View {
                     .foregroundStyle(.white)
                     .frame(width: size * feedType.iconScaleFactor, height: size * feedType.iconScaleFactor)
             }
-        
     }
 }
 

--- a/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
@@ -26,7 +26,7 @@ struct AggregateFeedView: View {
     
     @State var postSortType: PostSortType
     
-    @Binding var selectedFeed: FeedType?
+    @Binding var selectedFeed: PostFeedType?
     
     @Namespace var scrollToTop
     @State private var scrollToTopAppeared = false
@@ -34,8 +34,8 @@ struct AggregateFeedView: View {
         postTracker.items.first?.id
     }
     
-    init(selectedFeed: Binding<FeedType?>) {
-        var feedType: FeedType = .all
+    init(selectedFeed: Binding<PostFeedType?>) {
+        var feedType: PostFeedType = .all
         if let selectedFeed = selectedFeed.wrappedValue {
             feedType = selectedFeed
         } else {
@@ -62,8 +62,8 @@ struct AggregateFeedView: View {
         self._selectedFeed = selectedFeed
     }
     
-    var availableFeeds: [FeedType] {
-        var availableFeeds: [FeedType] = [.all, .local, .subscribed]
+    var availableFeeds: [PostFeedType] {
+        var availableFeeds: [PostFeedType] = [.all, .local, .subscribed]
         if siteInformation.moderatorFeedAvailable {
             availableFeeds.append(.moderated)
         }
@@ -174,7 +174,7 @@ struct AggregateFeedView: View {
                 MenuButton(menuFunction: menuFunction, menuFunctionPopup: .constant(nil))
             }
         } label: {
-            if let selectedFeed, FeedType.allAggregateFeedCases.contains(selectedFeed) {
+            if let selectedFeed, PostFeedType.allAggregateFeedCases.contains(selectedFeed) {
                 FeedHeaderView(feedType: selectedFeed)
             } else {
                 EmptyView() // shouldn't be possible

--- a/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/AggregateFeedView.swift
@@ -150,7 +150,6 @@ struct AggregateFeedView: View {
                     ScrollToView(appeared: $scrollToTopAppeared)
                         .id(scrollToTop)
                     headerView
-                        .padding(.top, -1)
                 }
                 
                 switch selectedFeed {

--- a/Mlem/Views/Tabs/Feeds/Feed Types/CommunityFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Feed Types/CommunityFeedView.swift
@@ -190,8 +190,8 @@ struct CommunityFeedView: View {
     @ViewBuilder
     var headerView: some View {
         Group {
-            VStack(spacing: 5) {
-                HStack(alignment: .center, spacing: 10) {
+            VStack(spacing: AppConstants.standardSpacing) {
+                HStack(alignment: .center, spacing: AppConstants.standardSpacing) {
                     if shouldShowCommunityIcons {
                         AvatarView(community: communityModel, avatarSize: 44, iconResolution: .unrestricted)
                     }
@@ -217,13 +217,11 @@ struct CommunityFeedView: View {
                     subscribeButton
                 }
                 .padding(.horizontal, AppConstants.standardSpacing)
-                .padding(.bottom, 3)
-                Divider()
-                BubblePicker(availableTabs, selected: $selectedTab) {
+                
+                BubblePicker(availableTabs, selected: $selectedTab, withDividers: [.top, .bottom]) {
                     Text($0.rawValue.capitalized)
                 }
             }
-            Divider()
         }
     }
     

--- a/Mlem/Views/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/Views/Tabs/Feeds/FeedsView.swift
@@ -18,7 +18,7 @@ struct FeedsView: View {
     
     @EnvironmentObject var appState: AppState
     
-    @State private var selectedFeed: FeedType?
+    @State private var selectedFeed: PostFeedType?
     @State var appeared: Bool = false // tracks whether this is the view's first appearance
     
     @StateObject private var communityListModel: CommunityListModel = .init()
@@ -42,7 +42,7 @@ struct FeedsView: View {
                 }
             }
             .onChange(of: scenePhase) { newPhase in
-                if newPhase == .active, let shortcutItem = FeedType.fromShortcutString(shortcut: shortcutItemToProcess?.type) {
+                if newPhase == .active, let shortcutItem = PostFeedType.fromShortcutString(shortcut: shortcutItemToProcess?.type) {
                     selectedFeed = shortcutItem
                 }
             }
@@ -66,7 +66,7 @@ struct FeedsView: View {
                         ForEach(communityListModel.visibleSections) { section in
                             Section(header: communitySectionHeaderView(for: section)) {
                                 ForEach(communityListModel.communities(for: section)) { community in
-                                    NavigationLink(value: FeedType.community(.init(from: community, subscribed: true))) {
+                                    NavigationLink(value: PostFeedType.community(.init(from: community, subscribed: true))) {
                                         CommunityFeedRowView(
                                             community: community,
                                             subscribed: communityListModel.isSubscribed(to: community),

--- a/Mlem/Views/Tabs/Inbox/Feed/AllItemsFeedView.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/AllItemsFeedView.swift
@@ -18,10 +18,7 @@ struct AllItemsFeedView: View {
             } else if inboxTracker.items.isEmpty {
                 noItemsView()
             } else {
-                LazyVStack(spacing: 0) {
-                    EmptyView().id("top")
-                    inboxListView()
-                }
+                inboxListView()
             }
         }
     }

--- a/Mlem/Views/Tabs/Inbox/Feed/Mentions Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Mentions Feed View.swift
@@ -15,10 +15,7 @@ struct MentionsFeedView: View {
         if mentionTracker.loadingState == .done, mentionTracker.items.isEmpty {
             noMentionsView()
         } else {
-            LazyVStack(spacing: 0) {
-                EmptyView().id("top")
-                mentionsListView()
-            }
+            mentionsListView()
         }
     }
     

--- a/Mlem/Views/Tabs/Inbox/Feed/Messages Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Messages Feed View.swift
@@ -15,10 +15,7 @@ struct MessagesFeedView: View {
         if messageTracker.loadingState == .done, messageTracker.items.isEmpty {
             noMessagesView()
         } else {
-            LazyVStack(spacing: 0) {
-                EmptyView().id("top")
-                messagesListView()
-            }
+            messagesListView()
         }
     }
     

--- a/Mlem/Views/Tabs/Inbox/Feed/Replies Feed View.swift
+++ b/Mlem/Views/Tabs/Inbox/Feed/Replies Feed View.swift
@@ -15,10 +15,7 @@ struct RepliesFeedView: View {
         if replyTracker.loadingState == .done, replyTracker.items.isEmpty {
             noRepliesView()
         } else {
-            LazyVStack(spacing: 0) {
-                EmptyView().id("top")
-                repliesListView()
-            }
+            repliesListView()
         }
     }
     

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -9,6 +9,40 @@ import Dependencies
 import Foundation
 import SwiftUI
 
+enum InboxFeed: FeedType {
+    case inbox
+    
+    var label: String {
+        switch self {
+        case .inbox: "Inbox"
+        }
+    }
+        
+    var subtitle: String {
+        switch self {
+        case .inbox: "Replies, mentions, and messages"
+        }
+    }
+    
+    var color: Color? {
+        switch self {
+        case .inbox: .purple
+        }
+    }
+    
+    var iconNameFill: String {
+        switch self {
+        case .inbox: Icons.inboxFill
+        }
+    }
+    
+    var iconScaleFactor: CGFloat {
+        switch self {
+        case .inbox: 0.55
+        }
+    }
+}
+
 enum InboxTab: String, CaseIterable, Identifiable {
     case all, replies, mentions, messages
     
@@ -80,8 +114,9 @@ struct InboxView: View {
         self._messageTracker = StateObject(wrappedValue: newMessageTracker)
     }
     
-    // input state handling
-    // - current view
+    let headerHeight: CGFloat = 40.0
+    @State var pickerOffset: CGFloat = 40.0
+    
     @State var curTab: InboxTab = .all
     
     // utility
@@ -92,7 +127,7 @@ struct InboxView: View {
         ScrollViewReader { scrollProxy in
             // NOTE: there appears to be a SwiftUI issue with segmented pickers stacked on top of ScrollViews which causes the tab bar to appear fully transparent. The internet suggests that this may be a bug that only manifests in dev mode, so, unless this pops up in a build, don't worry about it. If it does manifest, we can either put the Picker *in* the ScrollView (bad because then you can't access it without scrolling to the top) or put a Divider() at the bottom of the VStack (bad because then the material tab bar doesn't show)
             NavigationStack(path: $inboxTabNavigation.path) {
-                contentView(scrollProxy: scrollProxy)
+                content(scrollProxy: scrollProxy)
                     .navigationTitle("Inbox")
                     .navigationBarTitleDisplayMode(.inline)
                     .navigationBarColor()
@@ -101,6 +136,12 @@ struct InboxView: View {
                     }
                     .listStyle(PlainListStyle())
                     .tabBarNavigationEnabled(.inbox, navigation)
+                    .hoistNavigation {
+                        withAnimation {
+                            scrollProxy.scrollTo(scrollToTop)
+                        }
+                        return true
+                    }
                     .handleLemmyViews()
                     .environmentObject(inboxTabNavigation)
                     .environmentObject(inboxTracker)
@@ -117,21 +158,45 @@ struct InboxView: View {
         }
     }
     
-    @ViewBuilder private func contentView(scrollProxy: ScrollViewProxy) -> some View {
-        VStack(spacing: AppConstants.postAndCommentSpacing) {
-            Picker(selection: $curTab, label: Text("Inbox tab")) {
-                ForEach(InboxTab.allCases) { tab in
-                    Text(tab.label).tag(tab.rawValue)
-                }
+    @ViewBuilder
+    private func content(scrollProxy: ScrollViewProxy) -> some View {
+        ScrollView {
+            feed
+        }
+        .fancyTabScrollCompatible()
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                navBarTitle
+                    .opacity(scrollToTopAppeared ? 0 : 1)
+                    .animation(.easeOut(duration: 0.2), value: scrollToTopAppeared)
             }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, AppConstants.postAndCommentSpacing)
-            .padding(.top, AppConstants.postAndCommentSpacing)
-            
-            ScrollView {
+        }
+        .refreshable {
+            // wrapping in task so view redraws don't cancel
+            // awaiting the value makes the refreshable indicator properly wait for the call to finish
+            await Task {
+                await refresh()
+            }.value
+        }
+        .task {
+            // wrapping in task so view redraws don't cancel
+            Task(priority: .userInitiated) {
+                await refresh()
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var feed: some View {
+        LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+            Section {
                 ScrollToView(appeared: $scrollToTopAppeared)
                     .id(scrollToTop)
-                
+            } header: {
+                FeedHeaderView(feedType: InboxFeed.inbox, suppressDropdownIndicator: true)
+            }
+            
+            Section {
                 if errorOccurred {
                     errorView()
                 } else {
@@ -146,26 +211,17 @@ struct InboxView: View {
                         MessagesFeedView(messageTracker: messageTracker)
                     }
                 }
-            }
-            .fancyTabScrollCompatible()
-            .refreshable {
-                // wrapping in task so view redraws don't cancel
-                // awaiting the value makes the refreshable indicator properly wait for the call to finish
-                await Task {
-                    await refresh()
-                }.value
-            }
-            .hoistNavigation {
-                withAnimation {
-                    scrollProxy.scrollTo(scrollToTop)
+            } header: {
+                VStack(spacing: 0) {
+                    BubblePicker(InboxTab.allCases, selected: $curTab) { tab in
+                        Text(tab.label)
+                    }
+                    .background(Color.systemBackground.opacity(scrollToTopAppeared ? 1 : 0))
+                    .background(.regularMaterial)
+                    .animation(.easeOut(duration: 0.2), value: scrollToTopAppeared)
+                    
+                    Divider()
                 }
-                return true
-            }
-        }
-        .task {
-            // wrapping in task so view redraws don't cancel
-            Task(priority: .userInitiated) {
-                await refresh()
             }
         }
     }
@@ -195,5 +251,12 @@ struct InboxView: View {
                 .frame(height: AppConstants.barIconHitbox)
                 .contentShape(Rectangle())
         }
+    }
+    
+    @ViewBuilder
+    var navBarTitle: some View {
+        // this is a bit silly as its own view right now but it will be a menu once mod mail is implemented
+        Text(curTab.label)
+            .font(.headline)
     }
 }

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -172,12 +172,10 @@ struct InboxView: View {
     @ViewBuilder
     var feed: some View {
         LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-            Section {
-                ScrollToView(appeared: $scrollToTopAppeared)
-                    .id(scrollToTop)
-            } header: {
-                FeedHeaderView(feedType: InboxFeed.inbox, suppressDropdownIndicator: true)
-            }
+            ScrollToView(appeared: $scrollToTopAppeared)
+                .id(scrollToTop)
+            
+            FeedHeaderView(feedType: InboxFeed.inbox, suppressDropdownIndicator: true)
             
             Section {
                 if errorOccurred {

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -197,7 +197,7 @@ struct InboxView: View {
                 }
             } header: {
                 VStack(spacing: 0) {
-                    BubblePicker(InboxTab.allCases, selected: $curTab) { tab in
+                    BubblePicker(InboxTab.allCases, selected: $curTab, withDividers: [.bottom]) { tab in
                         Text(tab.label)
                     }
                     .background(Color.systemBackground.opacity(scrollToTopAppeared ? 1 : 0))

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -159,6 +159,9 @@ struct InboxView: View {
         ScrollView {
             feed
         }
+        .onChange(of: curTab) { _ in
+            scrollProxy?.scrollTo(scrollToTop)
+        }
         .fancyTabScrollCompatible()
         .refreshable {
             // wrapping in task so view redraws don't cancel

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -201,7 +201,7 @@ struct InboxView: View {
                         Text(tab.label)
                     }
                     .background(Color.systemBackground.opacity(scrollToTopAppeared ? 1 : 0))
-                    .background(.thickMaterial)
+                    .background(.bar)
                     .animation(.easeOut(duration: 0.2), value: scrollToTopAppeared)
                     
                     Divider()

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -196,14 +196,12 @@ struct InboxView: View {
                     }
                 }
             } header: {
-                VStack(spacing: 0) {
-                    BubblePicker(InboxTab.allCases, selected: $curTab, withDividers: [.bottom]) { tab in
-                        Text(tab.label)
-                    }
-                    .background(Color.systemBackground.opacity(scrollToTopAppeared ? 1 : 0))
-                    .background(.bar)
-                    .animation(.easeOut(duration: 0.2), value: scrollToTopAppeared)
+                BubblePicker(InboxTab.allCases, selected: $curTab, withDividers: [.bottom]) { tab in
+                    Text(tab.label)
                 }
+                .background(Color.systemBackground.opacity(scrollToTopAppeared ? 1 : 0))
+                .background(.bar)
+                .animation(.easeOut(duration: 0.2), value: scrollToTopAppeared)
             }
         }
     }

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -203,8 +203,6 @@ struct InboxView: View {
                     .background(Color.systemBackground.opacity(scrollToTopAppeared ? 1 : 0))
                     .background(.bar)
                     .animation(.easeOut(duration: 0.2), value: scrollToTopAppeared)
-                    
-                    Divider()
                 }
             }
         }

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -200,7 +200,7 @@ struct InboxView: View {
                         Text(tab.label)
                     }
                     .background(Color.systemBackground.opacity(scrollToTopAppeared ? 1 : 0))
-                    .background(.regularMaterial)
+                    .background(.thickMaterial)
                     .animation(.easeOut(duration: 0.2), value: scrollToTopAppeared)
                     
                     Divider()
@@ -239,7 +239,7 @@ struct InboxView: View {
     @ViewBuilder
     var navBarTitle: some View {
         // this is a bit silly as its own view right now but it will be a menu once mod mail is implemented
-        Text(curTab.label)
+        Text(InboxFeed.inbox.label)
             .font(.headline)
     }
 }

--- a/Mlem/Views/Tabs/Inbox/Inbox View.swift
+++ b/Mlem/Views/Tabs/Inbox/Inbox View.swift
@@ -178,7 +178,7 @@ struct InboxView: View {
             ScrollToView(appeared: $scrollToTopAppeared)
                 .id(scrollToTop)
             
-            FeedHeaderView(feedType: InboxFeed.inbox, suppressDropdownIndicator: true)
+            FeedHeaderView(feedType: InboxFeed.inbox, showDropdownIndicator: false)
             
             Section {
                 if errorOccurred {

--- a/Mlem/Views/Tabs/Inbox/InboxRoot.swift
+++ b/Mlem/Views/Tabs/Inbox/InboxRoot.swift
@@ -1,0 +1,28 @@
+//
+//  InboxRoot.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-20.
+//
+
+import Foundation
+import SwiftUI
+
+struct InboxRoot: View {
+    @StateObject private var inboxRouter: AnyNavigationPath<AppRoute> = .init()
+    @StateObject private var navigation: Navigation = .init()
+    
+    var body: some View {
+        ScrollViewReader { scrollProxy in
+            NavigationStack(path: $inboxRouter.path) {
+                InboxView()
+                    .environmentObject(inboxRouter)
+                    .tabBarNavigationEnabled(.search, navigation)
+            }
+            .environment(\.navigationPathWithRoutes, $inboxRouter.path)
+            .environment(\.navigation, navigation)
+            .environment(\.scrollViewProxy, scrollProxy)
+            .handleLemmyLinkResolution(navigationPath: .constant(inboxRouter))
+        }
+    }
+}

--- a/Mlem/Views/Tabs/Inbox/InboxRoot.swift
+++ b/Mlem/Views/Tabs/Inbox/InboxRoot.swift
@@ -17,7 +17,7 @@ struct InboxRoot: View {
             NavigationStack(path: $inboxRouter.path) {
                 InboxView()
                     .environmentObject(inboxRouter)
-                    .tabBarNavigationEnabled(.search, navigation)
+                    .tabBarNavigationEnabled(.inbox, navigation)
             }
             .environment(\.navigationPathWithRoutes, $inboxRouter.path)
             .environment(\.navigation, navigation)

--- a/Mlem/Views/Tabs/Profile/UserView.swift
+++ b/Mlem/Views/Tabs/Profile/UserView.swift
@@ -119,16 +119,14 @@ struct UserView: View {
             ScrollToView(appeared: $scrollToTopAppeared)
                 .id(scrollToTop)
             
-            VStack(spacing: AppConstants.postAndCommentSpacing) {
+            VStack(spacing: AppConstants.standardSpacing) {
                 header
                 
                 flairs
                 
-                VStack(spacing: 0) {
+                Group {
                     bio
-                    
-                    Divider()
-                        .padding(.top, AppConstants.postAndCommentSpacing * 2)
+                        .padding(.bottom, AppConstants.halfSpacing)
                     
                     userContent
                 }
@@ -225,7 +223,7 @@ struct UserView: View {
             .transition(.opacity)
         } else {
             VStack(spacing: 0) {
-                BubblePicker(tabs, selected: $selectedTab) { tab in
+                BubblePicker(tabs, selected: $selectedTab, withDividers: [.top, .bottom]) { tab in
                     switch tab {
                     case .posts:
                         Text("Posts (\(abbreviateNumber(user.postCount ?? 0)))")
@@ -237,8 +235,7 @@ struct UserView: View {
                         Text(tab.label)
                     }
                 }
-                .padding(.vertical, 4)
-                Divider()
+                
                 UserFeedView(
                     user: user,
                     privatePostTracker: privatePostTracker,

--- a/Mlem/Views/Tabs/Search/BubblePicker.swift
+++ b/Mlem/Views/Tabs/Search/BubblePicker.swift
@@ -5,66 +5,87 @@
 //  Created by Sjmarf on 18/09/2023.
 //
 
-import SwiftUI
 import Dependencies
+import SwiftUI
+
+enum DividerPlacement {
+    case top, bottom
+}
 
 struct BubblePicker<Value: Identifiable & Equatable & Hashable>: View {
     @Dependency(\.hapticManager) var hapticManager
     
     @Binding var selected: Value
     let tabs: [Value]
+    let dividers: [DividerPlacement]
     @ViewBuilder let labelBuilder: (Value) -> any View
     
     init(
         _ tabs: [Value],
         selected: Binding<Value>,
+        withDividers: [DividerPlacement] = .init(),
         @ViewBuilder labelBuilder: @escaping (Value) -> any View
     ) {
         self._selected = selected
         self.tabs = tabs
+        self.dividers = withDividers
         self.labelBuilder = labelBuilder
     }
     
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.horizontal) {
-                // Use negative spacing as well as padding the HStack's children so that scrollTo leaves extra space around each tab
-                HStack(spacing: -2*AppConstants.postAndCommentSpacing) {
-                    ForEach(Array(zip(tabs.indices, tabs)), id: \.0) { index, tab in
-                        Button {
-                            selected = tab
-                            hapticManager.play(haptic: .gentleInfo, priority: .low)
-                            withAnimation {
-                                proxy.scrollTo(index)
-                            }
-                        } label: {
-                            AnyView(labelBuilder(tab))
-                                .padding(.vertical, 6)
-                                .padding(.horizontal, 12)
-                                .foregroundStyle(selected == tab ? .white : .primary)
-                                .font(.subheadline)
-                                .fontWeight(.semibold)
-                                .background(
-                                    Group {
-                                        if selected == tab {
-                                            Capsule()
-                                                .fill(.blue)
-                                                .transition(.scale.combined(with: .opacity))
-                                        }
-                                    }
-                                )
-                                .animation(.spring(response: 0.15, dampingFraction: 0.7), value: selected)
-                                .padding(.vertical, 4)
-                                .contentShape(Rectangle())
+        VStack(spacing: 0) {
+            if dividers.contains(.top) {
+                Divider()
+            }
+            
+            ScrollViewReader { scrollProxy in
+                ScrollView(.horizontal) {
+                    // Use negative spacing as well as padding the HStack's children so that scrollTo leaves extra space around each tab
+                    HStack(spacing: -AppConstants.doubleSpacing) {
+                        ForEach(Array(zip(tabs.indices, tabs)), id: \.0) { index, tab in
+                            bubbleButton(index: index, tab: tab, scrollProxy: scrollProxy)
                         }
-                        .buttonStyle(EmptyButtonStyle())
-                        .padding(.horizontal, AppConstants.postAndCommentSpacing)
-                        .id(index)
                     }
                 }
+                .scrollIndicators(.hidden)
             }
-            .scrollIndicators(.hidden)
+            
+            if dividers.contains(.bottom) {
+                Divider()
+            }
         }
+    }
+    
+    @ViewBuilder
+    func bubbleButton(index: Int, tab: Value, scrollProxy: ScrollViewProxy) -> some View {
+        Button {
+            selected = tab
+            hapticManager.play(haptic: .gentleInfo, priority: .low)
+            withAnimation {
+                scrollProxy.scrollTo(index)
+            }
+        } label: {
+            AnyView(labelBuilder(tab))
+                .padding(.vertical, 6)
+                .padding(.horizontal, 12)
+                .foregroundStyle(selected == tab ? .white : .primary)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .background(
+                    Group {
+                        if selected == tab {
+                            Capsule()
+                                .fill(.blue)
+                                .transition(.scale.combined(with: .opacity))
+                        }
+                    }
+                )
+                .padding(AppConstants.standardSpacing)
+                .animation(.spring(response: 0.15, dampingFraction: 0.7), value: selected)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(EmptyButtonStyle())
+        .id(index)
     }
 }
 

--- a/Mlem/Views/Tabs/Search/BubblePicker.swift
+++ b/Mlem/Views/Tabs/Search/BubblePicker.swift
@@ -17,13 +17,13 @@ struct BubblePicker<Value: Identifiable & Equatable & Hashable>: View {
     
     @Binding var selected: Value
     let tabs: [Value]
-    let dividers: [DividerPlacement]
+    let dividers: Set<DividerPlacement>
     @ViewBuilder let labelBuilder: (Value) -> any View
     
     init(
         _ tabs: [Value],
         selected: Binding<Value>,
-        withDividers: [DividerPlacement] = .init(),
+        withDividers: Set<DividerPlacement> = .init(),
         @ViewBuilder labelBuilder: @escaping (Value) -> any View
     ) {
         self._selected = selected

--- a/Mlem/Views/Tabs/Search/SearchHomeView.swift
+++ b/Mlem/Views/Tabs/Search/SearchHomeView.swift
@@ -23,7 +23,6 @@ struct SearchHomeView: View {
             BubblePicker(SearchTab.homePageCases, selected: $searchModel.searchTab) {
                 Text($0.label)
             }
-            .padding(.bottom, 10)
             Divider()
             SearchResultListView(showTypeLabel: false)
         }
@@ -46,7 +45,6 @@ struct SearchHomeView: View {
 }
 
 struct SearchHomeViewPreview: View {
-    
     @StateObject var homeSearchModel: SearchModel = .init()
     @StateObject var homeContentTracker: ContentTracker<AnyContentModel> = .init()
     

--- a/Mlem/Views/Tabs/Search/SearchHomeView.swift
+++ b/Mlem/Views/Tabs/Search/SearchHomeView.swift
@@ -20,10 +20,12 @@ struct SearchHomeView: View {
                 .fontWeight(.semibold)
                 .padding(.horizontal, 18)
                 .padding(.top, 12)
-            BubblePicker(SearchTab.homePageCases, selected: $searchModel.searchTab) {
+                .padding(.bottom, -AppConstants.halfSpacing)
+            
+            BubblePicker(SearchTab.homePageCases, selected: $searchModel.searchTab, withDividers: [.bottom]) {
                 Text($0.label)
             }
-            Divider()
+            
             SearchResultListView(showTypeLabel: false)
         }
         .frame(maxWidth: .infinity)

--- a/Mlem/Views/Tabs/Search/SearchResultsView.swift
+++ b/Mlem/Views/Tabs/Search/SearchResultsView.swift
@@ -19,7 +19,7 @@ struct SearchResultsView: View {
             BubblePicker(SearchTab.allCases, selected: $searchModel.searchTab) {
                 Text($0.label)
             }
-            .padding(.top, -AppConstants.halfSpacing)
+            .padding(.top, -2.5)
             .padding(.bottom, AppConstants.halfSpacing)
             Divider()
             SearchResultListView(showTypeLabel: searchModel.searchTab == .topResults)

--- a/Mlem/Views/Tabs/Search/SearchResultsView.swift
+++ b/Mlem/Views/Tabs/Search/SearchResultsView.swift
@@ -16,9 +16,12 @@ struct SearchResultsView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            tabs
+            BubblePicker(SearchTab.allCases, selected: $searchModel.searchTab) {
+                Text($0.label)
+            }
+            .padding(.top, 5)
+            .padding(.bottom, 10)
             Divider()
-                .padding(.top, 8)
             SearchResultListView(showTypeLabel: searchModel.searchTab == .topResults)
         }
         .onReceive(
@@ -35,15 +38,6 @@ struct SearchResultsView: View {
             searchModel.tabSwitchRefresh(contentTracker: contentTracker)
         }
         .environmentObject(contentTracker)
-    }
-    
-    @ViewBuilder
-    private var tabs: some View {
-        HStack {
-            BubblePicker(SearchTab.allCases, selected: $searchModel.searchTab) {
-                Text($0.label)
-            }
-        }
     }
 }
 

--- a/Mlem/Views/Tabs/Search/SearchResultsView.swift
+++ b/Mlem/Views/Tabs/Search/SearchResultsView.swift
@@ -19,8 +19,8 @@ struct SearchResultsView: View {
             BubblePicker(SearchTab.allCases, selected: $searchModel.searchTab) {
                 Text($0.label)
             }
-            .padding(.top, 5)
-            .padding(.bottom, 10)
+            .padding(.top, -AppConstants.halfSpacing)
+            .padding(.bottom, AppConstants.halfSpacing)
             Divider()
             SearchResultListView(showTypeLabel: searchModel.searchTab == .topResults)
         }


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - progress towards #934 

# Pull Request Information

## About this Pull Request
In preparation for moderator inbox, replaces the old inbox header with a feed header matching the Feeds tab and updates its selector to use bubble pickers that stay pinned to the top of the view when scrolling. Also performs some long-overdue refactoring on the inbox view structure.

To use `FeedHeaderView`, `FeedType` is now a protocol to which `PostFeedType` and `InboxFeedType` both conform.

Note that there are some slightly funky things like the one-case `InboxFeedType` enum that only make sense given the context that moderator inbox will be added shortly.

https://github.com/mlemgroup/mlem/assets/44140166/15d0aaf6-3c62-4c93-a652-9ce8b9462823