### PR TITLE
Update swipe action priority

### DIFF
--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware.git",
       "state" : {
-        "revision" : "a52ae3c7964237a2af36ce2e93884743364c9584",
-        "version" : "0.25.0"
+        "revision" : "b6c2923e70d1901349a3d5a0c6eab88f4d844dad",
+        "version" : "0.26.0"
       }
     },
     {

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/Quick Swipes/View+QuickSwipes.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/Quick Swipes/View+QuickSwipes.swift
@@ -46,7 +46,7 @@ struct QuickSwipeView: ViewModifier {
                 .background(shadowBackground)
                 .geometryGroup()
                 .offset(x: dragPosition) // using dragPosition so we can apply withAnimation() to it
-                .gesture(
+                .highPriorityGesture(
                     DragGesture(
                         minimumDistance: config.behavior.minimumDrag, // min distance prevents conflict with scrolling drag gesture
                         coordinateSpace: .global


### PR DESCRIPTION
Makes `.quickSwipes` a `.highPriorityGesture`. This significantly improves responsiveness on iOS 17, and Apple has fixed the conflict with scrolling on iOS 18.