### PR TITLE
Fix confirmation dialog on iPad

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		03ECD7212C8654BA00D48BF6 /* PostEditorView+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD7202C8654BA00D48BF6 /* PostEditorView+Toolbar.swift */; };
 		03FA318C2C6FECAE00D47FA3 /* Flow in Frameworks */ = {isa = PBXBuildFile; productRef = 03FA318B2C6FECAE00D47FA3 /* Flow */; };
 		03FA318F2C6FEF2000D47FA3 /* InteractionBarActionLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FA318E2C6FEF2000D47FA3 /* InteractionBarActionLabelView.swift */; };
+		03FD6CB02C9B719100500FD6 /* View+PopupAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FD6CAF2C9B719100500FD6 /* View+PopupAnchor.swift */; };
 		03FE14042BF93FDD00A8377F /* ErrorDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE14032BF93FDD00A8377F /* ErrorDetails.swift */; };
 		03FE14062BF9445F00A8377F /* CloseButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE14052BF9445F00A8377F /* CloseButtonView.swift */; };
 		03FE14082BF94FFB00A8377F /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE14072BF94FFB00A8377F /* ErrorView.swift */; };
@@ -575,6 +576,7 @@
 		03ECD71E2C864DB700D48BF6 /* ImageUploadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadManager.swift; sourceTree = "<group>"; };
 		03ECD7202C8654BA00D48BF6 /* PostEditorView+Toolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+Toolbar.swift"; sourceTree = "<group>"; };
 		03FA318E2C6FEF2000D47FA3 /* InteractionBarActionLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionBarActionLabelView.swift; sourceTree = "<group>"; };
+		03FD6CAF2C9B719100500FD6 /* View+PopupAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+PopupAnchor.swift"; sourceTree = "<group>"; };
 		03FE14032BF93FDD00A8377F /* ErrorDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDetails.swift; sourceTree = "<group>"; };
 		03FE14052BF9445F00A8377F /* CloseButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseButtonView.swift; sourceTree = "<group>"; };
 		03FE14072BF94FFB00A8377F /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
@@ -1509,6 +1511,7 @@
 				CD0F28092C6CEFBE00C1F65B /* View+IsAtTopSubscriber.swift */,
 				CDFB8C682C7796020070845F /* View+DynamicBlur.swift */,
 				CD1B2E202C7F84160075C7EA /* View+MarkReadOnScroll.swift */,
+				03FD6CAF2C9B719100500FD6 /* View+PopupAnchor.swift */,
 			);
 			path = "View Modifiers";
 			sourceTree = "<group>";
@@ -1976,6 +1979,7 @@
 				CD13CC652C5D2B9D001AF428 /* CircleCroppedImageView.swift in Sources */,
 				CDAA02DD2C81792500D75633 /* SolarizedPalette.swift in Sources */,
 				035EDF032C2ED0DE00F51144 /* PersonListRowBody.swift in Sources */,
+				03FD6CB02C9B719100500FD6 /* View+PopupAnchor.swift in Sources */,
 				CDBFCB652C03920C008CD468 /* PostLinkHostView.swift in Sources */,
 				03B04FC02C5FC32300824128 /* SimpleAvatarView.swift in Sources */,
 				035BE08D2BDE88EC00F77D73 /* NavigationLayerView.swift in Sources */,

--- a/Mlem/App/Models/Action/BasicAction.swift
+++ b/Mlem/App/Models/Action/BasicAction.swift
@@ -34,10 +34,10 @@ struct BasicAction: Action {
         self.callback = enabled ? callback : nil
     }
     
