### PR TITLE
Fix load feed cancellation error

### DIFF
--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+LoadFeed.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+LoadFeed.swift
@@ -16,12 +16,15 @@ private struct LoadFeed: ViewModifier {
     
     func body(content: Content) -> some View {
         content
-            .task(id: feedLoader == nil) {
+            .onChange(of: feedLoader == nil, initial: true) {
                 if let feedLoader, feedLoader.items.isEmpty, feedLoader.loadingState == .idle {
-                    do {
-                        try await feedLoader.loadMoreItems()
-                    } catch {
-                        handleError(error)
+                    // wrapping this in a Task instead of using .task prevents cancellation errors from the parent view de-rendering
+                    Task {
+                        do {
+                            try await feedLoader.loadMoreItems()
+                        } catch {
+                            handleError(error)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixed an issue where `loadFeed` was being cancelled, leaving the feed loader in a permanent `.loading` state. The work is now performed on an independent thread that is not cancelled when the parent view is derendered.