### PR TITLE
Show transition on account switch

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		036CC3AF2B8145C30098B6A1 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036CC3AE2B8145C30098B6A1 /* AppState.swift */; };
 		037386472BDAFE81007492B5 /* LemmyMarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 037386462BDAFE81007492B5 /* LemmyMarkdownUI */; };
 		037658DF2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037658DE2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift */; };
+		0380965F2C10AA80003ED1D8 /* AppState+transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0380965E2C10AA80003ED1D8 /* AppState+transition.swift */; };
+		038096612C10AAD8003ED1D8 /* TransitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038096602C10AAD8003ED1D8 /* TransitionView.swift */; };
 		0382A7F02C09F0F800C79DDA /* PersonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0382A7EF2C09F0F800C79DDA /* PersonView.swift */; };
 		0382A7F22C0A758E00C79DDA /* ProfileDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0382A7F12C0A758E00C79DDA /* ProfileDateView.swift */; };
 		0382A7F42C0A76A900C79DDA /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0382A7F32C0A76A900C79DDA /* Date+Extensions.swift */; };
@@ -203,6 +205,8 @@
 		0369B35A2BFB86E3001EFEDF /* Account.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		036CC3AE2B8145C30098B6A1 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		037658DE2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Community1Providing+Extensions.swift"; sourceTree = "<group>"; };
+		0380965E2C10AA80003ED1D8 /* AppState+transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+transition.swift"; sourceTree = "<group>"; };
+		038096602C10AAD8003ED1D8 /* TransitionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionView.swift; sourceTree = "<group>"; };
 		0382A7EF2C09F0F800C79DDA /* PersonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonView.swift; sourceTree = "<group>"; };
 		0382A7F12C0A758E00C79DDA /* ProfileDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDateView.swift; sourceTree = "<group>"; };
 		0382A7F32C0A76A900C79DDA /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
@@ -633,6 +637,7 @@
 				6363D5C627EE196700E34822 /* ContentView.swift */,
 				6363D5C427EE196700E34822 /* MlemApp.swift */,
 				B157E0C32A507B8000B02C8B /* FlowRoot.swift */,
+				038096602C10AAD8003ED1D8 /* TransitionView.swift */,
 				CDA1E81A2B8FC39A007953EF /* Onboarding */,
 				6363D5F427EE1BAE00E34822 /* Tabs */,
 			);
@@ -781,6 +786,7 @@
 			children = (
 				CD4D58B22B86BFD400B82964 /* AccountsTracker.swift */,
 				036CC3AE2B8145C30098B6A1 /* AppState.swift */,
+				0380965E2C10AA80003ED1D8 /* AppState+transition.swift */,
 				CD317D4B2BE97FED008F63E2 /* Palette.swift */,
 				CD4D58A42B86BD1B00B82964 /* PersistenceRepository.swift */,
 				CD4ED8462BF110FA00EFA0A2 /* TabReselectTracker.swift */,
@@ -1079,6 +1085,7 @@
 				CD1446212A5B328E00610EF1 /* Privacy Policy.swift in Sources */,
 				03FE140C2BF953B000A8377F /* HandleError.swift in Sources */,
 				CD1446272A5B36DA00610EF1 /* EULA.swift in Sources */,
+				038096612C10AAD8003ED1D8 /* TransitionView.swift in Sources */,
 				0382A7F42C0A76A900C79DDA /* Date+Extensions.swift in Sources */,
 				03D2A63B2C010B7500ED4FF2 /* GuestAccount.swift in Sources */,
 				CD4ED84A2BF1113800EFA0A2 /* View+TabReselectConsumer.swift in Sources */,
@@ -1163,6 +1170,7 @@
 				CD4D58F82B87B0D100B82964 /* InternetSpeed.swift in Sources */,
 				0382A7F02C09F0F800C79DDA /* PersonView.swift in Sources */,
 				CDBFCB6C2C054AA7008CD468 /* TilePostView.swift in Sources */,
+				0380965F2C10AA80003ED1D8 /* AppState+transition.swift in Sources */,
 				CD4D58932B86BA5C00B82964 /* StandardPalette.swift in Sources */,
 				03D2A63F2C010DBF00ED4FF2 /* GuestSession.swift in Sources */,
 				030FF6812BC859FD00F6BFAC /* CustomTabViewHostingController.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		036CC3AF2B8145C30098B6A1 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036CC3AE2B8145C30098B6A1 /* AppState.swift */; };
 		037386472BDAFE81007492B5 /* LemmyMarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 037386462BDAFE81007492B5 /* LemmyMarkdownUI */; };
 		037658DF2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037658DE2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift */; };