-    func callbackWithConfirmation(navigation: NavigationLayer) {
+    func callbackWithConfirmation(popupModel: PopupAnchorModel) {
         if let callback {
             if let confirmationPrompt {
-                navigation.showPopup(ActionGroup(
+                popupModel.showPopup(ActionGroup(
                     appearance: .init(label: "Confirm", color: .gray, icon: Icons.success),
                     prompt: confirmationPrompt,
                     children: [

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/Quick Swipes/View+QuickSwipes.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/Quick Swipes/View+QuickSwipes.swift
@@ -22,6 +22,7 @@ struct QuickSwipeView: ViewModifier {
     @State var dragBackground: Color? = Palette.main.background
     @State var leadingSwipeSymbol: String?
     @State var trailingSwipeSymbol: String?
+    @State var popupModel: PopupAnchorModel = .init()
     
     let config: SwipeConfiguration
     
@@ -60,6 +61,7 @@ struct QuickSwipeView: ViewModifier {
             // disables links from highlighting when tapped
             .buttonStyle(EmptyButtonStyle())
             .clipShape(RoundedRectangle(cornerRadius: config.behavior.cornerRadius))
+            .popupAnchor(model: popupModel)
         } else {
             content
         }
@@ -191,11 +193,11 @@ struct QuickSwipeView: ViewModifier {
         let action = swipeAction(at: finalDragPosition)
         
         if let action = action as? BasicAction {
-            action.callbackWithConfirmation(navigation: navigation)
+            action.callbackWithConfirmation(popupModel: popupModel)
         } else if let action = action as? ShareAction {
             navigation.shareUrl = action.url
         } else if let action = action as? ActionGroup {
-            navigation.showPopup(action)
+            popupModel.showPopup(action)
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+ContextMenu.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+ContextMenu.swift
@@ -17,6 +17,7 @@ extension View {
             // Having a proper view here is necessary - if `ForEach` is used directly, `actions()` gets called early.
             MenuButtons(actions: actions)
         }
+        .popupAnchor()
     }
 }
 

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PopupAnchor.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PopupAnchor.swift
@@ -1,0 +1,60 @@
+//
+//  View+PopupAnchor.swift
+//  Mlem
+//
+//  Created by Sjmarf on 18/09/2024.
+//
+
+import SwiftUI
+
+struct PopupAnchor: ViewModifier {
+    @State var model: PopupAnchorModel
+    
+    func body(content: Content) -> some View {
+        content
+            .confirmationDialog(
+                model.popup?.appearance.label ?? "",
+                isPresented: Binding(
+                    get: { model.popup != nil },
+                    set: {
+                        if !$0 { model.dismissPopup() }
+                    }
+                )
+            ) {
+                ForEach(model.popup?.children ?? [], id: \.id) { action in
+                    MenuButton(action: action)
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text(model.popup?.prompt ?? "")
+            }
+            .environment(model)
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func popupAnchor(model: PopupAnchorModel = .init()) -> some View {
+        modifier(PopupAnchor(model: model))
+    }
+}
+
+@Observable
+class PopupAnchorModel {
+    private(set) var popup: ActionGroup?
+    
+    func showPopup(_ actionGroup: ActionGroup) {
+        if popup == nil {
+            popup = actionGroup
+        } else {
+            popup = nil
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                self.popup = actionGroup
+            }
+        }
+    }
+        
+    func dismissPopup() {
+        popup = nil
+    }
+}

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/TileCommentView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/TileCommentView.swift
@@ -104,5 +104,6 @@ struct TileCommentView: View {
             TileScoreView(comment)
         }
         .onTapGesture {}
+        .popupAnchor()
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/TilePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/TilePostView.swift
@@ -100,6 +100,7 @@ struct TilePostView: View {
             TileScoreView(saved: post.saved_ ?? false, votes: post.votes_ ?? .init(upvotes: 0, downvotes: 0, myVote: .none))
         }
         .onTapGesture {}
+        .popupAnchor()
     }
     
     // MARK: - BaseImage

--- a/Mlem/App/Views/Shared/EllipsisMenu.swift
+++ b/Mlem/App/Views/Shared/EllipsisMenu.swift
@@ -28,6 +28,7 @@ struct EllipsisMenu: View {
                 .frame(width: 24, height: size)
                 .contentShape(.rect)
         }
+        .popupAnchor()
         .buttonStyle(EmptyButtonStyle())
         .onTapGesture {} // prevent NavigationLink from disabling menu (thanks Swift)
     }

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
@@ -159,6 +159,7 @@ struct InteractionBarView: View {
                 return false
             }
         }())
+        .popupAnchor()
     }
 }
 

--- a/Mlem/App/Views/Shared/MenuButton.swift
+++ b/Mlem/App/Views/Shared/MenuButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MenuButton: View {
-    @Environment(NavigationLayer.self) var navigation
+    @Environment(PopupAnchorModel.self) var popupModel: PopupAnchorModel?
     
     let action: any Action
     
@@ -22,7 +22,13 @@ struct MenuButton: View {
                 action.appearance.label,
                 systemImage: action.appearance.menuIcon,
                 role: action.appearance.isDestructive ? .destructive : nil,
-                action: { action.callbackWithConfirmation(navigation: navigation) }
+                action: {
+                    if let popupModel {
+                        action.callbackWithConfirmation(popupModel: popupModel)
+                    } else {
+                        assertionFailure()
+                    }
+                }
             )
             .disabled(action.disabled)
         } else if let action = action as? ShareAction {
@@ -50,7 +56,11 @@ struct MenuButton: View {
                     systemImage: action.appearance.menuIcon,
                     role: action.appearance.isDestructive ? .destructive : nil,
                     action: {
-                        navigation.showPopup(action)
+                        if let popupModel {
+                            popupModel.showPopup(action)
+                        } else {
+                            assertionFailure()
+                        }
                     }
                 )
                 .disabled(action.disabled)

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -15,7 +15,6 @@ class NavigationLayer {
     
     var root: NavigationPage
     var path: [NavigationPage]
-    private(set) var popup: ActionGroup?
     var shareUrl: URL?
     var hasNavigationStack: Bool
     var isFullScreenCover: Bool
@@ -46,22 +45,7 @@ class NavigationLayer {
             openSheet(page)
         }
     }
-    
-    func showPopup(_ actionGroup: ActionGroup) {
-        if popup == nil {
-            popup = actionGroup
-        } else {
-            popup = nil
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                self.popup = actionGroup
-            }
-        }
-    }
-    
-    func dismissPopup() {
-        popup = nil
-    }
-    
+
     func pop() {
         if !path.isEmpty {
             path.removeLast()

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
@@ -57,22 +57,6 @@ struct NavigationLayerView: View {
             )
             .padding(.bottom, 8)
         }
-        .confirmationDialog(
-            layer.popup?.appearance.label ?? "",
-            isPresented: Binding(
-                get: { layer.popup != nil },
-                set: {
-                    if !$0 { layer.dismissPopup() }
-                }
-            )
-        ) {
-            ForEach(layer.popup?.children ?? [], id: \.id) { action in
-                MenuButton(action: action)
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text(layer.popup?.prompt ?? "")
-        }
         // https://stackoverflow.com/questions/69693871/how-to-open-share-sheet-from-presented-sheet
         .background(SharingViewController(
             isPresenting: Binding(get: { layer.shareUrl != nil }, set: { if !$0 { layer.shareUrl = nil }})

--- a/Mlem/App/Views/Shared/ToolbarEllipsisMenu.swift
+++ b/Mlem/App/Views/Shared/ToolbarEllipsisMenu.swift
@@ -30,5 +30,6 @@ struct ToolbarEllipsisMenu<Content: View>: View {
                 .frame(height: Constants.main.barIconHitbox)
                 .contentShape(Rectangle())
         }
+        .popupAnchor()
     }
 }


### PR DESCRIPTION
Fixes #1336 by Attaching the `.confirmationDialog` to a relevant view rather than at the top of the view hierarchy.

Screenshot of the new, correct behavior:

![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-09-18 at 22 06 57](https://github.com/user-attachments/assets/d2278c14-8940-4701-ac65-739eb19f6abb)
