### PR TITLE
Prevent unread count from dropping below 0

### DIFF
--- a/Mlem/Models/Content/Inbox/ReplyModel.swift
+++ b/Mlem/Models/Content/Inbox/ReplyModel.swift
@@ -180,7 +180,9 @@ extension ReplyModel {
             await reinit(from: updatedReply)
             if !original.commentReply.read {
                 _ = try await inboxRepository.markReplyRead(id: commentReply.id, isRead: true)
-                await unreadTracker.replies.read()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    unreadTracker.replies.read()
+                }
             }
         } catch {
             hapticManager.play(haptic: .failure, priority: .high)

--- a/Mlem/Models/Trackers/Inbox/UnreadTracker.swift
+++ b/Mlem/Models/Trackers/Inbox/UnreadTracker.swift
@@ -19,16 +19,18 @@ struct UnreadCount {
         self.count = 0
     }
     
-    // @MainActor
     mutating func reset() { count = 0 }
     
-    // @MainActor
-    mutating func read() { count -= 1 }
+    mutating func read() {
+        if count > 0 {
+            count -= 1
+        } else {
+            assertionFailure("read() called but count was <= 0!")
+        }
+    }
     
-    // @MainActor
     mutating func unread() { count += 1 }
     
-    // @MainActor
     mutating func toggleRead(originalState: Bool) {
         if originalState {
             unread()


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [ ] This PR addresses one or more open issues that were assigned to me:

# Pull Request Information

This PR fixes the inbox count dropping below 0.

It also fixes the `.read()` call triggered by voting on a reply not executing on a delay and also using a background thread.