-		0380965F2C10AA80003ED1D8 /* AppState+transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0380965E2C10AA80003ED1D8 /* AppState+transition.swift */; };
+		0380965F2C10AA80003ED1D8 /* AppState+Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0380965E2C10AA80003ED1D8 /* AppState+Transition.swift */; };
 		038096612C10AAD8003ED1D8 /* TransitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038096602C10AAD8003ED1D8 /* TransitionView.swift */; };
 		0382A7F02C09F0F800C79DDA /* PersonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0382A7EF2C09F0F800C79DDA /* PersonView.swift */; };
 		0382A7F22C0A758E00C79DDA /* ProfileDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0382A7F12C0A758E00C79DDA /* ProfileDateView.swift */; };
@@ -205,7 +205,7 @@
 		0369B35A2BFB86E3001EFEDF /* Account.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		036CC3AE2B8145C30098B6A1 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		037658DE2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Community1Providing+Extensions.swift"; sourceTree = "<group>"; };
-		0380965E2C10AA80003ED1D8 /* AppState+transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+transition.swift"; sourceTree = "<group>"; };
+		0380965E2C10AA80003ED1D8 /* AppState+Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+Transition.swift"; sourceTree = "<group>"; };
 		038096602C10AAD8003ED1D8 /* TransitionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionView.swift; sourceTree = "<group>"; };
 		0382A7EF2C09F0F800C79DDA /* PersonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonView.swift; sourceTree = "<group>"; };
 		0382A7F12C0A758E00C79DDA /* ProfileDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDateView.swift; sourceTree = "<group>"; };
@@ -786,7 +786,7 @@
 			children = (
 				CD4D58B22B86BFD400B82964 /* AccountsTracker.swift */,
 				036CC3AE2B8145C30098B6A1 /* AppState.swift */,
-				0380965E2C10AA80003ED1D8 /* AppState+transition.swift */,
+				0380965E2C10AA80003ED1D8 /* AppState+Transition.swift */,
 				CD317D4B2BE97FED008F63E2 /* Palette.swift */,
 				CD4D58A42B86BD1B00B82964 /* PersistenceRepository.swift */,
 				CD4ED8462BF110FA00EFA0A2 /* TabReselectTracker.swift */,
@@ -1170,7 +1170,7 @@
 				CD4D58F82B87B0D100B82964 /* InternetSpeed.swift in Sources */,
 				0382A7F02C09F0F800C79DDA /* PersonView.swift in Sources */,
 				CDBFCB6C2C054AA7008CD468 /* TilePostView.swift in Sources */,
-				0380965F2C10AA80003ED1D8 /* AppState+transition.swift in Sources */,
+				0380965F2C10AA80003ED1D8 /* AppState+Transition.swift in Sources */,
 				CD4D58932B86BA5C00B82964 /* StandardPalette.swift in Sources */,
 				03D2A63F2C010DBF00ED4FF2 /* GuestSession.swift in Sources */,
 				030FF6812BC859FD00F6BFAC /* CustomTabViewHostingController.swift in Sources */,

--- a/Mlem/App/Constants/Icons.swift
+++ b/Mlem/App/Constants/Icons.swift
@@ -228,4 +228,6 @@ enum Icons {
     static let noFile: String = "questionmark.folder"
     static let forward: String = "chevron.right"
     static let imageDetails: String = "doc.badge.ellipsis"
+    static let accountSwitchReload: String = "arrow.2.circlepath"
+    static let accountSwitchKeepPlace: String = "checkmark.diamond"
 }

--- a/Mlem/App/Globals/Definitions/AppState+transition.swift
+++ b/Mlem/App/Globals/Definitions/AppState+transition.swift
@@ -20,6 +20,8 @@ extension AppState {
             window.addSubview(transitionView)
             UIView.animate(withDuration: 0.15) {
                 transitionView.alpha = 1
+            } completion: { _ in
+                self.appRefreshToggle = false
             }
             
             transitionView.translatesAutoresizingMaskIntoConstraints = false
@@ -31,6 +33,7 @@ extension AppState {
                     transitionView.alpha = 0
                 } completion: { _ in
                     transitionView.removeFromSuperview()
+                    self.appRefreshToggle = true
                 }
             }
         }

