### PR TITLE
Fix "Calling into SwiftUI on non-main thread is not supported" (maybe)

### DIFF
--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -82,8 +82,6 @@ struct ContentView: View {
     }
     
     @ViewBuilder
-    // I got another one of those "Calling into SwiftUI on non-main thread" errors... hopefully this fixes it? Hard to reproduce
-    @MainActor
     var content: some View {
         CustomTabView(selectedIndex: Binding(get: {
             Tab.allCases.firstIndex(of: appState.contentViewTab) ?? 0

--- a/Mlem/App/Views/Shared/CustomTabView.swift
+++ b/Mlem/App/Views/Shared/CustomTabView.swift
@@ -12,14 +12,12 @@ struct CustomTabView: UIViewControllerRepresentable {
     @Environment(Palette.self) var palette
     
     let tabs: [CustomTabItem]
-    var viewControllers: [CustomTabViewHostingController]
     let swipeGestureCallback: () -> Void
     
     @Binding var selectedIndex: Int
     
     init(selectedIndex: Binding<Int>, tabs: [CustomTabItem], onSwipeUp: @escaping () -> Void) {
         self.tabs = tabs
-        self.viewControllers = tabs.enumerated().map { CustomTabViewHostingController(item: $1, index: $0) }
         self.swipeGestureCallback = onSwipeUp
         self._selectedIndex = selectedIndex
     }
@@ -31,8 +29,7 @@ struct CustomTabView: UIViewControllerRepresentable {
             selectedIndex: $selectedIndex,
             swipeGestureCallback: swipeGestureCallback
         )
-        tabBarController.viewControllers = viewControllers
-        
+        tabBarController.viewControllers = tabs.enumerated().map { CustomTabViewHostingController(item: $1, index: $0) }
         return tabBarController
     }
     


### PR DESCRIPTION
This fatal error would _occasionally_ occur on `CustomTabViewHostingController.swift` line 16. It's hard to tell whether it's been fixed or not because the bug is random and somewhat improbable.

My shaky repro for this is to switch back and forth between two accounts with "Reload on Switch" off. Eventually it would occur. I've also had this happen before when switching between tabs. This occurs on both Xcode 15 and 16. 