### PR TITLE
ContentLoader

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -104,7 +104,7 @@
 		CD4ED84A2BF1113800EFA0A2 /* View+TabReselectConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED8492BF1113800EFA0A2 /* View+TabReselectConsumer.swift */; };
 		CD4ED84C2BF111BA00EFA0A2 /* ScrollToView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED84B2BF111BA00EFA0A2 /* ScrollToView.swift */; };
 		CD4ED84E2BF113C800EFA0A2 /* ExpandedPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED84D2BF113C800EFA0A2 /* ExpandedPostView.swift */; };
-		CD59DE2C2BE467E600445EED /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD59DE2B2BE467E600445EED /* MlemMiddleware */; };
+		CD748C962BF538B9009C1CE9 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD748C952BF538B9009C1CE9 /* MlemMiddleware */; };
 		CDA1E8212B8FC411007953EF /* LandingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA1E8202B8FC411007953EF /* LandingPage.swift */; };
 		CDA1E8272B90EF24007953EF /* AppFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA1E8262B90EF24007953EF /* AppFlow.swift */; };
 		CDA1E8542B952C3D007953EF /* StateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA1E8532B952C3D007953EF /* StateManager.swift */; };
@@ -246,7 +246,7 @@
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
 				CD4E03532BE42E6F009D11D6 /* MlemMiddleware in Frameworks */,
-				CD59DE2C2BE467E600445EED /* MlemMiddleware in Frameworks */,
+				CD748C962BF538B9009C1CE9 /* MlemMiddleware in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -731,7 +731,7 @@
 				037386432BDAF574007492B5 /* LemmyMarkdownUI */,
 				037386462BDAFE81007492B5 /* LemmyMarkdownUI */,
 				CD4E03522BE42E6F009D11D6 /* MlemMiddleware */,
-				CD59DE2B2BE467E600445EED /* MlemMiddleware */,
+				CD748C952BF538B9009C1CE9 /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -814,7 +814,7 @@
 				CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */,
 				0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */,
-				CD59DE2A2BE467E600445EED /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
+				CD748C942BF538B9009C1CE9 /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -1384,12 +1384,12 @@
 				minimumVersion = 0.0.8;
 			};
 		};
-		CD59DE2A2BE467E600445EED /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
+		CD748C942BF538B9009C1CE9 /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware.git";
+			repositoryURL = "git@github.com:mlemgroup/MlemMiddleware.git";
 			requirement = {
-				branch = "eric/upgradable-1";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1448,9 +1448,9 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = MlemMiddleware;
 		};
-		CD59DE2B2BE467E600445EED /* MlemMiddleware */ = {
+		CD748C952BF538B9009C1CE9 /* MlemMiddleware */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = CD59DE2A2BE467E600445EED /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
+			package = CD748C942BF538B9009C1CE9 /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
 			productName = MlemMiddleware;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */ = {isa = PBXBuildFile; productRef = B104A6DD2A59BF3C00B3E725 /* NukeVideo */; };
 		B157E0C42A507B8000B02C8B /* FlowRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = B157E0C32A507B8000B02C8B /* FlowRoot.swift */; };
 		B1B78D642A51D53900F72485 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B78D632A51D53900F72485 /* AppDelegate.swift */; };
+		CD03D8D92BF6A44C00D1FB5D /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD03D8D82BF6A44C00D1FB5D /* MlemMiddleware */; };
 		CD1446212A5B328E00610EF1 /* Privacy Policy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1446202A5B328E00610EF1 /* Privacy Policy.swift */; };
 		CD1446252A5B357900610EF1 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1446242A5B357900610EF1 /* Document.swift */; };
 		CD1446272A5B36DA00610EF1 /* EULA.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1446262A5B36DA00610EF1 /* EULA.swift */; };
