### PR TITLE
Fixed app slowdown with many communities

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -170,7 +170,6 @@
 		504ECBAE2AB45B2A006C0B96 /* LemmyURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504ECBAD2AB45B2A006C0B96 /* LemmyURL.swift */; };
 		504ECBB12AB4B101006C0B96 /* LemmyURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504ECBB02AB4B101006C0B96 /* LemmyURLTests.swift */; };
 		505240E32A86916500EA4558 /* FavoriteCommunitiesTracker+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505240E22A86916500EA4558 /* FavoriteCommunitiesTracker+Dependency.swift */; };
-		505240E52A86E32700EA4558 /* CommunityListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505240E42A86E32700EA4558 /* CommunityListModel.swift */; };
 		505240E72A88D36D00EA4558 /* SectionIndexTitles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505240E62A88D36D00EA4558 /* SectionIndexTitles.swift */; };
 		5064D03D2A6DE0AA00B22EE3 /* Notifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5064D03C2A6DE0AA00B22EE3 /* Notifier.swift */; };
 		5064D03F2A6DE0DB00B22EE3 /* Notifier+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5064D03E2A6DE0DB00B22EE3 /* Notifier+Dependency.swift */; };
@@ -578,6 +577,7 @@
 		CDB652592B8EC024007B7797 /* LockPostRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB652582B8EC024007B7797 /* LockPostRequest.swift */; };
 		CDBA5FC62BC9C58300469C05 /* GetUnreadRegistrationApplicationCountRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBA5FC52BC9C58300469C05 /* GetUnreadRegistrationApplicationCountRequest.swift */; };
 		CDBA5FC82BCC477F00469C05 /* WarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBA5FC72BCC477F00469C05 /* WarningView.swift */; };
+		CDBA5FCA2BD17F3D00469C05 /* CommunityListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBA5FC92BD17F3D00469C05 /* CommunityListModel.swift */; };
 		CDBCBA202B537A4B0070F60D /* PostFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBCBA1F2B537A4B0070F60D /* PostFeedView.swift */; };
 		CDBCBA242B54A5F40070F60D /* NoPostsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBCBA232B54A5F40070F60D /* NoPostsView.swift */; };
 		CDC1C93C2A7AA76000072E3D /* InternetSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC1C93B2A7AA76000072E3D /* InternetSpeed.swift */; };
@@ -895,7 +895,6 @@
 		504ECBAD2AB45B2A006C0B96 /* LemmyURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LemmyURL.swift; sourceTree = "<group>"; };
 		504ECBB02AB4B101006C0B96 /* LemmyURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LemmyURLTests.swift; sourceTree = "<group>"; };
 		505240E22A86916500EA4558 /* FavoriteCommunitiesTracker+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FavoriteCommunitiesTracker+Dependency.swift"; sourceTree = "<group>"; };
-		505240E42A86E32700EA4558 /* CommunityListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityListModel.swift; sourceTree = "<group>"; };
 		505240E62A88D36D00EA4558 /* SectionIndexTitles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIndexTitles.swift; sourceTree = "<group>"; };
 		5064D03C2A6DE0AA00B22EE3 /* Notifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifier.swift; sourceTree = "<group>"; };
 		5064D03E2A6DE0DB00B22EE3 /* Notifier+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notifier+Dependency.swift"; sourceTree = "<group>"; };
@@ -1301,6 +1300,7 @@
 		CDB652582B8EC024007B7797 /* LockPostRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockPostRequest.swift; sourceTree = "<group>"; };
 		CDBA5FC52BC9C58300469C05 /* GetUnreadRegistrationApplicationCountRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUnreadRegistrationApplicationCountRequest.swift; sourceTree = "<group>"; };
 		CDBA5FC72BCC477F00469C05 /* WarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningView.swift; sourceTree = "<group>"; };
+		CDBA5FC92BD17F3D00469C05 /* CommunityListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityListModel.swift; sourceTree = "<group>"; };
 		CDBCBA1F2B537A4B0070F60D /* PostFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostFeedView.swift; sourceTree = "<group>"; };
 		CDBCBA232B54A5F40070F60D /* NoPostsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoPostsView.swift; sourceTree = "<group>"; };
 		CDC1C93B2A7AA76000072E3D /* InternetSpeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetSpeed.swift; sourceTree = "<group>"; };
@@ -3117,7 +3117,7 @@
 			isa = PBXGroup;
 			children = (
 				6D8F08FE2A4029AE003EB4FD /* CommunityListSection.swift */,
