### PR TITLE
Fix thumbnail placeholders

### DIFF
--- a/Mlem/App/Views/Shared/Images/Core/FixedImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Core/FixedImageView.swift
@@ -89,6 +89,7 @@ struct FixedImageView: View {
         case .image:
             Image(systemName: fallback.icon)
                 .font(.title)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .foregroundStyle(palette.secondary)
                 .background(palette.thumbnailBackground)
         }

--- a/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
@@ -89,7 +89,7 @@ struct ThumbnailImageView: View {
                 showProgress: true
             )
             .frame(width: Constants.main.thumbnailSize, height: Constants.main.thumbnailSize)
-            .blur(radius: blurred ? 10 : 0, opaque: true)
+            .blur(radius: blurred && (loading == .done) ? 10 : 0, opaque: true)
             .clipShape(RoundedRectangle(cornerRadius: Constants.main.smallItemCornerRadius))
             .onPreferenceChange(ImageLoadingPreferenceKey.self, perform: { loading = $0 })
         } else {


### PR DESCRIPTION
Fix two issues related to thumbnail placeholders:

- Fix fallback image not filling available space:
<img width="453" alt="Screenshot 2024-08-17 at 5 02 10 PM" src="https://github.com/user-attachments/assets/cf71218c-2a0a-4cd8-a670-5afb0fdc9ab1">

- Fix loading/fallback view being blurred:
<img width="102" alt="Screenshot 2024-08-17 at 5 03 34 PM" src="https://github.com/user-attachments/assets/af717654-15b2-45f3-8319-7276cded3fe6">
