### PR TITLE
Fix Nightly Build

### DIFF
--- a/Mlem/App/Views/Shared/ExpandedPostView+Logic.swift
+++ b/Mlem/App/Views/Shared/ExpandedPostView+Logic.swift
@@ -9,6 +9,15 @@ import MlemMiddleware
 import SwiftUI
 
 extension ExpandedPostView {
+    func resolveComments(post: any Post) {
+        Task {
+            commentResolveLoading = true
+            loadingState = .idle
+            await loadComments(post: post)
+            commentResolveLoading = false
+        }
+    }
+    
     func loadComments(post: any Post) async {
         guard loadingState == .idle else { return }
         loadingState = .loading

--- a/Mlem/App/Views/Shared/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPostView.swift
@@ -54,12 +54,7 @@ struct ExpandedPostView: View {
                     }
                 }
                 .onChange(of: post.api) {
-                    Task {
-                        commentResolveLoading = true
-                        loadingState = .idle
-                        await loadComments(post: post)
-                        commentResolveLoading = false
-                    }
+                    resolveComments(post: post)
                 }
                 .toolbar {
                     if proxy.isLoading {


### PR DESCRIPTION
For ✨ Xcode Reasons✨, the lines modified here cause the build to _sort of_ fail. A valid archive is still produced, but because of the "failure," it is not automatically pushed out to the internal beta.

Moving the offending code into its own function appears to appease the compiler gremlins.

<img width="1386" alt="Screenshot 2024-08-06 at 10 19 41 PM" src="https://github.com/user-attachments/assets/1cee8b89-1405-4ca5-9aeb-f2f2a95bffab">
