### PR TITLE
Block Instances

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		030E86482AC6FD1D000283A6 /* _assignIfNotEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E86472AC6FD1D000283A6 /* _assignIfNotEqual.swift */; };
 		030E864C2AC7037F000283A6 /* SearchBarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E864B2AC7037F000283A6 /* SearchBarExtensions.swift */; };
 		030FF6862BCB218000F6BFAC /* Int+Abbreviated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030FF6852BCB218000F6BFAC /* Int+Abbreviated.swift */; };
+		030FF6882BCEE58900F6BFAC /* BlockInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030FF6872BCEE58900F6BFAC /* BlockInstance.swift */; };
 		0317D46F2B558CB500EEE72C /* BadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0317D46E2B558CB500EEE72C /* BadgeView.swift */; };
 		0317D4712B55AE0700EEE72C /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0317D4702B55AE0700EEE72C /* Color+Hex.swift */; };
 		031A617C2B1BDFD100ABF23B /* AdvancedAccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031A617B2B1BDFD100ABF23B /* AdvancedAccountSettingsView.swift */; };
@@ -759,6 +760,7 @@
 		030E86472AC6FD1D000283A6 /* _assignIfNotEqual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _assignIfNotEqual.swift; sourceTree = "<group>"; };
 		030E864B2AC7037F000283A6 /* SearchBarExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarExtensions.swift; sourceTree = "<group>"; };
 		030FF6852BCB218000F6BFAC /* Int+Abbreviated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Abbreviated.swift"; sourceTree = "<group>"; };
+		030FF6872BCEE58900F6BFAC /* BlockInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockInstance.swift; sourceTree = "<group>"; };
 		0317D46E2B558CB500EEE72C /* BadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeView.swift; sourceTree = "<group>"; };
 		0317D4702B55AE0700EEE72C /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
 		031A617B2B1BDFD100ABF23B /* AdvancedAccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedAccountSettingsView.swift; sourceTree = "<group>"; };
@@ -2446,6 +2448,7 @@
 				CD2697E42B9E14FB0002B459 /* GetModlogRequest.swift */,
 				6372183B2A3A2AAD008C4816 /* GetSite.swift */,
 				031A617F2B1CEA7300ABF23B /* ChangePassword.swift */,
+				030FF6872BCEE58900F6BFAC /* BlockInstance.swift */,
 				03A18CBC2B1005A400BA69D2 /* SaveUserSettings.swift */,
 			);
 			path = Site;
@@ -4363,6 +4366,7 @@
 				CD04D5E72A3636FB008EF95B /* Headline Post.swift in Sources */,
 				50A8812E2A72D76C003E3661 /* APIClient+Comment.swift in Sources */,
 				CDD0B8CF2BBA0D31003E7174 /* ResolveCommentReportRequest.swift in Sources */,
+				030FF6882BCEE58900F6BFAC /* BlockInstance.swift in Sources */,
 				6363D5C527EE196700E34822 /* MlemApp.swift in Sources */,
 				CDF1EF162A6C3BC2003594B6 /* End Of Feed View.swift in Sources */,
 				CDD0B8D32BBB4158003E7174 /* InboxView+Feeds.swift in Sources */,

--- a/Mlem/API/APIClient/APIClient+Instance.swift
+++ b/Mlem/API/APIClient/APIClient+Instance.swift
@@ -79,4 +79,14 @@ extension APIClient {
         
         return ret.sorted(by: { $0.date > $1.date })
     }
+    
+    func blockSite(id: Int, shouldBlock: Bool) async throws -> BlockInstanceResponse {
+        let request = try BlockInstanceRequest(
+            session: session,
+            instanceId: id,
+            block: shouldBlock
+        )
+        
+        return try await perform(request: request)
+    }
 }

--- a/Mlem/API/Requests/Site/BlockInstance.swift
+++ b/Mlem/API/Requests/Site/BlockInstance.swift
@@ -1,0 +1,41 @@
+//
+//  BlockInstance.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/04/2024.
+//
+
+import Foundation
+
+struct BlockInstanceRequest: APIPostRequest {
+    typealias Response = BlockInstanceResponse
+
+    let instanceURL: URL
+    let path = "site/block"
+    let body: Body
+
+    // lemmy_api_common::community::BlockCommunity
+    struct Body: Encodable {
+        let instance_id: Int
+        let block: Bool
+
+        let auth: String
+    }
+
+    init(
+        session: APISession,
+        instanceId: Int,
+        block: Bool
+    ) throws {
+        self.instanceURL = try session.instanceUrl
+        self.body = try .init(
+            instance_id: instanceId,
+            block: block,
+            auth: session.token
+        )
+    }
+}
+
+struct BlockInstanceResponse: Decodable {
+    let blocked: Bool
+}

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -67,4 +67,5 @@ enum AppConstants {
 
     static let blockUserPrompt: String = "Really block this user?"
     static let blockCommunityPrompt: String = "Really block this community?"
+    static let blockInstancePrompt: String = "Really block this instance?"
 }

