### PR TITLE
create folder

### DIFF
--- a/Mlem/Repositories/PersistenceRepository.swift
+++ b/Mlem/Repositories/PersistenceRepository.swift
@@ -65,6 +65,12 @@ class PersistenceRepository {
         self.read = read
         self.write = write
         self.bundle = bundle
+        
+        do {
+            try FileManager.default.createDirectory(at: Path.systemSettings, withIntermediateDirectories: true)
+        } catch {
+            fatalError("Could not create settings directories")
+        }
     }
     
     // MARK: - Public methods


### PR DESCRIPTION
Fix an issue where system settings folder wasn't being created, leading to settings saving failing--this slipped through the previous PR because the v2 PersistenceRepository was creating the folder.