--- a/Mlem/App/Globals/Definitions/AppState+transition.swift
+++ b/Mlem/App/Globals/Definitions/AppState+transition.swift
@@ -20,20 +20,17 @@ extension AppState {
             window.addSubview(transitionView)
             UIView.animate(withDuration: 0.15) {
                 transitionView.alpha = 1
-            } completion: { _ in
-                self.appRefreshToggle = false
             }
             
             transitionView.translatesAutoresizingMaskIntoConstraints = false
             transitionView.heightAnchor.constraint(equalTo: window.heightAnchor).isActive = true
             transitionView.widthAnchor.constraint(equalTo: window.widthAnchor).isActive = true
-            
+                    
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                 UIView.animate(withDuration: 0.3) {
                     transitionView.alpha = 0
                 } completion: { _ in
                     transitionView.removeFromSuperview()
-                    self.appRefreshToggle = true
                 }
             }
         }

--- a/Mlem/App/Globals/Definitions/AppState+transition.swift
+++ b/Mlem/App/Globals/Definitions/AppState+transition.swift
@@ -10,7 +10,7 @@ import SwiftUI
 extension AppState {
     func transition(_ account: any Account) {
         Task { @MainActor in
-            let transition = TransitionView(accountName: account.nickname)
+            let transition = TransitionView(account: account)
             guard let transitionView = UIHostingController(rootView: transition).view,
                   let window = UIApplication.shared.firstKeyWindow else {
                 return

--- a/Mlem/App/Globals/Definitions/AppState+transition.swift
+++ b/Mlem/App/Globals/Definitions/AppState+transition.swift
@@ -1,0 +1,38 @@
+//
+//  AppState+transition.swift
+//  Mlem
+//
+//  Created by Sjmarf on 05/06/2024.
+//
+
+import SwiftUI
+
+extension AppState {
+    func transition(_ account: any Account) {
+        Task { @MainActor in
+            let transition = TransitionView(accountName: account.nickname)
+            guard let transitionView = UIHostingController(rootView: transition).view,
+                  let window = UIApplication.shared.firstKeyWindow else {
+                return
+            }
+            
+            transitionView.alpha = 0
+            window.addSubview(transitionView)
+            UIView.animate(withDuration: 0.15) {
+                transitionView.alpha = 1
+            }
+            
+            transitionView.translatesAutoresizingMaskIntoConstraints = false
+            transitionView.heightAnchor.constraint(equalTo: window.heightAnchor).isActive = true
+            transitionView.widthAnchor.constraint(equalTo: window.widthAnchor).isActive = true
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                UIView.animate(withDuration: 0.3) {
+                    transitionView.alpha = 0
+                } completion: { _ in
+                    transitionView.removeFromSuperview()
+                }
+            }
+        }
+    }
+}

--- a/Mlem/App/Globals/Definitions/AppState+transition.swift
+++ b/Mlem/App/Globals/Definitions/AppState+transition.swift
@@ -1,5 +1,5 @@
 //
-//  AppState+transition.swift
+//  AppState+Transition.swift
 //  Mlem
 //
 //  Created by Sjmarf on 05/06/2024.

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -8,7 +8,7 @@
 import Dependencies
 import Foundation
 import MlemMiddleware
-import Observation
+import SwiftUI
 
 @Observable
 class AppState {
@@ -40,7 +40,8 @@ class AppState {
     
     /// If `keepPlace` is `nil`, use the value from `UserDefaults`.
     func changeAccount(to account: any Account, keepPlace: Bool? = nil) {
-        let keepPlace = keepPlace ?? UserDefaults.standard.bool(forKey: "accounts.keepPlace")
+        @AppStorage("accounts.keepPlace") var keepPlaceSetting = false
+        let keepPlace = keepPlace ?? keepPlaceSetting
         if keepPlace {
             ToastModel.main.add(.account(account))
             setAccount(to: account)

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -46,6 +46,9 @@ class AppState {
             setAccount(to: account)
         } else {
             transition(account)
+            // The delays between these events are necessary to stop SwiftUIIntrospect from causing a lag spike.
+            // That library seems to not like us adding subviews to the window directly. For some reason adding
+            // these delays fixes that.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.appRefreshToggle = false
             }

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -12,26 +12,53 @@ import Observation
 
 @Observable
 class AppState {
-    private(set) var guestSession: GuestSession!
-    private(set) var activeSessions: [UserSession] = []
+    private(set) var guestSession: GuestSession! {
+        didSet {
+            if oldValue != guestSession {
+                oldValue?.deactivate()
+            }
+        }
+    }
+    
+    private(set) var activeSessions: [UserSession] = [] {
+        didSet {
+            if oldValue != activeSessions {
+                for session in Set(oldValue).subtracting(activeSessions) {
+                    session.deactivate()
+                }
+            }
+        }
+    }
+    
+    /// ``ContentView`` watches this for changes. When it is toggled, the app is refreshed.
+    private(set) var appRefreshToggle: Bool = true
     
     private init() {
         self.guestSession = .init(account: AccountsTracker.main.defaultGuestAccount)
-        changeAccount(to: AccountsTracker.main.defaultAccount, deactivateOldGuest: false)
+        changeAccount(to: AccountsTracker.main.defaultAccount)
     }
     
-    func changeAccount(to account: any Account) {
-        changeAccount(to: account, deactivateOldGuest: true)
-    }
-    
-    private func changeAccount(to account: any Account, deactivateOldGuest: Bool) {
-        ToastModel.main.add(.account(account))
-        
-        activeSessions.forEach { $0.deactivate() }
-        if deactivateOldGuest {
-            guestSession?.deactivate()
+    /// If `keepPlace` is `nil`, use the value from `UserDefaults`.
+    func changeAccount(to account: any Account, keepPlace: Bool? = nil) {
+        let keepPlace = keepPlace ?? UserDefaults.standard.bool(forKey: "accounts.keepPlace")
+        if keepPlace {
+            ToastModel.main.add(.account(account))
+            setAccount(to: account)
+        } else {
+            transition(account)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.appRefreshToggle = false
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                self.setAccount(to: account)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                self.appRefreshToggle = true
+            }
         }
-        
+    }
+    
+    private func setAccount(to account: any Account) {
         // Save because we updated `lastUsed` in the above `deactivate()` calls
         AccountsTracker.main.saveAccounts(ofType: .all)
         

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -46,8 +46,17 @@ class AppState {
             setAccount(to: account)
         } else {
             transition(account)
+            // The delays between these events are necessary to stop SwiftUIIntrospect from causing a lag spike.
+            // That library seems to not like us adding subviews to the window directly. For some reason adding
+            // these delays fixes that.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.appRefreshToggle = false
+            }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                 self.setAccount(to: account)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                self.appRefreshToggle = true
             }
         }
     }

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -31,7 +31,7 @@ class AppState {
     }
     
     /// ``ContentView`` watches this for changes. When it is toggled, the app is refreshed.
-    private(set) var appRefreshToggle: Bool = true
+    var appRefreshToggle: Bool = true
     
     private init() {
         self.guestSession = .init(account: AccountsTracker.main.defaultGuestAccount)
@@ -46,17 +46,8 @@ class AppState {
             setAccount(to: account)
         } else {
             transition(account)
-            // The delays between these events are necessary to stop SwiftUIIntrospect from causing a lag spike.
-            // That library seems to not like us adding subviews to the window directly. For some reason adding
-            // these delays fixes that.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.appRefreshToggle = false
-            }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                 self.setAccount(to: account)
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-                self.appRefreshToggle = true
             }
         }
     }

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -35,7 +35,7 @@ class AppState {
     
     private init() {
         self.guestSession = .init(account: AccountsTracker.main.defaultGuestAccount)
-        changeAccount(to: AccountsTracker.main.defaultAccount)
+        setAccount(to: AccountsTracker.main.defaultAccount)
     }
     
     /// If `keepPlace` is `nil`, use the value from `UserDefaults`.

--- a/Mlem/App/Logic/HandleError.swift
+++ b/Mlem/App/Logic/HandleError.swift
@@ -18,33 +18,42 @@ func handleError(
     #if DEBUG
         print("☠️ ERROR ☠️")
         print("📝 -> \(error.localizedDescription)")
+        if let error = error as? ApiClientError {
+            print("     \(error.description)")
+        }
         print("📂 -> \(file) | \(function) | line: \(line)")
     #endif
     
     switch error {
     // TODO: Modify MlemMiddleware to attach the ApiClient throwing the error to ApiClientError.invalidSession, so that we can access the relevant UserStub in a multi-account context
     case ApiClientError.invalidSession:
-        if let user = AppState.main.firstSession.account as? UserAccount {
-            for layer in NavigationModel.main.layers {
-                switch layer.path.first {
-                case let .login(page):
-                    switch page {
-                    case .reauth:
-                        return
-                    default:
-                        break
-                    }
-                default:
-                    break
-                }
-            }
-            NavigationModel.main.openSheet(.login(.reauth(user)))
-        }
+        showReauthSheet()
+    case ApiClientError.cancelled:
+        print("Cancellation error")
     default:
         if let errorDetails {
             errorDetails.wrappedValue = .init(error: error)
         } else {
             ToastModel.main.add(.error(.init(error: error)))
         }
+    }
+}
+
+private func showReauthSheet() {
+    if let user = AppState.main.firstSession.account as? UserAccount {
+        for layer in NavigationModel.main.layers {
+            switch layer.path.first {
+            case let .login(page):
+                switch page {
+                case .reauth:
+                    return
+                default:
+                    break
+                }
+            default:
+                break
+            }
+        }
+        NavigationModel.main.openSheet(.login(.reauth(user)))
     }
 }

--- a/Mlem/App/Models/ErrorDetails.swift
+++ b/Mlem/App/Models/ErrorDetails.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import MlemMiddleware
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -30,5 +31,12 @@ struct ErrorDetails: Hashable {
 
     static func == (lhs: ErrorDetails, rhs: ErrorDetails) -> Bool {
         lhs.hashValue == rhs.hashValue
+    }
+    
+    var errorText: String {
+        if let error = error as? ApiClientError {
+            return error.description
+        }
+        return error?.localizedDescription ?? ""
     }
 }

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -23,26 +23,28 @@ struct ContentView: View {
     var navigationModel: NavigationModel { .main }
     
     var body: some View {
-        content
-            .onReceive(timer) { _ in
-                appState.cleanCaches()
-            }
-            .sheet(isPresented: Binding(
-                get: { !(navigationModel.layers.first?.isFullScreenCover ?? true) },
-                set: { if !$0 { navigationModel.layers.removeAll() } }
-            )) {
-                NavigationLayerView(layer: navigationModel.layers[0], hasSheetModifiers: true)
-            }
-            .fullScreenCover(isPresented: Binding(
-                get: { navigationModel.layers.first?.isFullScreenCover ?? false },
-                set: { if !$0 { navigationModel.layers.removeAll() } }
-            )) {
-                NavigationLayerView(layer: navigationModel.layers[0], hasSheetModifiers: true)
-            }
-            .tint(palette.accent)
-            .environment(palette)
-            .environment(tabReselectTracker)
-            .environment(appState)
+        if appState.appRefreshToggle {
+            content
+                .onReceive(timer) { _ in
+                    appState.cleanCaches()
+                }
+                .sheet(isPresented: Binding(
+                    get: { !(navigationModel.layers.first?.isFullScreenCover ?? true) },
+                    set: { if !$0 { navigationModel.layers.removeAll() } }
+                )) {
+                    NavigationLayerView(layer: navigationModel.layers[0], hasSheetModifiers: true)
+                }
+                .fullScreenCover(isPresented: Binding(
+                    get: { navigationModel.layers.first?.isFullScreenCover ?? false },
+                    set: { if !$0 { navigationModel.layers.removeAll() } }
+                )) {
+                    NavigationLayerView(layer: navigationModel.layers[0], hasSheetModifiers: true)
+                }
+                .tint(palette.accent)
+                .environment(palette)
+                .environment(tabReselectTracker)
+                .environment(appState)
+        }
     }
 
     var shouldDisplayToasts: Bool {

--- a/Mlem/App/Views/Root/Onboarding/LandingPage.swift
+++ b/Mlem/App/Views/Root/Onboarding/LandingPage.swift
@@ -112,7 +112,9 @@ struct LandingPage: View {
 //
 //            let newAccount = try await authenticatedApiClient.loadUser()
 //
-//            // MARK: Save the account's credentials into the keychain
+
+    // MARK: Save the account's credentials into the keychain
+
 //
 //            AppConstants.keychain["\(newAccount.id)_accessToken"] = response.jwt
 //            AccountsTracker.main.addAccount(account: newAccount)

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -80,13 +80,6 @@ struct MinimalPostFeedView: View {
             }
             .task(id: appState.firstApi) {
                 do {
-                    try await postTracker.loadMoreItems()
-                } catch {
-                    handleError(error)
-                }
-            }
-            .task(id: appState.firstApi) {
-                do {
                     try await postTracker.changeFeedType(to: .aggregateFeed(appState.firstApi, type: .subscribed))
                 } catch {
                     handleError(error)

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
@@ -11,12 +11,20 @@ import SwiftUI
 struct AccountListSettingsView: View {
     @Environment(AppState.self) var appState
     
+    @AppStorage("accounts.keepPlace") var keepPlace: Bool = false
+    
     var accounts: [UserAccount] { AccountsTracker.main.userAccounts }
     
     var body: some View {
         Form {
             headerView
             AccountListView()
+            Section {
+                Toggle(
+                    "Reload on Switch",
+                    isOn: Binding(get: { !keepPlace }, set: { keepPlace = !$0 })
+                )
+            }
         }
     }
     

--- a/Mlem/App/Views/Root/TransitionView.swift
+++ b/Mlem/App/Views/Root/TransitionView.swift
@@ -1,0 +1,34 @@
+//
+//  AccountTransitionView.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-10-02.
+//
+
+import Foundation
+import SwiftUI
+
+struct TransitionView: View {
+    let accountName: String?
+    @State var accountNameOpacity: CGFloat = .zero
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            if let accountName {
+                Text("Welcome")
+                    .onAppear {
+                        withAnimation(.easeIn(duration: 0.5)) {
+                            accountNameOpacity = 1.0
+                        }
+                    }
+                Text(accountName)
+                    .opacity(accountNameOpacity)
+            } else {
+                Text("Goodbye!")
+            }
+        }
+        .font(.largeTitle)
+        .bold()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Mlem/App/Views/Root/TransitionView.swift
+++ b/Mlem/App/Views/Root/TransitionView.swift
@@ -9,23 +9,19 @@ import Foundation
 import SwiftUI
 
 struct TransitionView: View {
-    let accountName: String?
+    let account: any Account
     @State var accountNameOpacity: CGFloat = .zero
     
     var body: some View {
         VStack(spacing: 24) {
-            if let accountName {
-                Text("Welcome")
-                    .onAppear {
-                        withAnimation(.easeIn(duration: 0.5)) {
-                            accountNameOpacity = 1.0
-                        }
+            Text(account is UserAccount ? "Welcome" : "Welcome to")
+                .onAppear {
+                    withAnimation(.easeIn(duration: 0.5)) {
+                        accountNameOpacity = 1.0
                     }
-                Text(accountName)
-                    .opacity(accountNameOpacity)
-            } else {
-                Text("Goodbye!")
-            }
+                }
+            Text(account.nickname)
+                .opacity(accountNameOpacity)
         }
         .font(.largeTitle)
         .bold()

--- a/Mlem/App/Views/Shared/Avatar/AvatarView.swift
+++ b/Mlem/App/Views/Shared/Avatar/AvatarView.swift
@@ -36,7 +36,7 @@ struct AvatarView: View {
             .aspectRatio(1, contentMode: .fill)
             .clipShape(Circle())
             .background {
-                if url != nil, loading {
+                if url != nil, loading, showLoadingPlaceholder {
                     ProgressView()
                 } else if url == nil {
                     DefaultAvatarView(avatarType: type)

--- a/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
@@ -46,6 +46,7 @@ struct AccountListRow: View {
                 }
             }
             .tint(.blue)
+            .disabled(appState.firstSession.actorId == account.actorId)
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if (account as? GuestAccount)?.isSaved ?? true {

--- a/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
@@ -34,19 +34,20 @@ struct AccountListRow: View {
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel)
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
-            Group {
-                if keepPlace {
-                    Button("Reload", systemImage: Icons.accountSwitchReload) {
-                        changeAccount(keepPlace: false)
-                    }
-                } else {
-                    Button("Keep Place", systemImage: Icons.accountSwitchKeepPlace) {
-                        changeAccount(keepPlace: true)
+            if appState.firstSession.actorId != account.actorId {
+                Group {
+                    if keepPlace {
+                        Button("Reload", systemImage: Icons.accountSwitchReload) {
+                            changeAccount(keepPlace: false)
+                        }
+                    } else {
+                        Button("Keep Place", systemImage: Icons.accountSwitchKeepPlace) {
+                            changeAccount(keepPlace: true)
+                        }
                     }
                 }
+                .tint(.blue)
             }
-            .tint(.blue)
-            .disabled(appState.firstSession.actorId == account.actorId)
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if (account as? GuestAccount)?.isSaved ?? true {
@@ -54,7 +55,6 @@ struct AccountListRow: View {
                     showingSignOutConfirmation = true
                 }
                 .tint(.red)
-                .disabled(appState.firstSession.actorId == account.actorId)
             }
         }
         .contextMenu {

--- a/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
@@ -20,7 +20,7 @@ struct AccountListRowBody: View {
     
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
-            AvatarView(account)
+            AvatarView(account, showLoadingPlaceholder: false)
                 .frame(height: 40)
                 .padding(.leading, -5)
             VStack(alignment: .leading) {

--- a/Mlem/App/Views/Shared/Toast/Toast.swift
+++ b/Mlem/App/Views/Shared/Toast/Toast.swift
@@ -19,11 +19,13 @@ class Toast: Identifiable, Hashable {
     
     var shouldTimeout: Bool = true {
         didSet {
-            if shouldTimeout {
-                startKillTask()
-            } else {
-                killTask?.cancel()
-                killTask = nil
+            if oldValue != shouldTimeout {
+                if shouldTimeout {
+                    startKillTask()
+                } else {
+                    killTask?.cancel()
+                    killTask = nil
+                }
             }
         }
     }
@@ -48,7 +50,9 @@ class Toast: Identifiable, Hashable {
                 try await Task.sleep(
                     nanoseconds: UInt64(1_000_000_000 * type.duration)
                 )
-                self.kill()
+                Task { @MainActor in
+                    self.kill()
+                }
             }
         }
     }
@@ -58,6 +62,7 @@ class Toast: Identifiable, Hashable {
         hasher.combine(type)
         hasher.combine(location)
         hasher.combine(important)
+        hasher.combine(shouldTimeout)
     }
     
     static func == (lhs: Toast, rhs: Toast) -> Bool {

--- a/Mlem/App/Views/Shared/Toast/ToastModel.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastModel.swift
@@ -14,7 +14,7 @@ class ToastModel {
     static let main: ToastModel = .init()
     
     func activeToasts(location: ToastLocation) -> [Toast] {
-        Array(toasts.lazy.filter { $0.location == location }.prefix(3))
+        Array(toasts.filter { $0.location == location }.prefix(3))
     }
     
     func add(_ type: ToastType, location: ToastLocation? = nil, important: Bool? = nil) {
@@ -34,6 +34,8 @@ class ToastModel {
     func removeToast(id: UUID) {
         if let index = toasts.firstIndex(where: { $0.id == id }) {
             toasts.remove(at: index)
+        } else {
+            print("No Toast Index")
         }
     }
 }

--- a/Mlem/App/Views/Shared/Toast/ToastView.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastView.swift
@@ -154,7 +154,7 @@ struct ToastView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     if isExpanded {
                         ScrollView {
-                            Text(details.error?.localizedDescription ?? "")
+                            Text(details.errorText)
                                 .foregroundStyle(.red)
                                 .padding(8)
                         }


### PR DESCRIPTION
Closes #1065

The toggle for this is under the account list in settings. It's set to reload the feed by default. In the account switcher, you can swipe or long press to access the non-default behaviour.

I also fixed the quick switcher always showing a`.large` sheet, not the `.medium` sheet it's supposed to - this seems to be caused by the `ProgressView`, so I've disabled it for now.

Also made some tweaks the toast system to (hopefully) stop toasts from occasionally getting stuck and not going away.