### PR TITLE
[1.3] v2 `SavedAccount` compatibility

### DIFF
--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -76,7 +76,7 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(Int.self, forKey: .id)
         self.instanceLink = try container.decode(URL.self, forKey: .instanceLink)
-        self.accessToken = try container.decode(String?.self, forKey: .accessToken) ?? "redacted"
+        self.accessToken = (try? container.decode(String.self, forKey: .accessToken)) ?? "redacted"
         self.siteVersion = try container.decodeIfPresent(SiteVersion.self, forKey: .siteVersion)
         self.username = try container.decode(String.self, forKey: .username)
         self.storedNickname = try container.decodeIfPresent(String.self, forKey: .storedNickname)

--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -10,7 +10,7 @@ import Foundation
 struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
     let id: Int
     let instanceLink: URL
-    var accessToken: String = "redacted"
+    let accessToken: String
     var siteVersion: SiteVersion?
     let username: String
     var storedNickname: String?
@@ -59,6 +59,29 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
         self.avatarUrl = avatarUrl ?? account.avatarUrl
         self.siteVersion = siteVersion ?? account.siteVersion
         self.lastUsed = lastUsed ?? account.lastUsed
+    }
+    
+    enum CodingKeys: CodingKey {
+        case id
+        case instanceLink
+        case accessToken
+        case siteVersion
+        case username
+        case storedNickname
+        case avatarUrl
+        case lastUsed
+    }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.instanceLink = try container.decode(URL.self, forKey: .instanceLink)
+        self.accessToken = try container.decode(String?.self, forKey: .accessToken) ?? "redacted"
+        self.siteVersion = try container.decodeIfPresent(SiteVersion.self, forKey: .siteVersion)
+        self.username = try container.decode(String.self, forKey: .username)
+        self.storedNickname = try container.decodeIfPresent(String.self, forKey: .storedNickname)
+        self.avatarUrl = try container.decodeIfPresent(URL.self, forKey: .avatarUrl)
+        self.lastUsed = try container.decodeIfPresent(Date.self, forKey: .lastUsed)
     }
   
     // convenience

--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -10,7 +10,7 @@ import Foundation
 struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
     let id: Int
     let instanceLink: URL
-    let accessToken: String
+    var accessToken: String = "redacted"
     var siteVersion: SiteVersion?
     let username: String
     var storedNickname: String?

