### PR TITLE
Post and Image Tweaks

### DIFF
--- a/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
@@ -55,7 +55,7 @@ extension Interactable1Providing {
             print("DEBUG no self2 found in toggleSave!")
         }
     }
-        
+    
     // MARK: Counters
     
     var upvoteCounter: Counter {

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -36,6 +36,10 @@ extension Post1Providing {
         }
     }
     
+    func markRead() {
+        self2?.updateRead(true)
+    }
+    
     func swipeActions(behavior: SwipeBehavior) -> SwipeConfiguration {
         .init(
             behavior: behavior,

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
@@ -54,6 +54,7 @@ struct CompactPostView: View {
   
                 post.taggedTitle(communityContext: communityContext)
                     .imageScale(.small)
+                    .foregroundStyle(post.read_ ?? false ? palette.secondary : palette.primary)
                     .font(.subheadline)
                 
                 if let host = post.linkHost {

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
@@ -25,12 +25,16 @@ struct LargePostBodyView: View {
             
             switch post.type {
             case let .image(url):
-                LargeImageView(url: url, nsfw: post.nsfw)
-                    // Set maximum image height to 1.2 * width
-                    .aspectRatio(CGSize(width: 1, height: 1.2), contentMode: .fill)
-                    .frame(maxWidth: .infinity)
+                LargeImageView(url: url, nsfw: post.nsfw) {
+                    post.markRead()
+                }
+                // Set maximum image height to 1.2 * width
+                .aspectRatio(CGSize(width: 1, height: 1.2), contentMode: .fill)
+                .frame(maxWidth: .infinity)
             case let .link(link):
-                WebsitePreviewView(link: link, nsfw: post.nsfw)
+                WebsitePreviewView(link: link, nsfw: post.nsfw) {
+                    post.markRead()
+                }
             default:
                 EmptyView()
             }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostView.swift
@@ -65,38 +65,6 @@ struct LargePostView: View {
             .padding(.vertical, 2)
         }
     }
-
-    @ViewBuilder
-    var postDetail: some View {
-        switch post.type {
-        case let .image(url):
-            LargeImageView(url: url, nsfw: post.nsfw)
-                // Set maximum image height to 1.2 * width
-                .aspectRatio(CGSize(width: 1, height: 1.2), contentMode: .fill)
-                .frame(maxWidth: .infinity)
-        case let .link(link):
-            WebsitePreviewView(link: link, nsfw: post.nsfw)
-        default:
-            EmptyView()
-        }
-        if let content = post.content {
-            if isExpanded {
-                Markdown(content, configuration: post.nsfw ? .defaultBlurred : .default)
-            } else {
-                // Cut down on compute time for very long text posts by only rendering the first 4 blocks
-                MarkdownText(Array([BlockNode](content).prefix(4)), configuration: .dimmed)
-                    .lineLimit(post.linkUrl == nil ? 8 : 4)
-            }
-        }
-    }
-    
-    var mockImage: some View {
-        Image(systemName: "photo.artframe")
-            .resizable()
-            .scaledToFit()
-            .frame(maxWidth: .infinity)
-            .foregroundStyle(palette.secondary)
-    }
     
     @ViewBuilder
     var personLink: some View {

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/TilePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/TilePostView.swift
@@ -99,7 +99,7 @@ struct TilePostView: View {
         } label: {
             Group {
                 postTag(active: post.saved_ ?? false, icon: Icons.saveFill, color: palette.save) + // saved status
-                    Text(post.saved_ ?? false ? " " : "") + // spacing after save
+                    Text(verbatim: post.saved_ ?? false ? " " : "") + // spacing after save
                     Text(Image(systemName: post.votes_?.iconName ?? Icons.upvoteSquare)) + // vote status
                     Text(verbatim: " \(post.votes_?.total.abbreviated ?? "0")")
             }

--- a/Mlem/App/Views/Shared/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPostView.swift
@@ -49,6 +49,7 @@ struct ExpandedPostView: View {
                 .animation(.default, value: showLoadingSymbol)
                 .task {
                     if post.api == appState.firstApi {
+                        post.markRead()
                         await loadComments(post: post)
                     }
                 }

--- a/Mlem/App/Views/Shared/Images/Core/DynamicImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Core/DynamicImageView.swift
@@ -17,6 +17,7 @@ struct DynamicImageView: View {
     
     @State var uiImage: UIImage?
     @State var loading: ImageLoadingState
+    @State var loadingPref: ImageLoadingState?
     @State var aspectRatio: CGSize
     @State var error: Error?
     
@@ -64,7 +65,8 @@ struct DynamicImageView: View {
             }
             .task(loadImage)
             .clipShape(.rect(cornerRadius: cornerRadius))
-            .preference(key: ImageLoadingPreferenceKey.self, value: loading)
+            .onChange(of: loading, initial: true) { loadingPref = loading }
+            .preference(key: ImageLoadingPreferenceKey.self, value: loadingPref)
     }
     
     @Sendable

--- a/Mlem/App/Views/Shared/Images/Core/FixedImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Core/FixedImageView.swift
@@ -16,6 +16,7 @@ struct FixedImageView: View {
     
     @State private var uiImage: UIImage
     @State private var loading: ImageLoadingState
+    @State var loadingPref: ImageLoadingState? // tracked separately to allow correct propagation of inital value
     
     let url: URL?
     let fallback: Fallback
@@ -60,7 +61,8 @@ struct FixedImageView: View {
                 content
                     .task(loadImage)
                     .aspectRatio(1, contentMode: .fill)
-                    .preference(key: ImageLoadingPreferenceKey.self, value: loading)
+                    .onChange(of: loading, initial: true) { loadingPref = loading }
+                    .preference(key: ImageLoadingPreferenceKey.self, value: loadingPref)
                     .allowsHitTesting(false)
             }
     }

--- a/Mlem/App/Views/Shared/Images/Helpers/ImageLoadingPreferenceKey.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/ImageLoadingPreferenceKey.swift
@@ -9,8 +9,8 @@ import Foundation
 import SwiftUI
 
 struct ImageLoadingPreferenceKey: PreferenceKey {
-    typealias Value = ImageLoadingState
-    static var defaultValue: Value = .loading
+    typealias Value = ImageLoadingState?
+    static var defaultValue: Value = nil
 
     static func reduce(value _: inout Value, nextValue: () -> Value) {
         _ = nextValue()

--- a/Mlem/App/Views/Shared/Images/Wrappers/LargeImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Wrappers/LargeImageView.swift
@@ -26,7 +26,7 @@ struct LargeImageView: View {
         self._blurred = .init(wrappedValue: blurNsfw ? nsfw : false)
     }
     
-    @State private var loading: ImageLoadingState = .loading
+    @State private var loading: ImageLoadingState?
 
     var body: some View {
         DynamicImageView(url: url)
@@ -39,7 +39,7 @@ struct LargeImageView: View {
             .onTapGesture {
                 if blurred {
                     blurred = false
-                } else if loading == .done, let url {
+                } else if let loading, loading == .done, let url {
                     // Sheets don't cover the whole screen on iPad, so use a fullScreenCover instead
                     if UIDevice.isPad {
                         navigation.showFullScreenCover(.imageViewer(url))

--- a/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
@@ -14,7 +14,7 @@ struct ThumbnailImageView: View {
     @Environment(NavigationLayer.self) var navigation
     @Environment(\.openURL) var openURL
     
-    @State var loading: ImageLoadingState = .loading
+    @State var loading: ImageLoadingState?
     
     let post: any Post1Providing
     var blurred: Bool = false
@@ -49,7 +49,7 @@ struct ThumbnailImageView: View {
         case let .image(url):
             content
                 .onTapGesture {
-                    if loading == .done {
+                    if let loading, loading == .done {
                         // Sheets don't cover the whole screen on iPad, so use a fullScreenCover instead
                         if UIDevice.isPad {
                             navigation.showFullScreenCover(.imageViewer(url))

--- a/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
@@ -50,6 +50,8 @@ struct ThumbnailImageView: View {
             content
                 .onTapGesture {
                     if let loading, loading == .done {
+                        post.markRead()
+                        
                         // Sheets don't cover the whole screen on iPad, so use a fullScreenCover instead
                         if UIDevice.isPad {
                             navigation.showFullScreenCover(.imageViewer(url))
@@ -61,6 +63,7 @@ struct ThumbnailImageView: View {
         case let .link(link):
             content
                 .onTapGesture {
+                    post.markRead()
                     openURL(link.content)
                 }
         default:

--- a/Mlem/App/Views/Shared/WebsitePreviewView.swift
+++ b/Mlem/App/Views/Shared/WebsitePreviewView.swift
@@ -31,6 +31,9 @@ struct WebsitePreviewView: View {
         content
             .contentShape(.rect)
             .onTapGesture {
+                if let onTapActions {
+                    onTapActions()
+                }
                 openURL(link.content)
             }
             .contextMenu {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1,6 +1,12 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "" : {
+
+    },
+    " " : {
+
+    },
     "**%@** and **%@** chose to defederate from one another." : {
       "localizations" : {
         "en" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1,12 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "" : {
-
-    },
-    " " : {
-
-    },
     "**%@** and **%@** chose to defederate from one another." : {
       "localizations" : {
         "en" : {


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #1188 

This PR includes several assorted post and image related features:
- Tile posts show both NSFW and saved status: 
![IMG_5E46830381F5-1](https://github.com/user-attachments/assets/27528d5c-e96c-4dde-8cd5-5ac6179dd276)
- The following actions now mark posts as read:
  - Opening the image viewer
  - Navigating to the linked content
  - Opening the expanded post
- Fixed an issue where the image viewer would not appear. This was due to the `PreferenceKey` used to propagate image loading state up the tree not passing the initial state of `loading` up though its preference key. I have fixed this by adding the `loadingPref` state var to both core images and using that to drive the `PreferenceKey`.