### PR TITLE
`PersistenceRepository`: Don't show error toast if file not found

### DIFF
--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -161,6 +161,9 @@ class PersistenceRepository {
             }
             
             return try JSONDecoder().decode(T.self, from: data)
+        } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == 260 {
+            // Don't show error toast if file not found
+            return nil
         } catch {
             handleError(error)
             return nil


### PR DESCRIPTION
Without this, an error toast will be shown the first time the user opens a post after opening the app if they're using the default interaction bar.