### PR TITLE
Fixed private messages not using correct id

### DIFF
--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/swift-markdown-ui.git",
       "state" : {
-        "revision" : "ae799d015a5374708f7b4c85f3294c05f2a564e2",
-        "version" : "2.3.0"
+        "revision" : "9a8119b37e09a770367eeb26e05267c75d854053",
+        "version" : "2.3.1"
       }
     },
     {

--- a/Mlem/API/APIClient/APIClient.swift
+++ b/Mlem/API/APIClient/APIClient.swift
@@ -99,6 +99,7 @@ class APIClient {
     @discardableResult
     func perform<Request: APIRequest>(request: Request, overrideToken: String? = nil) async throws -> Request.Response {
         let urlRequest = try urlRequest(from: request, overrideToken: overrideToken)
+        
         let (data, response) = try await execute(urlRequest)
         
         if let response = response as? HTTPURLResponse {

--- a/Mlem/API/APIClient/APIClient.swift
+++ b/Mlem/API/APIClient/APIClient.swift
@@ -99,7 +99,6 @@ class APIClient {
     @discardableResult
     func perform<Request: APIRequest>(request: Request, overrideToken: String? = nil) async throws -> Request.Response {
         let urlRequest = try urlRequest(from: request, overrideToken: overrideToken)
-
         let (data, response) = try await execute(urlRequest)
         
         if let response = response as? HTTPURLResponse {
@@ -489,13 +488,6 @@ extension APIClient {
     func reportPrivateMessage(id: Int, reason: String) async throws -> APIPrivateMessageReportView {
         let request = try CreatePrivateMessageReportRequest(session: session, privateMessageId: id, reason: reason)
         return try await perform(request: request).privateMessageReportView
-    }
-    
-    @available(*, deprecated, message: "Use id-based sendPrivateMessage instead")
-    @discardableResult
-    func sendPrivateMessage(content: String, recipient: APIPerson) async throws -> PrivateMessageResponse {
-        let request = try CreatePrivateMessageRequest(session: session, content: content, recipient: recipient)
-        return try await perform(request: request)
     }
     
     @discardableResult

--- a/Mlem/Models/Composers/Response Composers/Replies/ReplyToMessage.swift
+++ b/Mlem/Models/Composers/Response Composers/Replies/ReplyToMessage.swift
@@ -27,7 +27,7 @@ struct ReplyToMessage: ResponseEditorModel {
     
     func sendResponse(responseContents: String) async throws {
         do {
-            _ = try await inboxRepository.sendMessage(content: responseContents, recipientId: message.creator.id)
+            _ = try await inboxRepository.sendMessage(content: responseContents, recipientId: message.creator.userId)
             hapticManager.play(haptic: .success, priority: .high)
         } catch {
             hapticManager.play(haptic: .failure, priority: .high)


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #1096 

# Pull Request Information

This PR fixes an issue where private messages failed to send due to them incorrectly sending to `.id` instead of `.userId`.

It also removes the unused deprecated person-based `sendPrivateMessage` method.