### PR TITLE
Clip comment view in posts

### DIFF
--- a/Mlem/Views/Shared/Posts/Expanded Post.swift
+++ b/Mlem/Views/Shared/Posts/Expanded Post.swift
@@ -141,6 +141,7 @@ struct ExpandedPost: View {
                             noCommentsView()
                         } else {
                             commentsView
+                                .clipped()
                                 .onAppear {
                                     if let target = scrollTarget {
                                         scrollTarget = nil


### PR DESCRIPTION
# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #1041 

# Pull Request Information

## About this Pull Request

Fixes #1041 where the issue was that the comment collapse animations could show the comments overlapping the post. By adding the `.clipped()` view modifier on the comments view inside of the post the comments no longer clip into the featured post when collapsed.

## Screenshots and Videos

The linked issue (#1041) has a video of the issue, here is a similar video showing the fix.

https://github.com/mlemgroup/mlem/assets/1799888/98c7392c-ffc8-4346-966a-8927eae9fb54
