### PR TITLE
LemmyMarkdownUI update

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2095,7 +2095,7 @@
 			repositoryURL = "https://github.com/mlemgroup/LemmyMarkdownUI";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.2.0;
+				minimumVersion = 0.2.1;
 			};
 		};
 		0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2095,7 +2095,7 @@
 			repositoryURL = "https://github.com/mlemgroup/LemmyMarkdownUI";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.2.1;
+				minimumVersion = 0.3.0;
 			};
 		};
 		0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -1885,7 +1885,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = 8B9GNJW88W;
+				DEVELOPMENT_TEAM = V4747CQLU2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -1905,7 +1905,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sjmarf.mlem1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
@@ -2095,7 +2095,7 @@
 			repositoryURL = "https://github.com/mlemgroup/LemmyMarkdownUI";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.2.0;
 			};
 		};
 		0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -1885,7 +1885,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "local build";
 				DEVELOPMENT_ASSET_PATHS = "\"Mlem/Preview Content\"";
-				DEVELOPMENT_TEAM = V4747CQLU2;
+				DEVELOPMENT_TEAM = 8B9GNJW88W;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mlem/Info.plist;
@@ -1905,7 +1905,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sjmarf.mlem1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanners.Mlem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/LemmyMarkdownUI",
       "state" : {
-        "revision" : "c2e046ffb8573af4c826ef5570d9bdd79624c299",
-        "version" : "0.2.1"
+        "revision" : "d9ca5af18c5204e5a54ffe226bd6cb1191531127",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/LemmyMarkdownUI",
       "state" : {
-        "revision" : "055dfa8e000d3f95b348f377b2fee1958ce485d8",
-        "version" : "0.2.0"
+        "revision" : "c2e046ffb8573af4c826ef5570d9bdd79624c299",
+        "version" : "0.2.1"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "b159f0a20b9c47bf2fae7b8e8322b8f3fff96046592270bf1b94b96530aa91b0",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -23,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/LemmyMarkdownUI",
       "state" : {
-        "revision" : "bd3982bf5c5446455dce394e94ab89b5012901ab",
-        "version" : "0.1.0"
+        "revision" : "055dfa8e000d3f95b348f377b2fee1958ce485d8",
+        "version" : "0.2.0"
       }
     },
     {
@@ -100,5 +101,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 extension MarkdownConfiguration {
     static let defaultBlurred: Self = .init(
+        allowInlineImages: false,
         inlineImageLoader: loadInlineImage,
         imageBlockView: {
             imageView($0, blurred: true)
@@ -20,6 +21,7 @@ extension MarkdownConfiguration {
     )
     
     static let `default`: Self = .init(
+        allowInlineImages: false,
         inlineImageLoader: loadInlineImage,
         imageBlockView: { imageView($0, blurred: false) },
         primaryColor: Palette.main.primary,
@@ -27,10 +29,20 @@ extension MarkdownConfiguration {
     )
     
     static let dimmed: Self = .init(
+        allowInlineImages: false,
         inlineImageLoader: loadInlineImage,
         imageBlockView: { imageView($0, blurred: false) },
         primaryColor: Palette.main.secondary,
         secondaryColor: Palette.main.tertiary
+    )
+    
+    static let caption: Self = .init(
+        allowInlineImages: false,
+        inlineImageLoader: loadInlineImage,
+        imageBlockView: { imageView($0, blurred: false) },
+        primaryColor: Palette.main.secondary,
+        secondaryColor: Palette.main.tertiary,
+        font: .caption1
     )
 }
 

--- a/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
@@ -11,7 +11,6 @@ import SwiftUI
 
 extension MarkdownConfiguration {
     static let defaultBlurred: Self = .init(
-        allowInlineImages: false,
         inlineImageLoader: loadInlineImage,
         imageBlockView: {
             imageView($0, blurred: true)
@@ -21,7 +20,6 @@ extension MarkdownConfiguration {
     )
     
     static let `default`: Self = .init(
-        allowInlineImages: false,
         inlineImageLoader: loadInlineImage,
         imageBlockView: { imageView($0, blurred: false) },
         primaryColor: Palette.main.primary,
@@ -29,16 +27,14 @@ extension MarkdownConfiguration {
     )
     
     static let dimmed: Self = .init(
-        allowInlineImages: false,
-        inlineImageLoader: loadInlineImage,
+        inlineImageLoader: { _ in },
         imageBlockView: { imageView($0, blurred: false) },
         primaryColor: Palette.main.secondary,
         secondaryColor: Palette.main.tertiary
     )
     
     static let caption: Self = .init(
-        allowInlineImages: false,
-        inlineImageLoader: loadInlineImage,
+        inlineImageLoader: { _ in },
         imageBlockView: { imageView($0, blurred: false) },
         primaryColor: Palette.main.secondary,
         secondaryColor: Palette.main.tertiary,
@@ -55,6 +51,15 @@ private func imageView(_ inlineImage: InlineImage, blurred: Bool) -> AnyView {
 }
 
 private func loadInlineImage(inlineImage: InlineImage) async {
+    // Only custom emojis should be displayed inline. Custom emojis have tooltips.
+    // People are unlikely to use tooltips in any other circumstances, so images
+    // with tooltips are displayed inline. I haven't found a better way to test for
+    // a custom emoji.
+    if inlineImage.tooltip == nil {
+        inlineImage.renderFullWidth = true
+        return
+    }
+    
     guard inlineImage.image == nil else { return }
     let imageTask = ImagePipeline.shared.imageTask(with: inlineImage.url)
     guard let image: UIImage = try? await imageTask.image else { return }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/TileCommentView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/TileCommentView.swift
@@ -54,8 +54,7 @@ struct TileCommentView: View {
                         .fill(palette.tertiaryGroupedBackground)
                 }
             
-            MarkdownText(comment.content, configuration: .default)
-                .font(.caption)
+            MarkdownText(comment.content, configuration: .caption)
                 .frame(height: contentHeight, alignment: .top)
                 .clipped()
 

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/TilePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/TilePostView.swift
@@ -118,8 +118,7 @@ struct TilePostView: View {
         var body: some View {
             switch post.type {
             case let .text(text):
-                MarkdownText(text, configuration: .default)
-                    .font(.caption)
+                MarkdownText(text, configuration: .caption)
                     .foregroundStyle(palette.secondary)
                     .padding(AppConstants.standardSpacing)
                     .frame(maxWidth: .infinity, maxHeight: height, alignment: .topLeading)


### PR DESCRIPTION
Updates LemmyMarkdownUI to include some bug-fixes and tweaks. 

The main change here is to how Mlem decides whether to render an image inline or full-size. Previously, an image would have to be on it's own line to be counted as full-size. The problem with that method is that people frequently _don't_ put images on their own line, which causes Mlem to incorrectly display those images as inline emoji. 

When you insert a custom emoji, it adds a tooltip to the inserted image in this format:

```
![alt_text](https://example.com/image.png "tooltip")
```

The new solution is to display all images that have a tooltip as inline emojis, and display all other images as full-size. I think this is a good enough fix because people are unlikely to use tooltips outside of custom emojis.

Full diff: https://github.com/mlemgroup/LemmyMarkdownUI/compare/0.1.0...0.3.0