@@ -104,7 +105,6 @@
 		CD4ED84A2BF1113800EFA0A2 /* View+TabReselectConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED8492BF1113800EFA0A2 /* View+TabReselectConsumer.swift */; };
 		CD4ED84C2BF111BA00EFA0A2 /* ScrollToView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED84B2BF111BA00EFA0A2 /* ScrollToView.swift */; };
 		CD4ED84E2BF113C800EFA0A2 /* ExpandedPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED84D2BF113C800EFA0A2 /* ExpandedPostView.swift */; };
-		CD748C962BF538B9009C1CE9 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD748C952BF538B9009C1CE9 /* MlemMiddleware */; };
 		CDA1E8212B8FC411007953EF /* LandingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA1E8202B8FC411007953EF /* LandingPage.swift */; };
 		CDA1E8272B90EF24007953EF /* AppFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA1E8262B90EF24007953EF /* AppFlow.swift */; };
 		CDA1E8542B952C3D007953EF /* StateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA1E8532B952C3D007953EF /* StateManager.swift */; };
@@ -246,7 +246,7 @@
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
 				CD4E03532BE42E6F009D11D6 /* MlemMiddleware in Frameworks */,
-				CD748C962BF538B9009C1CE9 /* MlemMiddleware in Frameworks */,
+				CD03D8D92BF6A44C00D1FB5D /* MlemMiddleware in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -731,7 +731,7 @@
 				037386432BDAF574007492B5 /* LemmyMarkdownUI */,
 				037386462BDAFE81007492B5 /* LemmyMarkdownUI */,
 				CD4E03522BE42E6F009D11D6 /* MlemMiddleware */,
-				CD748C952BF538B9009C1CE9 /* MlemMiddleware */,
+				CD03D8D82BF6A44C00D1FB5D /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -814,7 +814,7 @@
 				CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */,
 				0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */,
-				CD748C942BF538B9009C1CE9 /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
+				CD03D8D72BF6A44C00D1FB5D /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -1376,20 +1376,20 @@
 				minimumVersion = 12.1.2;
 			};
 		};
+		CD03D8D72BF6A44C00D1FB5D /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.2;
+			};
+		};
 		CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/groue/Semaphore";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.0.8;
-			};
-		};
-		CD748C942BF538B9009C1CE9 /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "git@github.com:mlemgroup/MlemMiddleware.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1439,6 +1439,11 @@
 			package = B104A6D62A59BF3C00B3E725 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeVideo;
 		};
+		CD03D8D82BF6A44C00D1FB5D /* MlemMiddleware */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD03D8D72BF6A44C00D1FB5D /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
+			productName = MlemMiddleware;
+		};
 		CD4368C02AE23FD400BD8BD1 /* Semaphore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */;
@@ -1446,11 +1451,6 @@
 		};
 		CD4E03522BE42E6F009D11D6 /* MlemMiddleware */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = MlemMiddleware;
-		};
-		CD748C952BF538B9009C1CE9 /* MlemMiddleware */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CD748C942BF538B9009C1CE9 /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
 			productName = MlemMiddleware;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		CD317D4C2BE97FED008F63E2 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4B2BE97FED008F63E2 /* Palette.swift */; };
 		CD317D4F2BE983ED008F63E2 /* MonochromePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4E2BE983ED008F63E2 /* MonochromePalette.swift */; };
 		CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */ = {isa = PBXBuildFile; productRef = CD4368C02AE23FD400BD8BD1 /* Semaphore */; };
+		CD43E8B32BF2C24E007C3D71 /* ContentLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD43E8B22BF2C24E007C3D71 /* ContentLoader.swift */; };
 		CD4BAD352B4B2C0B00A1E726 /* FeedsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD342B4B2C0B00A1E726 /* FeedsView.swift */; };
 		CD4D583F2B86855F00B82964 /* MlemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D583E2B86855F00B82964 /* MlemTests.swift */; };
 		CD4D58412B86858100B82964 /* MlemUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D58402B86858100B82964 /* MlemUITests.swift */; };
