### PR TITLE
Default Feed

### DIFF
--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3b9cb9ec5b4c2e50829d61f5814786d7609aabbbca9b78717dba703d500c4fac",
+  "originHash" : "693546cfc633cb179f53728b918542e0d98a3518ffce28aa97b5c239441ee75a",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "4e311f0784ea12bf269ef88221d6c636e066a1f5",
         "version" : "0.4.3"
+      }
+    },
+    {
+      "identity" : "mlemmiddleware",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mlemgroup/MlemMiddleware.git",
+      "state" : {
+        "revision" : "9e6582f316759f54ebec9a80882224855a5b16e6",
+        "version" : "0.31.0"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "693546cfc633cb179f53728b918542e0d98a3518ffce28aa97b5c239441ee75a",
+  "originHash" : "3b9cb9ec5b4c2e50829d61f5814786d7609aabbbca9b78717dba703d500c4fac",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "4e311f0784ea12bf269ef88221d6c636e066a1f5",
         "version" : "0.4.3"
-      }
-    },
-    {
-      "identity" : "mlemmiddleware",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlemgroup/MlemMiddleware.git",
-      "state" : {
-        "revision" : "9e6582f316759f54ebec9a80882224855a5b16e6",
-        "version" : "0.31.0"
       }
     },
     {

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -41,6 +41,7 @@ class Settings: ObservableObject {
     @AppStorage("links.readerMode") var openLinksInReaderMode = false
     
     @AppStorage("feed.showRead") var showReadInFeed: Bool = true
+    @AppStorage("feed.default") var defaultFeed: FeedSelection = .subscribed
     
     @AppStorage("inbox.showRead") var showReadInInbox: Bool = true
     

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -95,7 +95,7 @@ struct ContentView: View {
                 image: UIImage(systemName: Icons.feeds),
                 selectedImage: UIImage(systemName: Icons.feedsFill)
             ) {
-                NavigationSplitRootView(sidebar: .subscriptionList, root: .feeds(appState.firstApi.willSendToken ? .subscribed : .all))
+                NavigationSplitRootView(sidebar: .subscriptionList, root: .feeds())
             },
             CustomTabItem(
                 title: "Inbox",

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedSelection.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedSelection.swift
@@ -8,7 +8,7 @@
 import Foundation
 import MlemMiddleware
 
-enum FeedSelection: CaseIterable {
+enum FeedSelection: String, CaseIterable {
     case all, local, subscribed, saved
     // TODO: moderated
     

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedSelection.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedSelection.swift
@@ -33,8 +33,4 @@ enum FeedSelection: String, CaseIterable {
         case .saved: .all // dummy value
         }
     }
-    
-    var localized: LocalizedStringResource {
-        .init(stringLiteral: rawValue)
-    }
 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedSelection.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedSelection.swift
@@ -33,4 +33,8 @@ enum FeedSelection: String, CaseIterable {
         case .saved: .all // dummy value
         }
     }
+    
+    var localized: LocalizedStringResource {
+        .init(stringLiteral: rawValue)
+    }
 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -61,8 +61,14 @@ struct FeedsView: View {
         if let feedSelection {
             initialFeedSelection = feedSelection
         } else {
-            initialFeedSelection = AppState.main.firstAccount is UserAccount ? defaultFeed : .local
+            initialFeedSelection = defaultFeed
         }
+        
+        // fallback to local if using guest account and selection requires authenticated account
+        if !(AppState.main.firstAccount is UserAccount), !FeedSelection.guestCases.contains(initialFeedSelection) {
+            initialFeedSelection = .local
+        }
+        
         _feedSelection = .init(initialValue: initialFeedSelection)
         
         if let firstUser = AppState.main.firstAccount as? UserAccount {

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -47,7 +47,7 @@ struct FeedsView: View {
         appState.firstAccount is UserAccount ? FeedSelection.allCases : FeedSelection.guestCases
     }
     
-    init(feedSelection: FeedSelection = .subscribed) {
+    init(feedSelection: FeedSelection? = nil) {
         // need to grab some stuff from app storage to initialize with
         @Setting(\.internetSpeed) var internetSpeed
         @Setting(\.showReadInFeed) var showReadPosts
@@ -57,7 +57,13 @@ struct FeedsView: View {
         
         @Dependency(\.persistenceRepository) var persistenceRepository
         
-        _feedSelection = .init(initialValue: AppState.main.firstAccount is UserAccount ? defaultFeed : .local)
+        var initialFeedSelection: FeedSelection
+        if let feedSelection {
+            initialFeedSelection = feedSelection
+        } else {
+            initialFeedSelection = AppState.main.firstAccount is UserAccount ? defaultFeed : .local
+        }
+        _feedSelection = .init(initialValue: initialFeedSelection)
         
         if let firstUser = AppState.main.firstAccount as? UserAccount {
             _savedFeedLoader = .init(wrappedValue: .init(

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -53,11 +53,11 @@ struct FeedsView: View {
         @Setting(\.showReadInFeed) var showReadPosts
         @Setting(\.defaultPostSort) var defaultSort
         @Setting(\.postSize) var postSize
+        @Setting(\.defaultFeed) var defaultFeed
         
         @Dependency(\.persistenceRepository) var persistenceRepository
         
-        let initialFeedSelection: FeedSelection = feedSelection
-        _feedSelection = .init(initialValue: initialFeedSelection)
+        _feedSelection = .init(initialValue: AppState.main.firstAccount is UserAccount ? defaultFeed : .local)
         
         if let firstUser = AppState.main.firstAccount as? UserAccount {
             _savedFeedLoader = .init(wrappedValue: .init(

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -14,6 +14,7 @@ struct GeneralSettingsView: View {
     @Setting(\.upvoteOnSave) var upvoteOnSave
     @Setting(\.quickSwipesEnabled) var swipeActionsEnabled
     @Setting(\.jumpButton) var jumpButton
+    @Setting(\.defaultFeed) var defaultFeed
     
     var body: some View {
         Form {
@@ -31,6 +32,11 @@ struct GeneralSettingsView: View {
             }
             
             Section {
+                Picker("Default Feed", selection: $defaultFeed) {
+                    ForEach(FeedSelection.allCases, id: \.self) { item in
+                        Text(item.rawValue.capitalized)
+                    }
+                }
                 Toggle("Upvote on Save", isOn: $upvoteOnSave)
                 Toggle("Swipe Actions", isOn: $swipeActionsEnabled)
                 Picker("Jump Button", selection: $jumpButton) {
@@ -38,6 +44,8 @@ struct GeneralSettingsView: View {
                         Text(item.label)
                     }
                 }
+            } header: {
+                Text("Behavior")
             }
         }
         .navigationTitle("General")

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -34,7 +34,7 @@ struct GeneralSettingsView: View {
             Section {
                 Picker("Default Feed", selection: $defaultFeed) {
                     ForEach(FeedSelection.allCases, id: \.self) { item in
-                        Text(String(localized: item.localized).capitalized)
+                        Text(item.rawValue.capitalized)
                     }
                 }
                 Toggle("Upvote on Save", isOn: $upvoteOnSave)

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -34,7 +34,7 @@ struct GeneralSettingsView: View {
             Section {
                 Picker("Default Feed", selection: $defaultFeed) {
                     ForEach(FeedSelection.allCases, id: \.self) { item in
-                        Text(item.rawValue.capitalized)
+                        Text(String(localized: item.localized).capitalized)
                     }
                 }
                 Toggle("Upvote on Save", isOn: $upvoteOnSave)

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -11,7 +11,7 @@ import SwiftUI
 enum NavigationPage: Hashable {
     case settings(_ page: SettingsPage = .root)
     case login(_ page: LoginPage = .pickInstance)
-    case feeds(_ selection: FeedSelection = .all)
+    case feeds(_ selection: FeedSelection? = nil)
     case profile, inbox, search
     case quickSwitcher
     case expandedPost(_ post: AnyPost, commentActorId: URL? = nil, communityContext: HashWrapper<any Community1Providing>? = nil)

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -137,6 +137,9 @@
     "Banned from Instance" : {
 
     },
+    "Behavior" : {
+
+    },
     "Block" : {
 
     },
@@ -263,6 +266,9 @@
 
     },
     "Default" : {
+
+    },
+    "Default Feed" : {
 
     },
     "Default Feed Type (Desktop)" : {


### PR DESCRIPTION
Adds the "default feed" option. `FeedsView` intended behavior is now as follows:

- By default, use `defaultFeed` setting; if `feedSelection` provided, override with that value
- Fallback to `.local` if above logic would initialize with an authenticated account and the current account is not authenticated

The `.feeds` navigation page now takes an optional parameter to support the above logic.