-				505240E42A86E32700EA4558 /* CommunityListModel.swift */,
+				CDBA5FC92BD17F3D00469C05 /* CommunityListModel.swift */,
 			);
 			path = "Community List";
 			sourceTree = "<group>";
@@ -3925,7 +3925,6 @@
 				CDB652532B8EABFC007B7797 /* FeaturePostRequest.swift in Sources */,
 				0304F58A2B44AF5B00537BFA /* CollapsibleSection.swift in Sources */,
 				CDDCF6432A66343D003DA3AC /* FancyTabBar.swift in Sources */,
-				505240E52A86E32700EA4558 /* CommunityListModel.swift in Sources */,
 				CD05E77F2A4F263B0081D102 /* Menu Function.swift in Sources */,
 				036ED3BC2ABF1058009664BC /* SearchModel.swift in Sources */,
 				CDDB08782A5DF1330075BFEE /* CommentSettingsView.swift in Sources */,
@@ -4265,6 +4264,7 @@
 				0308E1162B0EA42B000CA955 /* APILocalUserView.swift in Sources */,
 				030E863F2AC6C5E9000283A6 /* PictrsImageModel.swift in Sources */,
 				632E8EE627EE63D3007E8D75 /* UpvoteButtonView.swift in Sources */,
+				CDBA5FCA2BD17F3D00469C05 /* CommunityListModel.swift in Sources */,
 				CDD0B9022BC084A9003E7174 /* DenyApplicationView.swift in Sources */,
 				B1A26FE32A45B11800B91A32 /* View+HandleLemmyLinks.swift in Sources */,
 				03B643572A6864CD00F65700 /* TabBarSettingsView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -4583,6 +4583,7 @@
 				INFOPLIST_FILE = Mlem/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Mlem;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
+				INFOPLIST_KEY_NSFaceIDUsageDescription = "$(PRODUCT_NAME) requires Face ID permissions for app locking feature.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -4625,6 +4626,7 @@
 				INFOPLIST_FILE = Mlem/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Mlem;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
+				INFOPLIST_KEY_NSFaceIDUsageDescription = "$(PRODUCT_NAME) requires Face ID permissions for app locking feature.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 		CD4368D92AE2478300BD8BD1 /* MentionModel+InboxItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4368D82AE2478300BD8BD1 /* MentionModel+InboxItem.swift */; };
 		CD4368DB2AE247B700BD8BD1 /* MentionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4368DA2AE247B700BD8BD1 /* MentionTracker.swift */; };
 		CD4368DD2AE24E1A00BD8BD1 /* InboxView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4368DC2AE24E1A00BD8BD1 /* InboxView+Logic.swift */; };
+		CD436F292BD325CB001711B9 /* String+StrippingDiacritics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD436F282BD325CB001711B9 /* String+StrippingDiacritics.swift */; };
 		CD45BCEE2A75CA7200A2899C /* Thumbnail Image View.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD45BCED2A75CA7200A2899C /* Thumbnail Image View.swift */; };
 		CD46C1F62B0D0A5700065953 /* EnvironmentValues+TabReselectionHashValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD46C1F52B0D0A5700065953 /* EnvironmentValues+TabReselectionHashValue.swift */; };
 		CD46C1F82B0D0A8A00065953 /* View+ReselectAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD46C1F72B0D0A8A00065953 /* View+ReselectAction.swift */; };
@@ -1217,6 +1218,7 @@
 		CD4368D82AE2478300BD8BD1 /* MentionModel+InboxItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MentionModel+InboxItem.swift"; sourceTree = "<group>"; };
 		CD4368DA2AE247B700BD8BD1 /* MentionTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MentionTracker.swift; sourceTree = "<group>"; };
 		CD4368DC2AE24E1A00BD8BD1 /* InboxView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InboxView+Logic.swift"; sourceTree = "<group>"; };
+		CD436F282BD325CB001711B9 /* String+StrippingDiacritics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+StrippingDiacritics.swift"; sourceTree = "<group>"; };
 		CD45BCED2A75CA7200A2899C /* Thumbnail Image View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Thumbnail Image View.swift"; sourceTree = "<group>"; };
 		CD46C1F52B0D0A5700065953 /* EnvironmentValues+TabReselectionHashValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+TabReselectionHashValue.swift"; sourceTree = "<group>"; };
 		CD46C1F72B0D0A8A00065953 /* View+ReselectAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ReselectAction.swift"; sourceTree = "<group>"; };
@@ -3355,6 +3357,7 @@
 				CDD55D212B2674BD002020C7 /* String+ParseLinks.swift */,
 				CD29ED382B2E860C006937CE /* String+Trimmed.swift */,
 				CD29ED3C2B2E863C006937CE /* String+WithEscapedCharacters.swift */,