@@ -182,6 +183,7 @@
 		CD1446262A5B36DA00610EF1 /* EULA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EULA.swift; sourceTree = "<group>"; };
 		CD317D4B2BE97FED008F63E2 /* Palette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Palette.swift; sourceTree = "<group>"; };
 		CD317D4E2BE983ED008F63E2 /* MonochromePalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonochromePalette.swift; sourceTree = "<group>"; };
+		CD43E8B22BF2C24E007C3D71 /* ContentLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLoader.swift; sourceTree = "<group>"; };
 		CD4BAD342B4B2C0B00A1E726 /* FeedsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedsView.swift; sourceTree = "<group>"; };
 		CD4D583E2B86855F00B82964 /* MlemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlemTests.swift; sourceTree = "<group>"; };
 		CD4D58402B86858100B82964 /* MlemUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlemUITests.swift; sourceTree = "<group>"; };
@@ -525,6 +527,7 @@
 				03267D802BED4714009D6268 /* Avatar */,
 				CD4ED84B2BF111BA00EFA0A2 /* ScrollToView.swift */,
 				CD4ED84D2BF113C800EFA0A2 /* ExpandedPostView.swift */,
+				CD43E8B22BF2C24E007C3D71 /* ContentLoader.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -915,6 +918,7 @@
 				CD4D58FD2B87B14D00B82964 /* ContextualError.swift in Sources */,
 				CD4D58C82B86DCED00B82964 /* AvatarType.swift in Sources */,
 				CD4D58BB2B86DA7D00B82964 /* AccountListView+Logic.swift in Sources */,
+				CD43E8B32BF2C24E007C3D71 /* ContentLoader.swift in Sources */,
 				031E2D5D2BEFCC630003BC45 /* SettingsView.swift in Sources */,
 				CD4ED8472BF110FA00EFA0A2 /* TabReselectTracker.swift in Sources */,
 				035BE0912BDEA01E00F77D73 /* NavigationPage+View.swift in Sources */,
