### PR TITLE
MultiplatformView

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		CD4ED8472BF110FA00EFA0A2 /* TabReselectTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED8462BF110FA00EFA0A2 /* TabReselectTracker.swift */; };
 		CD4ED84A2BF1113800EFA0A2 /* View+TabReselectConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED8492BF1113800EFA0A2 /* View+TabReselectConsumer.swift */; };
 		CD4ED84E2BF113C800EFA0A2 /* ExpandedPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED84D2BF113C800EFA0A2 /* ExpandedPostView.swift */; };
+		CD77437F2C1BA5CE0085BB43 /* MultiplatformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD77437E2C1BA5CE0085BB43 /* MultiplatformView.swift */; };
 		CD7882A22BFE4B47002E1A30 /* PostContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7882A12BFE4B47002E1A30 /* PostContext.swift */; };
 		CD7882A52BFE94D2002E1A30 /* CommunityContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7882A42BFE94D2002E1A30 /* CommunityContext.swift */; };
 		CD7882A72BFFD1A3002E1A30 /* ThumbnailLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7882A62BFFD1A3002E1A30 /* ThumbnailLocation.swift */; };
@@ -284,6 +285,7 @@
 		CD4ED8462BF110FA00EFA0A2 /* TabReselectTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabReselectTracker.swift; sourceTree = "<group>"; };
 		CD4ED8492BF1113800EFA0A2 /* View+TabReselectConsumer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+TabReselectConsumer.swift"; sourceTree = "<group>"; };
 		CD4ED84D2BF113C800EFA0A2 /* ExpandedPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedPostView.swift; sourceTree = "<group>"; };
+		CD77437E2C1BA5CE0085BB43 /* MultiplatformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplatformView.swift; sourceTree = "<group>"; };
 		CD7882A12BFE4B47002E1A30 /* PostContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostContext.swift; sourceTree = "<group>"; };
 		CD7882A42BFE94D2002E1A30 /* CommunityContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityContext.swift; sourceTree = "<group>"; };
 		CD7882A62BFFD1A3002E1A30 /* ThumbnailLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailLocation.swift; sourceTree = "<group>"; };
@@ -695,6 +697,7 @@
 				03FE14052BF9445F00A8377F /* CloseButtonView.swift */,
 				CD7882AA2C013005002E1A30 /* EllipsisMenu.swift */,
 				CD0E07002C12707700445849 /* ToolbarEllipsisMenu.swift */,
+				CD77437E2C1BA5CE0085BB43 /* MultiplatformView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1190,6 +1193,7 @@
 				CD4D58AD2B86BE7100B82964 /* QuickSwitcherView.swift in Sources */,
 				6363D5C527EE196700E34822 /* MlemApp.swift in Sources */,
 				AD1B0D372A5F7A260006F554 /* Licenses.swift in Sources */,
+				CD77437F2C1BA5CE0085BB43 /* MultiplatformView.swift in Sources */,
 				03E614E72C0BCDC200F692A4 /* FullyQualifiedLinkView.swift in Sources */,
 				B1B78D642A51D53900F72485 /* AppDelegate.swift in Sources */,
 			);

--- a/Mlem/App/Views/Shared/MultiplatformView.swift
+++ b/Mlem/App/Views/Shared/MultiplatformView.swift
@@ -9,14 +9,14 @@ import Foundation
 import SwiftUI
 
 struct MultiplatformView<Content: View>: View {
-    let ios: () -> Content
-    let ipad: () -> Content
+    let phone: () -> Content
+    let pad: () -> Content
     
     var body: some View {
         if UIDevice.current.userInterfaceIdiom == .phone {
-            ios()
+            phone()
         } else if UIDevice.current.userInterfaceIdiom == .pad {
-            ipad()
+            pad()
         } else {
             preconditionFailure("Unsupported platform!")
         }

--- a/Mlem/App/Views/Shared/MultiplatformView.swift
+++ b/Mlem/App/Views/Shared/MultiplatformView.swift
@@ -1,0 +1,24 @@
+//
+//  MultiplatformView.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-06-13.
+//
+
+import Foundation
+import SwiftUI
+
+struct MultiplatformView<Content: View>: View {
+    let ios: () -> Content
+    let ipad: () -> Content
+    
+    var body: some View {
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            ios()
+        } else if UIDevice.current.userInterfaceIdiom == .pad {
+            ipad()
+        } else {
+            preconditionFailure("Unsupported platform!")
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the `MultiplatformView`, a construct designed to streamline creating different views for different platforms. Its operation is very simple: it takes in two `View` closures, one to render for iPhone and one to render for iPad, and renders the one appropriate for the current platform.

```
var body: some View {
  MultiplatformView {
    contentForPhone
  } pad: {
    contentForPad
  }
}
```

Ideally we would do this with compile-time checks to avoid the runtime conditional, but I can't seem to find a good way to check for iPadOS at compile time.