### PR TITLE
Account Switch bug fixes

### DIFF
--- a/Mlem/App/Globals/Definitions/AppState+transition.swift
+++ b/Mlem/App/Globals/Definitions/AppState+transition.swift
@@ -10,6 +10,9 @@ import SwiftUI
 extension AppState {
     func transition(_ account: any Account) {
         Task { @MainActor in
+            // Close all sheets
+            NavigationModel.main.layers = []
+            
             let transition = TransitionView(account: account)
             guard let transitionView = UIHostingController(rootView: transition).view,
                   let window = UIApplication.shared.firstKeyWindow else {

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -33,7 +33,7 @@ extension Person1Providing {
         }
         
         if let interactable {
-            assert(interactable.creator.id == id)
+            assert(interactable.creator.actorId == actorId)
             output.formUnion(interactable.contextualFlairs())
         } else {
             if api.myInstance?.administrators.contains(where: { $0.id == id }) ?? false {

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+OutdatedFeedPopup.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+OutdatedFeedPopup.swift
@@ -13,6 +13,13 @@ private struct OutdatedFeedPopupModifier: ViewModifier {
     
     let feedLoader: (any FeedLoading)?
     
+    let canShowPopup: Bool
+    
+    init(feedLoader: (any FeedLoading)?, showPopup canShowPopup: Bool) {
+        self.feedLoader = feedLoader
+        self.canShowPopup = canShowPopup
+    }
+    
     @State var showRefreshPopup: Bool = false
     
     func body(content: Content) -> some View {
@@ -34,13 +41,15 @@ private struct OutdatedFeedPopupModifier: ViewModifier {
                     }
                 }
                 .overlay(alignment: .bottom) {
-                    RefreshPopupView("Feed is outdated", isPresented: $showRefreshPopup) {
-                        Task {
-                            do {
-                                showRefreshPopup = false
-                                try await refresh()
-                            } catch {
-                                handleError(error)
+                    if canShowPopup {
+                        RefreshPopupView("Feed is outdated", isPresented: $showRefreshPopup) {
+                            Task {
+                                do {
+                                    showRefreshPopup = false
+                                    try await refresh()
+                                } catch {
+                                    handleError(error)
+                                }
                             }
                         }
                     }
@@ -70,7 +79,7 @@ private struct OutdatedFeedPopupModifier: ViewModifier {
 }
 
 extension View {
-    func outdatedFeedPopup(feedLoader: (any FeedLoading)?) -> some View {
-        modifier(OutdatedFeedPopupModifier(feedLoader: feedLoader))
+    func outdatedFeedPopup(feedLoader: (any FeedLoading)?, showPopup: Bool = true) -> some View {
+        modifier(OutdatedFeedPopupModifier(feedLoader: feedLoader, showPopup: showPopup))
     }
 }

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -105,7 +105,7 @@ struct CommunityView: View {
             .environment(\.communityContext, community)
         }
         .background(postSize.tiled ? palette.groupedBackground : palette.background)
-        .outdatedFeedPopup(feedLoader: postFeedLoader)
+        .outdatedFeedPopup(feedLoader: postFeedLoader, showPopup: selectedTab == .posts)
         .toolbar {
             ToolbarItemGroup(placement: .secondaryAction) {
                 MenuButtons { community.menuActions(navigation: navigation) }

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -39,7 +39,7 @@ struct PersonView: View {
     init(person: AnyPerson) {
         self._person = .init(wrappedValue: person)
         
-        if let person1 = person.wrappedValue as? any Person1Providing {
+        if let person1 = person.wrappedValue as? any Person1Providing, person1.api === AppState.main.firstApi {
             self._feedLoader = .init(wrappedValue: .init(
                 api: AppState.main.firstApi,
                 userId: person1.id,
@@ -138,7 +138,7 @@ struct PersonView: View {
             }
             .animation(.easeOut(duration: 0.2), value: person is any Person3Providing)
         }
-        .outdatedFeedPopup(feedLoader: feedLoader)
+        .outdatedFeedPopup(feedLoader: feedLoader, showPopup: selectedTab != .communities)
         .background(postSize.tiled ? palette.groupedBackground : palette.background)
     }
     

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -98,9 +98,9 @@ struct PersonView: View {
                             prefetchingConfiguration: .forPostSize(postSize)
                         )
                         preheatFeedLoader()
-                    } else if feedLoader?.api !== entity.api {
+                    } else if let feedLoader, feedLoader.api !== entity.api {
                         Task {
-                            await feedLoader?.switchUser(api: entity.api, userId: entity.id)
+                            await feedLoader.switchUser(api: entity.api, userId: entity.id)
                         }
                     }
                     

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -26,6 +26,7 @@ struct PersonView: View {
     
     @Setting(\.postSize) var postSize
     
+    @Environment(AppState.self) var appState
     @Environment(Palette.self) var palette
     @Environment(NavigationLayer.self) var navigation
     
@@ -96,8 +97,11 @@ struct PersonView: View {
                             savedOnly: false,
                             prefetchingConfiguration: .forPostSize(postSize)
                         )
-                        
                         preheatFeedLoader()
+                    } else if feedLoader?.api !== entity.api {
+                        Task {
+                            await feedLoader?.switchUser(api: entity.api, userId: entity.id)
+                        }
                     }
                     
                     return response.person

--- a/Mlem/App/Views/Shared/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPostView.swift
@@ -15,14 +15,14 @@ struct ExpandedPostView: View {
     @Environment(\.dismiss) var dismiss
     
     let post: AnyPost
-    @State var showCommentWithId: Int?
+    @State var showCommentWithActorId: URL?
     
     let tracker: ExpandedPostTracker = .init()
     
     var body: some View {
         ContentLoader(model: post) { proxy in
             if let post = proxy.entity {
-                let showLoadingSymbol = showCommentWithId == nil || (self.post.isUpgraded && tracker.loadingState != .loading)
+                let showLoadingSymbol = showCommentWithActorId == nil || (self.post.isUpgraded && tracker.loadingState != .loading)
                 VStack {
                     if showLoadingSymbol {
                         content(for: post)
@@ -74,22 +74,22 @@ struct ExpandedPostView: View {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     LargePostView(post: post, isExpanded: true)
                     Divider()
-                    ForEach(tracker.comments.tree()) { comment in
-                        CommentView(comment: comment, highlight: showCommentWithId == comment.id)
+                    ForEach(tracker.comments.tree(), id: \.actorId) { comment in
+                        CommentView(comment: comment, highlight: showCommentWithActorId == comment.actorId)
                             .transition(.move(edge: .top).combined(with: .opacity))
                             .zIndex(1000 - Double(comment.depth))
                     }
                 }
-                .animation(.easeInOut(duration: 0.4), value: showCommentWithId)
+                .animation(.easeInOut(duration: 0.4), value: showCommentWithActorId)
             }
             .onAppear {
-                if let showCommentWithId {
+                if let showCommentWithActorId {
                     // The scroll destination isn't always accurate. Possibly due to the post image changing
                     // size on load? Using `anchor: .top` would be better here, but `anchor: .center` makes
                     // the inaccuracy less noticeable. See also the comment further up the file.
-                    proxy.scrollTo(showCommentWithId, anchor: .center)
+                    proxy.scrollTo(showCommentWithActorId, anchor: .center)
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        self.showCommentWithId = nil
+                        self.showCommentWithActorId = nil
                     }
                 }
             }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -14,7 +14,7 @@ enum NavigationPage: Hashable {
     case feeds(_ selection: FeedSelection = .all)
     case profile, inbox, search
     case quickSwitcher
-    case expandedPost(_ post: AnyPost, commentId: Int? = nil)
+    case expandedPost(_ post: AnyPost, commentActorId: URL? = nil)
     case community(_ community: AnyCommunity)
     case person(_ person: AnyPerson)
     case instance(_ instance: InstanceHashWrapper)
@@ -28,8 +28,8 @@ enum NavigationPage: Hashable {
     case reply(_ target: ResponseContext, expandedPostTracker: ExpandedPostTracker? = nil)
     case report(_ interactable: ReportableHashWrapper, community: AnyCommunity? = nil)
     
-    static func expandedPost(_ post: any PostStubProviding, commentId: Int? = nil) -> NavigationPage {
-        expandedPost(.init(post), commentId: commentId)
+    static func expandedPost(_ post: any PostStubProviding, commentActorId: URL? = nil) -> NavigationPage {
+        expandedPost(.init(post), commentActorId: commentActorId)
     }
     
     static func person(_ person: any PersonStubProviding) -> NavigationPage {
@@ -97,8 +97,8 @@ extension NavigationPage {
             QuickSwitcherView()
         case let .report(target, community):
             ReportComposerView(target: target.wrappedValue, community: community)
-        case let .expandedPost(post, commentId):
-            ExpandedPostView(post: post, showCommentWithId: commentId)
+        case let .expandedPost(post, commentActorId):
+            ExpandedPostView(post: post, showCommentWithActorId: commentActorId)
         case let .person(person):
             PersonView(person: person)
         case let .reply(context, expandedPostTracker):

--- a/Mlem/App/Views/Shared/PersonContentGridView.swift
+++ b/Mlem/App/Views/Shared/PersonContentGridView.swift
@@ -107,7 +107,7 @@ struct PersonContentGridView: View {
                 FeedPostView(post: post)
             }
         case let .comment(comment):
-            NavigationLink(value: NavigationPage.expandedPost(comment.post, commentId: comment.id)) {
+            NavigationLink(value: NavigationPage.expandedPost(comment.post, commentActorId: comment.actorId)) {
                 FeedCommentView(comment: comment)
             }
         }

--- a/Mlem/App/Views/Shared/ReplyView.swift
+++ b/Mlem/App/Views/Shared/ReplyView.swift
@@ -44,7 +44,7 @@ struct ReplyView: View {
         .background(palette.background)
         .contentShape(.rect)
         .onTapGesture {
-            navigation.push(.expandedPost(reply.post, commentId: reply.commentId))
+            navigation.push(.expandedPost(reply.post, commentActorId: reply.comment.actorId))
         }
         .quickSwipes(reply.swipeActions(behavior: .standard))
         .contextMenu { reply.menuActions() }


### PR DESCRIPTION
Fixed bugs when "Reload on Switch" is off:
- The refresh popup is now hidden when viewing non-feed tabs of a `CommunityView`
- Fixed `PersonView` not always loading the new feed when "refresh" tapped
- Fixed `ExpandedPostView` not correctly highlighting a comment when the view was opened using a `Post` with a non-active `ApiClient`.

Also fixed a bug where the quick switcher would remain open after logging into a new account when "Reload on Switch" is on.