### PR TITLE
Fix `ContentLoader`

### DIFF
--- a/Mlem/App/Views/Pages/PersonView.swift
+++ b/Mlem/App/Views/Pages/PersonView.swift
@@ -25,18 +25,20 @@ struct PersonView: View {
     @State var posts: [Post2] = []
     
     var body: some View {
-        ContentLoader(model: person) { person, isLoading in
-            content(person: person)
-                .externalApiWarning(entity: person, isLoading: isLoading)
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        if person is any Person3Providing, isLoading {
-                            ProgressView()
-                        } else {
-                            ToolbarEllipsisMenu {}
+        ContentLoader(model: person) { proxy in
+            if let person = proxy.entity {
+                content(person: person)
+                    .externalApiWarning(entity: person, isLoading: proxy.isLoading)
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            if person is any Person3Providing, proxy.isLoading {
+                                ProgressView()
+                            } else {
+                                ToolbarEllipsisMenu {}
+                            }
                         }
                     }
-                }
+            }
         } upgradeOperation: { model, api in
             try await model.upgrade(api: api) { entity in
                 if let entity = entity as? any Person1Providing {
@@ -113,7 +115,7 @@ struct PersonView: View {
     
     @ViewBuilder
     func personContent(person: any Person3Providing) -> some View {
-        VStack {
+        VStack(spacing: 0) {
             BubblePicker(
                 tabs(person: person),
                 selected: $selectedTab,
@@ -133,10 +135,10 @@ struct PersonView: View {
                 }
             )
             // I was going to render this, but there's some weird view update issues going on with ContentLoader that we'll need to work out first...
-//            ForEach(posts, id: \.id) { post in
-//                FeedPostView(post: post)
-//                Divider()
-//            }
+            ForEach(posts, id: \.id) { post in
+                FeedPostView(post: post)
+                Divider()
+            }
         }
     }
     

--- a/Mlem/App/Views/Pages/PersonView.swift
+++ b/Mlem/App/Views/Pages/PersonView.swift
@@ -17,6 +17,8 @@ struct PersonView: View {
         var label: String { rawValue.capitalized }
     }
     
+    @Environment(Palette.self) var palette
+    
     @State var person: AnyPerson
     @State private var selectedTab: Tab = .overview
     @State private var isAtTop: Bool = true
@@ -38,6 +40,9 @@ struct PersonView: View {
                             }
                         }
                     }
+            } else {
+                ProgressView()
+                    .tint(palette.secondary)
             }
         } upgradeOperation: { model, api in
             try await model.upgrade(api: api) { entity in

--- a/Mlem/App/Views/Shared/Avatar/DefaultAvatarView.swift
+++ b/Mlem/App/Views/Shared/Avatar/DefaultAvatarView.swift
@@ -29,7 +29,7 @@ struct DefaultAvatarView: View {
         default:
             Image(systemName: avatarType.iconNameFill)
                 .resizable()
-                .scaledToFill()
+                .scaledToFit()
                 .symbolRenderingMode(.multicolor)
                 .foregroundStyle(Color.gray.gradient, .white)
         }

--- a/Mlem/App/Views/Shared/ContentLoader.swift
+++ b/Mlem/App/Views/Shared/ContentLoader.swift
@@ -29,30 +29,23 @@ struct ContentLoader<Content: View, Model: Upgradable>: View {
     }
     
     var body: some View {
-        VStack {
-            if let modelValue = proxy.model.wrappedValue as? Model.MinimumRenderable {
-                content
-            } else {
-                ProgressView()
-                    .tint(palette.secondary)
-            }
-        }
-        .animation(.easeOut(duration: 0.2), value: proxy.model.wrappedValue is Model.MinimumRenderable)
-        .task {
-            if !proxy.model.isUpgraded, proxy.upgradeState == .idle {
-                await proxy.upgradeModel(upgradeOperation: upgradeOperation)
-            }
-        }
-        .onChange(of: appState.firstApi.actorId) {
-            if proxy.upgradeState != .loading {
-                // This code is needed here despite also being in `upgradeModel` to
-                // ensure that `upgradeState` is changed fast enough
-                proxy.upgradeState = .loading
-                Task { @MainActor in
-                    await proxy.upgradeModel(api: appState.firstApi, upgradeOperation: upgradeOperation)
+        content
+            .animation(.easeOut(duration: 0.2), value: proxy.model.wrappedValue is Model.MinimumRenderable)
+            .task {
+                if !proxy.model.isUpgraded, proxy.upgradeState == .idle {
+                    await proxy.upgradeModel(upgradeOperation: upgradeOperation)
                 }
             }
-        }
+            .onChange(of: appState.firstApi.actorId) {
+                if proxy.upgradeState != .loading {
+                    // This code is needed here despite also being in `upgradeModel` to
+                    // ensure that `upgradeState` is changed fast enough
+                    proxy.upgradeState = .loading
+                    Task { @MainActor in
+                        await proxy.upgradeModel(api: appState.firstApi, upgradeOperation: upgradeOperation)
+                    }
+                }
+            }
     }
 }
 

--- a/Mlem/App/Views/Shared/ContentLoader.swift
+++ b/Mlem/App/Views/Shared/ContentLoader.swift
@@ -14,57 +14,73 @@ struct ContentLoader<Content: View, Model: Upgradable>: View {
     @Environment(Palette.self) var palette: Palette
     @Environment(AppState.self) var appState: AppState
     
-    enum UpgradeState: String {
-        case idle, loading, done, failed
-    }
-        
-    @State var upgradeState: UpgradeState = .idle
-    @State var error: Error?
-    
-    private let loadingSemaphore: AsyncSemaphore = .init(value: 1)
-    
-    let model: Model
-    @ViewBuilder var content: (_ model: Model.MinimumRenderable, _ isLoading: Bool) -> Content
+    let proxy: ContentLoaderProxy<Model>
+    let content: Content
     var upgradeOperation: ((_ model: Model, _ api: ApiClient) async throws -> Void)?
     
     init(
         model: Model,
-        @ViewBuilder content: @escaping (_ model: Model.MinimumRenderable, _ isLoading: Bool) -> Content,
+        @ViewBuilder content: @escaping (_ proxy: ContentLoaderProxy<Model>) -> Content,
         upgradeOperation: ((_ model: Model, _ api: ApiClient) async throws -> Void)? = nil
     ) {
-        self.model = model
-        self.content = content
+        self.proxy = .init(model: model)
         self.upgradeOperation = upgradeOperation
+        self.content = content(proxy)
     }
     
     var body: some View {
         VStack {
-            if let modelValue = model.wrappedValue as? Model.MinimumRenderable {
-                content(modelValue, upgradeState == .loading)
+            if let modelValue = proxy.model.wrappedValue as? Model.MinimumRenderable {
+                content
             } else {
                 ProgressView()
                     .tint(palette.secondary)
             }
         }
-        .animation(.easeOut(duration: 0.2), value: model.wrappedValue is Model.MinimumRenderable)
+        .animation(.easeOut(duration: 0.2), value: proxy.model.wrappedValue is Model.MinimumRenderable)
         .task {
-            if !model.isUpgraded, upgradeState == .idle {
-                await upgradeModel()
+            if !proxy.model.isUpgraded, proxy.upgradeState == .idle {
+                await proxy.upgradeModel(upgradeOperation: upgradeOperation)
             }
         }
         .onChange(of: appState.firstApi.actorId) {
-            if upgradeState != .loading {
+            if proxy.upgradeState != .loading {
                 // This code is needed here despite also being in `upgradeModel` to
                 // ensure that `upgradeState` is changed fast enough
-                upgradeState = .loading
+                proxy.upgradeState = .loading
                 Task { @MainActor in
-                    await upgradeModel(api: appState.firstApi)
+                    await proxy.upgradeModel(api: appState.firstApi, upgradeOperation: upgradeOperation)
                 }
             }
         }
     }
+}
+
+@Observable
+class ContentLoaderProxy<Model: Upgradable> {
+    fileprivate enum UpgradeState: String {
+        case idle, loading, done, failed
+    }
     
-    func upgradeModel(api: ApiClient? = nil) async {
+    fileprivate var model: Model
+    fileprivate var upgradeState: UpgradeState = .idle
+    var error: Error?
+    private let loadingSemaphore: AsyncSemaphore = .init(value: 1)
+    
+    init(model: Model) {
+        self.model = model
+    }
+    
+    var entity: (Model.MinimumRenderable)? {
+        model.wrappedValue as? Model.MinimumRenderable
+    }
+    
+    var isLoading: Bool { upgradeState == .loading }
+    
+    func upgradeModel(
+        api: ApiClient? = nil,
+        upgradeOperation: ((_ model: Model, _ api: ApiClient) async throws -> Void)?
+    ) async {
         // critical function, only one thread allowed!
         await loadingSemaphore.wait()
         defer { loadingSemaphore.signal() }

--- a/Mlem/App/Views/Shared/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPostView.swift
@@ -15,8 +15,10 @@ struct ExpandedPostView: View {
     let post: AnyPost
     
     var body: some View {
-        ContentLoader(model: post) { post1, _ in
-            content(for: post1)
+        ContentLoader(model: post) { proxy in
+            if let post = proxy.entity {
+                content(for: post)
+            }
         }
     }
     

--- a/Mlem/App/Views/Shared/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPostView.swift
@@ -10,6 +10,7 @@ import MlemMiddleware
 import SwiftUI
 
 struct ExpandedPostView: View {
+    @Environment(Palette.self) var palette
     @Environment(\.dismiss) var dismiss
     
     let post: AnyPost
@@ -18,6 +19,9 @@ struct ExpandedPostView: View {
         ContentLoader(model: post) { proxy in
             if let post = proxy.entity {
                 content(for: post)
+            } else {
+                ProgressView()
+                    .tint(palette.secondary)
             }
         }
     }


### PR DESCRIPTION
Fixes the state update issue we had with `ContentLoader`. I've done this by calling the `content` method passed to `init` inside of the initializer itself rather than in `body`.