### PR TITLE
fix scroll to top

### DIFF
--- a/Mlem/App/Views/Shared/FancyScrollView.swift
+++ b/Mlem/App/Views/Shared/FancyScrollView.swift
@@ -15,15 +15,11 @@ struct IsAtTopPreferenceKey: PreferenceKey {
 struct FancyScrollView<Content: View>: View {
     @Environment(\.dismiss) var dismiss
     
-    // Avoid using `@State` because we don't need to cause a view update
-    class Model {
-        var isAtTop: Bool = true
-    }
-    
     @ViewBuilder var content: () -> Content
-    let model: Model = .init()
     @Binding var scrollToTopTrigger: Bool // TODO: investigate unifying this and isAtTop
     var reselectAction: (() -> Void)?
+    
+    @State var isAtTop: Bool = true
 
     private let topId: String = "scrollToTop"
     
@@ -54,7 +50,7 @@ struct FancyScrollView<Content: View>: View {
                 }
             }
             .onReselectTab {
-                if model.isAtTop {
+                if isAtTop {
                     if let reselectAction {
                         reselectAction()
                     } else {
@@ -73,8 +69,8 @@ struct FancyScrollView<Content: View>: View {
             }
             .coordinateSpace(name: "scrollView")
             .onPreferenceChange(IsAtTopPreferenceKey.self) { offset in
-                if offset != model.isAtTop {
-                    model.isAtTop = offset
+                if offset != isAtTop {
+                    isAtTop = offset
                 }
             }
         }


### PR DESCRIPTION
Fixes tab reselect scroll-to-top not working. I've gone back to using `@State` to track `isAtTop`; I analyzed view updates thoroughly with [`Self._printChanges()` ](https://developer.apple.com/documentation/swift-playgrounds/console-print-debugging#Understand-when-and-why-your-views-change), and both the `@State` and `Model` implementations cause an `@self changed` view update. Adding an overlay that prints the current value of `isAtTop` does invoke a new update which cites `isAtTop` as the driving change; from this I believe it is safe to conclude that the use of an `@State` variable offers no performance reduction as compared to `Model`.