--- a/Mlem/Models/Saved Account.swift
+++ b/Mlem/Models/Saved Account.swift
@@ -75,8 +75,13 @@ struct SavedAccount: Identifiable, Codable, Equatable, Hashable {
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(Int.self, forKey: .id)
-        self.instanceLink = try container.decode(URL.self, forKey: .instanceLink)
-        self.accessToken = (try? container.decode(String.self, forKey: .accessToken)) ?? "redacted"
+        var instanceLink = try container.decode(URL.self, forKey: .instanceLink)
+        // v2 compat
+        if instanceLink.pathComponents.count == 0 {
+            instanceLink.append(path: "api/v3")
+        }
+        self.instanceLink = instanceLink
+        self.accessToken = try container.decodeIfPresent(String.self, forKey: .accessToken) ?? "redacted"
         self.siteVersion = try container.decodeIfPresent(SiteVersion.self, forKey: .siteVersion)
         self.username = try container.decode(String.self, forKey: .username)
         self.storedNickname = try container.decodeIfPresent(String.self, forKey: .storedNickname)

--- a/Mlem/Models/Trackers/Saved Account Tracker.swift
+++ b/Mlem/Models/Trackers/Saved Account Tracker.swift
@@ -22,7 +22,7 @@ class SavedAccountTracker: ObservableObject {
     @Published var savedAccounts = [SavedAccount]()
     
     var defaultAccount: SavedAccount? {
-        savedAccounts.first(where: { $0.id == defaultAccountId })
+        savedAccounts.first(where: { $0.id == defaultAccountId }) ?? savedAccounts.first
     }
     
     private var cancellables = Set<AnyCancellable>()

--- a/Mlem/Repositories/PersistenceRepository.swift
+++ b/Mlem/Repositories/PersistenceRepository.swift
@@ -71,7 +71,7 @@ class PersistenceRepository {
     func loadAccounts() -> [SavedAccount] {
         let accounts = load([SavedAccount].self, from: Path.savedAccounts) ?? []
         return accounts.compactMap { account -> SavedAccount? in
-            guard let token = keychainAccess("\(account.id)_accessToken") else {
+            guard let token = keychainAccess("\(account.id)_accessToken") ?? keychainAccess("\(account.stableIdString)_accessToken") else {
                 return nil
             }
             return SavedAccount(from: account, accessToken: token, avatarUrl: account.avatarUrl)

--- a/Mlem/Repositories/PersistenceRepository.swift
+++ b/Mlem/Repositories/PersistenceRepository.swift
@@ -69,12 +69,19 @@ class PersistenceRepository {
     // MARK: - Public methods
     
     func loadAccounts() -> [SavedAccount] {
+        print(Path.savedAccounts)
         let accounts = load([SavedAccount].self, from: Path.savedAccounts) ?? []
         return accounts.compactMap { account -> SavedAccount? in
-            guard let token = keychainAccess("\(account.id)_accessToken") ?? keychainAccess("\(account.stableIdString)_accessToken") else {
+            var actorComponents = URLComponents(url: account.instanceLink, resolvingAgainstBaseURL: false)!
+            actorComponents.path = "/u/\(account.username)"
+            let url = actorComponents.url!
+            guard let token = keychainAccess("\(account.id)_accessToken")
+                ?? keychainAccess("\(url.absoluteString)_accessToken") else {
                 return nil
             }
-            return SavedAccount(from: account, accessToken: token, avatarUrl: account.avatarUrl)
+            let acc = SavedAccount(from: account, accessToken: token, avatarUrl: account.avatarUrl)
+            print("TOKEN", acc.accessToken)
+            return acc
         }
     }
     

--- a/Mlem/Repositories/PersistenceRepository.swift
+++ b/Mlem/Repositories/PersistenceRepository.swift
@@ -69,9 +69,9 @@ class PersistenceRepository {
     // MARK: - Public methods
     
     func loadAccounts() -> [SavedAccount] {
-        print(Path.savedAccounts)
         let accounts = load([SavedAccount].self, from: Path.savedAccounts) ?? []
         return accounts.compactMap { account -> SavedAccount? in
+            // Attempt to get v2 access token if v1 access token doesn't exist
             var actorComponents = URLComponents(url: account.instanceLink, resolvingAgainstBaseURL: false)!
             actorComponents.path = "/u/\(account.username)"
             let url = actorComponents.url!
@@ -79,9 +79,7 @@ class PersistenceRepository {
                 ?? keychainAccess("\(url.absoluteString)_accessToken") else {
                 return nil
             }
-            let acc = SavedAccount(from: account, accessToken: token, avatarUrl: account.avatarUrl)
-            print("TOKEN", acc.accessToken)
-            return acc
+            return SavedAccount(from: account, accessToken: token, avatarUrl: account.avatarUrl)
         }
     }
     

--- a/MlemTests/Persistence/PersistenceRepositoryTests.swift
+++ b/MlemTests/Persistence/PersistenceRepositoryTests.swift
@@ -51,8 +51,8 @@ final class PersistenceRepositoryTests: XCTestCase {
     
     func testSaveAccounts() async throws {
         let accounts: [SavedAccount] = [
-            .init(id: 0, instanceLink: URL(string: "https://mlem.group")!, accessToken: "token_0", username: "User0"),
-            .init(id: 1, instanceLink: URL(string: "https://mlem.group")!, accessToken: "token_1", username: "User1")
+            .init(id: 0, instanceLink: URL(string: "https://mlem.group/api/v3")!, accessToken: "token_0", username: "User0"),
+            .init(id: 1, instanceLink: URL(string: "https://mlem.group/api/v3")!, accessToken: "token_1", username: "User1")
         ]
         
         XCTAssert(disk.keys.isEmpty) // confirm we have a blank slate
@@ -80,8 +80,8 @@ final class PersistenceRepositoryTests: XCTestCase {
     
     func testLoadAccounts() async throws {
         let accounts: [SavedAccount] = [
-            .init(id: 0, instanceLink: URL(string: "https://mlem.group")!, accessToken: "token_0", username: "User0"),
-            .init(id: 1, instanceLink: URL(string: "https://mlem.group")!, accessToken: "token_1", username: "User1")
+            .init(id: 0, instanceLink: URL(string: "https://mlem.group/api/v3")!, accessToken: "token_0", username: "User0"),
+            .init(id: 1, instanceLink: URL(string: "https://mlem.group/api/v3")!, accessToken: "token_1", username: "User1")
         ]
         
         // as we are testing the `.loadAccounts` method, we need to supply tokens
@@ -102,8 +102,8 @@ final class PersistenceRepositoryTests: XCTestCase {
     
     func testAccountsWithoutTokensAreOmitted() async throws {
         let accounts: [SavedAccount] = [
-            .init(id: 0, instanceLink: URL(string: "https://mlem.group")!, accessToken: "token_0", username: "User0"),
-            .init(id: 1, instanceLink: URL(string: "https://mlem.group")!, accessToken: "token_1", username: "User1")
+            .init(id: 0, instanceLink: URL(string: "https://mlem.group/api/v3")!, accessToken: "token_0", username: "User0"),
+            .init(id: 1, instanceLink: URL(string: "https://mlem.group/api/v3")!, accessToken: "token_1", username: "User1")
         ]
         
         // only provide a token for the first account in this test


### PR DESCRIPTION
Added compatibility for decoding Mlem v2's saved accounts. This ensures that the saved accounts aren't lost if the user downgrades from v2 to v1 (by leaving the beta).