### PR TITLE
Collapse post in `ExpandedPostView`

### DIFF
--- a/Mlem/App/Views/Pages/CommentEditor/CommentEditorView.swift
+++ b/Mlem/App/Views/Pages/CommentEditor/CommentEditorView.swift
@@ -182,7 +182,7 @@ struct CommentEditorView: View {
                     Spacer()
                     selectTextButton
                 }
-                LargePostBodyView(post: post, isExpanded: true, shouldBlur: false)
+                LargePostBodyView(post: post, isPostPage: true, shouldBlur: false)
                 FullyQualifiedLinkView(
                     entity: post.creator_,
                     labelStyle: .medium,

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
@@ -22,7 +22,6 @@ struct FeedPostView: View {
         content
             .contentShape(.interaction, .rect)
             .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
-            .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
             .quickSwipes(post.swipeActions(behavior: postSize.swipeBehavior))
             .contextMenu { post.allMenuActions() }
             .shadow(color: postSize.tiled ? palette.primary.opacity(0.1) : .clear, radius: 3) // after quickSwipes to prevent clipping

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
@@ -14,13 +14,13 @@ struct LargePostBodyView: View {
     @Environment(\.communityContext) private var communityContext: (any Community1Providing)?
     
     let post: any Post1Providing
-    let isExpanded: Bool
+    let isPostPage: Bool
     let shouldBlur: Bool
     
     var body: some View {
         VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
             post.taggedTitle(communityContext: communityContext)
-                .foregroundStyle((post.read_ ?? false) ? palette.secondary : palette.primary)
+                .foregroundStyle((post.read_ ?? false && !isPostPage) ? palette.secondary : palette.primary)
                 .font(.headline)
                 .imageScale(.small)
             
@@ -43,7 +43,7 @@ struct LargePostBodyView: View {
                 EmptyView()
             }
             if let content = post.content {
-                if isExpanded {
+                if isPostPage {
                     Markdown(content, configuration: .default)
                 } else {
                     // Cut down on compute time for very long text posts by only rendering the first 4 blocks

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostView.swift
@@ -20,7 +20,7 @@ struct LargePostView: View {
     @Environment(\.communityContext) private var communityContext
     
     let post: any Post1Providing
-    var isExpanded: Bool = false
+    var isPostPage: Bool = false
     
     var shouldBlur: Bool {
         switch blurNsfw {
@@ -40,7 +40,7 @@ struct LargePostView: View {
     var content: some View {
         VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
             HStack {
-                if communityContext == nil {
+                if communityContext == nil || isPostPage {
                     communityLink
                 } else {
                     personLink
@@ -53,16 +53,16 @@ struct LargePostView: View {
                         .foregroundStyle(palette.warning)
                 }
 
-                if !isExpanded {
+                if !isPostPage {
                     PostEllipsisMenus(post: post)
                 }
             }
             .padding(.horizontal, Constants.main.standardSpacing)
             
-            LargePostBodyView(post: post, isExpanded: isExpanded, shouldBlur: shouldBlur)
+            LargePostBodyView(post: post, isPostPage: isPostPage, shouldBlur: shouldBlur)
                 .padding(.horizontal, Constants.main.standardSpacing)
             
-            if showCreator || isExpanded, communityContext == nil {
+            if (showCreator && communityContext == nil) || isPostPage {
                 personLink
                     .padding(.horizontal, Constants.main.standardSpacing)
             }

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -96,11 +96,12 @@ struct ExpandedPostView<Content: View>: View {
                 FancyScrollView {
                     LazyVStack(
                         alignment: .leading,
-                        spacing: compactComments ? Constants.main.halfSpacing : Constants.main.standardSpacing
+                        spacing: 0
                     ) {
                         postView(post)
                             .padding(.horizontal, Constants.main.standardSpacing)
                         content
+                            .padding(.top, compactComments ? Constants.main.halfSpacing : Constants.main.standardSpacing)
                         if let tracker {
                             commentTree(tracker: tracker)
                         }
@@ -237,6 +238,7 @@ struct ExpandedPostView<Content: View>: View {
                 }
             }
             .padding(.horizontal, Constants.main.standardSpacing)
+            .padding(.top, compactComments ? Constants.main.halfSpacing : Constants.main.standardSpacing)
         }
     }
     


### PR DESCRIPTION
Tap on the post to collapse it. Also added context menu and swipe actions to the post in the expanded view, and tweaked the jump button to include the padding above a comment when scrolling to it.
Closes #1160 