### PR TITLE
Fix interaction bar being reset to default when upgrading to 1.3

### DIFF
--- a/Mlem/Models/Settings/LayoutWidgets/LayoutWidget.swift
+++ b/Mlem/Models/Settings/LayoutWidgets/LayoutWidget.swift
@@ -88,6 +88,10 @@ indirect enum LayoutWidgetType: String, Hashable, Codable, CaseIterable {
     var canRemove: Bool {
         self != .infoStack
     }
+    
+    static let defaultPostWidgets: [Self] = [.scoreCounter, .infoStack, .save, .reply]
+    static let defaultCommentWidgets: [Self] = [.scoreCounter, .infoStack, .save, .reply]
+    static let defaultModeratorWidgets: [Self] = [.resolve, .remove, .infoStack, .ban, .purge]
 }
 
 class LayoutWidget: Equatable, Hashable {

--- a/Mlem/Models/Trackers/LayoutWidgetTracker.swift
+++ b/Mlem/Models/Trackers/LayoutWidgetTracker.swift
@@ -12,13 +12,20 @@ struct LayoutWidgetGroups: Codable {
     var post: [LayoutWidgetType]
     var comment: [LayoutWidgetType]
     var moderator: [LayoutWidgetType]
+    
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        post = (try? values.decode([LayoutWidgetType].self, forKey: .post)) ?? LayoutWidgetType.defaultPostWidgets
+        comment = (try? values.decode([LayoutWidgetType].self, forKey: .comment)) ?? LayoutWidgetType.defaultCommentWidgets
+        moderator = (try? values.decode([LayoutWidgetType].self, forKey: .moderator)) ?? LayoutWidgetType.defaultModeratorWidgets
+    }
 }
 
 extension LayoutWidgetGroups {
     init() {
-        self.post = [.scoreCounter, .infoStack, .save, .reply]
-        self.comment = [.scoreCounter, .infoStack, .save, .reply]
-        self.moderator = [.resolve, .remove, .infoStack, .ban, .purge]
+        self.post = LayoutWidgetType.defaultPostWidgets
+        self.comment = LayoutWidgetType.defaultCommentWidgets
+        self.moderator = LayoutWidgetType.defaultModeratorWidgets
     }
 }
 

--- a/Mlem/Models/Trackers/LayoutWidgetTracker.swift
+++ b/Mlem/Models/Trackers/LayoutWidgetTracker.swift
@@ -8,11 +8,13 @@
 import Dependencies
 import Foundation
 
-struct LayoutWidgetGroups: Codable {
+struct LayoutWidgetGroups {
     var post: [LayoutWidgetType]
     var comment: [LayoutWidgetType]
     var moderator: [LayoutWidgetType]
-    
+}
+
+extension LayoutWidgetGroups: Codable {
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         post = (try? values.decode([LayoutWidgetType].self, forKey: .post)) ?? LayoutWidgetType.defaultPostWidgets

--- a/Mlem/Views/Tabs/Inbox/InboxView+Logic.swift
+++ b/Mlem/Views/Tabs/Inbox/InboxView+Logic.swift
@@ -47,10 +47,9 @@ extension InboxView {
             let (imageName, enabled) = type != selectedInbox
                 ? (type.iconName, true)
                 : (type.iconNameFill, false)
-            let label = switch type {
-            case .personal: type.enrichedLabel(unread: unreadTracker.personal)
-            case .mod: type.enrichedLabel(unread: unreadTracker.modAndAdmin)
-            }
+            let label = type.enrichedLabel(
+                unread: type == .personal ? unreadTracker.personal : unreadTracker.modAndAdmin
+            )
             ret.append(MenuFunction.standardMenuFunction(
                 text: label,
                 imageName: imageName,


### PR DESCRIPTION
Also rewrote the piece of code that was causing the lint issue... I upgraded to Swiftlint 0.53.0 and it still complains about that part of the code; I'll look into it some more later