### PR TITLE
FaceID fix for locked out user

### DIFF
--- a/Mlem/Logic/BiometricUnlock.swift
+++ b/Mlem/Logic/BiometricUnlock.swift
@@ -32,10 +32,10 @@ class BiometricUnlock: ObservableObject {
         let context = LAContext()
         var error: NSError?
         
-        if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
+        if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
             let reason = "Please authenticate to unlock app."
             
-            context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, _ in
+            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, _ in
                 DispatchQueue.main.async {
                     if success {
                         self.isUnlocked = true
@@ -56,7 +56,7 @@ class BiometricUnlock: ObservableObject {
         var error: NSError?
         let context = LAContext()
         
-        let isBioMetricsAvailable = context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+        let isBioMetricsAvailable = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
         
         if let error {
             print("Biometrics error: \(error.localizedDescription)")


### PR DESCRIPTION
# Pull Request Information

## About this Pull Request


Changed biometric login to use `.deviceOwnerAuthentication`, allowing users to input their device password instead. For some reason this is not built into the `.deviceOwnerAuthenticationWithBiometrics` API.


