### PR TITLE
Saved Guest Accounts

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -1424,7 +1424,7 @@
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.5.0;
+				minimumVersion = 0.6.0;
 			};
 		};
 		CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -1423,8 +1423,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware.git";
 			requirement = {
-				branch = "sjmarf/public-core-cache";
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.5.0;
 			};
 		};
 		CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -47,6 +47,12 @@
 		03C93CF22BF0256700327BFE /* EnvironmentValue+IsRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C93CF12BF0256700327BFE /* EnvironmentValue+IsRootView.swift */; };
 		03CCDAA02BF2795300C0C851 /* LoginPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CCDA9F2BF2795300C0C851 /* LoginPage.swift */; };
 		03CCDAA42BF2852E00C0C851 /* LoginTotpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CCDAA32BF2852E00C0C851 /* LoginTotpView.swift */; };
+		03D2A6372C00F92400ED4FF2 /* ActiveAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A6362C00F92400ED4FF2 /* ActiveAccount.swift */; };
+		03D2A6392C00FAE000ED4FF2 /* UserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A6382C00FAE000ED4FF2 /* UserAccount.swift */; };
+		03D2A63B2C010B7500ED4FF2 /* GuestAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A63A2C010B7500ED4FF2 /* GuestAccount.swift */; };
+		03D2A63D2C010CD400ED4FF2 /* ActiveUserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A63C2C010CD400ED4FF2 /* ActiveUserAccount.swift */; };
+		03D2A63F2C010DBF00ED4FF2 /* ActiveGuestAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A63E2C010DBF00ED4FF2 /* ActiveGuestAccount.swift */; };
+		03D2A6422C011F4A00ED4FF2 /* AccountListRowBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A6412C011F4A00ED4FF2 /* AccountListRowBody.swift */; };
 		03D3A1D42BB88EF1009DE55E /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D3A1D32BB88EF1009DE55E /* Action.swift */; };
 		03D3A1E32BB8A40A009DE55E /* EmptyButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D3A1E22BB8A40A009DE55E /* EmptyButtonStyle.swift */; };
 		03D3A1E52BB8B7A3009DE55E /* ActionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D3A1E42BB8B7A3009DE55E /* ActionType.swift */; };
@@ -168,6 +174,12 @@
 		03C93CF12BF0256700327BFE /* EnvironmentValue+IsRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValue+IsRootView.swift"; sourceTree = "<group>"; };
 		03CCDA9F2BF2795300C0C851 /* LoginPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPage.swift; sourceTree = "<group>"; };
 		03CCDAA32BF2852E00C0C851 /* LoginTotpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTotpView.swift; sourceTree = "<group>"; };
+		03D2A6362C00F92400ED4FF2 /* ActiveAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveAccount.swift; sourceTree = "<group>"; };
+		03D2A6382C00FAE000ED4FF2 /* UserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccount.swift; sourceTree = "<group>"; };
+		03D2A63A2C010B7500ED4FF2 /* GuestAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestAccount.swift; sourceTree = "<group>"; };
+		03D2A63C2C010CD400ED4FF2 /* ActiveUserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveUserAccount.swift; sourceTree = "<group>"; };
+		03D2A63E2C010DBF00ED4FF2 /* ActiveGuestAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveGuestAccount.swift; sourceTree = "<group>"; };
+		03D2A6412C011F4A00ED4FF2 /* AccountListRowBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListRowBody.swift; sourceTree = "<group>"; };
 		03D3A1D32BB88EF1009DE55E /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		03D3A1E22BB8A40A009DE55E /* EmptyButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyButtonStyle.swift; sourceTree = "<group>"; };
 		03D3A1E42BB8B7A3009DE55E /* ActionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionType.swift; sourceTree = "<group>"; };
@@ -338,6 +350,8 @@
 			isa = PBXGroup;
 			children = (
 				0369B35A2BFB86E3001EFEDF /* Account.swift */,
+				03D2A6382C00FAE000ED4FF2 /* UserAccount.swift */,
+				03D2A63A2C010B7500ED4FF2 /* GuestAccount.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -347,6 +361,24 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		03D2A6352C00F91A00ED4FF2 /* ActiveAccount */ = {
+			isa = PBXGroup;
+			children = (
+				03D2A6362C00F92400ED4FF2 /* ActiveAccount.swift */,
+				03D2A63C2C010CD400ED4FF2 /* ActiveUserAccount.swift */,
+				03D2A63E2C010DBF00ED4FF2 /* ActiveGuestAccount.swift */,
+			);
+			path = ActiveAccount;
+			sourceTree = "<group>";
+		};
+		03D2A6402C011F3E00ED4FF2 /* ListRow */ = {
+			isa = PBXGroup;
+			children = (
+				03D2A6412C011F4A00ED4FF2 /* AccountListRowBody.swift */,
+			);
+			path = ListRow;
 			sourceTree = "<group>";
 		};
 		03D3A1EB2BB8CDFB009DE55E /* Action */ = {
@@ -363,6 +395,7 @@
 		6318EDC427EE4E0500BFCAE8 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				03D2A6352C00F91A00ED4FF2 /* ActiveAccount */,
 				03D3A1EB2BB8CDFB009DE55E /* Action */,
 				0369B3592BFB86C6001EFEDF /* Account */,
 				CD4D58CC2B86DDC300B82964 /* Settings */,
@@ -546,6 +579,7 @@
 		CD4D58A82B86BE4C00B82964 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				03D2A6402C011F3E00ED4FF2 /* ListRow */,
 				03500C252BF694A800CAA076 /* Toast */,
 				035BE0852BDD8D9100F77D73 /* Navigation */,
 				CD4D58BE2B86DBC900B82964 /* Avatars */,
@@ -886,6 +920,7 @@
 				03FE14042BF93FDD00A8377F /* ErrorDetails.swift in Sources */,
 				031E2D5B2BEFC9460003BC45 /* ThemeSettingsView.swift in Sources */,
 				03D3A1F12BB9D48E009DE55E /* BasicAction.swift in Sources */,
+				03D2A6392C00FAE000ED4FF2 /* UserAccount.swift in Sources */,
 				03C93CF02BEFFB1A00327BFE /* LoginCredentialsView.swift in Sources */,
 				CD4ED84E2BF113C800EFA0A2 /* ExpandedPostView.swift in Sources */,
 				035BE08D2BDE88EC00F77D73 /* NavigationLayerView.swift in Sources */,
@@ -895,6 +930,7 @@
 				03C93CF22BF0256700327BFE /* EnvironmentValue+IsRootView.swift in Sources */,
 				037386412BDAF3F7007492B5 /* Markdown.swift in Sources */,
 				CD4D58CF2B86DDEC00B82964 /* AccountSortMode.swift in Sources */,
+				03D2A6372C00F92400ED4FF2 /* ActiveAccount.swift in Sources */,
 				03134A522BEAD69F002662CC /* SettingsPage.swift in Sources */,
 				03CCDAA02BF2795300C0C851 /* LoginPage.swift in Sources */,
 				037658DF2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift in Sources */,
@@ -902,6 +938,7 @@
 				CD1446212A5B328E00610EF1 /* Privacy Policy.swift in Sources */,
 				03FE140C2BF953B000A8377F /* HandleError.swift in Sources */,
 				CD1446272A5B36DA00610EF1 /* EULA.swift in Sources */,
+				03D2A63B2C010B7500ED4FF2 /* GuestAccount.swift in Sources */,
 				CD4ED84A2BF1113800EFA0A2 /* View+TabReselectConsumer.swift in Sources */,
 				03500C222BF5594100CAA076 /* ToastType.swift in Sources */,
 				CD4D58A52B86BD1B00B82964 /* PersistenceRepository.swift in Sources */,
@@ -915,6 +952,7 @@
 				CD4D58EB2B86E63300B82964 /* AssociatedColor.swift in Sources */,
 				CD317D4C2BE97FED008F63E2 /* Palette.swift in Sources */,
 				03FE14062BF9445F00A8377F /* CloseButtonView.swift in Sources */,
+				03D2A6422C011F4A00ED4FF2 /* AccountListRowBody.swift in Sources */,
 				03134A5A2BEC2253002662CC /* AvatarStackView.swift in Sources */,
 				03D3A1F32BB9D49B009DE55E /* ActionGroup.swift in Sources */,
 				CD4D58C82B86DCED00B82964 /* AvatarType.swift in Sources */,
@@ -951,6 +989,7 @@
 				03500C2B2BF7F1B100CAA076 /* ToastOverlayView.swift in Sources */,
 				CD4D59182B87B3B000B82964 /* UIViewController+Extensions.swift in Sources */,
 				03D3A1E52BB8B7A3009DE55E /* ActionType.swift in Sources */,
+				03D2A63D2C010CD400ED4FF2 /* ActiveUserAccount.swift in Sources */,
 				63DF71F12A02999C002AC14E /* AppConstants.swift in Sources */,
 				03D3A1D42BB88EF1009DE55E /* Action.swift in Sources */,
 				6363D5C727EE196700E34822 /* ContentView.swift in Sources */,
@@ -966,6 +1005,7 @@
 				CD4D58F82B87B0D100B82964 /* InternetSpeed.swift in Sources */,
 				CD4D58932B86BA5C00B82964 /* StandardPalette.swift in Sources */,
 				CD4ED84C2BF111BA00EFA0A2 /* ScrollToView.swift in Sources */,
+				03D2A63F2C010DBF00ED4FF2 /* ActiveGuestAccount.swift in Sources */,
 				030FF6812BC859FD00F6BFAC /* CustomTabViewHostingController.swift in Sources */,
 				CD4D58AD2B86BE7100B82964 /* QuickSwitcherView.swift in Sources */,
 				6363D5C527EE196700E34822 /* MlemApp.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -1423,8 +1423,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.0;
+				branch = "sjmarf/public-core-cache";
+				kind = branch;
 			};
 		};
 		CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -47,11 +47,11 @@
 		03C93CF22BF0256700327BFE /* EnvironmentValue+IsRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C93CF12BF0256700327BFE /* EnvironmentValue+IsRootView.swift */; };
 		03CCDAA02BF2795300C0C851 /* LoginPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CCDA9F2BF2795300C0C851 /* LoginPage.swift */; };
 		03CCDAA42BF2852E00C0C851 /* LoginTotpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CCDAA32BF2852E00C0C851 /* LoginTotpView.swift */; };
-		03D2A6372C00F92400ED4FF2 /* ActiveAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A6362C00F92400ED4FF2 /* ActiveAccount.swift */; };
+		03D2A6372C00F92400ED4FF2 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A6362C00F92400ED4FF2 /* Session.swift */; };
 		03D2A6392C00FAE000ED4FF2 /* UserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A6382C00FAE000ED4FF2 /* UserAccount.swift */; };
 		03D2A63B2C010B7500ED4FF2 /* GuestAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A63A2C010B7500ED4FF2 /* GuestAccount.swift */; };
-		03D2A63D2C010CD400ED4FF2 /* ActiveUserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A63C2C010CD400ED4FF2 /* ActiveUserAccount.swift */; };
-		03D2A63F2C010DBF00ED4FF2 /* ActiveGuestAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A63E2C010DBF00ED4FF2 /* ActiveGuestAccount.swift */; };
+		03D2A63D2C010CD400ED4FF2 /* UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A63C2C010CD400ED4FF2 /* UserSession.swift */; };
+		03D2A63F2C010DBF00ED4FF2 /* GuestSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A63E2C010DBF00ED4FF2 /* GuestSession.swift */; };
 		03D2A6422C011F4A00ED4FF2 /* AccountListRowBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D2A6412C011F4A00ED4FF2 /* AccountListRowBody.swift */; };
 		03D3A1D42BB88EF1009DE55E /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D3A1D32BB88EF1009DE55E /* Action.swift */; };
 		03D3A1E32BB8A40A009DE55E /* EmptyButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D3A1E22BB8A40A009DE55E /* EmptyButtonStyle.swift */; };
