### PR TITLE
Flush Mark Read Batcher on View Disappear

### DIFF
--- a/Mlem/Views/Tabs/Feeds/Components/PostFeedView.swift
+++ b/Mlem/Views/Tabs/Feeds/Components/PostFeedView.swift
@@ -83,6 +83,11 @@ struct PostFeedView: View {
                     ToolbarItem(placement: .topBarTrailing) { sortMenu }
                 }
             }
+            .onDisappear {
+                Task {
+                    await markReadBatcher.flush()
+                }
+            }
     }
     
     var content: some View {


### PR DESCRIPTION
Steps to repro the issue this fixes:

- Scroll to "read" some posts in a feed
- Go back to the feeds page
- Re-enter the feed
- Posts that were previously "read" appear unread