--- a/Mlem/Models/Content/Community/CommunityModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Community/CommunityModel+MenuFunctions.swift
@@ -118,9 +118,9 @@ extension CommunityModel {
         }
         do {
             if let instanceHost = communityUrl.host() {
-                let instance: InstanceModel
+                var instance: InstanceModel
                 if let site {
-                    instance = .init(from: site)
+                    instance = .init(from: site, isLocal: true)
                 } else {
                     instance = try .init(domainName: instanceHost)
                 }

--- a/Mlem/Models/Content/Instance/InstanceModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Instance/InstanceModel+MenuFunctions.swift
@@ -31,12 +31,15 @@ extension InstanceModel {
     
     func menuFunctions(_ callback: @escaping (_ item: Self) -> Void = { _ in }) -> [MenuFunction] {
         if let url {
-            return [
+            var functions: [MenuFunction] = [
                 .shareMenuFunction(url: url),
                 .openUrlMenuFunction(text: "View on Web", imageName: Icons.browser, destination: url),
-                .divider,
-                blockMenuFunction(callback)
+                .divider
             ]
+            if localSiteId != nil {
+                functions.append(blockMenuFunction(callback))
+            }
+            return functions
         }
         return []
     }

--- a/Mlem/Models/Content/Instance/InstanceModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/Instance/InstanceModel+MenuFunctions.swift
@@ -8,9 +8,35 @@
 import Foundation
 
 extension InstanceModel {
-    func menuFunctions() -> [MenuFunction] {
+    
+    func blockMenuFunction(_ callback: @escaping (_ item: Self) -> Void = { _ in }) -> MenuFunction {
+        if blocked {
+            return .standardMenuFunction(
+                text: "Unblock",
+                imageName: Icons.show,
+                enabled: localSiteId != nil
+            ) {
+                Task { await toggleBlock(callback) }
+            }
+        }
+        return .standardMenuFunction(
+            text: "Block",
+            imageName: Icons.hide,
+            confirmationPrompt: AppConstants.blockInstancePrompt,
+            enabled: localSiteId != nil
+        ) {
+            Task { await toggleBlock(callback) }
+        }
+    }
+    
+    func menuFunctions(_ callback: @escaping (_ item: Self) -> Void = { _ in }) -> [MenuFunction] {
         if let url {
-            return [.shareMenuFunction(url: url)]
+            return [
+                .shareMenuFunction(url: url),
+                .openUrlMenuFunction(text: "View on Web", imageName: Icons.browser, destination: url),
+                .divider,
+                blockMenuFunction(callback)
+            ]
         }
         return []
     }

--- a/Mlem/Models/Content/Instance/InstanceModel.swift
+++ b/Mlem/Models/Content/Instance/InstanceModel.swift
@@ -80,7 +80,7 @@ struct InstanceModel {
     init(from site: APISite, isLocal: Bool = false) {
         update(with: site)
         if isLocal {
-            self.localSiteId = site.id
+            self.localSiteId = site.instanceId
         }
     }
     

--- a/Mlem/Models/Content/User/UserModel+MenuFunctions.swift
+++ b/Mlem/Models/Content/User/UserModel+MenuFunctions.swift
@@ -57,7 +57,7 @@ extension UserModel {
             if let instanceHost = profileUrl.host() {
                 let instance: InstanceModel
                 if let site {
-                    instance = .init(from: site)
+                    instance = .init(from: site, isLocal: true)
                 } else {
                     instance = try .init(domainName: instanceHost)
                 }

--- a/Mlem/Views/Shared/Instance/InstanceView.swift
+++ b/Mlem/Views/Shared/Instance/InstanceView.swift
@@ -48,6 +48,8 @@ struct InstanceView: View {
     @Namespace var scrollToTop
     @State private var scrollToTopAppeared = false
     
+    @State private var menuFunctionPopup: MenuFunctionPopup?
+    
     @State var selectedTab: InstanceViewTab = .about
     
     var uptimeRefreshTimer = Timer.publish(every: 30, tolerance: 0.5, on: .main, in: .common)
@@ -176,11 +178,16 @@ struct InstanceView: View {
         }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Link(destination: instance.url) {
-                    Label("Open in Browser", systemImage: Icons.browser)
+                ToolbarEllipsisMenu {
+                    ForEach(instance.menuFunctions { new in
+                        self.instance = new
+                    }) { item in
+                        MenuButton(menuFunction: item, menuFunctionPopup: $menuFunctionPopup)
+                    }
                 }
             }
         }
+        .destructiveConfirmation(menuFunctionPopup: $menuFunctionPopup)
         .onAppear(perform: attemptToLoadInstanceData)
         .fancyTabScrollCompatible()
         .hoistNavigation {


### PR DESCRIPTION
Added a "Block" action to the ellipsis menu in `InstanceView`. Due to an API limitation, the "block" action is only available when you visit the `InstanceView` from a community page or user page (on 0.19.4 and above), and not from search. I've [submitted an issue on the Lemmy repo](https://github.com/LemmyNet/lemmy/issues/4636) to hopefully resolve this limitation in future.

This PR doesn't add the block lists where you'll be able to unblock users/communities/instances - I'll do that in a follow-up PR

Closes #672