@@ -96,7 +96,7 @@
 		CD4D58AD2B86BE7100B82964 /* QuickSwitcherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D58AC2B86BE7100B82964 /* QuickSwitcherView.swift */; };
 		CD4D58B32B86BFD400B82964 /* AccountsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D58B22B86BFD400B82964 /* AccountsTracker.swift */; };
 		CD4D58B52B86BFFB00B82964 /* PersistenceRepository+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D58B42B86BFFA00B82964 /* PersistenceRepository+Dependency.swift */; };
-		CD4D58B92B86D9F800B82964 /* AccountButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D58B82B86D9F800B82964 /* AccountButtonView.swift */; };
+		CD4D58B92B86D9F800B82964 /* AccountListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D58B82B86D9F800B82964 /* AccountListRow.swift */; };
 		CD4D58BB2B86DA7D00B82964 /* AccountListView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D58BA2B86DA7D00B82964 /* AccountListView+Logic.swift */; };
 		CD4D58C02B86DBD100B82964 /* DefaultAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D58BF2B86DBD100B82964 /* DefaultAvatarView.swift */; };
 		CD4D58C82B86DCED00B82964 /* AvatarType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D58C72B86DCED00B82964 /* AvatarType.swift */; };
@@ -174,11 +174,11 @@
 		03C93CF12BF0256700327BFE /* EnvironmentValue+IsRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValue+IsRootView.swift"; sourceTree = "<group>"; };
 		03CCDA9F2BF2795300C0C851 /* LoginPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPage.swift; sourceTree = "<group>"; };
 		03CCDAA32BF2852E00C0C851 /* LoginTotpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTotpView.swift; sourceTree = "<group>"; };
-		03D2A6362C00F92400ED4FF2 /* ActiveAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveAccount.swift; sourceTree = "<group>"; };
+		03D2A6362C00F92400ED4FF2 /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		03D2A6382C00FAE000ED4FF2 /* UserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccount.swift; sourceTree = "<group>"; };
 		03D2A63A2C010B7500ED4FF2 /* GuestAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestAccount.swift; sourceTree = "<group>"; };
-		03D2A63C2C010CD400ED4FF2 /* ActiveUserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveUserAccount.swift; sourceTree = "<group>"; };
-		03D2A63E2C010DBF00ED4FF2 /* ActiveGuestAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveGuestAccount.swift; sourceTree = "<group>"; };
+		03D2A63C2C010CD400ED4FF2 /* UserSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSession.swift; sourceTree = "<group>"; };
+		03D2A63E2C010DBF00ED4FF2 /* GuestSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestSession.swift; sourceTree = "<group>"; };
 		03D2A6412C011F4A00ED4FF2 /* AccountListRowBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListRowBody.swift; sourceTree = "<group>"; };
 		03D3A1D32BB88EF1009DE55E /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		03D3A1E22BB8A40A009DE55E /* EmptyButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyButtonStyle.swift; sourceTree = "<group>"; };
@@ -221,7 +221,7 @@
 		CD4D58AC2B86BE7100B82964 /* QuickSwitcherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSwitcherView.swift; sourceTree = "<group>"; };
 		CD4D58B22B86BFD400B82964 /* AccountsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsTracker.swift; sourceTree = "<group>"; };
 		CD4D58B42B86BFFA00B82964 /* PersistenceRepository+Dependency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PersistenceRepository+Dependency.swift"; sourceTree = "<group>"; };
-		CD4D58B82B86D9F800B82964 /* AccountButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountButtonView.swift; sourceTree = "<group>"; };
+		CD4D58B82B86D9F800B82964 /* AccountListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListRow.swift; sourceTree = "<group>"; };
 		CD4D58BA2B86DA7D00B82964 /* AccountListView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountListView+Logic.swift"; sourceTree = "<group>"; };
 		CD4D58BF2B86DBD100B82964 /* DefaultAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAvatarView.swift; sourceTree = "<group>"; };
 		CD4D58C72B86DCED00B82964 /* AvatarType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarType.swift; sourceTree = "<group>"; };
@@ -363,19 +363,20 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		03D2A6352C00F91A00ED4FF2 /* ActiveAccount */ = {
+		03D2A6352C00F91A00ED4FF2 /* Session */ = {
 			isa = PBXGroup;
 			children = (
-				03D2A6362C00F92400ED4FF2 /* ActiveAccount.swift */,
-				03D2A63C2C010CD400ED4FF2 /* ActiveUserAccount.swift */,
-				03D2A63E2C010DBF00ED4FF2 /* ActiveGuestAccount.swift */,
+				03D2A6362C00F92400ED4FF2 /* Session.swift */,
+				03D2A63C2C010CD400ED4FF2 /* UserSession.swift */,
+				03D2A63E2C010DBF00ED4FF2 /* GuestSession.swift */,
 			);
-			path = ActiveAccount;
+			path = Session;
 			sourceTree = "<group>";
 		};
 		03D2A6402C011F3E00ED4FF2 /* ListRow */ = {
 			isa = PBXGroup;
 			children = (
+				CD4D58B82B86D9F800B82964 /* AccountListRow.swift */,
 				03D2A6412C011F4A00ED4FF2 /* AccountListRowBody.swift */,
 			);
 			path = ListRow;
@@ -395,7 +396,7 @@
 		6318EDC427EE4E0500BFCAE8 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				03D2A6352C00F91A00ED4FF2 /* ActiveAccount */,
+				03D2A6352C00F91A00ED4FF2 /* Session */,
 				03D3A1EB2BB8CDFB009DE55E /* Action */,
 				0369B3592BFB86C6001EFEDF /* Account */,
 				CD4D58CC2B86DDC300B82964 /* Settings */,
@@ -606,7 +607,6 @@
 			children = (
 				CD4D58A92B86BE5900B82964 /* AccountListView.swift */,
 				CD4D58AC2B86BE7100B82964 /* QuickSwitcherView.swift */,
-				CD4D58B82B86D9F800B82964 /* AccountButtonView.swift */,
 				CD4D58BA2B86DA7D00B82964 /* AccountListView+Logic.swift */,
 			);
 			path = Accounts;
@@ -930,7 +930,7 @@
 				03C93CF22BF0256700327BFE /* EnvironmentValue+IsRootView.swift in Sources */,
 				037386412BDAF3F7007492B5 /* Markdown.swift in Sources */,
 				CD4D58CF2B86DDEC00B82964 /* AccountSortMode.swift in Sources */,
-				03D2A6372C00F92400ED4FF2 /* ActiveAccount.swift in Sources */,
+				03D2A6372C00F92400ED4FF2 /* Session.swift in Sources */,
 				03134A522BEAD69F002662CC /* SettingsPage.swift in Sources */,
 				03CCDAA02BF2795300C0C851 /* LoginPage.swift in Sources */,
 				037658DF2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift in Sources */,
@@ -945,7 +945,7 @@
 				CD1446252A5B357900610EF1 /* Document.swift in Sources */,
 				03134A4D2BEAD058002662CC /* AvatarView.swift in Sources */,
 				CD4D58AA2B86BE5900B82964 /* AccountListView.swift in Sources */,
-				CD4D58B92B86D9F800B82964 /* AccountButtonView.swift in Sources */,
+				CD4D58B92B86D9F800B82964 /* AccountListRow.swift in Sources */,
 				CD4D58B32B86BFD400B82964 /* AccountsTracker.swift in Sources */,
 				CD317D4F2BE983ED008F63E2 /* MonochromePalette.swift in Sources */,
 				CD4D58B52B86BFFB00B82964 /* PersistenceRepository+Dependency.swift in Sources */,
@@ -989,7 +989,7 @@
 				03500C2B2BF7F1B100CAA076 /* ToastOverlayView.swift in Sources */,
 				CD4D59182B87B3B000B82964 /* UIViewController+Extensions.swift in Sources */,
 				03D3A1E52BB8B7A3009DE55E /* ActionType.swift in Sources */,
-				03D2A63D2C010CD400ED4FF2 /* ActiveUserAccount.swift in Sources */,
+				03D2A63D2C010CD400ED4FF2 /* UserSession.swift in Sources */,
 				63DF71F12A02999C002AC14E /* AppConstants.swift in Sources */,
 				03D3A1D42BB88EF1009DE55E /* Action.swift in Sources */,
 				6363D5C727EE196700E34822 /* ContentView.swift in Sources */,
@@ -1005,7 +1005,7 @@
 				CD4D58F82B87B0D100B82964 /* InternetSpeed.swift in Sources */,
 				CD4D58932B86BA5C00B82964 /* StandardPalette.swift in Sources */,
 				CD4ED84C2BF111BA00EFA0A2 /* ScrollToView.swift in Sources */,
-				03D2A63F2C010DBF00ED4FF2 /* ActiveGuestAccount.swift in Sources */,
+				03D2A63F2C010DBF00ED4FF2 /* GuestSession.swift in Sources */,
 				030FF6812BC859FD00F6BFAC /* CustomTabViewHostingController.swift in Sources */,
 				CD4D58AD2B86BE7100B82964 /* QuickSwitcherView.swift in Sources */,
 				6363D5C527EE196700E34822 /* MlemApp.swift in Sources */,

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -30,10 +30,10 @@
     {
       "identity" : "mlemmiddleware",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlemgroup/MlemMiddleware",
+      "location" : "https://github.com/mlemgroup/MlemMiddleware.git",
       "state" : {
-        "revision" : "8a8784c789683df9248662108721a573e41ba6b8",
-        "version" : "0.1.2"
+        "revision" : "aad754bf914107114e7e3ee74591b46190a8cdcc",
+        "version" : "0.6.0"
       }
     },
     {

--- a/Mlem/App/Constants/Icons.swift
+++ b/Mlem/App/Constants/Icons.swift
@@ -179,6 +179,7 @@ enum Icons {
     static let edit: String = "pencil"
     static let delete: String = "trash"
     static let copy: String = "doc.on.doc"
+    static let signOut: String = "minus.circle"
     
     // settings
     static let upvoteOnSave: String = "arrow.up.heart"

--- a/Mlem/App/Globals/Definitions/AccountsTracker.swift
+++ b/Mlem/App/Globals/Definitions/AccountsTracker.swift
@@ -78,6 +78,7 @@ class AccountsTracker {
             assertionFailure()
         }
         AppState.main.deactivate(account: account)
+        GuestAccountCache.main.clean()
     }
     
     @discardableResult

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -52,17 +52,12 @@ class AppState {
             if let index = AppState.main.activeSessions.firstIndex(where: { $0.account === account }) {
                 activeSessions[index].deactivate()
                 activeSessions.remove(at: index)
-            }
+            } else { return }
         } else if let account = account as? GuestAccount {
-            guard account == guestSession.account else {
-                assertionFailure("Tried to deactivate a non-active GuestAccount")
-                return
-            }
+            guard account == guestSession.account else { return }
             guestSession = .init(account: AccountsTracker.main.defaultGuestAccount)
-            GuestAccountCache.main.clean()
         }
         changeAccount(to: AccountsTracker.main.defaultAccount)
-        AccountsTracker.main.saveAccounts(ofType: .all)
     }
     
     var firstSession: any Session { activeSessions.first ?? guestSession }

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -22,7 +22,7 @@ class AppState {
         guestSession.deactivate()
         
         // Save because we updated `lastUsed` in the above `deactivate()` calls
-        AccountsTracker.main.saveAccounts()
+        AccountsTracker.main.saveAccounts(ofType: .all)
         
         if let account = account as? UserAccount {
             let activeAccount = UserSession(account: account)
@@ -42,7 +42,7 @@ class AppState {
             if activeSessions.isEmpty, let defaultAccount = AccountsTracker.main.defaultAccount {
                 changeAccount(to: defaultAccount)
             } else {
-                AccountsTracker.main.saveAccounts()
+                AccountsTracker.main.saveAccounts(ofType: .all)
             }
         }
     }
@@ -54,7 +54,7 @@ class AppState {
     private init() {
         if let user = AccountsTracker.main.defaultAccount {
             changeAccount(to: user)
-        } else if let user = AccountsTracker.main.savedAccounts.first {
+        } else if let user = AccountsTracker.main.userAccounts.first {
             changeAccount(to: user)
         }
     }

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -12,30 +12,37 @@ import SwiftUI
 
 @Observable
 class AppState {
-    private(set) var guestAccount: ActiveAccount = .init(instanceUrl: URL(string: "https://lemmy.world")!)
-    private(set) var activeAccounts: [ActiveAccount] = []
+    private(set) var guestAccount: ActiveGuestAccount = .init(url: URL(string: "https://lemmy.world")!)
+    private(set) var activeAccounts: [ActiveUserAccount] = []
 
-    func changeUser(to account: Account) {
+    func changeAccount(to account: any Account) {
         ToastModel.main.add(.account(account))
-        let newAccount = ActiveAccount(account: account)
+        
         activeAccounts.forEach { $0.deactivate() }
         guestAccount.deactivate()
-        activeAccounts = [newAccount]
+        
+        // Save because we updated `lastUsed` in the above `deactivate()` calls
+        AccountsTracker.main.saveAccounts()
+        
+        if let account = account as? UserAccount {
+            let activeAccount = ActiveUserAccount(account: account)
+            activeAccounts = [activeAccount]
+        } else if let account = account as? GuestAccount {
+            activeAccounts = []
+            guestAccount = .init(account: account)
+        } else {
+            assertionFailure()
+        }
     }
     
-    func enterGuestMode(for instanceUrl: URL) {
-        activeAccounts.forEach { $0.deactivate() }
-        activeAccounts = []
-        guestAccount.deactivate()
-        guestAccount = .init(instanceUrl: instanceUrl)
-    }
-    
-    func deactivate(account: Account) {
+    func deactivate(account: UserAccount) {
         if let index = AppState.main.activeAccounts.firstIndex(where: { $0.account === account }) {
             activeAccounts[index].deactivate()
             activeAccounts.remove(at: index)
             if activeAccounts.isEmpty, let defaultAccount = AccountsTracker.main.defaultAccount {
-                changeUser(to: defaultAccount)
+                changeAccount(to: defaultAccount)
+            } else {
+                AccountsTracker.main.saveAccounts()
             }
         }
     }
@@ -46,16 +53,16 @@ class AppState {
     
     private init() {
         if let user = AccountsTracker.main.defaultAccount {
-            changeUser(to: user)
+            changeAccount(to: user)
         } else if let user = AccountsTracker.main.savedAccounts.first {
-            changeUser(to: user)
+            changeAccount(to: user)
         }
     }
     
-    var firstAccount: ActiveAccount { activeAccounts.first ?? guestAccount }
+    var firstAccount: any ActiveAccount { activeAccounts.first ?? guestAccount }
     var firstApi: ApiClient { firstAccount.api }
     
-    func accountThatModerates(actorId: URL) -> ActiveAccount? {
+    func accountThatModerates(actorId: URL) -> ActiveUserAccount? {
         activeAccounts.first(where: { account in
             account.person?.moderatedCommunities.contains { $0.actorId == actorId } ?? false
         })
@@ -68,60 +75,4 @@ class AppState {
     }
     
     static var main: AppState = .init()
-}
-
-@Observable
-class ActiveAccount: Hashable {
-    private(set) var api: ApiClient
-    private(set) var account: Account?
-    private(set) var person: Person4?
-    private(set) var instance: Instance3?
-    private(set) var subscriptions: SubscriptionList?
-    
-    // TODO: Store this in a file; make sure to translate 1.0 favorites to 2.0 favorites
-    private var favorites: Set<Int> = []
-    
-    var actorId: URL? { account?.actorId }
-  
-    init(account: Account) {
-        self.api = account.api
-        self.account = account
-        api.permissions = .all
-        self.subscriptions = api.setupSubscriptionList(
-            getFavorites: { self.favorites },
-            setFavorites: { self.favorites = $0 }
-        )
-        
-        Task {
-            try await self.api.fetchSiteVersion(task: Task {
-                let (person, instance) = try await self.api.getMyPerson()
-                if let person {
-                    self.account?.update(person: person, instance: instance)
-                    self.person = person
-                }
-                self.instance = instance
-                return instance.version
-            })
-            
-            try await self.api.getSubscriptionList()
-        }
-    }
-    
-    init(instanceUrl: URL) {
-        self.api = .getApiClient(for: instanceUrl, with: nil)
-        api.permissions = .all // should this be .getOnly?
-    }
-    
-    func deactivate() {
-        api.permissions = .getOnly
-        api.cleanCaches()
-    }
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(actorId)
-    }
-    
-    static func == (lhs: ActiveAccount, rhs: ActiveAccount) -> Bool {
-        lhs.actorId == rhs.actorId
-    }
 }

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -8,18 +8,29 @@
 import Dependencies
 import Foundation
 import MlemMiddleware
-import SwiftUI
+import Observation
 
 @Observable
 class AppState {
-    private(set) var guestSession: GuestSession = .init(url: URL(string: "https://lemmy.world")!)
+    private(set) var guestSession: GuestSession!
     private(set) var activeSessions: [UserSession] = []
-
+    
+    private init() {
+        self.guestSession = .init(account: AccountsTracker.main.defaultGuestAccount)
+        changeAccount(to: AccountsTracker.main.defaultAccount, deactivateOldGuest: false)
+    }
+    
     func changeAccount(to account: any Account) {
+        changeAccount(to: account, deactivateOldGuest: true)
+    }
+    
+    private func changeAccount(to account: any Account, deactivateOldGuest: Bool) {
         ToastModel.main.add(.account(account))
         
         activeSessions.forEach { $0.deactivate() }
-        guestSession.deactivate()
+        if deactivateOldGuest {
+            guestSession?.deactivate()
+        }
         
         // Save because we updated `lastUsed` in the above `deactivate()` calls
         AccountsTracker.main.saveAccounts(ofType: .all)
@@ -30,33 +41,28 @@ class AppState {
         } else if let account = account as? GuestAccount {
             activeSessions = []
             guestSession = .init(account: account)
+            GuestAccountCache.main.clean()
         } else {
             assertionFailure()
         }
     }
     
-    func deactivate(account: UserAccount) {
-        if let index = AppState.main.activeSessions.firstIndex(where: { $0.account === account }) {
-            activeSessions[index].deactivate()
-            activeSessions.remove(at: index)
-            if activeSessions.isEmpty, let defaultAccount = AccountsTracker.main.defaultAccount {
-                changeAccount(to: defaultAccount)
-            } else {
-                AccountsTracker.main.saveAccounts(ofType: .all)
+    func deactivate(account: any Account) {
+        if let account = account as? UserAccount {
+            if let index = AppState.main.activeSessions.firstIndex(where: { $0.account === account }) {
+                activeSessions[index].deactivate()
+                activeSessions.remove(at: index)
             }
+        } else if let account = account as? GuestAccount {
+            guard account == guestSession.account else {
+                assertionFailure("Tried to deactivate a non-active GuestAccount")
+                return
+            }
+            guestSession = .init(account: AccountsTracker.main.defaultGuestAccount)
+            GuestAccountCache.main.clean()
         }
-    }
-    
-    func enterOnboarding() {
-        activeSessions.removeAll()
-    }
-    
-    private init() {
-        if let user = AccountsTracker.main.defaultAccount {
-            changeAccount(to: user)
-        } else if let user = AccountsTracker.main.userAccounts.first {
-            changeAccount(to: user)
-        }
+        changeAccount(to: AccountsTracker.main.defaultAccount)
+        AccountsTracker.main.saveAccounts(ofType: .all)
     }
     
     var firstSession: any Session { activeSessions.first ?? guestSession }

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -68,11 +68,11 @@ class PersistenceRepository {
     
     // MARK: - Public methods
     
-    func loadAccounts() -> [Account] {
-        load([Account].self, from: Path.savedAccounts) ?? []
+    func loadAccounts() -> [UserAccount] {
+        load([UserAccount].self, from: Path.savedAccounts) ?? []
     }
     
-    func saveAccounts(_ value: [Account]) async throws {
+    func saveAccounts(_ value: [UserAccount]) async throws {
         try await save(value, to: Path.savedAccounts)
     }
     

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -24,7 +24,8 @@ private enum Path {
         return path
     }()
 
-    static var savedAccounts = root.appendingPathComponent("Saved Accounts", conformingTo: .json)
+    static var userAccounts = root.appendingPathComponent("Saved Accounts", conformingTo: .json)
+    static var guestAccounts = root.appendingPathComponent("Guest Accounts", conformingTo: .json)
     static var filteredKeywords = root.appendingPathComponent("Blocked Keywords", conformingTo: .json)
     static var favoriteCommunities = root.appendingPathComponent("Favorite Communities", conformingTo: .json)
     static var recentSearches = root.appendingPathComponent("Recent Searches", conformingTo: .json)
@@ -68,12 +69,20 @@ class PersistenceRepository {
     
     // MARK: - Public methods
     
-    func loadAccounts() -> [UserAccount] {
-        load([UserAccount].self, from: Path.savedAccounts) ?? []
+    func loadUserAccounts() -> [UserAccount] {
+        load([UserAccount].self, from: Path.userAccounts) ?? []
     }
     
-    func saveAccounts(_ value: [UserAccount]) async throws {
-        try await save(value, to: Path.savedAccounts)
+    func saveUserAccounts(_ value: [UserAccount]) async throws {
+        try await save(value, to: Path.userAccounts)
+    }
+    
+    func loadGuestAccounts() -> [GuestAccount] {
+        load([GuestAccount].self, from: Path.guestAccounts) ?? []
+    }
+    
+    func saveGuestAccounts(_ value: [GuestAccount]) async throws {
+        try await save(value, to: Path.guestAccounts)
     }
     
     func loadRecentSearches(for accountId: String) -> [ContentModelIdentifier] {

--- a/Mlem/App/Logic/HandleError.swift
+++ b/Mlem/App/Logic/HandleError.swift
@@ -24,7 +24,7 @@ func handleError(
     switch error {
     // TODO: Modify MlemMiddleware to attach the ApiClient throwing the error to ApiClientError.invalidSession, so that we can access the relevant UserStub in a multi-account context
     case ApiClientError.invalidSession:
-        if let user = AppState.main.firstAccount.account as? UserAccount {
+        if let user = AppState.main.firstSession.account as? UserAccount {
             for layer in NavigationModel.main.layers {
                 switch layer.path.first {
                 case let .login(page):

--- a/Mlem/App/Logic/HandleError.swift
+++ b/Mlem/App/Logic/HandleError.swift
@@ -24,7 +24,7 @@ func handleError(
     switch error {
     // TODO: Modify MlemMiddleware to attach the ApiClient throwing the error to ApiClientError.invalidSession, so that we can access the relevant UserStub in a multi-account context
     case ApiClientError.invalidSession:
-        if let user = AppState.main.firstAccount.account {
+        if let user = AppState.main.firstAccount.account as? UserAccount {
             for layer in NavigationModel.main.layers {
                 switch layer.path.first {
                 case let .login(page):

--- a/Mlem/App/Models/Account/Account.swift
+++ b/Mlem/App/Models/Account/Account.swift
@@ -10,162 +10,30 @@ import KeychainAccess
 import MlemMiddleware
 import SwiftUI
 
-enum UserError: Error {
-    case noUserInResponse
-    case unauthenticated
+protocol Account: AnyObject, Codable, ContentStub, Profile1Providing {
+    // Stored
+    var name: String { get }
+    var storedNickname: String? { get }
+    var cachedSiteVersion: SiteVersion? { get }
+    var avatar: URL? { get }
+    var lastUsed: Date? { get set }
+    
+    // Computed
+    var nickname: String { get }
+    var nicknameSortKey: String { get }
+    var instanceSortKey: String { get }
+    var host: String? { get }
+    var isActive: Bool { get }
 }
 
-@Observable
-final class Account: Codable, CommunityOrPersonStub, Profile1Providing {
-    static let identifierPrefix: String = "@"
-    
-    var api: ApiClient
-    
-    let id: Int
-    let name: String
-    var actorId: URL
-    
-    var nickname: String?
-    var cachedSiteVersion: SiteVersion?
-    var avatar: URL?
-    var lastLoggedIn: Date?
-    
-    enum CodingKeys: String, CodingKey {
-        // These key names don't match the identifiers of their corresponding properties - this is because these key names must match the property names used in SavedAccount pre-1.3 in order to maintain compatibility
-        case id, username, storedNickname, instanceLink, siteVersion, avatarUrl, lastUsed
-    }
-    
-    enum DecodingError: Error {
-        case noTokenInKeychain, cannotRemoveExtraneousPathComponents
-    }
-    
-    init(
-        api: ApiClient,
-        id: Int,
-        name: String,
-        actorId: URL,
-        nickname: String? = nil,
-        cachedSiteVersion: SiteVersion? = nil,
-        avatar: URL? = nil,
-        lastLoggedIn: Date? = nil
-    ) {
-        self.api = api
-        self.id = id
-        self.name = name
-        self.actorId = actorId
-        self.nickname = nickname
-        self.cachedSiteVersion = cachedSiteVersion
-        self.avatar = avatar
-        self.lastLoggedIn = lastLoggedIn
-    }
-    
-    init(person: Person4, instance: Instance3) {
-        self.api = person.api
-        self.id = person.id
-        self.name = person.name
-        self.actorId = person.actorId
-        self.nickname = nil
-        self.cachedSiteVersion = instance.version
-        self.avatar = person.avatar
-        self.lastLoggedIn = .now
-    }
-    
-    init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        
-        // copy simple values
-        self.id = try values.decode(Int.self, forKey: .id)
-        self.name = try values.decode(String.self, forKey: .username)
-        self.nickname = try values.decode(String?.self, forKey: .storedNickname)
-        self.cachedSiteVersion = try values.decode(SiteVersion?.self, forKey: .siteVersion)
-        self.avatar = try values.decode(URL?.self, forKey: .avatarUrl)
-        self.lastLoggedIn = try values.decode(Date?.self, forKey: .lastUsed)
-
-        // parse instance link
-        let instanceLink = try values.decode(URL.self, forKey: .instanceLink)
-        // Remove the "api/v3" path that we attached to the instanceLink pre-2.0
-        var components = URLComponents(url: instanceLink, resolvingAgainstBaseURL: false)!
-        components.path = ""
-        guard let instanceLink = components.url else { throw DecodingError.cannotRemoveExtraneousPathComponents }
-        
-        // parse actor id
-        let actorId = parseActorId(instanceLink: instanceLink, name: name)
-        self.actorId = actorId
-        
-        // retrive token and initialize ApiClient
-        guard let token = AppConstants.keychain[getKeychainId(actorId: actorId)] ?? AppConstants.keychain[getKeychainId(id: id)] else {
-            throw DecodingError.noTokenInKeychain
-        }
-        self.api = ApiClient.getApiClient(for: instanceLink, with: token)
-    }
-    
-    func encode(to encoder: Encoder) throws {
-        saveTokenToKeychain()
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(id, forKey: .id)
-        try container.encode(name, forKey: .username)
-        try container.encode(nickname, forKey: .storedNickname)
-        try container.encode(cachedSiteVersion, forKey: .siteVersion)
-        try container.encode(avatar, forKey: .avatarUrl)
-        try container.encode(lastLoggedIn, forKey: .lastUsed)
-        try container.encode(api.baseUrl, forKey: .instanceLink)
-    }
-    
-    func update(person: Person4, instance: Instance3) {
-        var shouldSave = false
-        if avatar != person.avatar {
-            avatar = person.avatar
-            shouldSave = true
-        }
-        if cachedSiteVersion != instance.version {
-            cachedSiteVersion = instance.version
-            shouldSave = true
-        }
-        if shouldSave {
-            AccountsTracker.main.saveAccounts()
-        }
-    }
-    
-    var keychainId: String {
-        getKeychainId(actorId: actorId)
-    }
-    
-    func updateToken(_ newToken: String) {
-        api.updateToken(newToken)
-    }
-    
-    func saveTokenToKeychain() {
-        AppConstants.keychain[getKeychainId(actorId: actorId)] = api.token
-    }
-    
-    func deleteTokenFromKeychain() {
-        try? AppConstants.keychain.remove(getKeychainId(actorId: actorId))
-        try? AppConstants.keychain.remove(getKeychainId(id: id))
-    }
-    
+extension Account {
     func signOut() {
         AccountsTracker.main.removeAccount(account: self)
     }
     
-    var nicknameSortKey: String {
-        (nickname ?? name) + (host ?? "")
+    func logActivity() {
+        lastUsed = .now
     }
     
-    var instanceSortKey: String {
-        (host ?? "") + (nickname ?? name)
-    }
-}
-
-private func getKeychainId(actorId: URL) -> String {
-    "\(actorId.absoluteString)_accessToken"
-}
-
-private func getKeychainId(id: Int) -> String {
-    "\(id)_accessToken"
-}
-
-private func parseActorId(instanceLink: URL, name: String) -> URL {
-    var actorComponents = URLComponents(url: instanceLink, resolvingAgainstBaseURL: false)!
-    actorComponents.path = "/u/\(name)"
-    return actorComponents.url!
+    var nickname: String { storedNickname ?? name }
 }

--- a/Mlem/App/Models/Account/GuestAccount.swift
+++ b/Mlem/App/Models/Account/GuestAccount.swift
@@ -83,7 +83,11 @@ class GuestAccount: Account {
         actorId.host() ?? "unknown"
     }
     
-    var isActive: Bool { AppState.main.guestAccount === self }
+    var isActive: Bool { AppState.main.guestSession === self }
+    
+    var isSaved: Bool {
+        false
+    }
     
     var nicknameSortKey: String { storedNickname ?? name }
     var instanceSortKey: String { host ?? "" }

--- a/Mlem/App/Models/Account/GuestAccount.swift
+++ b/Mlem/App/Models/Account/GuestAccount.swift
@@ -1,0 +1,90 @@
+//
+//  GuestAccount.swift
+//  Mlem
+//
+//  Created by Sjmarf on 24/05/2024.
+//
+
+import Foundation
+import MlemMiddleware
+import Observation
+
+@Observable
+class GuestAccount: Account {
+    let actorId: URL
+    let api: ApiClient
+    var storedNickname: String?
+    var cachedSiteVersion: SiteVersion?
+    var avatar: URL?
+    var lastUsed: Date?
+    
+    init(url: URL) {
+        self.actorId = url
+        self.api = .getApiClient(for: url, with: nil)
+    }
+    
+    init(instance: Instance3) {
+        self.api = instance.guestApi
+        self.actorId = instance.actorId
+        self.storedNickname = nil
+        self.cachedSiteVersion = instance.version
+        self.avatar = instance.avatar
+        self.lastUsed = .now
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        // Keys are named this way to be consistent with the `UserAccount.CodingKey` cases
+        case storedNickname, instanceLink, siteVersion, avatarUrl, lastUsed
+    }
+    
+    enum DecodingError: Error {
+        case cannotRemoveExtraneousPathComponents, noTokenInKeychain
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.storedNickname = try values.decode(String?.self, forKey: .storedNickname)
+        self.cachedSiteVersion = try values.decode(SiteVersion?.self, forKey: .siteVersion)
+        self.avatar = try values.decode(URL?.self, forKey: .avatarUrl)
+        self.lastUsed = try values.decode(Date?.self, forKey: .lastUsed)
+
+        let instanceLink = try values.decode(URL.self, forKey: .instanceLink)
+        self.actorId = instanceLink
+        
+        self.api = ApiClient.getApiClient(for: instanceLink, with: nil)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(storedNickname, forKey: .storedNickname)
+        try container.encode(cachedSiteVersion, forKey: .siteVersion)
+        try container.encode(avatar, forKey: .avatarUrl)
+        try container.encode(lastUsed, forKey: .lastUsed)
+        try container.encode(api.baseUrl, forKey: .instanceLink)
+    }
+    
+    func update(instance: Instance3) {
+        var shouldSave = false
+        if avatar != instance.avatar {
+            avatar = instance.avatar
+            shouldSave = true
+        }
+        if cachedSiteVersion != instance.version {
+            cachedSiteVersion = instance.version
+            shouldSave = true
+        }
+        if shouldSave {
+            AccountsTracker.main.saveAccounts()
+        }
+    }
+    
+    var name: String {
+        actorId.host() ?? "unknown"
+    }
+    
+    var isActive: Bool { AppState.main.guestAccount === self }
+    
+    var nicknameSortKey: String { storedNickname ?? name }
+    var instanceSortKey: String { host ?? "" }
+}

--- a/Mlem/App/Models/Account/GuestAccount.swift
+++ b/Mlem/App/Models/Account/GuestAccount.swift
@@ -23,6 +23,11 @@ class GuestAccount: Account {
         self.api = .getApiClient(for: url, with: nil)
     }
     
+    init(api: ApiClient) {
+        self.api = api
+        self.actorId = api.actorId
+    }
+    
     init(instance: Instance3) {
         self.api = instance.guestApi
         self.actorId = instance.actorId
@@ -75,7 +80,7 @@ class GuestAccount: Account {
             shouldSave = true
         }
         if shouldSave {
-            AccountsTracker.main.saveAccounts()
+            AccountsTracker.main.saveAccounts(ofType: .guest)
         }
     }
     
@@ -86,9 +91,16 @@ class GuestAccount: Account {
     var isActive: Bool { AppState.main.guestSession === self }
     
     var isSaved: Bool {
-        false
+        AccountsTracker.main.guestAccounts.contains(where: { $0 === self })
     }
     
     var nicknameSortKey: String { storedNickname ?? name }
     var instanceSortKey: String { host ?? "" }
+    
+    func resetStoredSettings(withSave: Bool = true) {
+        storedNickname = nil
+        if withSave {
+            AccountsTracker.main.saveAccounts(ofType: .guest)
+        }
+    }
 }

--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -115,7 +115,7 @@ class UserAccount: Account, CommunityOrPersonStub {
         try? AppConstants.keychain.remove(getKeychainId(id: id))
     }
     
-    var isActive: Bool { AppState.main.activeAccounts.contains(where: { $0 === self }) }
+    var isActive: Bool { AppState.main.activeSessions.contains(where: { $0 === self }) }
     
     var nicknameSortKey: String { nickname + (actorId.host() ?? "") }
     var instanceSortKey: String { (actorId.host() ?? "") + nickname }

--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -1,0 +1,136 @@
+//
+//  AuthenticatedAccount.swift
+//  Mlem
+//
+//  Created by Sjmarf on 24/05/2024.
+//
+
+import Foundation
+import MlemMiddleware
+import Observation
+
+@Observable
+class UserAccount: Account, CommunityOrPersonStub {
+    static let identifierPrefix: String = "@"
+    
+    let actorId: URL
+    let id: Int
+    let api: ApiClient
+    let name: String
+    var storedNickname: String?
+    var cachedSiteVersion: SiteVersion?
+    var avatar: URL?
+    var lastUsed: Date?
+    
+    init(person: Person4, instance: Instance3) {
+        self.api = person.api
+        self.id = person.id
+        self.name = person.name
+        self.actorId = person.actorId
+        self.storedNickname = nil
+        self.cachedSiteVersion = instance.version
+        self.avatar = person.avatar
+        self.lastUsed = .now
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        // These key names don't match the identifiers of their corresponding properties - this is because these key names must match the property names used in SavedAccount pre-1.3 in order to maintain compatibility
+        case id, username, storedNickname, instanceLink, siteVersion, avatarUrl, lastUsed
+    }
+    
+    enum DecodingError: Error {
+        case cannotRemoveExtraneousPathComponents, noTokenInKeychain
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        // copy simple values
+        self.id = try values.decode(Int.self, forKey: .id)
+        self.name = try values.decode(String.self, forKey: .username)
+        self.storedNickname = try values.decode(String?.self, forKey: .storedNickname)
+        self.cachedSiteVersion = try values.decode(SiteVersion?.self, forKey: .siteVersion)
+        self.avatar = try values.decode(URL?.self, forKey: .avatarUrl)
+        self.lastUsed = try values.decode(Date?.self, forKey: .lastUsed)
+
+        // parse instance link
+        let instanceLink = try values.decode(URL.self, forKey: .instanceLink)
+        // Remove the "api/v3" path that we attached to the instanceLink pre-2.0
+        var components = URLComponents(url: instanceLink, resolvingAgainstBaseURL: false)!
+        components.path = ""
+        guard let instanceLink = components.url else { throw DecodingError.cannotRemoveExtraneousPathComponents }
+        
+        // parse actor id
+        let actorId = parseActorId(instanceLink: instanceLink, name: name)
+        self.actorId = actorId
+        
+        // retrive token and initialize ApiClient
+        guard let token = AppConstants.keychain[getKeychainId(actorId: actorId)] ?? AppConstants.keychain[getKeychainId(id: id)] else {
+            throw DecodingError.noTokenInKeychain
+        }
+        self.api = ApiClient.getApiClient(for: instanceLink, with: token)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        saveTokenToKeychain()
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .username)
+        try container.encode(storedNickname, forKey: .storedNickname)
+        try container.encode(cachedSiteVersion, forKey: .siteVersion)
+        try container.encode(avatar, forKey: .avatarUrl)
+        try container.encode(lastUsed, forKey: .lastUsed)
+        try container.encode(api.baseUrl, forKey: .instanceLink)
+    }
+    
+    var keychainId: String {
+        getKeychainId(actorId: actorId)
+    }
+    
+    func update(person: Person4, instance: Instance3) {
+        var shouldSave = false
+        if avatar != person.avatar {
+            avatar = person.avatar
+            shouldSave = true
+        }
+        if cachedSiteVersion != instance.version {
+            cachedSiteVersion = instance.version
+            shouldSave = true
+        }
+        if shouldSave {
+            AccountsTracker.main.saveAccounts()
+        }
+    }
+    
+    func updateToken(_ newToken: String) {
+        api.updateToken(newToken)
+    }
+    
+    func saveTokenToKeychain() {
+        AppConstants.keychain[getKeychainId(actorId: actorId)] = api.token
+    }
+    
+    func deleteTokenFromKeychain() {
+        try? AppConstants.keychain.remove(getKeychainId(actorId: actorId))
+        try? AppConstants.keychain.remove(getKeychainId(id: id))
+    }
+    
+    var isActive: Bool { AppState.main.activeAccounts.contains(where: { $0 === self }) }
+    
+    var nicknameSortKey: String { nickname + (actorId.host() ?? "") }
+    var instanceSortKey: String { (actorId.host() ?? "") + nickname }
+}
+
+private func getKeychainId(actorId: URL) -> String {
+    "\(actorId.absoluteString)_accessToken"
+}
+
+private func getKeychainId(id: Int) -> String {
+    "\(id)_accessToken"
+}
+
+private func parseActorId(instanceLink: URL, name: String) -> URL {
+    var actorComponents = URLComponents(url: instanceLink, resolvingAgainstBaseURL: false)!
+    actorComponents.path = "/u/\(name)"
+    return actorComponents.url!
+}

--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -98,7 +98,7 @@ class UserAccount: Account, CommunityOrPersonStub {
             shouldSave = true
         }
         if shouldSave {
-            AccountsTracker.main.saveAccounts()
+            AccountsTracker.main.saveAccounts(ofType: .guest)
         }
     }
     

--- a/Mlem/App/Models/ActiveAccount/ActiveAccount.swift
+++ b/Mlem/App/Models/ActiveAccount/ActiveAccount.swift
@@ -1,0 +1,26 @@
+//
+//  ActiveAccount.swift
+//  Mlem
+//
+//  Created by Sjmarf on 24/05/2024.
+//
+
+import Foundation
+import MlemMiddleware
+import Observation
+
+protocol ActiveAccount: ActorIdentifiable, Hashable {
+    associatedtype AccountType: Account
+    
+    var api: ApiClient { get }
+    var account: AccountType { get }
+    var instance: Instance3? { get }
+    
+    func deactivate()
+}
+
+extension ActiveAccount {
+    var api: ApiClient { account.api }
+    var actorId: URL { account.actorId }
+    var host: String? { actorId.host() }
+}

--- a/Mlem/App/Models/ActiveAccount/ActiveGuestAccount.swift
+++ b/Mlem/App/Models/ActiveAccount/ActiveGuestAccount.swift
@@ -1,0 +1,48 @@
+//
+//  ActiveGuestAccount.swift
+//  Mlem
+//
+//  Created by Sjmarf on 24/05/2024.
+//
+
+import Foundation
+import MlemMiddleware
+import Observation
+
+@Observable
+class ActiveGuestAccount: ActiveAccount {
+    typealias AccountType = GuestAccount
+    
+    private(set) var account: GuestAccount
+    private(set) var instance: Instance3?
+
+    init(account: GuestAccount) {
+        self.account = account
+        
+        Task {
+            try await self.api.fetchSiteVersion(task: Task {
+                let (_, instance) = try await self.api.getMyPerson()
+                self.instance = instance
+                self.account.update(instance: instance)
+                return instance.version
+            })
+        }
+    }
+    
+    convenience init(url: URL) {
+        self.init(account: .init(url: url))
+    }
+    
+    func deactivate() {
+        account.logActivity()
+        api.cleanCaches()
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(actorId)
+    }
+    
+    static func == (lhs: ActiveGuestAccount, rhs: ActiveGuestAccount) -> Bool {
+        lhs.actorId == rhs.actorId
+    }
+}

--- a/Mlem/App/Models/ActiveAccount/ActiveUserAccount.swift
+++ b/Mlem/App/Models/ActiveAccount/ActiveUserAccount.swift
@@ -1,0 +1,61 @@
+//
+//  ActiveUserAccount.swift
+//  Mlem
+//
+//  Created by Sjmarf on 24/05/2024.
+//
+
+import Foundation
+import MlemMiddleware
+import Observation
+
+@Observable
+class ActiveUserAccount: ActiveAccount {
+    typealias AccountType = UserAccount
+    
+    private(set) var account: UserAccount
+    
+    private(set) var person: Person4?
+    private(set) var instance: Instance3?
+    private(set) var subscriptions: SubscriptionList?
+    
+    // TODO: Store this in a file; make sure to translate 1.0 favorites to 2.0 favorites
+    private var favorites: Set<Int> = []
+
+    init(account: UserAccount) {
+        self.account = account
+        api.permissions = .all
+        self.subscriptions = api.setupSubscriptionList(
+            getFavorites: { self.favorites },
+            setFavorites: { self.favorites = $0 }
+        )
+        
+        Task {
+            try await self.api.fetchSiteVersion(task: Task {
+                let (person, instance) = try await self.api.getMyPerson()
+                if let person {
+                    self.account.update(person: person, instance: instance)
+                    self.person = person
+                }
+                self.instance = instance
+                return instance.version
+            })
+            
+            try await self.api.getSubscriptionList()
+        }
+    }
+    
+    func deactivate() {
+        account.logActivity()
+        api.permissions = .getOnly
+        api.cleanCaches()
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(actorId)
+    }
+    
+    static func == (lhs: ActiveUserAccount, rhs: ActiveUserAccount) -> Bool {
+        lhs.actorId == rhs.actorId
+    }
+}

--- a/Mlem/App/Models/Session/GuestSession.swift
+++ b/Mlem/App/Models/Session/GuestSession.swift
@@ -30,7 +30,7 @@ class GuestSession: Session {
     }
     
     convenience init(url: URL) {
-        self.init(account: .init(url: url))
+        self.init(account: .getGuestAccount(url: url))
     }
     
     func deactivate() {

--- a/Mlem/App/Models/Session/GuestSession.swift
+++ b/Mlem/App/Models/Session/GuestSession.swift
@@ -1,5 +1,5 @@
 //
-//  ActiveGuestAccount.swift
+//  GuestSession.swift
 //  Mlem
 //
 //  Created by Sjmarf on 24/05/2024.
@@ -10,7 +10,7 @@ import MlemMiddleware
 import Observation
 
 @Observable
-class ActiveGuestAccount: ActiveAccount {
+class GuestSession: Session {
     typealias AccountType = GuestAccount
     
     private(set) var account: GuestAccount
@@ -42,7 +42,7 @@ class ActiveGuestAccount: ActiveAccount {
         hasher.combine(actorId)
     }
     
-    static func == (lhs: ActiveGuestAccount, rhs: ActiveGuestAccount) -> Bool {
+    static func == (lhs: GuestSession, rhs: GuestSession) -> Bool {
         lhs.actorId == rhs.actorId
     }
 }

--- a/Mlem/App/Models/Session/Session.swift
+++ b/Mlem/App/Models/Session/Session.swift
@@ -1,5 +1,5 @@
 //
-//  ActiveAccount.swift
+//  Session.swift
 //  Mlem
 //
 //  Created by Sjmarf on 24/05/2024.
@@ -9,7 +9,7 @@ import Foundation
 import MlemMiddleware
 import Observation
 
-protocol ActiveAccount: ActorIdentifiable, Hashable {
+protocol Session: ActorIdentifiable, Hashable {
     associatedtype AccountType: Account
     
     var api: ApiClient { get }
@@ -19,7 +19,7 @@ protocol ActiveAccount: ActorIdentifiable, Hashable {
     func deactivate()
 }
 
-extension ActiveAccount {
+extension Session {
     var api: ApiClient { account.api }
     var actorId: URL { account.actorId }
     var host: String? { actorId.host() }

--- a/Mlem/App/Models/Session/UserSession.swift
+++ b/Mlem/App/Models/Session/UserSession.swift
@@ -1,5 +1,5 @@
 //
-//  ActiveUserAccount.swift
+//  UserSession.swift
 //  Mlem
 //
 //  Created by Sjmarf on 24/05/2024.
@@ -10,7 +10,7 @@ import MlemMiddleware
 import Observation
 
 @Observable
-class ActiveUserAccount: ActiveAccount {
+class UserSession: Session {
     typealias AccountType = UserAccount
     
     private(set) var account: UserAccount
@@ -55,7 +55,7 @@ class ActiveUserAccount: ActiveAccount {
         hasher.combine(actorId)
     }
     
-    static func == (lhs: ActiveUserAccount, rhs: ActiveUserAccount) -> Bool {
+    static func == (lhs: UserSession, rhs: UserSession) -> Bool {
         lhs.actorId == rhs.actorId
     }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/Profile1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Profile1Providing+Extensions.swift
@@ -13,7 +13,7 @@ extension Profile1Providing {
             return .community
         } else if self is any Instance.Type {
             return .instance
-        } else if self is any Person.Type || self is Account.Type {
+        } else if self is any Person.Type || self is any Account.Type {
             return .person
         } else {
             assertionFailure()

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -24,7 +24,6 @@ struct ContentView: View {
     
     var body: some View {
         content
-            .tint(palette.accent)
             .onReceive(timer) { _ in
                 appState.cleanCaches()
             }
@@ -40,13 +39,7 @@ struct ContentView: View {
             )) {
                 NavigationLayerView(layer: navigationModel.layers[0], hasSheetModifiers: true)
             }
-            .overlay(alignment: .top) {
-                ToastOverlayView(
-                    shouldDisplayNewToasts: shouldDisplayToasts,
-                    location: .top
-                )
-                .padding(.top, -6)
-            }
+            .tint(palette.accent)
             .environment(palette)
             .environment(tabReselectTracker)
             .environment(appState)
@@ -93,5 +86,11 @@ struct ContentView: View {
             .padding(.bottom, 100)
         }
         .ignoresSafeArea()
+        .overlay(alignment: .top) {
+            ToastOverlayView(
+                shouldDisplayNewToasts: shouldDisplayToasts,
+                location: .top
+            )
+        }
     }
 }

--- a/Mlem/App/Views/Root/Onboarding/LoginCredentialsView.swift
+++ b/Mlem/App/Views/Root/Onboarding/LoginCredentialsView.swift
@@ -15,7 +15,7 @@ struct LoginCredentialsView: View {
     @Environment(AppState.self) var appState
     
     let instance: (any Instance)?
-    let account: Account?
+    let account: UserAccount?
     
     @State var username: String
     @State var password: String = ""
@@ -34,7 +34,7 @@ struct LoginCredentialsView: View {
         self._username = .init(wrappedValue: "")
     }
     
-    init(account: Account) {
+    init(account: UserAccount) {
         self.instance = nil
         self.account = account
         self._username = .init(wrappedValue: account.name)
@@ -91,7 +91,7 @@ struct LoginCredentialsView: View {
     }
     
     @ViewBuilder
-    func reauthHeader(_ account: Account) -> some View {
+    func reauthHeader(_ account: UserAccount) -> some View {
         VStack {
             AvatarView(account)
                 .frame(height: 50)
@@ -164,7 +164,7 @@ struct LoginCredentialsView: View {
             Task {
                 do {
                     let user = try await AccountsTracker.main.login(client: client, username: username, password: password)
-                    appState.changeUser(to: user)
+                    appState.changeAccount(to: user)
                     if navigation.isTopSheet {
                         navigation.dismissSheet()
                     }

--- a/Mlem/App/Views/Root/Onboarding/LoginTotpView.swift
+++ b/Mlem/App/Views/Root/Onboarding/LoginTotpView.swift
@@ -113,7 +113,7 @@ struct LoginTotpView: View {
                     password: password,
                     totpToken: totpToken
                 )
-                appState.changeUser(to: user)
+                appState.changeAccount(to: user)
                 if navigation.isTopSheet {
                     navigation.dismissSheet()
                 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -33,7 +33,7 @@ struct SubscriptionListView: View {
     
     var body: some View {
         List {
-            if let subscriptions = (appState.firstAccount as? ActiveUserAccount)?.subscriptions {
+            if let subscriptions = (appState.firstSession as? UserSession)?.subscriptions {
                 ForEach(subscriptions.visibleSections) { section in
                     Section(section.label) {
                         ForEach(section.communities) { community in

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -33,20 +33,22 @@ struct SubscriptionListView: View {
     
     var body: some View {
         List {
-            ForEach(appState.firstAccount.subscriptions?.visibleSections ?? .init()) { section in
-                Section(section.label) {
-                    ForEach(section.communities) { community in
-                        HStack {
-                            Text(community.name)
-                            Spacer()
-                            let action = community.favoriteAction
-                            Button(action: action.callback ?? {}) {
-                                Image(systemName: action.menuIcon)
-                                    .foregroundStyle(action.isOn ? action.color : .primary)
+            if let subscriptions = (appState.firstAccount as? ActiveUserAccount)?.subscriptions {
+                ForEach(subscriptions.visibleSections) { section in
+                    Section(section.label) {
+                        ForEach(section.communities) { community in
+                            HStack {
+                                Text(community.name)
+                                Spacer()
+                                let action = community.favoriteAction
+                                Button(action: action.callback ?? {}) {
+                                    Image(systemName: action.menuIcon)
+                                        .foregroundStyle(action.isOn ? action.color : .primary)
+                                }
+                                .buttonStyle(EmptyButtonStyle())
+                                .disabled(action.callback == nil)
+                                .opacity(action.callback == nil ? 0.5 : 1)
                             }
-                            .buttonStyle(EmptyButtonStyle())
-                            .disabled(action.callback == nil)
-                            .opacity(action.callback == nil ? 0.5 : 1)
                         }
                     }
                 }

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
@@ -20,9 +20,7 @@ struct InboxView: View {
                 ToastModel.main.add(.failure())
             }
             Button("Profile") {
-                if let account = AppState.main.firstAccount.account {
-                    ToastModel.main.add(.account(account))
-                }
+                ToastModel.main.add(.account(AppState.main.firstAccount.account))
             }
             Button("Undoable") {
                 ToastModel.main.add(
@@ -37,9 +35,13 @@ struct InboxView: View {
             Button("Error") {
                 handleError(ApiClientError.cancelled)
             }
+            Button("Super Long Text") {
+                ToastModel.main.add(.success("Super long text"))
+            }
             Button("Open Sheet") {
                 navigation.openSheet(.inbox)
             }
+            ToastView(.success("Really super long text"))
         }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
@@ -20,7 +20,7 @@ struct InboxView: View {
                 ToastModel.main.add(.failure())
             }
             Button("Profile") {
-                ToastModel.main.add(.account(AppState.main.firstAccount.account))
+                ToastModel.main.add(.account(AppState.main.firstSession.account))
             }
             Button("Undoable") {
                 ToastModel.main.add(
@@ -41,7 +41,6 @@ struct InboxView: View {
             Button("Open Sheet") {
                 navigation.openSheet(.inbox)
             }
-            ToastView(.success("Really super long text"))
         }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
@@ -36,7 +36,7 @@ struct InboxView: View {
                 handleError(ApiClientError.cancelled)
             }
             Button("Super Long Text") {
-                ToastModel.main.add(.success("Super long text"))
+                ToastModel.main.add(.success("Really Super Long Text"))
             }
             Button("Open Sheet") {
                 navigation.openSheet(.inbox)

--- a/Mlem/App/Views/Root/Tabs/Profile/Profile View.swift
+++ b/Mlem/App/Views/Root/Tabs/Profile/Profile View.swift
@@ -12,7 +12,6 @@ import SwiftUI
 struct ProfileView: View {
     @Environment(AppState.self) var appState
     @Environment(NavigationLayer.self) var navigation
-    @AppStorage("upvoteOnSave") var upvoteOnSave = false
     
     var body: some View {
         content
@@ -26,17 +25,8 @@ struct ProfileView: View {
     
     var content: some View {
         ScrollView {
-            VStack {
-                Text("\(appState.firstAccount.person?.name ?? "No User")")
-                Text("\(appState.firstApi.baseUrl)")
-                Text(appState.firstAccount.person?.displayName ?? "...")
-                Divider()
-                Toggle("Upvote On Save", isOn: $upvoteOnSave)
-                    .padding(.horizontal, 50)
-                Divider()
-                Markdown(markdown)
-                    .padding()
-            }
+            Markdown(markdown)
+                .padding()
         }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct AccountListSettingsView: View {
     @Environment(AppState.self) var appState
     
-    var accounts: [UserAccount] { AccountsTracker.main.savedAccounts }
+    var accounts: [UserAccount] { AccountsTracker.main.userAccounts }
     
     var body: some View {
         Form {

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
@@ -9,20 +9,14 @@ import MlemMiddleware
 import SwiftUI
 
 struct AccountListSettingsView: View {
-    @Environment(NavigationLayer.self) var navigation
     @Environment(AppState.self) var appState
     
-    var accounts: [Account] { AccountsTracker.main.savedAccounts }
+    var accounts: [UserAccount] { AccountsTracker.main.savedAccounts }
     
     var body: some View {
         Form {
             headerView
             AccountListView()
-            Button("Re-authenticate", systemImage: "arrow.2.circlepath") {
-                if let account = appState.firstAccount.account {
-                    navigation.openSheet(.login(.reauth(account)))
-                }
-            }
         }
     }
     

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
@@ -14,18 +14,20 @@ struct AccountSettingsView: View {
         Form {
             Section {
                 VStack(spacing: AppConstants.standardSpacing) {
-                    AvatarBannerView(appState.firstAccount.person)
+                    if let userAccount = appState.firstAccount as? ActiveUserAccount {
+                        AvatarBannerView(userAccount.person)
+                    } else {
+                        AvatarBannerView(appState.firstAccount.instance)
+                    }
                     VStack(spacing: 5) {
-                        Text(appState.firstAccount.person?.displayName ?? "Guest")
+                        Text(title)
                             .font(.title)
                             .fontWeight(.semibold)
                             .lineLimit(1)
                             .minimumScaleFactor(0.01)
-                        if let person = appState.firstAccount.person, let hostName = person.host {
-                            Text("@\(person.name)@\(hostName)")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 }
                 .frame(maxWidth: .infinity)
@@ -35,5 +37,20 @@ struct AccountSettingsView: View {
             }
         }
         .navigationTitle("Account")
+    }
+    
+    var title: String {
+        if let userAccount = appState.firstAccount as? ActiveUserAccount {
+            return userAccount.person?.displayName ?? "Account"
+        } else {
+            return appState.firstAccount.instance?.displayName ?? "User"
+        }
+    }
+    
+    var subtitle: String {
+        if let userAccount = appState.firstAccount as? ActiveUserAccount {
+            return userAccount.person?.fullNameWithPrefix ?? "Loading..."
+        }
+        return appState.firstAccount.instance?.name ?? "Loading..."
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
@@ -14,10 +14,10 @@ struct AccountSettingsView: View {
         Form {
             Section {
                 VStack(spacing: AppConstants.standardSpacing) {
-                    if let userAccount = appState.firstAccount as? ActiveUserAccount {
+                    if let userAccount = appState.firstSession as? UserSession {
                         AvatarBannerView(userAccount.person)
                     } else {
-                        AvatarBannerView(appState.firstAccount.instance)
+                        AvatarBannerView(appState.firstSession.instance)
                     }
                     VStack(spacing: 5) {
                         Text(title)
@@ -40,17 +40,17 @@ struct AccountSettingsView: View {
     }
     
     var title: String {
-        if let userAccount = appState.firstAccount as? ActiveUserAccount {
+        if let userAccount = appState.firstSession as? UserSession {
             return userAccount.person?.displayName ?? "Account"
         } else {
-            return appState.firstAccount.instance?.displayName ?? "User"
+            return appState.firstSession.instance?.displayName ?? "User"
         }
     }
     
     var subtitle: String {
-        if let userAccount = appState.firstAccount as? ActiveUserAccount {
+        if let userAccount = appState.firstSession as? UserSession {
             return userAccount.person?.fullNameWithPrefix ?? "Loading..."
         }
-        return appState.firstAccount.instance?.name ?? "Loading..."
+        return appState.firstSession.instance?.name ?? "Loading..."
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -35,14 +35,14 @@ struct SettingsView: View {
     
     var accountSettingsLink: some View {
         NavigationLink(.settings(.account)) {
-            let account = appState.firstAccount
+            let account = appState.firstSession
             HStack(spacing: 23) {
                 AvatarView(account.account)
                     .frame(width: 54)
                     .padding(.vertical, -6)
                     .padding(.leading, 3)
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(account is ActiveUserAccount ? account.account.nickname : "Guest")
+                    Text(account is UserSession ? account.account.nickname : "Guest")
                         .font(.title2)
                     Text(accountSettingsLinkSubtitle)
                         .foregroundStyle(.secondary)
@@ -54,7 +54,7 @@ struct SettingsView: View {
     }
     
     var accountSettingsLinkSubtitle: String {
-        let account = appState.firstAccount
+        let account = appState.firstSession
         if let host = account.account.host {
             return "@\(host)"
         }

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -54,8 +54,7 @@ struct SettingsView: View {
     }
     
     var accountSettingsLinkSubtitle: String {
-        let account = appState.firstSession
-        if let host = account.account.host {
+        if let host = appState.firstSession.account.host {
             return "@\(host)"
         }
         return ""

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -12,24 +12,28 @@ struct SettingsView: View {
     @Environment(AppState.self) var appState
     @Environment(NavigationLayer.self) var navigation
     
-    var accounts: [Account] { AccountsTracker.main.savedAccounts }
+    @AppStorage("upvoteOnSave") var upvoteOnSave = false
+    
+    var accounts: [UserAccount] { AccountsTracker.main.savedAccounts }
     
     var body: some View {
         Form {
             Section {
-                accountSettingsLink()
-                accountListLink()
+                accountSettingsLink
+                accountListLink
             }
             Section {
                 NavigationLink("Theme", destination: .settings(.theme))
+            }
+            Section {
+                Toggle("Upvote On Save", isOn: $upvoteOnSave)
             }
         }
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
     }
     
-    @ViewBuilder
-    func accountSettingsLink() -> some View {
+    var accountSettingsLink: some View {
         NavigationLink(.settings(.account)) {
             let account = appState.firstAccount
             HStack(spacing: 23) {
@@ -38,21 +42,26 @@ struct SettingsView: View {
                     .padding(.vertical, -6)
                     .padding(.leading, 3)
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(account.account?.nickname ?? account.account?.name ?? "Guest")
+                    Text(account is ActiveUserAccount ? account.account.nickname : "Guest")
                         .font(.title2)
-                    if let hostName = account.api.baseUrl.host() {
-                        Text("@\(hostName)")
-                            .foregroundStyle(.secondary)
-                            .font(.caption)
-                    }
+                    Text(accountSettingsLinkSubtitle)
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
                 }
                 Spacer()
             }
         }
     }
     
-    @ViewBuilder
-    func accountListLink() -> some View {
+    var accountSettingsLinkSubtitle: String {
+        let account = appState.firstAccount
+        if let host = account.account.host {
+            return "@\(host)"
+        }
+        return ""
+    }
+    
+    var accountListLink: some View {
         NavigationLink(.settings(.accounts)) {
             HStack(spacing: 10) {
                 AvatarStackView(

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -14,7 +14,7 @@ struct SettingsView: View {
     
     @AppStorage("upvoteOnSave") var upvoteOnSave = false
     
-    var accounts: [UserAccount] { AccountsTracker.main.savedAccounts }
+    var accounts: [UserAccount] { AccountsTracker.main.userAccounts }
     
     var body: some View {
         Form {

--- a/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
@@ -20,9 +20,9 @@ extension AccountListView {
             return accountsTracker.savedAccounts.sorted { $0.instanceSortKey < $1.instanceSortKey }
         case .mostRecent:
             return accountsTracker.savedAccounts.sorted { left, right in
-                if appState.firstAccount.actorId == left.actorId {
+                if appState.firstSession.actorId == left.actorId {
                     return true
-                } else if appState.firstAccount.actorId == right.actorId {
+                } else if appState.firstSession.actorId == right.actorId {
                     return false
                 }
                 return left.lastUsed ?? .distantPast > right.lastUsed ?? .distantPast
@@ -70,7 +70,7 @@ extension AccountListView {
             var last30Days = [any Account]()
             var older = [any Account]()
             for account in accountsTracker.savedAccounts {
-                if account.actorId == appState.firstAccount.actorId {
+                if account.actorId == appState.firstSession.actorId {
                     continue
                 }
                 
@@ -95,7 +95,7 @@ extension AccountListView {
             var groups = [AccountGroup]()
             
             today.sort { $0.lastUsed ?? .distantPast > $1.lastUsed ?? .distantPast }
-            today.prepend(appState.firstAccount.account)
+            today.prepend(appState.firstSession.account)
             
             if !today.isEmpty {
                 groups.append(

--- a/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
@@ -10,16 +10,16 @@ import SwiftUI
 
 extension AccountListView {
     var accounts: [any Account] {
-        let accountSort = accountsTracker.savedAccounts.count == 2 ? .custom : accountSort
+        let accountSort = accountsTracker.userAccounts.count == 2 ? .custom : accountSort
         switch accountSort {
         case .custom:
-            return accountsTracker.savedAccounts
+            return accountsTracker.userAccounts
         case .name:
-            return accountsTracker.savedAccounts.sorted { $0.nicknameSortKey < $1.nicknameSortKey }
+            return accountsTracker.userAccounts.sorted { $0.nicknameSortKey < $1.nicknameSortKey }
         case .instance:
-            return accountsTracker.savedAccounts.sorted { $0.instanceSortKey < $1.instanceSortKey }
+            return accountsTracker.userAccounts.sorted { $0.instanceSortKey < $1.instanceSortKey }
         case .mostRecent:
-            return accountsTracker.savedAccounts.sorted { left, right in
+            return accountsTracker.userAccounts.sorted { left, right in
                 if appState.firstSession.actorId == left.actorId {
                     return true
                 } else if appState.firstSession.actorId == right.actorId {
@@ -41,16 +41,16 @@ extension AccountListView {
     var accountGroups: [AccountGroup] {
         switch accountSort {
         case .custom:
-            return [.init(header: "Custom", accounts: accountsTracker.savedAccounts)]
+            return [.init(header: "Custom", accounts: accountsTracker.userAccounts)]
         case .name:
             return Dictionary(
-                grouping: accountsTracker.savedAccounts,
+                grouping: accountsTracker.userAccounts,
                 by: { getNameCategory(account: $0) }
             ).map { AccountGroup(header: $0, accounts: $1.sorted { $0.nicknameSortKey < $1.nicknameSortKey }) }
                 .sorted { $0.header < $1.header }
         case .instance:
             let dict = Dictionary(
-                grouping: accountsTracker.savedAccounts,
+                grouping: accountsTracker.userAccounts,
                 by: { $0.host ?? "Unknown" }
             )
             let uniqueInstances = dict.filter { $1.count == 1 }.values.map { $0.first! }
@@ -69,7 +69,7 @@ extension AccountListView {
             var today = [any Account]()
             var last30Days = [any Account]()
             var older = [any Account]()
-            for account in accountsTracker.savedAccounts {
+            for account in accountsTracker.userAccounts {
                 if account.actorId == appState.firstSession.actorId {
                     continue
                 }
@@ -126,6 +126,6 @@ extension AccountListView {
     }
     
     func reorderAccount(fromOffsets: IndexSet, toOffset: Int) {
-        accountsTracker.savedAccounts.move(fromOffsets: fromOffsets, toOffset: toOffset)
+        accountsTracker.userAccounts.move(fromOffsets: fromOffsets, toOffset: toOffset)
     }
 }

--- a/Mlem/App/Views/Shared/Accounts/AccountListView.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView.swift
@@ -51,9 +51,14 @@ struct AccountListView: View {
                 } else {
                     Section(header: topHeader()) {
                         ForEach(accounts, id: \.actorId) { account in
-                            AccountButtonView(account: account, isSwitching: $isSwitching)
+                            AccountListRow(account: account, isSwitching: $isSwitching)
                         }
                         .onMove(perform: shouldAllowReordering ? reorderAccount : nil)
+                    }
+                    Section {
+                        if let activeAccount = appState.firstSession as? GuestSession {
+                            AccountListRow(account: activeAccount.account, isSwitching: $isSwitching)
+                        }
                     }
                     addAccountButton
                 }
@@ -79,7 +84,7 @@ struct AccountListView: View {
         ForEach(Array(accountGroups.enumerated()), id: \.offset) { offset, group in
             Section {
                 ForEach(group.accounts, id: \.actorId) { account in
-                    AccountButtonView(
+                    AccountListRow(
                         account: account,
                         complications: accountSort != .instance || group.header == "Other" ? .withTime : .timeOnly,
                         isSwitching: $isSwitching

--- a/Mlem/App/Views/Shared/Accounts/AccountListView.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView.swift
@@ -73,14 +73,16 @@ struct AccountListView: View {
                 addAccountButton
             }
         }
-        .alert("Enter domain name", isPresented: $isShowingAddGuestAlert) {
+        .alert("Enter Domain Name", isPresented: $isShowingAddGuestAlert) {
             TextField("lemmy.world", text: $newGuestDomain)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
             Button("OK") {
                 if !newGuestDomain.isEmpty, let url = URL(string: "https://\(newGuestDomain)") {
-                    let guest = AccountsTracker.main.loginGuest(url: url)
-                    AccountsTracker.main.addAccount(account: guest)
+                    let guest = GuestAccount.getGuestAccount(url: url)
+                    if !guest.isSaved {
+                        AccountsTracker.main.addAccount(account: guest)
+                    }
                     AppState.main.changeAccount(to: guest)
                     if navigation.isInsideSheet {
                         dismiss()

--- a/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
@@ -24,7 +24,7 @@ struct AccountListRow: View {
 
     var body: some View {
         Button {
-            if appState.firstSession.actorId != account.actorId, let account = account as? UserAccount {
+            if appState.firstSession.actorId != account.actorId {
                 appState.changeAccount(to: account)
                 if navigation.isInsideSheet {
                     dismiss()

--- a/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
@@ -41,9 +41,6 @@ struct AccountListRow: View {
                     showingSignOutConfirmation = true
                 }
                 .tint(.red)
-            } else {
-                Button("Keep") {}
-                    .tint(.blue)
             }
         }
         .confirmationDialog("Really sign out of \(account.nickname)?", isPresented: $showingSignOutConfirmation) {

--- a/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
@@ -37,21 +37,33 @@ struct AccountListRow: View {
         .accessibilityLabel(accessibilityLabel)
         .swipeActions {
             if (account as? GuestAccount)?.isSaved ?? true {
-                Button("Sign Out") {
+                Button(signOutLabel) {
                     showingSignOutConfirmation = true
                 }
                 .tint(.red)
             }
         }
-        .confirmationDialog("Really sign out of \(account.nickname)?", isPresented: $showingSignOutConfirmation) {
-            Button("Sign Out", role: .destructive) {
+        .confirmationDialog(signOutPrompt, isPresented: $showingSignOutConfirmation) {
+            Button(signOutLabel, role: .destructive) {
                 if navigation.isInsideSheet, appState.activeSessions.contains(where: { $0.account === account }) {
                     dismiss()
                 }
                 account.signOut()
             }
         } message: {
-            Text("Really sign out?")
+            Text(signOutPrompt)
+        }
+    }
+    
+    var signOutLabel: String {
+        account is UserAccount ? "Sign Out" : "Remove"
+    }
+    
+    var signOutPrompt: String {
+        if account is UserAccount {
+            "Really sign out of \(account.nickname)?"
+        } else {
+            "Really remove \(account.nickname)?"
         }
     }
     

--- a/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
@@ -1,5 +1,5 @@
 //
-//  AccountButtonView.swift
+//  AccountListRow.swift
 //  Mlem
 //
 //  Created by Sjmarf on 22/12/2023.
@@ -10,7 +10,7 @@ import MlemMiddleware
 import NukeUI
 import SwiftUI
 
-struct AccountButtonView: View {
+struct AccountListRow: View {
     @Environment(\.dismiss) private var dismiss
     
     @Environment(AppState.self) private var appState
@@ -24,7 +24,7 @@ struct AccountButtonView: View {
 
     var body: some View {
         Button {
-            if appState.firstAccount.actorId != account.actorId, let account = account as? UserAccount {
+            if appState.firstSession.actorId != account.actorId, let account = account as? UserAccount {
                 appState.changeAccount(to: account)
                 if navigation.isInsideSheet {
                     dismiss()
@@ -36,14 +36,19 @@ struct AccountButtonView: View {
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel)
         .swipeActions {
-            Button("Sign Out") {
-                showingSignOutConfirmation = true
+            if (account as? GuestAccount)?.isSaved ?? true {
+                Button("Sign Out") {
+                    showingSignOutConfirmation = true
+                }
+                .tint(.red)
+            } else {
+                Button("Keep") {}
+                    .tint(.blue)
             }
-            .tint(.red)
         }
         .confirmationDialog("Really sign out of \(account.nickname)?", isPresented: $showingSignOutConfirmation) {
             Button("Sign Out", role: .destructive) {
-                if navigation.isInsideSheet, appState.activeAccounts.contains(where: { $0.account === account }) {
+                if navigation.isInsideSheet, appState.activeSessions.contains(where: { $0.account === account }) {
                     dismiss()
                 }
                 account.signOut()
@@ -61,7 +66,7 @@ struct AccountButtonView: View {
             text = "guest"
         }
         
-        if appState.firstAccount.actorId == account.actorId {
+        if appState.firstSession.actorId == account.actorId {
             text += ", active"
         }
         return text

--- a/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
@@ -42,7 +42,7 @@ struct AccountListRowBody: View {
             }
             .padding(.vertical, -2)
             Spacer()
-            if appState.firstAccount.actorId == account.actorId {
+            if appState.firstSession.actorId == account.actorId {
                 Image(systemName: Icons.present)
                     .foregroundStyle(.green)
                     .font(.system(size: 10.0))
@@ -52,7 +52,7 @@ struct AccountListRowBody: View {
     }
     
     var timeText: String? {
-        if account.actorId == appState.firstAccount.actorId {
+        if account.actorId == appState.firstSession.actorId {
             return "Now"
         }
         if let time = account.lastUsed {
@@ -67,22 +67,22 @@ struct AccountListRowBody: View {
     }
     
     var captionText: String? {
-        let host = account.api.baseUrl.host
-        let timeText = timeText
-        var complications = complications
-        if timeText == nil {
-            complications = .instanceOnly
+        var output: [String] = []
+        if complications.contains(.instance) {
+            if account is GuestAccount {
+                output.append("Guest")
+            } else {
+                output.append("@\(account.api.baseUrl.host ?? "unknown")")
+            }
         }
-        switch complications {
-        case [.instance]:
-            return "@\(host ?? "unknown")"
-        case [.lastUsed]:
-            return timeText ?? ""
-        case [.instance, .lastUsed]:
-            return "@\(host ?? "unknown") ∙ \(timeText ?? "")"
-        default:
-            return ""
+        if complications.contains(.lastUsed), let timeText {
+            if (account as? GuestAccount)?.isSaved ?? true {
+                output.append(timeText)
+            } else {
+                output.append("Temporary")
+            }
         }
+        return output.joined(separator: " • ")
     }
 }
 

--- a/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
@@ -12,7 +12,7 @@ struct AccountListRowBody: View {
     @Environment(AppState.self) private var appState
     
     enum Complication: CaseIterable {
-        case instance, lastUsed
+        case instance, lastUsed, isActive
     }
     
     let account: any Account
@@ -20,18 +20,9 @@ struct AccountListRowBody: View {
     
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
-            // Using AvatarView or CachedImage here causes the quick switcher sheet to be locked to `.large` on iOS 17. To avoid this, we're using LazyImage directly instead - Sjmarf
-            LazyImage(url: account.avatar) { state in
-                if let imageContainer = state.imageContainer {
-                    Image(uiImage: imageContainer.image)
-                        .resizable()
-                        .clipShape(Circle())
-                } else {
-                    DefaultAvatarView(avatarType: .person)
-                }
-            }
-            .frame(width: 40, height: 40)
-            .padding(.leading, -5)
+            AvatarView(account)
+                .frame(height: 40)
+                .padding(.leading, -5)
             VStack(alignment: .leading) {
                 Text(account.nickname)
                 if let captionText {
@@ -42,7 +33,7 @@ struct AccountListRowBody: View {
             }
             .padding(.vertical, -2)
             Spacer()
-            if appState.firstSession.actorId == account.actorId {
+            if complications.contains(.isActive), appState.firstSession.actorId == account.actorId {
                 Image(systemName: Icons.present)
                     .foregroundStyle(.green)
                     .font(.system(size: 10.0))
@@ -87,7 +78,7 @@ struct AccountListRowBody: View {
 }
 
 extension Set<AccountListRowBody.Complication> {
-    static let withTime: Self = [.instance, .lastUsed]
-    static let instanceOnly: Self = [.instance]
-    static let timeOnly: Self = [.lastUsed]
+    static let withTime: Self = [.instance, .lastUsed, .isActive]
+    static let instanceOnly: Self = [.instance, .isActive]
+    static let timeOnly: Self = [.lastUsed, .isActive]
 }

--- a/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
@@ -1,0 +1,93 @@
+//
+//  AccountListRowBody.swift
+//  Mlem
+//
+//  Created by Sjmarf on 24/05/2024.
+//
+
+import NukeUI
+import SwiftUI
+
+struct AccountListRowBody: View {
+    @Environment(AppState.self) private var appState
+    
+    enum Complication: CaseIterable {
+        case instance, lastUsed
+    }
+    
+    let account: any Account
+    var complications: Set<Complication> = .withTime
+    
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            // Using AvatarView or CachedImage here causes the quick switcher sheet to be locked to `.large` on iOS 17. To avoid this, we're using LazyImage directly instead - Sjmarf
+            LazyImage(url: account.avatar) { state in
+                if let imageContainer = state.imageContainer {
+                    Image(uiImage: imageContainer.image)
+                        .resizable()
+                        .clipShape(Circle())
+                } else {
+                    DefaultAvatarView(avatarType: .person)
+                }
+            }
+            .frame(width: 40, height: 40)
+            .padding(.leading, -5)
+            VStack(alignment: .leading) {
+                Text(account.nickname)
+                if let captionText {
+                    Text(captionText)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.vertical, -2)
+            Spacer()
+            if appState.firstAccount.actorId == account.actorId {
+                Image(systemName: Icons.present)
+                    .foregroundStyle(.green)
+                    .font(.system(size: 10.0))
+            }
+        }
+        .contentShape(Rectangle())
+    }
+    
+    var timeText: String? {
+        if account.actorId == appState.firstAccount.actorId {
+            return "Now"
+        }
+        if let time = account.lastUsed {
+            if abs(time.timeIntervalSinceNow) < 5 {
+                return "Just Now"
+            }
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .short
+            return formatter.localizedString(for: time, relativeTo: Date.now)
+        }
+        return nil
+    }
+    
+    var captionText: String? {
+        let host = account.api.baseUrl.host
+        let timeText = timeText
+        var complications = complications
+        if timeText == nil {
+            complications = .instanceOnly
+        }
+        switch complications {
+        case [.instance]:
+            return "@\(host ?? "unknown")"
+        case [.lastUsed]:
+            return timeText ?? ""
+        case [.instance, .lastUsed]:
+            return "@\(host ?? "unknown") ∙ \(timeText ?? "")"
+        default:
+            return ""
+        }
+    }
+}
+
+extension Set<AccountListRowBody.Complication> {
+    static let withTime: Self = [.instance, .lastUsed]
+    static let instanceOnly: Self = [.instance]
+    static let timeOnly: Self = [.lastUsed]
+}

--- a/Mlem/App/Views/Shared/Navigation/LoginPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/LoginPage.swift
@@ -11,7 +11,7 @@ import SwiftUI
 enum LoginPage: Hashable {
     case pickInstance
     case instance(_ instance: any Instance)
-    case reauth(_ account: Account)
+    case reauth(_ account: UserAccount)
     case totp(client: ApiClient, username: String, password: String)
     
     @ViewBuilder

--- a/Mlem/App/Views/Shared/Toast/ToastOverlayView.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastOverlayView.swift
@@ -22,13 +22,16 @@ struct ToastOverlayView: View {
                     .transition(
                         activeToasts.count <= 1 ? .move(edge: location.edge).combined(with: .opacity) : .opacity
                     )
+                    .onAppear {
+                        toast.startKillTask()
+                    }
             }
         }
         .animation(.snappy(duration: 0.3, extraBounce: 0.2), value: activeToasts)
         .onChange(of: onChangeHash) {
             let toasts = toastModel.activeToasts(location: location)
             if shouldDisplayNewToasts || toasts.isEmpty {
-                addNewToasts(toasts)
+                activeToasts = toasts
             }
         }
         .onChange(of: shouldDisplayNewToasts) { _, newValue in
@@ -61,7 +64,6 @@ struct ToastOverlayView: View {
         for toast in toasts where startTimersAgain || !toast.killTaskStarted {
             toast.startKillTask()
         }
-        activeToasts = toasts
     }
     
     var onChangeHash: Int {

--- a/Mlem/App/Views/Shared/Toast/ToastOverlayView.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastOverlayView.swift
@@ -102,4 +102,5 @@ struct ToastOverlayView: View {
     .overlay(alignment: .bottom) {
         ToastOverlayView(shouldDisplayNewToasts: true, location: .bottom)
     }
+    .environment(Palette.main)
 }

--- a/Mlem/App/Views/Shared/Toast/ToastType.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastType.swift
@@ -26,7 +26,7 @@ enum ToastType: Hashable {
     
     case error(_ details: ErrorDetails)
     
-    case account(Account)
+    case account(any Account)
     
     var duration: Double {
         switch self {

--- a/Mlem/App/Views/Shared/Toast/ToastView.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastView.swift
@@ -59,14 +59,7 @@ struct ToastView: View {
             case let .error(details):
                 errorView(details)
             case let .account(account):
-                HStack {
-                    AvatarView(account, showLoadingPlaceholder: false)
-                        .frame(height: 28)
-                        .padding(.leading, 10)
-                    Text(account.nickname)
-                        .frame(minWidth: 100)
-                        .padding(.trailing)
-                }
+                accountView(account)
             }
         }
         .frame(height: isExpanded ? nil : 47)
@@ -87,7 +80,7 @@ struct ToastView: View {
         imageColor: Color,
         subtitleColor: Color = .secondary
     ) -> some View {
-        HStack {
+        HStack(spacing: AppConstants.doubleSpacing) {
             if let systemImage {
                 image(systemImage, color: imageColor)
                     .contentTransition(.symbolEffect(.replace, options: .speed(4)))
@@ -107,11 +100,25 @@ struct ToastView: View {
                     }
                 } else {
                     Text(title)
+                        .frame(minWidth: 80)
                 }
             }
-            .frame(minWidth: 100)
-            .padding(.trailing)
+            .padding(.trailing, AppConstants.doubleSpacing)
         }
+        .frame(minWidth: 157)
+    }
+    
+    @ViewBuilder
+    func accountView(_ account: any Account) -> some View {
+        HStack(spacing: AppConstants.doubleSpacing) {
+            AvatarView(account, showLoadingPlaceholder: false)
+                .frame(height: 27)
+                .padding(.leading, 10)
+            Text(account.nickname)
+                .frame(minWidth: 80)
+                .padding(.trailing, AppConstants.doubleSpacing)
+        }
+        .frame(minWidth: 157)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Shared/Toast/ToastView.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastView.swift
@@ -63,7 +63,7 @@ struct ToastView: View {
                     AvatarView(account, showLoadingPlaceholder: false)
                         .frame(height: 28)
                         .padding(.leading, 10)
-                    Text(account.nickname ?? account.name)
+                    Text(account.nickname)
                         .frame(minWidth: 100)
                         .padding(.trailing)
                 }
@@ -202,6 +202,7 @@ extension ToastView {
             )
         )
         ToastView(.error(.init()))
+        ToastView(.success("Really super long text"))
     }
     .environment(Palette.main)
     .background {

--- a/Mlem/App/Views/Shared/Toast/ToastView.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastView.swift
@@ -100,6 +100,7 @@ struct ToastView: View {
                     }
                 } else {
                     Text(title)
+                        .lineLimit(1)
                         .frame(minWidth: 80)
                 }
             }
@@ -115,6 +116,7 @@ struct ToastView: View {
                 .frame(height: 27)
                 .padding(.leading, 10)
             Text(account.nickname)
+                .lineLimit(1)
                 .frame(minWidth: 80)
                 .padding(.trailing, AppConstants.doubleSpacing)
         }


### PR DESCRIPTION
You can now save guest accounts to a list below the main accounts. To add a new guest account, tap "Add Account" then "Add Guest". 

I'm temporarily using an alert as the text input for the guest domain. Before 2.0, we will instead show a sheet that allows the user to search for instances. The alert occasionally bugs out and goes full-caps, still :(

It's possible for a guest account to be active without it being a _saved_ guest account. Currently, this only happens if you have no accounts saved, in which case Mlem defaults to `lemmy.world`, and the account is marked as "temporary" in the account list. Switching to a different account will remove the temporary account from the list. In future, there could be other ways of accessing temporary guest accounts. For example, `InstanceView` could have a "Visit as guest" action that logs in as a temporary guest. In the account list, there could be a "Keep" action on the temporary guest item that adds it to the saved guest list.

### Implementation

I've renamed `ActiveAccount` to `UserSession`, so it isn't too similar in name to `Account`. I didn't like calling it `ActiveAccount` because the data-types of variables with names such as `account` wouldn't be immediately obvious. So maybe `UserSession` is better?

`Account` has been renamed to `UserAccount`, and a new `GuestAccount` class has been added. Both conform to an `Account` protocol. Similarly, `UserSession` and `GuestSession` (which replace `ActiveAccount`) both conform to a `Session` protocol.

I've also renamed `AccountListButton` to `AccountListRow` (to match `CommunityListRow` etc used in v1), and moved its rendering code to `AccountListRowBody`.