### PR TITLE
[1.3] Fix marking as read

### DIFF
--- a/Mlem/API/APIClient/APIClient+Post.swift
+++ b/Mlem/API/APIClient/APIClient+Post.swift
@@ -36,8 +36,13 @@ extension APIClient {
 
     // swiftlint:enable function_parameter_count
     
-    func markPostAsRead(for postId: Int, read: Bool) async throws -> SuccessResponse {
-        let request = try MarkPostReadRequest(session: session, postId: postId, read: read)
+    func markPostAsRead(for postId: Int, read: Bool, version: SiteVersion?) async throws -> SuccessResponse {
+        let request: MarkPostReadRequest
+        if (version ?? .infinity) < .init("0.19.0") {
+            request = try MarkPostReadRequest(session: session, postId: postId, read: read)
+        } else {
+            request = try MarkPostReadRequest(session: session, postIds: [postId], read: read)
+        }
         // TODO: 0.18 deprecation simply return result of perform
         let compatibilityResponse = try await perform(request: request)
         return SuccessResponse(from: compatibilityResponse)

--- a/Mlem/Models/Content/Post/PostModel.swift
+++ b/Mlem/Models/Content/Post/PostModel.swift
@@ -197,7 +197,11 @@ class PostModel: ContentIdentifiable, Removable, Purgable, ObservableObject {
         
         // API call
         do {
-            let updatedPost = try await postRepository.markRead(post: self, read: newRead)
+            let updatedPost = try await postRepository.markRead(
+                post: self,
+                read: newRead,
+                version: SiteInformationTracker.liveValue.version
+            )
             await reinit(from: updatedPost)
         } catch {
             hapticManager.play(haptic: .failure, priority: .high)

--- a/Mlem/Repositories/PostRepository.swift
+++ b/Mlem/Repositories/PostRepository.swift
@@ -55,8 +55,12 @@ class PostRepository {
     /// - Parameters:
     ///   - post: PostModel to attempt to read
     ///   - read: Intended read state of the post model (true to mark read, false to mark unread)
-    func markRead(post: PostModel, read: Bool) async throws -> PostModel {
-        let success = try await apiClient.markPostAsRead(for: post.postId, read: read).success
+    func markRead(post: PostModel, read: Bool, version: SiteVersion?) async throws -> PostModel {
+        let success = try await apiClient.markPostAsRead(
+            for: post.postId,
+            read: read,
+            version: version
+        ).success
         return PostModel(from: post, read: success ? read : post.read)
     }
     


### PR DESCRIPTION
In 0.19.4, Lemmy removed support for the `postId` parameter of `MarkPostReadRequest`. From 0.19.4 onwards, only the `postIds` parameter can be used. `postIds` was introduced in 0.19.0, but both `postId` and `postIds` were supported until 0.19.4.

Without this fix, an error notification is shown when opening a post or opening the image viewer on a 0.19.4 instance. This PR uses the `postIds` parameter instead of `postId` on instances running 0.19.0 or higher, which fixes the issue.

We should release a 1.3.1 patch with this fix. At the moment, 0.19.4 is in the release candidate stage; `lemmy.ml` is the only major instance running 0.19.4.