@@ -1384,8 +1388,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.1.0;
+				branch = "eric/hashable-content";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -1388,7 +1388,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware.git";
 			requirement = {
-				branch = eric/upgradable;
+				branch = "eric/hashable-content";
 				kind = branch;
 			};
 		};

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -1388,7 +1388,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware.git";
 			requirement = {
-				branch = "eric/hashable-content";
+				branch = eric/upgradable;
 				kind = branch;
 			};
 		};

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -1388,7 +1388,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware.git";
 			requirement = {
-				branch = "eric/hashable-content";
+				branch = "eric/upgradable-1";
 				kind = branch;
 			};
 		};

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware.git",
       "state" : {
-        "revision" : "3fc9bdebc74909dfdea2fcd51afb645d5d1ed2b6",
-        "version" : "0.1.0"
+        "branch" : "eric/hashable-content",
+        "revision" : "ad405d1b7845c833bc9d117318d63fd20c0571ea"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware.git",
       "state" : {
-        "branch" : "eric/upgradable",
-        "revision" : "74ed7a925675d31bcea2783e02b301981ca7b66f"
+        "branch" : "eric/hashable-content",
+        "revision" : "806d4ba7d93f7995f888927695dbeb287d4c2258"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware.git",
       "state" : {
-        "branch" : "eric/hashable-content",
-        "revision" : "806d4ba7d93f7995f888927695dbeb287d4c2258"
+        "branch" : "eric/upgradable-1",
+        "revision" : "027dc935175f510d05e846c9d2c056c3f0110c5f"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -30,7 +30,7 @@
     {
       "identity" : "mlemmiddleware",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:mlemgroup/MlemMiddleware.git",
+      "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
         "revision" : "8a8784c789683df9248662108721a573e41ba6b8",
         "version" : "0.1.2"

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -30,10 +30,10 @@
     {
       "identity" : "mlemmiddleware",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlemgroup/MlemMiddleware.git",
+      "location" : "git@github.com:mlemgroup/MlemMiddleware.git",
       "state" : {
-        "branch" : "eric/upgradable-1",
-        "revision" : "027dc935175f510d05e846c9d2c056c3f0110c5f"
+        "revision" : "8a8784c789683df9248662108721a573e41ba6b8",
+        "version" : "0.1.2"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware.git",
       "state" : {
-        "branch" : "eric/hashable-content",
-        "revision" : "70195be1bce9cec27feac527d979ceed1dca2634"
+        "branch" : "eric/upgradable",
+        "revision" : "74ed7a925675d31bcea2783e02b301981ca7b66f"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/mlemgroup/MlemMiddleware.git",
       "state" : {
         "branch" : "eric/hashable-content",
-        "revision" : "ad405d1b7845c833bc9d117318d63fd20c0571ea"
+        "revision" : "70195be1bce9cec27feac527d979ceed1dca2634"
       }
     },
     {

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -118,7 +118,8 @@ struct MinimalPostFeedView: View {
                     .id(scrollToTop)
                 
                 ForEach(postTracker.items, id: \.uid) { post in
-                    NavigationLink(value: NavigationPage.expandedPost(post)) {
+                    // NavigationLink(value: NavigationPage.expandedPost(post)) {
+                    NavigationLink(value: NavigationPage.expandedPost(PostStub(api: post.api, actorId: post.actorId))) {
                         HStack {
                             actionButton(post.upvoteAction)
                             actionButton(post.downvoteAction)

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -118,8 +118,7 @@ struct MinimalPostFeedView: View {
                     .id(scrollToTop)
                 
                 ForEach(postTracker.items, id: \.uid) { post in
-                    // NavigationLink(value: NavigationPage.expandedPost(post)) {
-                    NavigationLink(value: NavigationPage.expandedPost(PostStub(api: post.api, actorId: post.actorId))) {
+                    NavigationLink(value: NavigationPage.expandedPost(post)) {
                         HStack {
                             actionButton(post.upvoteAction)
                             actionButton(post.downvoteAction)

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -118,9 +118,7 @@ struct MinimalPostFeedView: View {
                     .id(scrollToTop)
                 
                 ForEach(postTracker.items, id: \.uid) { post in
-                    // NavigationLink(value: NavigationPage.expandedPost(post)) {
-                    // DELETEME: link to test that upgrading works correctly
-                    NavigationLink(value: NavigationPage.expandedPost(PostStub(api: post.api, actorId: post.actorId))) {
+                    NavigationLink(value: NavigationPage.expandedPost(post)) {
                         HStack {
                             actionButton(post.upvoteAction)
                             actionButton(post.downvoteAction)

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -118,7 +118,9 @@ struct MinimalPostFeedView: View {
                     .id(scrollToTop)
                 
                 ForEach(postTracker.items, id: \.uid) { post in
-                    NavigationLink(value: NavigationPage.expandedPost(post)) {
+                    // NavigationLink(value: NavigationPage.expandedPost(post)) {
+                    // DELETEME: link to test that upgrading works correctly
+                    NavigationLink(value: NavigationPage.expandedPost(PostStub(api: post.api, actorId: post.actorId))) {
                         HStack {
                             actionButton(post.upvoteAction)
                             actionButton(post.downvoteAction)

--- a/Mlem/App/Views/Shared/ContentLoader.swift
+++ b/Mlem/App/Views/Shared/ContentLoader.swift
@@ -1,0 +1,31 @@
+//
+//  ContentLoader.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-05-13.
+//
+
+import Foundation
+import MlemMiddleware
+import SwiftUI
+
+struct ContentLoader<Content: View, Model>: View {
+    var model: Model?
+    var content: (Model) -> Content
+    var upgrade: () async throws -> Void
+    
+    var body: some View {
+        if let model {
+            content(model)
+        } else {
+            Text("Loading")
+                .task {
+                    do {
+                        try await upgrade()
+                    } catch {
+                        print(error)
+                    }
+                }
+        }
+    }
+}

--- a/Mlem/App/Views/Shared/ContentLoader.swift
+++ b/Mlem/App/Views/Shared/ContentLoader.swift
@@ -10,9 +10,9 @@ import MlemMiddleware
 import SwiftUI
 
 struct ContentLoader<Content: View, Model>: View {
-    var model: Model?
+    @Binding var model: Model?
+    var upgrade: () async throws -> Model
     var content: (Model) -> Content
-    var upgrade: () async throws -> Void
     
     var body: some View {
         if let model {
@@ -20,8 +20,9 @@ struct ContentLoader<Content: View, Model>: View {
         } else {
             Text("Loading")
                 .task {
+                    print("Content not present, loading...")
                     do {
-                        try await upgrade()
+                        model = try await upgrade()
                     } catch {
                         print(error)
                     }

--- a/Mlem/App/Views/Shared/ContentLoader.swift
+++ b/Mlem/App/Views/Shared/ContentLoader.swift
@@ -20,7 +20,6 @@ struct ContentLoader<Content: View, Model>: View {
         } else {
             Text("Loading")
                 .task {
-                    print("Content not present, loading...")
                     do {
                         model = try await upgrade()
                     } catch {

--- a/Mlem/App/Views/Shared/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPostView.swift
@@ -29,27 +29,9 @@ struct ExpandedPostView: View {
     
     var body: some View {
         ScrollViewReader { _ in
-            ContentLoader(model: post) { post2 in
+            ContentLoader(model: $post, upgrade: postStub.upgrade) { post2 in
                 content(for: post2)
-            } upgrade: {
-                post = try await postStub.upgrade()
             }
-        }
-    }
-    
-    @ViewBuilder
-    var contentLoader: some View {
-        if let post {
-            content(for: post)
-        } else {
-            Text("Loading...")
-                .task {
-                    do {
-                        post = try await postStub.upgrade()
-                    } catch {
-                        print(error)
-                    }
-                }
         }
     }
     

--- a/Mlem/App/Views/Shared/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPostView.swift
@@ -13,24 +13,24 @@ struct ExpandedPostView: View {
     @Environment(\.dismiss) var dismiss
     
     @State private var scrollToTopAppeared = false
-    @State private var post: (any Post2Providing)?
     
     @Namespace var scrollToTop
     
-    let postStub: any PostStubProviding
-    
-    init(postStub: any PostStubProviding) {
-        if let post = postStub as? any Post2Providing {
-            self._post = .init(wrappedValue: post)
-        }
-        
-        self.postStub = postStub
-    }
+    let post: AnyPost
     
     var body: some View {
-        ScrollViewReader { _ in
-            ContentLoader(model: $post, upgrade: postStub.upgrade) { post2 in
+        ScrollViewReader { scrollProxy in
+            ContentLoader(model: post) { post2 in
                 content(for: post2)
+            }
+            .onReselectTab {
+                if scrollToTopAppeared {
+                    dismiss()
+                } else {
+                    withAnimation {
+                        scrollProxy.scrollTo(scrollToTop)
+                    }
+                }
             }
         }
     }
@@ -44,7 +44,7 @@ struct ExpandedPostView: View {
                 Text(post.title)
                 
                 Text("Some content really far below to scroll to")
-                    .padding(.top, 700)
+                    .padding([.top, .bottom], 700)
             }
         }
     }

--- a/Mlem/App/Views/Shared/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPostView.swift
@@ -20,8 +20,8 @@ struct ExpandedPostView: View {
     
     var body: some View {
         ScrollViewReader { scrollProxy in
-            ContentLoader(model: post) { post2 in
-                content(for: post2)
+            ContentLoader(model: post) { postStub in
+                content(for: postStub)
             }
             .onReselectTab {
                 if scrollToTopAppeared {
@@ -35,7 +35,7 @@ struct ExpandedPostView: View {
         }
     }
     
-    func content(for post: any Post2Providing) -> some View {
+    func content(for post: any Post1Providing) -> some View {
         ScrollView {
             VStack {
                 ScrollToView(appeared: $scrollToTopAppeared)

--- a/Mlem/App/Views/Shared/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPostView.swift
@@ -20,8 +20,8 @@ struct ExpandedPostView: View {
     
     var body: some View {
         ScrollViewReader { scrollProxy in
-            ContentLoader(model: post) { postStub in
-                content(for: postStub)
+            ContentLoader(model: post) { post1 in
+                content(for: post1)
             }
             .onReselectTab {
                 if scrollToTopAppeared {

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -13,17 +13,6 @@ enum NavigationPage: Hashable {
         lhs.hashValue == rhs.hashValue
     }
     
-    func hash(into hasher: inout Hasher) {
-        switch self {
-        case let .settings(settingsPage):
-            hasher.combine(settingsPage)
-        case let .expandedPost(post):
-            hasher.combine(post)
-        default:
-            hasher.combine(self)
-        }
-    }
-    
     case settings(_ page: SettingsPage = .root)
     case feeds, profile, inbox, search
     case quickSwitcher, addAccount
@@ -54,7 +43,7 @@ extension NavigationPage {
         case .addAccount:
             LandingPage()
         case let .expandedPost(post):
-            ExpandedPostView(postStub: post.post)
+            ExpandedPostView(post: post)
         }
     }
     

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -9,10 +9,29 @@ import MlemMiddleware
 import SwiftUI
 
 enum NavigationPage: Hashable {
+    static func == (lhs: NavigationPage, rhs: NavigationPage) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        switch self {
+        case let .settings(settingsPage):
+            hasher.combine(settingsPage)
+        case let .expandedPost(post):
+            hasher.combine(post)
+        default:
+            hasher.combine(self)
+        }
+    }
+    
     case settings(_ page: SettingsPage = .root)
     case feeds, profile, inbox, search
     case quickSwitcher, addAccount
-    case expandedPost(_ post: Post2)
+    case expandedPost(_ post: AnyPost)
+    
+    static func expandedPost(_ post: any PostStubProviding) -> NavigationPage {
+        expandedPost(.init(post: post))
+    }
 }
 
 extension NavigationPage {
@@ -35,7 +54,7 @@ extension NavigationPage {
         case .addAccount:
             LandingPage()
         case let .expandedPost(post):
-            ExpandedPostView(post: post)
+            ExpandedPostView(postStub: post.post)
         }
     }
     


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [ ] This PR addresses one or more open issues that were assigned to me:      

## Pull Request Information

This PR updates `ExpandedPost` to be navigable using `AnyPost` (and therefore using any class in the `PostProviding` family)

It also contains a first iteration at how we can handle loading upgradable content in the form of `ContentLoader`. `ContentLoader` takes in an `Upgradable` (see aforementioned PR) and a `@ViewBuilder` that creates a view from the given `Upgradable`'s `MinimumRenderable` type. If the `Upgradable` doesn't conform to `MinimumRenderable`, a loading spinner is displayed while `upgrade()` is performed. If the `Upgradable` is at least `MinimumRenderable`, the view is displayed; if it is not fully `Upgraded`, then `upgrade()` is called.

This system lets us neatly handle displaying upgradable content regardless of its current upgrade status by simply wrapping it in a `ContentLoader`. I haven't tested this, but we should in theory be able to nest one `ContentLoader` in the view closure of another, letting us render as fast as we can upgrade models.

The notion of `MinimumRenderable` does introduce rigidity in tying "renderable" directly to the model, but considering our models I do not judge at this time that that will be an issue.