### PR TITLE
Fix localhost account decoding

### DIFF
--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -134,7 +134,12 @@ class UserAccount: Account, CommunityOrPersonStub {
 }
 
 private func getKeychainId(actorId: URL) -> String {
-    "\(actorId.absoluteString)_accessToken"
+    // localhost sometimes has url "http://localhost:PORT" and sometimes "https://lemmy-alpha/beta/etc", so replace any of that with simple "localhost"
+    let keychainActorId = actorId.absoluteString.replacing(
+        /https?:\/\/(lemmy-(alpha|beta|gamma|delta|epsilon)|localhost:\d{4})/,
+        with: "localhost"
+    )
+    return "\(keychainActorId)_accessToken"
 }
 
 private func getKeychainId(id: Int) -> String {

--- a/Mlem/App/Models/Session/GuestSession.swift
+++ b/Mlem/App/Models/Session/GuestSession.swift
@@ -23,7 +23,9 @@ class GuestSession: Session {
             try await self.api.fetchSiteVersion(task: Task {
                 let (_, instance, _) = try await self.api.getMyPerson()
                 self.instance = instance
-                self.account.update(instance: instance)
+                Task { @MainActor in
+                    self.account.update(instance: instance)
+                }
                 return instance.version
             })
         }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -612,12 +612,6 @@
     "Temporary" : {
 
     },
-    "Test" : {
-
-    },
-    "Test Long" : {
-
-    },
     "Theme" : {
 
     },

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -459,6 +459,9 @@
     "Quote" : {
 
     },
+    "Really super long text" : {
+
+    },
     "Received %@" : {
 
     },
@@ -612,6 +615,12 @@
     "Temporary" : {
 
     },
+    "Test" : {
+
+    },
+    "Test Long" : {
+
+    },
     "Theme" : {
 
     },
@@ -670,6 +679,9 @@
           }
         }
       }
+    },
+    "Unfavorited Community" : {
+
     },
     "Unknown" : {
 

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -459,9 +459,6 @@
     "Quote" : {
 
     },
-    "Really super long text" : {
-
-    },
     "Received %@" : {
 
     },

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -671,9 +671,6 @@
         }
       }
     },
-    "Unfavorited Community" : {
-
-    },
     "Unknown" : {
 
     },


### PR DESCRIPTION
Adds logic to ensure localhost accounts are always encoded and decoded to the same values.

Closes #1194 