+				CD436F282BD325CB001711B9 /* String+StrippingDiacritics.swift */,
 			);
 			path = String;
 			sourceTree = "<group>";
@@ -4175,6 +4178,7 @@
 				CD309C462A93FBD300988F95 /* Logo View.swift in Sources */,
 				CD9A49D72B059303001E18A0 /* ImageSaver.swift in Sources */,
 				03E90FB12B3703ED00E5A802 /* AccountSortMode.swift in Sources */,
+				CD436F292BD325CB001711B9 /* String+StrippingDiacritics.swift in Sources */,
 				CDC1C93C2A7AA76000072E3D /* InternetSpeed.swift in Sources */,
 				50EC39B22A346DDC00E014C2 /* URLHandler.swift in Sources */,
 				03AFBEAD2B6EAAF000F01F3C /* APILocalSiteRateLimit+Mock.swift in Sources */,

--- a/Mlem/API/Requests/Community/ListCommunities.swift
+++ b/Mlem/API/Requests/Community/ListCommunities.swift
@@ -24,7 +24,7 @@ struct ListCommunitiesRequest: APIGetRequest {
     ) throws {
         self.instanceURL = try session.instanceUrl
         var queryItems: [URLQueryItem] = [
-            .init(name: "sort", value: sort),
+            .init(name: "sort", value: sort ?? "Old"), // provide explicit sort if not provided to ensure consistent pagination
             .init(name: "limit", value: limit?.description),
             .init(name: "page", value: page?.description),
             .init(name: "type_", value: type)

--- a/Mlem/Extensions/String/String+Alphabet.swift
+++ b/Mlem/Extensions/String/String+Alphabet.swift
@@ -11,4 +11,9 @@ extension [String] {
     static var alphabet: Self {
         ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
     }
+    
+    static var labelAlphabet: Self {
+        ["#", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+         "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
+    }
 }

--- a/Mlem/Extensions/String/String+Alphabet.swift
+++ b/Mlem/Extensions/String/String+Alphabet.swift
@@ -11,9 +11,4 @@ extension [String] {
     static var alphabet: Self {
         ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
     }
-    
-    static var labelAlphabet: Self {
-        ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N",
-         "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "#"]
-    }
 }

--- a/Mlem/Extensions/String/String+Alphabet.swift
+++ b/Mlem/Extensions/String/String+Alphabet.swift
@@ -11,4 +11,9 @@ extension [String] {
     static var alphabet: Self {
         ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
     }
+    
+    static var labelAlphabet: Self {
+        ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N",
+         "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "#"]
+    }
 }

--- a/Mlem/Extensions/String/String+StrippingDiacritics.swift
+++ b/Mlem/Extensions/String/String+StrippingDiacritics.swift
@@ -1,0 +1,14 @@
+//
+//  String+StrippingDiacritics.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-04-19.
+//
+
+import Foundation
+
+extension StringProtocol {
+    var strippingDiacritics: String {
+        applyingTransform(.stripDiacritics, reverse: false)!
+    }
+}

--- a/Mlem/Info.plist
+++ b/Mlem/Info.plist
@@ -19,10 +19,6 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<key>NSFaceIDUsageDescription</key>
-	<string>$(PRODUCT_NAME) requires Face ID permissions for app locking feature.</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string></string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
@@ -168,6 +168,7 @@ class CommunityListModel: ObservableObject {
         }
         
         let alphabeticSections = alphabeticSections()
+        
         newAllSections.append(contentsOf: alphabeticSections)
         newVisibleSections.append(contentsOf: alphabeticSections.filter { section in
             !section.communities.isEmpty
@@ -177,46 +178,28 @@ class CommunityListModel: ObservableObject {
     }
     
     private func alphabeticSections() -> [CommunityListSection] {
-        let communities: [String: [APICommunity]] = .init(
+        let sections: [String: [APICommunity]] = .init(
             grouping: subscribed,
             by: { item in
                 if let first = item.name.first, first.isLetter {
                     return first.uppercased()
                 }
-                return "other"
+                return "#"
             }
         )
         
-        assert(communities.values.reduce(0) { x, community in
-            x + community.count
+        assert(sections.values.reduce(0) { x, communities in
+            x + communities.count
         } == subscribed.count, "mapping operation produced mismatched counts")
         
-        var ret: [CommunityListSection] = .init()
-        
-        ret.append(
+        return [String].labelAlphabet.map { character in
             CommunityListSection(
-                viewId: "non_letter_titles",
-                sidebarEntry: .init(sidebarLabel: "#", sidebarIcon: nil),
-                inlineHeaderLabel: "#",
+                viewId: character,
+                sidebarEntry: .init(sidebarLabel: character, sidebarIcon: nil),
+                inlineHeaderLabel: character,
                 accessibilityLabel: "Communities starting with a symbol or number",
-                communities: communities["other"] ?? .init()
+                communities: sections[character, default: .init()].sorted()
             )
-        )
-        
-        let alphabetics = alphabet.map { character in
-            withDependencies(from: self) {
-                // This looks sinister but I didn't know how to string replace in a non-string based regex
-                CommunityListSection(
-                    viewId: character,
-                    sidebarEntry: .init(sidebarLabel: character, sidebarIcon: nil),
-                    inlineHeaderLabel: character,
-                    accessibilityLabel: "Communities starting with the letter '\(character)'",
-                    communities: communities[character, default: .init()]
-                )
-            }
         }
-        ret.append(contentsOf: alphabetics)
-        
-        return ret
     }
 }

--- a/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
@@ -27,7 +27,6 @@ class CommunityListModel: ObservableObject {
     init() {
         favoriteCommunitiesTracker
             .$favoritesForCurrentAccount
-            .dropFirst()
             .sink { [weak self] value in
                 if let self {
                     Task {

--- a/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
@@ -196,7 +196,7 @@ class CommunityListModel: ObservableObject {
                 viewId: character,
                 sidebarEntry: .init(sidebarLabel: character, sidebarIcon: nil),
                 inlineHeaderLabel: character,
-                accessibilityLabel: "Communities starting with a symbol or number",
+                accessibilityLabel: "Communities starting with \(character == "#" ? "a symbol or number" : character)",
                 communities: sections[character, default: .init()].sorted()
             )
         }

--- a/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
@@ -191,7 +191,7 @@ class CommunityListModel: ObservableObject {
             x + communities.count
         } == subscribed.count, "mapping operation produced mismatched counts")
         
-        return [String].labelAlphabet.map { character in
+        return sections.keys.sorted().map { character in
             CommunityListSection(
                 viewId: character,
                 sidebarEntry: .init(sidebarLabel: character, sidebarIcon: nil),

--- a/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
@@ -177,34 +177,15 @@ class CommunityListModel: ObservableObject {
     }
     
     private func alphabeticSections() -> [CommunityListSection] {
-        let alphabetSet = Set([String].alphabet)
-        let alphabet: [String] = .alphabet
-        
-        var communities: [String: [APICommunity]] = .init()
-        communities["other"] = .init()
-        communities[alphabet[0]] = .init()
-        
-        let sortedCommunities = subscribed.sorted()
-        var currentSectionIndex = 0
-        var currentSectionTitle: String = alphabet[0]
-        
-        // iterate through sorted communities, building up each letter's section
-        // it's not guaranteed that non-alphabetics be sorted to one side or the other of the alphabetics, so each element does have to be individually checked, hence the quick-lookup alphabetSet. They will be grouped, however, so branch prediction ought to make the performance impact of the conditional negligible
-        for community in sortedCommunities {
-            assert(community.name.first != nil, "\(community.name) has no first character!")
-            if !alphabetSet.contains(String(community.name.first!.uppercased())) {
-                assert(communities.keys.contains("other"), "No 'other' key in communities!")
-                communities["other"]?.append(community)
-            } else {
-                while currentSectionIndex < 25, !community.name.uppercased().starts(with: currentSectionTitle) {
-                    currentSectionIndex += 1
-                    currentSectionTitle = alphabet[currentSectionIndex]
-                    communities[currentSectionTitle] = .init()
+        let communities: [String: [APICommunity]] = .init(
+            grouping: subscribed,
+            by: { item in
+                if let first = item.name.first, first.isLetter {
+                    return first.uppercased()
                 }
-                assert(communities.keys.contains(currentSectionTitle), "No '\(currentSectionTitle)' key in communities!")
-                communities[currentSectionTitle]?.append(community)
+                return "other"
             }
-        }
+        )
         
         assert(communities.values.reduce(0) { x, community in
             x + community.count

--- a/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
@@ -138,7 +138,6 @@ class CommunityListModel: ObservableObject {
         }
     }
     
-    // swiftlint:disable:next function_body_length
     private func recomputeSections() -> (all: [CommunityListSection], visible: [CommunityListSection]) {
         var newAllSections: [CommunityListSection] = .init()
         var newVisibleSections: [CommunityListSection] = .init()
@@ -146,10 +145,7 @@ class CommunityListModel: ObservableObject {
         let topSection = withDependencies(from: self) {
             CommunityListSection(
                 viewId: "top",
-                sidebarEntry: EmptySidebarEntry(
-                    sidebarLabel: nil,
-                    sidebarIcon: "line.3.horizontal"
-                ),
+                sidebarEntry: .init(sidebarLabel: nil, sidebarIcon: "line.3.horizontal"),
                 inlineHeaderLabel: nil,
                 accessibilityLabel: "Top of communities",
                 communities: .init()
@@ -160,10 +156,7 @@ class CommunityListModel: ObservableObject {
         let favoritesSection = withDependencies(from: self) {
             CommunityListSection(
                 viewId: "favorites",
-                sidebarEntry: FavoritesSidebarEntry(
-                    sidebarLabel: nil,
-                    sidebarIcon: "star.fill"
-                ),
+                sidebarEntry: .init(sidebarLabel: nil, sidebarIcon: "star.fill"),
                 inlineHeaderLabel: "Favorites",
                 accessibilityLabel: "Favorited Communities",
                 communities: favorited
@@ -180,32 +173,9 @@ class CommunityListModel: ObservableObject {
             !section.communities.isEmpty
         })
         
-        let nonLetterSections = withDependencies(from: self) {
-            let sidebarEntry = RegexCommunityNameSidebarEntry(
-                communityNameRegex: /^[^a-zA-Z]/,
-                sidebarLabel: "#",
-                sidebarIcon: nil
-            )
-            
-            return CommunityListSection(
-                viewId: "non_letter_titles",
-                sidebarEntry: sidebarEntry,
-                inlineHeaderLabel: "#",
-                accessibilityLabel: "Communities starting with a symbol or number",
-                communities: subscribed.filter { community in
-                    sidebarEntry.contains(community: community, isSubscribed: true)
-                }
-            )
-        }
-        newAllSections.append(nonLetterSections)
-        if !nonLetterSections.communities.isEmpty {
-            newVisibleSections.append(nonLetterSections)
-        }
-        
         return (all: newAllSections, visible: newVisibleSections)
     }
     
-    // swiftlint:disable:next function_body_length
     private func alphabeticSections() -> [CommunityListSection] {
         let alphabetSet = Set([String].alphabet)
         let sectionTitles: [String] = .alphabet
@@ -247,11 +217,7 @@ class CommunityListModel: ObservableObject {
         ret.append(
             CommunityListSection(
                 viewId: "non_letter_titles",
-                sidebarEntry: RegexCommunityNameSidebarEntry(
-                    communityNameRegex: /^[^a-zA-Z]/,
-                    sidebarLabel: "#",
-                    sidebarIcon: nil
-                ),
+                sidebarEntry: .init(sidebarLabel: "#", sidebarIcon: nil),
                 inlineHeaderLabel: "#",
                 accessibilityLabel: "Communities starting with a symbol or number",
                 communities: communities["other"] ?? .init()
@@ -260,16 +226,10 @@ class CommunityListModel: ObservableObject {
         
         let alphabetics = alphabet.map { character in
             withDependencies(from: self) {
-                let sidebarEntry = RegexCommunityNameSidebarEntry(
-                    communityNameRegex: (try? Regex("^[\(character.uppercased())\(character.lowercased())]"))!,
-                    sidebarLabel: character,
-                    sidebarIcon: nil
-                )
-                
                 // This looks sinister but I didn't know how to string replace in a non-string based regex
                 return CommunityListSection(
                     viewId: character,
-                    sidebarEntry: sidebarEntry,
+                    sidebarEntry: .init(sidebarLabel: character, sidebarIcon: nil),
                     inlineHeaderLabel: character,
                     accessibilityLabel: "Communities starting with the letter '\(character)'",
                     communities: communities[character, default: .init()]

--- a/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
@@ -128,7 +128,7 @@ class CommunityListModel: ObservableObject {
     private func update(_ subscribed: [APICommunity], _ favorited: [APICommunity]) async {
         // store the values for future use
         self.subscribed = subscribed
-        subscribedSet = Set(subscribed.map(\.id))
+        subscribedSet = Set(subscribed.lazy.map(\.id))
         self.favorited = favorited.sorted()
   
         let (newAllSections, newVisibleSections) = recomputeSections()

--- a/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
@@ -180,7 +180,7 @@ class CommunityListModel: ObservableObject {
         let sections: [String: [APICommunity]] = .init(
             grouping: subscribed,
             by: { item in
-                if let first = item.name.first, first.isLetter {
+                if let first = item.name.strippingDiacritics.first, first.isLetter {
                     return first.uppercased()
                 }
                 return "#"
@@ -191,13 +191,15 @@ class CommunityListModel: ObservableObject {
             x + communities.count
         } == subscribed.count, "mapping operation produced mismatched counts")
         
-        return sections.keys.sorted().map { character in
+        return [String].labelAlphabet.map { character in
             CommunityListSection(
                 viewId: character,
                 sidebarEntry: .init(sidebarLabel: character, sidebarIcon: nil),
                 inlineHeaderLabel: character,
                 accessibilityLabel: "Communities starting with \(character == "#" ? "a symbol or number" : character)",
-                communities: sections[character, default: .init()].sorted()
+                communities: sections[character, default: .init()].sorted { lhs, rhs in
+                    lhs.name.strippingDiacritics < rhs.name.strippingDiacritics
+                }
             )
         }
     }

--- a/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListModel.swift
@@ -178,15 +178,15 @@ class CommunityListModel: ObservableObject {
     
     private func alphabeticSections() -> [CommunityListSection] {
         let alphabetSet = Set([String].alphabet)
-        let sectionTitles: [String] = .alphabet
+        let alphabet: [String] = .alphabet
         
         var communities: [String: [APICommunity]] = .init()
         communities["other"] = .init()
-        communities[sectionTitles[0]] = .init()
+        communities[alphabet[0]] = .init()
         
         let sortedCommunities = subscribed.sorted()
         var currentSectionIndex = 0
-        var currentSectionTitle: String = sectionTitles[0]
+        var currentSectionTitle: String = alphabet[0]
         
         // iterate through sorted communities, building up each letter's section
         // it's not guaranteed that non-alphabetics be sorted to one side or the other of the alphabetics, so each element does have to be individually checked, hence the quick-lookup alphabetSet. They will be grouped, however, so branch prediction ought to make the performance impact of the conditional negligible
@@ -196,9 +196,9 @@ class CommunityListModel: ObservableObject {
                 assert(communities.keys.contains("other"), "No 'other' key in communities!")
                 communities["other"]?.append(community)
             } else {
-                while currentSectionIndex < 26, !community.name.uppercased().starts(with: currentSectionTitle) {
+                while currentSectionIndex < 25, !community.name.uppercased().starts(with: currentSectionTitle) {
                     currentSectionIndex += 1
-                    currentSectionTitle = sectionTitles[currentSectionIndex]
+                    currentSectionTitle = alphabet[currentSectionIndex]
                     communities[currentSectionTitle] = .init()
                 }
                 assert(communities.keys.contains(currentSectionTitle), "No '\(currentSectionTitle)' key in communities!")
@@ -209,8 +209,6 @@ class CommunityListModel: ObservableObject {
         assert(communities.values.reduce(0) { x, community in
             x + community.count
         } == subscribed.count, "mapping operation produced mismatched counts")
-        
-        let alphabet: [String] = .alphabet
         
         var ret: [CommunityListSection] = .init()
         
@@ -227,7 +225,7 @@ class CommunityListModel: ObservableObject {
         let alphabetics = alphabet.map { character in
             withDependencies(from: self) {
                 // This looks sinister but I didn't know how to string replace in a non-string based regex
-                return CommunityListSection(
+                CommunityListSection(
                     viewId: character,
                     sidebarEntry: .init(sidebarLabel: character, sidebarIcon: nil),
                     inlineHeaderLabel: character,

--- a/Mlem/Models/Content/Community/Community List/CommunityListSection.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListSection.swift
@@ -14,4 +14,5 @@ struct CommunityListSection: Identifiable {
     let sidebarEntry: any SidebarEntry
     let inlineHeaderLabel: String?
     let accessibilityLabel: String
+    let communities: [APICommunity]
 }

--- a/Mlem/Models/Content/Community/Community List/CommunityListSection.swift
+++ b/Mlem/Models/Content/Community/Community List/CommunityListSection.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct CommunityListSection: Identifiable {
     let id = UUID()
     let viewId: String
-    let sidebarEntry: any SidebarEntry
+    let sidebarEntry: SidebarEntry
     let inlineHeaderLabel: String?
     let accessibilityLabel: String
     let communities: [APICommunity]

--- a/Mlem/Views/Tabs/Feeds/Community List/CommunityListSidebarEntry.swift
+++ b/Mlem/Views/Tabs/Feeds/Community List/CommunityListSidebarEntry.swift
@@ -8,47 +8,7 @@
 import Dependencies
 import Foundation
 
-protocol SidebarEntry {
-    var sidebarLabel: String? { get }
-    var sidebarIcon: String? { get }
-    
-    func contains(community: APICommunity, isSubscribed: Bool) -> Bool
-}
-
-// Filters no communities, used for top entry in sidebar
-struct EmptySidebarEntry: SidebarEntry {
-    var sidebarLabel: String?
-    var sidebarIcon: String?
-
-    func contains(community: APICommunity, isSubscribed: Bool) -> Bool {
-        false
-    }
-}
-
-// Filters based on community name
-struct RegexCommunityNameSidebarEntry: SidebarEntry {
-    var communityNameRegex: Regex<Substring>
-    var sidebarLabel: String?
-    var sidebarIcon: String?
-
-    func contains(community: APICommunity, isSubscribed: Bool) -> Bool {
-        // Ignore unsubscribed subs from main list
-        if !isSubscribed {
-            return false
-        }
-        return community.name.starts(with: communityNameRegex)
-    }
-}
-
-// Filters to favorited communities
-struct FavoritesSidebarEntry: SidebarEntry {
-    @Dependency(\.favoriteCommunitiesTracker) var favoriteCommunitiesTracker
-    
-    var sidebarLabel: String?
-    var sidebarIcon: String?
-
-    @MainActor
-    func contains(community: APICommunity, isSubscribed: Bool) -> Bool {
-        favoriteCommunitiesTracker.isFavorited(community)
-    }
+struct SidebarEntry {
+    let sidebarLabel: String?
+    let sidebarIcon: String?
 }

--- a/Mlem/Views/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/Views/Tabs/Feeds/FeedsView.swift
@@ -108,7 +108,7 @@ struct FeedsView: View {
                         CommunityFeedRowView(
                             community: community,
                             subscribed: communityListModel.isSubscribed(to: community),
-                            communitySubscriptionChanged: communityListModel.updateSubscriptionStatus,
+                            communitySubscriptionChanged: updateSubscriptionStatus, // communityListModel.updateSubscriptionStatus,
                             navigationContext: .sidebar
                         )
                     }
@@ -127,6 +127,12 @@ struct FeedsView: View {
                 .id(communityModel.uid) // explicit id forces redraw on change of community model
         case .none:
             Text("Please select a feed")
+        }
+    }
+    
+    private func updateSubscriptionStatus(_ community: APICommunity, _ status: Bool) {
+        Task {
+            await communityListModel.updateSubscriptionStatus(for: community, subscribed: status)
         }
     }
     

--- a/Mlem/Views/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/Views/Tabs/Feeds/FeedsView.swift
@@ -69,6 +69,11 @@ struct FeedsView: View {
                     .scrollIndicators(.hidden)
                     .navigationTitle("Feeds")
                     .listStyle(PlainListStyle())
+                    .refreshable {
+                        await Task {
+                            await communityListModel.load()
+                        }.value
+                    }
                     .fancyTabScrollCompatible()
                     
                     SectionIndexTitles(proxy: scrollProxy, communitySections: communityListModel.allSections)

--- a/Mlem/Views/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/Views/Tabs/Feeds/FeedsView.swift
@@ -103,7 +103,6 @@ struct FeedsView: View {
     var communitySections: some View {
         ForEach(communityListModel.visibleSections) { section in
             Section(header: communitySectionHeaderView(for: section)) {
-                // ForEach(communityListModel.communities(for: section)) { community in
                 ForEach(section.communities) { community in
                     NavigationLink(value: PostFeedType.community(.init(from: community, subscribed: true))) {
                         CommunityFeedRowView(

--- a/Mlem/Views/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/Views/Tabs/Feeds/FeedsView.swift
@@ -63,28 +63,15 @@ struct FeedsView: View {
                         .id(scrollToTop) // using this instead of ScrollToView because ScrollToView renders as an empty list item
                         .padding(.trailing, 10)
                         
-                        ForEach(communityListModel.visibleSections) { section in
-                            Section(header: communitySectionHeaderView(for: section)) {
-                                ForEach(communityListModel.communities(for: section)) { community in
-                                    NavigationLink(value: PostFeedType.community(.init(from: community, subscribed: true))) {
-                                        CommunityFeedRowView(
-                                            community: community,
-                                            subscribed: communityListModel.isSubscribed(to: community),
-                                            communitySubscriptionChanged: communityListModel.updateSubscriptionStatus,
-                                            navigationContext: .sidebar
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                        .padding(.trailing, 10)
+                        communitySections
+                            .padding(.trailing, 10)
                     }
                     .scrollIndicators(.hidden)
                     .navigationTitle("Feeds")
                     .listStyle(PlainListStyle())
                     .fancyTabScrollCompatible()
                     
-                    SectionIndexTitles(proxy: scrollProxy, communitySections: communityListModel.allSections())
+                    SectionIndexTitles(proxy: scrollProxy, communitySections: communityListModel.allSections)
                 }
                 .onChange(of: tabReselectionHashValue) { newValue in
                     // due to NavigationSplitView weirdness, the normal .hoistNavigation doesn't work here, so we do it manually
@@ -109,6 +96,25 @@ struct FeedsView: View {
             }
             .environment(\.navigationPathWithRoutes, $feedTabNavigation.path)
             .environment(\.navigation, navigation)
+        }
+    }
+    
+    @ViewBuilder
+    var communitySections: some View {
+        ForEach(communityListModel.visibleSections) { section in
+            Section(header: communitySectionHeaderView(for: section)) {
+                // ForEach(communityListModel.communities(for: section)) { community in
+                ForEach(section.communities) { community in
+                    NavigationLink(value: PostFeedType.community(.init(from: community, subscribed: true))) {
+                        CommunityFeedRowView(
+                            community: community,
+                            subscribed: communityListModel.isSubscribed(to: community),
+                            communitySubscriptionChanged: communityListModel.updateSubscriptionStatus,
+                            navigationContext: .sidebar
+                        )
+                    }
+                }
+            }
         }
     }
     

--- a/MlemTests/Community List/CommunityListModelTests.swift
+++ b/MlemTests/Community List/CommunityListModelTests.swift
@@ -278,7 +278,6 @@ final class CommunityListModelTests: XCTestCase {
         // assert we have 26 for alphabet + 3
         XCTAssert(model.allSections.count == 29)
         // assert order
-        print("DEBUG \(model.allSections.count)")
         XCTAssert(model.allSections[0].viewId == "top")
         XCTAssert(model.allSections[1].viewId == "favorites")
         
@@ -287,7 +286,7 @@ final class CommunityListModelTests: XCTestCase {
         alphabet.enumerated().forEach { index, character in
             XCTAssert(model.allSections[index + offset].viewId == character)
         }
-        XCTAssert(model.allSections[28].viewId == "non_letter_titles")
+        XCTAssert(model.allSections[28].viewId == "#")
     }
     
     // MARK: - Helpers

--- a/MlemTests/Community List/CommunityListModelTests.swift
+++ b/MlemTests/Community List/CommunityListModelTests.swift
@@ -36,8 +36,8 @@ final class CommunityListModelTests: XCTestCase {
             CommunityListModel()
         }
         
-        // assert that even though a subscription and favorite are available nothing is present without `load()` being called
-        XCTAssert(model.subscribed.isEmpty && model.favorited.isEmpty)
+        // assert that initial state propagates as expected--favorited appear from tracker, but subscribed does not appear until load
+        XCTAssert(model.subscribed.count == 0 && model.favorited.count == 1)
     }
     
     func testLoadingWithNoSubscriptionsOrFavourites() async throws {
@@ -280,13 +280,13 @@ final class CommunityListModelTests: XCTestCase {
         // assert order
         XCTAssert(model.allSections[0].viewId == "top")
         XCTAssert(model.allSections[1].viewId == "favorites")
+        XCTAssert(model.allSections[2].viewId == "#")
         
         let alphabet: [String] = .alphabet
-        let offset = 2
+        let offset = 3
         alphabet.enumerated().forEach { index, character in
             XCTAssert(model.allSections[index + offset].viewId == character)
         }
-        XCTAssert(model.allSections[28].viewId == "#")
     }
     
     // MARK: - Helpers


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #958 

# Pull Request Information

This PR fixes app slowdown when subscribed to hundreds of communities.

The slowdown was caused by `FeedsView` triggering unnecessary recomputations of the community sections, which required iterating over the list of subscribed communities several times and performing several filtering operations, many redundant.

To resolve this, I have implemented the following changes:
- Added a quick lookup set for subscribed and favorited communities
- Made `allSections` and `visibleSections` stored rather than computed, and they are recomputed only when `subscribed` or `favorited` changes
- Refactored section generation logic to avoid unnecessary filter calls (`allSections` and `visibleSections` are now built side-by-side)
- `CommunityListSection` now includes the list of communities in the section. This is now computed when the sections are recomputed rather than on-the-fly.
- Refactored how alphabetic sections are generated. They are now accumulated using a single pass of the sorted `subscribed` list, reducing the number of iterations by a factor of 26
- Removed the `SidebarEntry.contains` function; its logic is now entirely unnecessary. `SidebarEntry` is now a simple struct that contains a label and an icon.
- Removed `allCommunities`