### PR TITLE
OLED theme

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -338,6 +338,7 @@
 		CDB41E8A2C83C24400BD2DE9 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB41E892C83C24400BD2DE9 /* Section.swift */; };
 		CDB41E8C2C84CED500BD2DE9 /* FixedImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB41E8B2C84CED500BD2DE9 /* FixedImageLoader.swift */; };
 		CDB41E8E2C84CFA200BD2DE9 /* FixedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB41E8D2C84CFA200BD2DE9 /* FixedImageView.swift */; };
+		CDB738292CB8A6A5005B11BB /* View+PaletteBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB738282CB8A69D005B11BB /* View+PaletteBorder.swift */; };
 		CDBFCB652C03920C008CD468 /* PostLinkHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBFCB642C03920C008CD468 /* PostLinkHostView.swift */; };
 		CDBFCB6A2C04EFFE008CD468 /* PostSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBFCB692C04EFFE008CD468 /* PostSettingsView.swift */; };
 		CDBFCB6C2C054AA7008CD468 /* TilePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBFCB6B2C054AA7008CD468 /* TilePostView.swift */; };
@@ -721,6 +722,7 @@
 		CDB41E892C83C24400BD2DE9 /* Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
 		CDB41E8B2C84CED500BD2DE9 /* FixedImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedImageLoader.swift; sourceTree = "<group>"; };
 		CDB41E8D2C84CFA200BD2DE9 /* FixedImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedImageView.swift; sourceTree = "<group>"; };
+		CDB738282CB8A69D005B11BB /* View+PaletteBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+PaletteBorder.swift"; sourceTree = "<group>"; };
 		CDBFCB642C03920C008CD468 /* PostLinkHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostLinkHostView.swift; sourceTree = "<group>"; };
 		CDBFCB692C04EFFE008CD468 /* PostSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSettingsView.swift; sourceTree = "<group>"; };
 		CDBFCB6B2C054AA7008CD468 /* TilePostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TilePostView.swift; sourceTree = "<group>"; };
@@ -1573,6 +1575,7 @@
 		CD4ED8482BF1112A00EFA0A2 /* View Modifiers */ = {
 			isa = PBXGroup;
 			children = (
+				CDB738282CB8A69D005B11BB /* View+PaletteBorder.swift */,
 				CD17B2492C191073001E174B /* Quick Swipes */,
 				CD4ED8492BF1113800EFA0A2 /* View+TabReselectConsumer.swift */,
 				CDCA44B52C176C5000C092B3 /* View+EdgeBorders.swift */,
@@ -2050,6 +2053,7 @@
 				CDE4AC3F2CA2083200981010 /* VideoView.swift in Sources */,
 				03D3A1F12BB9D48E009DE55E /* BasicAction.swift in Sources */,
 				03D2A6392C00FAE000ED4FF2 /* UserAccount.swift in Sources */,
+				CDB738292CB8A6A5005B11BB /* View+PaletteBorder.swift in Sources */,
 				03C93CF02BEFFB1A00327BFE /* LoginCredentialsView.swift in Sources */,
 				CD332D7C2CA71E6F00A53988 /* GifView.swift in Sources */,
 				CD13CC652C5D2B9D001AF428 /* CircleCroppedImageView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */ = {isa = PBXBuildFile; productRef = B104A6DD2A59BF3C00B3E725 /* NukeVideo */; };
 		B1B78D642A51D53900F72485 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B78D632A51D53900F72485 /* AppDelegate.swift */; };
 		CD0507732C6AA0C8008B1505 /* FeedSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0507722C6AA0C8008B1505 /* FeedSelection.swift */; };
+		CD09BA7F2CB4698E00C93926 /* OledPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD09BA7E2CB4698600C93926 /* OledPalette.swift */; };
 		CD0E06F72C0E739F00445849 /* PostType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0E06F62C0E739F00445849 /* PostType+Extensions.swift */; };
 		CD0F280A2C6CEFBE00C1F65B /* View+IsAtTopSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0F28092C6CEFBE00C1F65B /* View+IsAtTopSubscriber.swift */; };
 		CD10FA772C7A8622008985AD /* ImageSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD10FA762C7A8622008985AD /* ImageSaver.swift */; };
