### PR TITLE
[2.0] Proposed refinement to ActiveAccount initializer

### DIFF
--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -84,6 +84,7 @@ class ActiveAccount: Hashable {
     
     init(instanceUrl: URL) {
         self.api = .getApiClient(for: instanceUrl, with: nil)
+        api.permissions = .getOnly
     }
     
     func deactivate() {

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -84,7 +84,7 @@ class ActiveAccount: Hashable {
     
     init(instanceUrl: URL) {
         self.api = .getApiClient(for: instanceUrl, with: nil)
-        api.permissions = .getOnly
+        api.permissions = .all // should this be .getOnly?
     }
     
     func deactivate() {

--- a/Mlem/App/Logic/API/API Client/ApiClient.swift
+++ b/Mlem/App/Logic/API/API Client/ApiClient.swift
@@ -140,9 +140,11 @@ class ApiClient {
         if definition as? any ApiGetRequest != nil {
             urlRequest.httpMethod = "GET"
         } else if let postDefinition = definition as? any ApiPostRequest {
+            guard permissions != .getOnly else { throw ApiClientError.insufficientPermissions }
             urlRequest.httpMethod = "POST"
             urlRequest.httpBody = try createBodyData(for: postDefinition)
         } else if let putDefinition = definition as? any ApiPutRequest {
+            guard permissions != .getOnly else { throw ApiClientError.insufficientPermissions }
             urlRequest.httpMethod = "PUT"
             urlRequest.httpBody = try createBodyData(for: putDefinition)
         }

--- a/Mlem/App/Logic/API/API Client/ApiClient.swift
+++ b/Mlem/App/Logic/API/API Client/ApiClient.swift
@@ -140,11 +140,9 @@ class ApiClient {
         if definition as? any ApiGetRequest != nil {
             urlRequest.httpMethod = "GET"
         } else if let postDefinition = definition as? any ApiPostRequest {
-            guard permissions != .getOnly else { throw ApiClientError.insufficientPermissions }
             urlRequest.httpMethod = "POST"
             urlRequest.httpBody = try createBodyData(for: postDefinition)
         } else if let putDefinition = definition as? any ApiPutRequest {
-            guard permissions != .getOnly else { throw ApiClientError.insufficientPermissions }
             urlRequest.httpMethod = "PUT"
             urlRequest.httpBody = try createBodyData(for: putDefinition)
         }

--- a/Mlem/App/Views/Shared/Accounts/AccountListView.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView.swift
@@ -77,7 +77,7 @@ struct AccountListView: View {
                     }
                     .accessibilityLabel("Add a new account.")
                     Button {
-                        appState.enterGuestMode(with: .getApiClient(for: URL(string: "https://lemmy.world")!, with: nil))
+                        appState.enterGuestMode(for: URL(string: "https://lemmy.world")!)
                         dismiss()
                     } label: {
                         Label("Enter Guest Mode", systemImage: Icons.person)


### PR DESCRIPTION
Changes the way `ActiveAccount` is initialized:
- Guest mode and user mode now have two separate initializers
- The guest mode initializer just takes the `URL` of the instance rather than an `ApiClient`

This approach makes the behavior of the initializer more transparent, removes the possibility of initializing a user account with an `ApiClient` pointing to a different instance, and removes the need to spin up `ApiClient`s just to call the guest mode initializer.