### PR TITLE
Eric/moderation color

### DIFF
--- a/Mlem/Enums/PostFeedType.swift
+++ b/Mlem/Enums/PostFeedType.swift
@@ -177,7 +177,7 @@ extension PostFeedType: AssociatedColor {
         case .all: .blue
         case .local: .purple
         case .subscribed: .red
-        case .moderated: .green
+        case .moderated: .moderation
         case .saved: .green
         case .community: .blue
         }

--- a/Mlem/Models/Content/Modlog/ModlogEntry.swift
+++ b/Mlem/Models/Content/Modlog/ModlogEntry.swift
@@ -249,7 +249,7 @@ struct ModlogEntry: Hashable, Equatable {
         
         self.icon = apiType.modAddCommunity.removed ?
             .init(imageName: Icons.unmodFill, color: .red) :
-            .init(imageName: Icons.moderationFill, color: .green)
+            .init(imageName: Icons.moderationFill, color: .moderation)
         
         self.contextLinks = [
             ModlogMenuFunction.moderator(apiType.moderator),
@@ -268,7 +268,7 @@ struct ModlogEntry: Hashable, Equatable {
         self.expires = .inapplicable
         self.additionalContext = nil
         
-        self.icon = .init(imageName: Icons.leftRight, color: .green)
+        self.icon = .init(imageName: Icons.leftRight, color: .moderation)
         
         self.contextLinks = [
             ModlogMenuFunction.moderator(apiType.moderator),

--- a/Mlem/Models/Content/Modlog/ModlogEntry.swift
+++ b/Mlem/Models/Content/Modlog/ModlogEntry.swift
@@ -115,7 +115,7 @@ struct ModlogEntry: Hashable, Equatable {
         
         self.icon = .init(
             imageName: apiType.modFeaturePost.featured ? Icons.pinned : Icons.unpinned,
-            color: apiType.modFeaturePost.isFeaturedCommunity ? .green : .red
+            color: apiType.modFeaturePost.isFeaturedCommunity ? .moderation : .red
         )
         
         self.contextLinks = [

--- a/Mlem/Models/UserFlair.swift
+++ b/Mlem/Models/UserFlair.swift
@@ -21,7 +21,7 @@ enum UserFlair {
         case .admin:
             return .teal
         case .moderator:
-            return .green
+            return .moderation
         case .op:
             return .orange
         case .bot:

--- a/Mlem/Views/Shared/Posts/Components/Stickied Tag.swift
+++ b/Mlem/Views/Shared/Posts/Components/Stickied Tag.swift
@@ -36,7 +36,7 @@ struct StickiedTag: View {
         case .local:
             return .red
         case .community:
-            return .green
+            return .moderation
         }
     }
 }

--- a/Mlem/Views/Tabs/Settings/Components/SettingsView.swift
+++ b/Mlem/Views/Tabs/Settings/Components/SettingsView.swift
@@ -89,7 +89,7 @@ struct SettingsView: View {
                         }
                         if siteInformation.isAdmin || !siteInformation.moderatedCommunities.isEmpty {
                             NavigationLink(.settings(.moderation)) {
-                                Label("Moderation", systemImage: Icons.moderationFill).labelStyle(SquircleLabelStyle(color: .green))
+                                Label("Moderation", systemImage: Icons.moderationFill).labelStyle(SquircleLabelStyle(color: .moderation))
                             }
                         }
                         NavigationLink(.settings(.links)) {


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - Slack

# Pull Request Information

This PR standardizes moderation color following #1001. It changes the color from `.green` to `Colors.moderation` for:
- Moderation feed header
- Community pin icon
- Moderator flair
- Moderation settings

It leaves moderation *actions* that are positive/negative (e.g., remove/restore) as red/green.