@@ -633,6 +634,7 @@
 		B104A6E12A5AFC9F00B3E725 /* Mlem.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Mlem.entitlements; sourceTree = "<group>"; };
 		B1B78D632A51D53900F72485 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CD0507722C6AA0C8008B1505 /* FeedSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSelection.swift; sourceTree = "<group>"; };
+		CD09BA7E2CB4698600C93926 /* OledPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OledPalette.swift; sourceTree = "<group>"; };
 		CD0E06F62C0E739F00445849 /* PostType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostType+Extensions.swift"; sourceTree = "<group>"; };
 		CD0E07002C12707700445849 /* ToolbarEllipsisMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarEllipsisMenu.swift; sourceTree = "<group>"; };
 		CD0F28092C6CEFBE00C1F65B /* View+IsAtTopSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+IsAtTopSubscriber.swift"; sourceTree = "<group>"; };
@@ -1305,6 +1307,7 @@
 		CD317D4D2BE97FFB008F63E2 /* Colors */ = {
 			isa = PBXGroup;
 			children = (
+				CD09BA7E2CB4698600C93926 /* OledPalette.swift */,
 				CD4D58922B86BA5C00B82964 /* StandardPalette.swift */,
 				CD317D4E2BE983ED008F63E2 /* MonochromePalette.swift */,
 				CDAA02DC2C81792500D75633 /* SolarizedPalette.swift */,
@@ -2313,6 +2316,7 @@
 				03500C242BF55D0E00CAA076 /* Toast.swift in Sources */,
 				032C320C2C3482CA00595286 /* Person1Providing+Extensions.swift in Sources */,
 				038028D32CAB3D2D0091A8A2 /* ShareActivity.swift in Sources */,
+				CD09BA7F2CB4698E00C93926 /* OledPalette.swift in Sources */,
 				030FF67F2BC8544700F6BFAC /* CustomTabBarController.swift in Sources */,
 				CD4D58F82B87B0D100B82964 /* InternetSpeed.swift in Sources */,
 				0353949C2CA4B3E800795AA5 /* CrossPostListView.swift in Sources */,

--- a/Mlem/App/Configuration/Colors/OledPalette.swift
+++ b/Mlem/App/Configuration/Colors/OledPalette.swift
@@ -10,6 +10,7 @@ import SwiftUI
 extension ColorPalette {
     static let oled: ColorPalette = .init(
         supportedModes: .dark,
+        bordered: true,
         primary: .primary,
         secondary: .secondary,
         tertiary: Color(UIColor.tertiaryLabel),

--- a/Mlem/App/Configuration/Colors/OledPalette.swift
+++ b/Mlem/App/Configuration/Colors/OledPalette.swift
@@ -8,38 +8,16 @@
 import SwiftUI
 
 extension ColorPalette {
-    static let oled: ColorPalette = .init(
-        supportedModes: .dark,
-        bordered: true,
-        primary: .primary,
-        secondary: .secondary,
-        tertiary: Color(UIColor.tertiaryLabel),
-        background: .black,
-        secondaryBackground: .black,
-        tertiaryBackground: .black,
-        groupedBackground: .black,
-        secondaryGroupedBackground: .black,
-        tertiaryGroupedBackground: .black,
-        thumbnailBackground: Color(UIColor.systemGray4),
-        positive: .green,
-        negative: .red,
-        warning: .red,
-        caution: .orange,
-        upvote: .blue,
-        downvote: .red,
-        save: .green,
-        read: .purple,
-        favorite: .blue,
-        selectedInteractionBarItem: .white,
-        administration: .teal,
-        moderation: .cyan,
-        federatedFeed: .blue,
-        localFeed: .purple,
-        subscribedFeed: .red,
-        inbox: .purple,
-        accent: .blue,
-        neutralAccent: .gray,
-        colorfulAccents: [.orange, .pink, .blue, .green, .purple, .indigo, .mint],
-        commentIndentColors: [.red, .orange, .yellow, .green, .blue, .purple]
-    )
+    static let oled: ColorPalette = {
+        var palette = ColorPalette.standard
+        palette.supportedModes = .dark
+        palette.bordered = true
+        palette.background = .black
+        palette.secondaryBackground = .black
+        palette.tertiaryBackground = .black
+        palette.groupedBackground = .black
+        palette.secondaryGroupedBackground = .black
+        palette.tertiaryGroupedBackground = .black
+        return palette
+    }()
 }

--- a/Mlem/App/Configuration/Colors/OledPalette.swift
+++ b/Mlem/App/Configuration/Colors/OledPalette.swift
@@ -1,0 +1,44 @@
+//
+//  OledPalette.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-10-07.
+//
+
+import SwiftUI
+
+extension ColorPalette {
+    static let oled: ColorPalette = .init(
+        supportedModes: .dark,
+        primary: .primary,
+        secondary: .secondary,
+        tertiary: Color(UIColor.tertiaryLabel),
+        background: .black,
+        secondaryBackground: .black,
+        tertiaryBackground: .black,
+        groupedBackground: .black,
+        secondaryGroupedBackground: .black,
+        tertiaryGroupedBackground: .black,
+        thumbnailBackground: Color(UIColor.systemGray4),
+        positive: .green,
+        negative: .red,
+        warning: .red,
+        caution: .orange,
+        upvote: .blue,
+        downvote: .red,
+        save: .green,
+        read: .purple,
+        favorite: .blue,
+        selectedInteractionBarItem: .white,
+        administration: .teal,
+        moderation: .cyan,
+        federatedFeed: .blue,
+        localFeed: .purple,
+        subscribedFeed: .red,
+        inbox: .purple,
+        accent: .blue,
+        neutralAccent: .gray,
+        colorfulAccents: [.orange, .pink, .blue, .green, .purple, .indigo, .mint],
+        commentIndentColors: [.red, .orange, .yellow, .green, .blue, .purple]
+    )
+}

--- a/Mlem/App/Globals/Definitions/Palette.swift
+++ b/Mlem/App/Globals/Definitions/Palette.swift
@@ -11,6 +11,7 @@ import SwiftUI
 protocol PaletteProviding {
     // meta
     var supportedModes: UIUserInterfaceStyle { get }
+    var bordered: Bool { get }
     
     // basics
     var primary: Color { get }
@@ -79,6 +80,7 @@ enum PaletteOption: String, CaseIterable, Codable {
 struct ColorPalette: PaletteProviding {
     // meta
     var supportedModes: UIUserInterfaceStyle
+    var bordered: Bool
     
     // basics
     var primary: Color
@@ -126,6 +128,7 @@ struct ColorPalette: PaletteProviding {
     
     init(
         supportedModes: UIUserInterfaceStyle,
+        bordered: Bool = false,
         primary: Color,
         secondary: Color,
         tertiary: Color,
@@ -160,6 +163,7 @@ struct ColorPalette: PaletteProviding {
         commentIndentColors: [Color]
     ) {
         self.supportedModes = supportedModes
+        self.bordered = bordered
         self.primary = primary
         self.secondary = secondary
         self.tertiary = tertiary
@@ -214,6 +218,7 @@ class Palette: PaletteProviding {
     
     // ColorProviding conformance
     var supportedModes: UIUserInterfaceStyle { palette.supportedModes }
+    var bordered: Bool { palette.bordered }
     
     var primary: Color { palette.primary }
     var secondary: Color { palette.secondary }
@@ -263,4 +268,5 @@ class Palette: PaletteProviding {
     var userAccent: Color { colorfulAccent(2) }
     var communityAccent: Color { colorfulAccent(3) }
     var lockAccent: Color { colorfulAccent(0) }
+    var divider: Color { .init(light: secondary.opacity(0.5), dark: neutralAccent.opacity(0.35)) }
 }

--- a/Mlem/App/Globals/Definitions/Palette.swift
+++ b/Mlem/App/Globals/Definitions/Palette.swift
@@ -69,7 +69,7 @@ enum PaletteOption: String, CaseIterable, Codable {
     var label: LocalizedStringResource {
         switch self {
         case .standard: "Default"
-        case .oled: "Oled"
+        case .oled: "OLED"
         case .monochrome: "Monochrome"
         case .solarized: "Solarized"
         case .dracula: "Dracula"

--- a/Mlem/App/Globals/Definitions/Palette.swift
+++ b/Mlem/App/Globals/Definitions/Palette.swift
@@ -53,11 +53,12 @@ protocol PaletteProviding {
 }
 
 enum PaletteOption: String, CaseIterable, Codable {
-    case standard, monochrome, solarized, dracula
+    case standard, oled, monochrome, solarized, dracula
     
     var palette: ColorPalette {
         switch self {
         case .standard: ColorPalette.standard
+        case .oled: ColorPalette.oled
         case .monochrome: ColorPalette.monochrome
         case .solarized: ColorPalette.solarized
         case .dracula: ColorPalette.dracula
@@ -67,6 +68,7 @@ enum PaletteOption: String, CaseIterable, Codable {
     var label: LocalizedStringResource {
         switch self {
         case .standard: "Default"
+        case .oled: "Oled"
         case .monochrome: "Monochrome"
         case .solarized: "Solarized"
         case .dracula: "Dracula"

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PaletteBorder.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PaletteBorder.swift
@@ -27,7 +27,7 @@ private struct PaletteBorder: ViewModifier {
 }
 
 extension View {
-    /// Blurs an image relative to its size
+    /// Applies a rounded rect border to the view if the current palette `.bordered` is `true`
     func paletteBorder(cornerRadius: CGFloat) -> some View {
         modifier(PaletteBorder(cornerRadius: cornerRadius))
     }

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PaletteBorder.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PaletteBorder.swift
@@ -1,0 +1,34 @@
+//
+//  View+PaletteBorder.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-10-10.
+//
+
+import SwiftUICore
+
+import Foundation
+import SwiftUI
+
+private struct PaletteBorder: ViewModifier {
+    @Environment(Palette.self) var palette
+    
+    var cornerRadius: CGFloat
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if palette.bordered {
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .stroke(palette.divider, lineWidth: 0.5)
+                }
+            }
+    }
+}
+
+extension View {
+    /// Blurs an image relative to its size
+    func paletteBorder(cornerRadius: CGFloat) -> some View {
+        modifier(PaletteBorder(cornerRadius: cornerRadius))
+    }
+}

--- a/Mlem/App/Views/Root/Onboarding/LoginCredentialsView.swift
+++ b/Mlem/App/Views/Root/Onboarding/LoginCredentialsView.swift
@@ -154,6 +154,7 @@ struct LoginCredentialsView: View {
             RoundedRectangle(cornerRadius: 16)
                 .fill(palette.secondaryGroupedBackground)
         )
+        .paletteBorder(cornerRadius: 16)
         .onAppear { focused = showUsernameField ? .username : .password }
         .onChange(of: username) { failureReason = nil }
         .onChange(of: password) { failureReason = nil }

--- a/Mlem/App/Views/Root/Onboarding/LoginInstancePickerView.swift
+++ b/Mlem/App/Views/Root/Onboarding/LoginInstancePickerView.swift
@@ -105,6 +105,7 @@ struct LoginInstancePickerView: View {
         .frame(maxWidth: .infinity)
         .background(palette.secondaryGroupedBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
+        .paletteBorder(cornerRadius: 16)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
@@ -18,9 +18,9 @@ struct FeedCommentView: View {
     var body: some View {
         content
             .contentShape(.interaction, .rect)
-            // .quickSwipes(comment.swipeActions(behavior: postSize.swipeBehavior))
+            .quickSwipes(comment.swipeActions(behavior: postSize.swipeBehavior))
             .contextMenu { comment.menuActions() }
-            .shadow(color: postSize.tiled ? palette.primary.opacity(0.1) : .clear, radius: 3) // after quickSwipes to prevent clipping
+            .paletteBorder(cornerRadius: postSize.swipeBehavior.cornerRadius)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/TileCommentView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/TileCommentView.swift
@@ -53,6 +53,7 @@ struct TileCommentView: View {
                     RoundedRectangle(cornerRadius: Constants.main.smallItemCornerRadius)
                         .fill(palette.tertiaryGroupedBackground)
                 }
+                .paletteBorder(cornerRadius: Constants.main.smallItemCornerRadius)
             
             MarkdownText(comment.content, configuration: .caption)
                 .frame(height: contentHeight, alignment: .top)

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/Feed Post Components/CrossPostListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/Feed Post Components/CrossPostListView.swift
@@ -73,6 +73,7 @@ struct CrossPostListView: View {
             .padding(.vertical, 8)
             .background(palette.secondaryGroupedBackground)
             .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
+            .paletteBorder(cornerRadius: Constants.main.standardSpacing)
         }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
@@ -24,7 +24,12 @@ struct FeedPostView: View {
             .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
             .quickSwipes(post.swipeActions(behavior: postSize.swipeBehavior))
             .contextMenu { post.allMenuActions() }
-            .shadow(color: postSize.tiled ? palette.primary.opacity(0.1) : .clear, radius: 3) // after quickSwipes to prevent clipping
+            .overlay {
+                RoundedRectangle(cornerRadius: postSize.swipeBehavior.cornerRadius)
+                    .stroke(palette.neutralAccent.opacity(0.35), lineWidth: 0.5)
+            }
+        // .shadow(color: .white.opacity(0.5), radius: 3)
+        // .shadow(color: postSize.tiled ? palette.primary.opacity(0.1) : .clear, radius: 3) // after quickSwipes to prevent clipping
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
@@ -24,12 +24,7 @@ struct FeedPostView: View {
             .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
             .quickSwipes(post.swipeActions(behavior: postSize.swipeBehavior))
             .contextMenu { post.allMenuActions() }
-            .overlay {
-                RoundedRectangle(cornerRadius: postSize.swipeBehavior.cornerRadius)
-                    .stroke(palette.neutralAccent.opacity(0.35), lineWidth: 0.5)
-            }
-        // .shadow(color: .white.opacity(0.5), radius: 3)
-        // .shadow(color: postSize.tiled ? palette.primary.opacity(0.1) : .clear, radius: 3) // after quickSwipes to prevent clipping
+            .paletteBorder(cornerRadius: postSize.swipeBehavior.cornerRadius)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Settings/AboutMlemView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AboutMlemView.swift
@@ -12,10 +12,13 @@ struct AboutMlemView: View {
     
     var body: some View {
         Form {
-            Section {
+            Section {} header: {
                 appHeaderView
                     .listRowBackground(palette.groupedBackground)
+                    .foregroundStyle(palette.primary)
             }
+            .textCase(nil)
+            .listRowInsets(.init(top: 50, leading: 0, bottom: 15, trailing: 0))
             Section {
                 Link(destination: URL(string: "https://mlem.group")!) {
                     FormChevron { Label("Website", systemImage: Icons.websiteIcon) }
@@ -28,11 +31,11 @@ struct AboutMlemView: View {
                 Link(destination: URL(string: "https://matrix.to/#/#mlemappspace:matrix.org")!) {
                     FormChevron { Label("Matrix Room", image: "matrix.logo") }
                 }
-                .tint(palette.primary)
+                .tint(.black) // non-palette because white tint turns this into white square
                 Link(destination: URL(string: "https://github.com/mlemgroup/mlem")!) {
                     FormChevron { Label("GitHub Repository", image: "github.logo") }
                 }
-                .tint(palette.primary)
+                .tint(.black) // non-palette because white tint turns this into white square
             }
             Section {
                 NavigationLink("Privacy Policy", systemImage: "hand.raised.fill", destination: .settings(.document(.privacyPolicy)))

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
@@ -47,7 +47,7 @@ struct AccountListSettingsView: View {
                     }
                 }
                 .frame(height: 64)
-                .padding(.top, -12)
+                // .padding(.top, -12)
                 
                 Text("Accounts")
                     .font(.title)

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
@@ -57,5 +57,6 @@ struct AccountListSettingsView: View {
             .foregroundStyle(palette.primary) // override default .secondary style
         }
         .textCase(nil) // override default all-caps
+        .listRowInsets(.init(top: 40, leading: 0, bottom: 0, trailing: 0))
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
@@ -27,7 +27,8 @@ struct AccountListSettingsView: View {
     
     @ViewBuilder
     var headerView: some View {
-        Section {
+        // empty section disables background
+        Section {} header: {
             VStack(alignment: .center) {
                 Group {
                     if accounts.count >= 2 {
@@ -53,7 +54,8 @@ struct AccountListSettingsView: View {
                     .fontWeight(.bold)
             }
             .frame(maxWidth: .infinity)
-            .listRowBackground(palette.groupedBackground)
+            .foregroundStyle(palette.primary) // override default .secondary style
         }
+        .textCase(nil) // override default all-caps
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
@@ -47,7 +47,6 @@ struct AccountListSettingsView: View {
                     }
                 }
                 .frame(height: 64)
-                // .padding(.top, -12)
                 
                 Text("Accounts")
                     .font(.title)

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
@@ -24,7 +24,9 @@ struct AccountSettingsView: View {
                     }
                 }
                 .foregroundStyle(palette.primary) // override default .secondary style
-            }.textCase(nil) // override default all-caps
+            }
+            .textCase(nil) // override default all-caps
+            .listRowInsets(.init(top: 40, leading: 0, bottom: 0, trailing: 0))
             
             Section {
                 Button("Sign Out") {

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
@@ -23,7 +23,6 @@ struct AccountSettingsView: View {
                     }
                 }
                 .listRowBackground(palette.groupedBackground)
-                .padding(.vertical, -12)
                 .padding(.horizontal, -16)
             }
             

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
@@ -14,7 +14,8 @@ struct AccountSettingsView: View {
     
     var body: some View {
         Form {
-            Section {
+            // empty section disables background
+            Section {} header: {
                 Group {
                     if let userAccount = appState.firstSession as? UserSession {
                         ProfileHeaderView(userAccount.person)
@@ -22,9 +23,8 @@ struct AccountSettingsView: View {
                         ProfileHeaderView(appState.firstSession.instance)
                     }
                 }
-                .listRowBackground(palette.groupedBackground)
-                .padding(.horizontal, -16)
-            }
+                .foregroundStyle(palette.primary) // override default .secondary style
+            }.textCase(nil) // override default all-caps
             
             Section {
                 Button("Sign Out") {

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
@@ -262,6 +262,7 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
             .frame(height: Constants.main.barIconSize)
             .padding(12)
             .background(palette.secondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.smallItemCornerRadius))
+            .paletteBorder(cornerRadius: Constants.main.smallItemCornerRadius)
     }
 }
 

--- a/Mlem/App/Views/Shared/CapsuleButtonStyle.swift
+++ b/Mlem/App/Views/Shared/CapsuleButtonStyle.swift
@@ -16,7 +16,11 @@ struct CapsuleButtonStyle: ButtonStyle {
             .foregroundStyle(palette.accent)
             .padding(.vertical, 10)
             .frame(maxWidth: .infinity)
-            .background(palette.secondaryGroupedBackground, in: .capsule)
+            .background {
+                Capsule()
+                    .fill(palette.secondaryGroupedBackground)
+                    .stroke(palette.bordered ? palette.divider : .clear, lineWidth: 0.5)
+            }
             .opacity(configuration.isPressed ? 0.8 : 1)
             .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
     }

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -107,6 +107,7 @@ struct CommentView: View {
         .contextMenu { comment.menuActions(commentTreeTracker: commentTreeTracker) }
         .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
         .environment(\.commentContext, comment)
+        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
 }
 

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -95,7 +95,7 @@ struct CommentView: View {
                 }
             }
             .padding(.vertical, Constants.main.standardSpacing)
-            .padding(.top, compactComments ? 0 : 3)
+            .padding(.top, compactComments || collapsed ? 0 : 3)
         }
         .padding(depth == 0 ? .horizontal : .trailing, Constants.main.standardSpacing)
         .background(highlight ? palette.accent.opacity(0.2) : .clear)

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -182,6 +182,7 @@ struct ExpandedPostView<Content: View>: View {
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .quickSwipes(post.swipeActions(behavior: .standard, commentTreeTracker: tracker))
         .contextMenu { post.allMenuActions() }
+        .paletteBorder(cornerRadius: PostSize.large.swipeBehavior.cornerRadius)
         .onTapGesture {
             withAnimation {
                 postCollapsed.toggle()

--- a/Mlem/App/Views/Shared/MessageView.swift
+++ b/Mlem/App/Views/Shared/MessageView.swift
@@ -52,5 +52,6 @@ struct MessageView: View {
         .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu { message.menuActions() }
+        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
 }

--- a/Mlem/App/Views/Shared/Palette Components/Divider.swift
+++ b/Mlem/App/Views/Shared/Palette Components/Divider.swift
@@ -16,6 +16,6 @@ struct Divider: View {
     var body: some View {
         SwiftUI.Divider()
             .hidden()
-            .overlay(Color(light: palette.secondary.opacity(0.5), dark: palette.neutralAccent.opacity(0.35)))
+            .overlay(palette.divider)
     }
 }

--- a/Mlem/App/Views/Shared/Palette Components/Form.swift
+++ b/Mlem/App/Views/Shared/Palette Components/Form.swift
@@ -22,7 +22,9 @@ struct Form<Content: View>: View {
                 .tint(palette.accent)
                 .buttonStyle(PaletteButton())
         }
+        .listStyle(InsetListStyle())
         .scrollContentBackground(.hidden)
         .background(palette.groupedBackground)
+        .shadow(color: palette.primary.opacity(palette.bordered ? 0.2 : 0.0), radius: 5)
     }
 }

--- a/Mlem/App/Views/Shared/ReplyView.swift
+++ b/Mlem/App/Views/Shared/ReplyView.swift
@@ -46,5 +46,6 @@ struct ReplyView: View {
         .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu { reply.menuActions() }
+        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
 }

--- a/Mlem/App/Views/Shared/Search/SearchResultsView.swift
+++ b/Mlem/App/Views/Shared/Search/SearchResultsView.swift
@@ -23,6 +23,7 @@ struct SearchResultsView<Item: Searchable, Content: View>: View {
     var body: some View {
         ForEach(results) { item in
             content(item)
+                .paletteBorder(cornerRadius: Constants.main.standardSpacing)
                 .padding(.horizontal, Constants.main.standardSpacing)
                 .padding(.bottom, Constants.main.halfSpacing)
         }

--- a/Mlem/App/Views/Shared/WebsitePreviewView.swift
+++ b/Mlem/App/Views/Shared/WebsitePreviewView.swift
@@ -53,6 +53,7 @@ struct WebsitePreviewView: View {
             .background(palette.tertiaryGroupedBackground)
             .clipShape(RoundedRectangle(cornerRadius: Constants.main.mediumItemCornerRadius))
             .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.mediumItemCornerRadius))
+            .paletteBorder(cornerRadius: Constants.main.mediumItemCornerRadius)
     }
     
     var complex: some View {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -820,6 +820,9 @@
     "Old" : {
 
     },
+    "Oled" : {
+
+    },
     "Once approved, you'll be able to log in to your account from the Settings tab." : {
 
     },

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -829,7 +829,7 @@
     "Old" : {
 
     },
-    "Oled" : {
+    "OLED" : {
 
     },
     "Once approved, you'll be able to log in to your account from the Settings tab." : {


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - Community feedback

# Pull Request Information

This PR adds an OLED theme that makes all backgrounds true black. To distinguish card entities, a light border is applied to the entity using the new `.paletteBorder` view modifier. This border has the same color as the palette-aware `Divider`.

To support this, `PaletteProviding` now defines a `bordered` boolean. `ColorPalette` defaults this to `false`, as it is a non-standard option. The divider color is now also a computed property of `PaletteProviding`

`List` and `Form` do not easily support a rounded border, so these views instead have a light shadow applied to them.

This PR also makes a couple minor changes:
- Padding on collapsed comments is adjusted to perfectly center the username within the collapsed comment when compact posts are off
- Padding on some account settings entities has been updated to play nice with the new shadow