### PR TITLE
Tappable Links

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2812,7 +2812,7 @@
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.43.0;
+				minimumVersion = 0.44.0;
 			};
 		};
 		CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -184,7 +184,7 @@
 		039F589D2C7B6C0A00C61658 /* FormChevron.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039F589C2C7B6C0A00C61658 /* FormChevron.swift */; };
 		03A82FA12C0D1E8500D01A5C /* ApiClient+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A82FA02C0D1E8500D01A5C /* ApiClient+Extensions.swift */; };
 		03A82FA32C0D1F2400D01A5C /* View+ExternalApiWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A82FA22C0D1F2400D01A5C /* View+ExternalApiWarning.swift */; };
-		03AB484F2CBAE33500567FF9 /* MarkdownWithLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB484E2CBAE33500567FF9 /* MarkdownWithLinks.swift */; };
+		03AB484F2CBAE33500567FF9 /* MarkdownWithLinkList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB484E2CBAE33500567FF9 /* MarkdownWithLinkList.swift */; };
 		03AF91DD2C1B23E500E56644 /* ImageViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AF91DC2C1B23E500E56644 /* ImageViewer.swift */; };
 		03AF91DF2C1B243D00E56644 /* ZoomableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AF91DE2C1B243D00E56644 /* ZoomableContainer.swift */; };
 		03AF91E12C1B25DE00E56644 /* UIDevice+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AF91E02C1B25DE00E56644 /* UIDevice+Extensions.swift */; };
@@ -578,7 +578,7 @@
 		039F589C2C7B6C0A00C61658 /* FormChevron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormChevron.swift; sourceTree = "<group>"; };
 		03A82FA02C0D1E8500D01A5C /* ApiClient+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApiClient+Extensions.swift"; sourceTree = "<group>"; };
 		03A82FA22C0D1F2400D01A5C /* View+ExternalApiWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ExternalApiWarning.swift"; sourceTree = "<group>"; };
-		03AB484E2CBAE33500567FF9 /* MarkdownWithLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownWithLinks.swift; sourceTree = "<group>"; };
+		03AB484E2CBAE33500567FF9 /* MarkdownWithLinkList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownWithLinkList.swift; sourceTree = "<group>"; };
 		03AF91DC2C1B23E500E56644 /* ImageViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewer.swift; sourceTree = "<group>"; };
 		03AF91DE2C1B243D00E56644 /* ZoomableContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableContainer.swift; sourceTree = "<group>"; };
 		03AF91E02C1B25DE00E56644 /* UIDevice+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extensions.swift"; sourceTree = "<group>"; };
@@ -1467,7 +1467,7 @@
 				CD13CC5A2C588B34001AF428 /* WebView.swift */,
 				03AF91DE2C1B243D00E56644 /* ZoomableContainer.swift */,
 				CD635E1A2C94DACD00864F75 /* BypassProxyWarningSheet.swift */,
-				03AB484E2CBAE33500567FF9 /* MarkdownWithLinks.swift */,
+				03AB484E2CBAE33500567FF9 /* MarkdownWithLinkList.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -2096,7 +2096,7 @@
 				CD13CC5B2C588B34001AF428 /* WebView.swift in Sources */,
 				CDB41E8C2C84CED500BD2DE9 /* FixedImageLoader.swift in Sources */,
 				039EFEC32BEEBEE0003AC372 /* LoginInstancePickerView.swift in Sources */,
-				03AB484F2CBAE33500567FF9 /* MarkdownWithLinks.swift in Sources */,
+				03AB484F2CBAE33500567FF9 /* MarkdownWithLinkList.swift in Sources */,
 				03531EF12C2DA298004A3464 /* SearchResultsView.swift in Sources */,
 				034B94852C09348400039AF4 /* MarkdownImageView.swift in Sources */,
 				CD9CFA2A2C2E1E8400739BBC /* FeedHeaderView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		039F589D2C7B6C0A00C61658 /* FormChevron.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039F589C2C7B6C0A00C61658 /* FormChevron.swift */; };
 		03A82FA12C0D1E8500D01A5C /* ApiClient+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A82FA02C0D1E8500D01A5C /* ApiClient+Extensions.swift */; };
 		03A82FA32C0D1F2400D01A5C /* View+ExternalApiWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A82FA22C0D1F2400D01A5C /* View+ExternalApiWarning.swift */; };
+		03AB484F2CBAE33500567FF9 /* MarkdownWithLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB484E2CBAE33500567FF9 /* MarkdownWithLinks.swift */; };
 		03AF91DD2C1B23E500E56644 /* ImageViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AF91DC2C1B23E500E56644 /* ImageViewer.swift */; };
 		03AF91DF2C1B243D00E56644 /* ZoomableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AF91DE2C1B243D00E56644 /* ZoomableContainer.swift */; };
 		03AF91E12C1B25DE00E56644 /* UIDevice+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AF91E02C1B25DE00E56644 /* UIDevice+Extensions.swift */; };
@@ -571,6 +572,7 @@
 		039F589C2C7B6C0A00C61658 /* FormChevron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormChevron.swift; sourceTree = "<group>"; };
 		03A82FA02C0D1E8500D01A5C /* ApiClient+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApiClient+Extensions.swift"; sourceTree = "<group>"; };
 		03A82FA22C0D1F2400D01A5C /* View+ExternalApiWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ExternalApiWarning.swift"; sourceTree = "<group>"; };
+		03AB484E2CBAE33500567FF9 /* MarkdownWithLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownWithLinks.swift; sourceTree = "<group>"; };
 		03AF91DC2C1B23E500E56644 /* ImageViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewer.swift; sourceTree = "<group>"; };
 		03AF91DE2C1B243D00E56644 /* ZoomableContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableContainer.swift; sourceTree = "<group>"; };
 		03AF91E02C1B25DE00E56644 /* UIDevice+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extensions.swift"; sourceTree = "<group>"; };
@@ -1454,6 +1456,7 @@
 				CD13CC5A2C588B34001AF428 /* WebView.swift */,
 				03AF91DE2C1B243D00E56644 /* ZoomableContainer.swift */,
 				CD635E1A2C94DACD00864F75 /* BypassProxyWarningSheet.swift */,
+				03AB484E2CBAE33500567FF9 /* MarkdownWithLinks.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -2080,6 +2083,7 @@
 				CD13CC5B2C588B34001AF428 /* WebView.swift in Sources */,
 				CDB41E8C2C84CED500BD2DE9 /* FixedImageLoader.swift in Sources */,
 				039EFEC32BEEBEE0003AC372 /* LoginInstancePickerView.swift in Sources */,
+				03AB484F2CBAE33500567FF9 /* MarkdownWithLinks.swift in Sources */,
 				03531EF12C2DA298004A3464 /* SearchResultsView.swift in Sources */,
 				034B94852C09348400039AF4 /* MarkdownImageView.swift in Sources */,
 				CD9CFA2A2C2E1E8400739BBC /* FeedHeaderView.swift in Sources */,

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
-        "revision" : "da7ee9773e605769502b87874a550af3883159e6",
-        "version" : "0.43.0"
+        "revision" : "b969b27dc62eb8c17791ebbac3b282e816c36af8",
+        "version" : "0.44.0"
       }
     },
     {

--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -49,7 +49,7 @@ struct CodableSettings: Codable {
     var links_displayMode: String // TODO: pending easy-tap links
     var links_openInBrowser: Bool
     var links_readerMode: Bool
-    var links_showTappableLinks: Bool
+    var links_tappableLinksDisplayMode: TappableLinksDisplayMode
     var menus_allModActions: Bool
     var menus_modActionGrouping: String // TODO: pending mod actions
     var post_defaultSort: ApiSortType
@@ -121,7 +121,7 @@ struct CodableSettings: Codable {
         self.links_displayMode = try container.decodeIfPresent(String.self, forKey: .links_displayMode) ?? "contextual"
         self.links_openInBrowser = try container.decodeIfPresent(Bool.self, forKey: .links_openInBrowser) ?? false
         self.links_readerMode = try container.decodeIfPresent(Bool.self, forKey: .links_readerMode) ?? false
-        self.links_showTappableLinks = try container.decodeIfPresent(Bool.self, forKey: .links_showTappableLinks) ?? true
+        self.links_tappableLinksDisplayMode = try container.decodeIfPresent(TappableLinksDisplayMode.self, forKey: .links_tappableLinksDisplayMode) ?? .contextual
         self.menus_allModActions = try container.decodeIfPresent(Bool.self, forKey: .menus_allModActions) ?? false
         self.menus_modActionGrouping = try container.decodeIfPresent(String.self, forKey: .menus_modActionGrouping) ?? "none"
         self.post_defaultSort = try container.decodeIfPresent(ApiSortType.self, forKey: .post_defaultSort) ?? .hot
@@ -194,7 +194,7 @@ struct CodableSettings: Codable {
         self.links_displayMode = "contextual"
         self.links_openInBrowser = settings.openLinksInBrowser
         self.links_readerMode = settings.openLinksInReaderMode
-        self.links_showTappableLinks = settings.showTappableLinks
+        self.links_tappableLinksDisplayMode = settings.tappableLinksDisplayMode
         self.menus_allModActions = false
         self.menus_modActionGrouping = "none"
         self.post_defaultSort = settings.defaultPostSort

--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -48,6 +48,7 @@ struct CodableSettings: Codable {
     var links_displayMode: String // TODO: pending easy-tap links
     var links_openInBrowser: Bool
     var links_readerMode: Bool
+    var links_showTappableLinks: Bool
     var menus_allModActions: Bool
     var menus_modActionGrouping: String // TODO: pending mod actions
     var post_defaultSort: ApiSortType
@@ -118,6 +119,7 @@ struct CodableSettings: Codable {
         self.links_displayMode = try container.decodeIfPresent(String.self, forKey: .links_displayMode) ?? "contextual"
         self.links_openInBrowser = try container.decodeIfPresent(Bool.self, forKey: .links_openInBrowser) ?? false
         self.links_readerMode = try container.decodeIfPresent(Bool.self, forKey: .links_readerMode) ?? false
+        self.links_showTappableLinks = try container.decodeIfPresent(Bool.self, forKey: .links_showTappableLinks) ?? true
         self.menus_allModActions = try container.decodeIfPresent(Bool.self, forKey: .menus_allModActions) ?? false
         self.menus_modActionGrouping = try container.decodeIfPresent(String.self, forKey: .menus_modActionGrouping) ?? "none"
         self.post_defaultSort = try container.decodeIfPresent(ApiSortType.self, forKey: .post_defaultSort) ?? .hot
@@ -189,6 +191,7 @@ struct CodableSettings: Codable {
         self.links_displayMode = "contextual"
         self.links_openInBrowser = settings.openLinksInBrowser
         self.links_readerMode = settings.openLinksInReaderMode
+        self.links_showTappableLinks = settings.showTappableLinks
         self.menus_allModActions = false
         self.menus_modActionGrouping = "none"
         self.post_defaultSort = settings.defaultPostSort

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -46,6 +46,7 @@ class Settings: ObservableObject {
     
     @AppStorage("links.openInBrowser") var openLinksInBrowser = false
     @AppStorage("links.readerMode") var openLinksInReaderMode = false
+    @AppStorage("links.showTappable") var showTappableLinks = true
     
     @AppStorage("feed.markReadOnScroll") var markReadOnScroll: Bool = false
     @AppStorage("feed.showRead") var showReadInFeed: Bool = true
@@ -116,6 +117,7 @@ class Settings: ObservableObject {
         showNsfwCommunityWarning = settings.safety_enableNsfwCommunityWarning
         openLinksInBrowser = settings.links_openInBrowser
         openLinksInReaderMode = settings.links_readerMode
+        showTappableLinks = settings.links_showTappableLinks
         markReadOnScroll = settings.feed_markReadOnScroll
         showReadInFeed = settings.feed_showRead
         defaultFeed = settings.feed_default

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -47,7 +47,7 @@ class Settings: ObservableObject {
     
     @AppStorage("links.openInBrowser") var openLinksInBrowser = false
     @AppStorage("links.readerMode") var openLinksInReaderMode = false
-    @AppStorage("links.showTappable") var showTappableLinks = true
+    @AppStorage("links.displayMode") var tappableLinksDisplayMode: TappableLinksDisplayMode = .contextual
     
     @AppStorage("feed.markReadOnScroll") var markReadOnScroll: Bool = false
     @AppStorage("feed.showRead") var showReadInFeed: Bool = true
@@ -118,7 +118,7 @@ class Settings: ObservableObject {
         showNsfwCommunityWarning = settings.safety_enableNsfwCommunityWarning
         openLinksInBrowser = settings.links_openInBrowser
         openLinksInReaderMode = settings.links_readerMode
-        showTappableLinks = settings.links_showTappableLinks
+        tappableLinksDisplayMode = settings.links_tappableLinksDisplayMode
         markReadOnScroll = settings.feed_markReadOnScroll
         showReadInFeed = settings.feed_showRead
         defaultFeed = settings.feed_default

--- a/Mlem/App/Utility/Extensions/Date+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Date+Extensions.swift
@@ -19,7 +19,8 @@ extension Date {
     // Returns strings like "5/10/2023"
     var dateString: String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = DateFormatter.dateFormat(fromTemplate: "ddMMYY", options: 0, locale: Locale.current)
+        dateFormatter.dateStyle = .short
+        dateFormatter.timeStyle = .none
         return dateFormatter.string(from: self)
     }
     

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
@@ -44,7 +44,7 @@ struct LargePostBodyView: View {
             }
             if let content = post.content {
                 if isPostPage {
-                    MarkdownWithLinks(content)
+                    MarkdownWithLinkList(content)
                 } else {
                     // Cut down on compute time for very long text posts by only rendering the first 4 blocks
                     MarkdownText(Array([BlockNode](content).prefix(4)), configuration: .dimmed)

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
@@ -44,7 +44,7 @@ struct LargePostBodyView: View {
             }
             if let content = post.content {
                 if isPostPage {
-                    Markdown(content, configuration: .default)
+                    MarkdownWithLinks(content)
                 } else {
                     // Cut down on compute time for very long text posts by only rendering the first 4 blocks
                     MarkdownText(Array([BlockNode](content).prefix(4)), configuration: .dimmed)

--- a/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct LinkSettingsView: View {
     @Setting(\.openLinksInBrowser) var openLinksInBrowser
     @Setting(\.openLinksInReaderMode) var openLinksInReaderMode
-    @Setting(\.showTappableLinks) var showTappableLinks
+    @Setting(\.compactComments) var compactComments
+    @Setting(\.tappableLinksDisplayMode) var tappableLinksDisplayMode
     
     var body: some View {
         Form {
@@ -31,7 +32,35 @@ struct LinkSettingsView: View {
             }
             
             Section {
-                Toggle("Show Tappable Links", isOn: $showTappableLinks)
+                Toggle(
+                    "Tappable Links",
+                    isOn: Binding(
+                        get: { tappableLinksDisplayMode != .disabled },
+                        set: { newValue in
+                            withAnimation(.easeOut(duration: 0.1)) {
+                                tappableLinksDisplayMode = newValue ? .large : .disabled
+                            }
+                        }
+                    )
+                )
+                if compactComments {
+                    Picker("Show Full URL", selection: $tappableLinksDisplayMode) {
+                        Text("Always").tag(TappableLinksDisplayMode.large)
+                        Text("Never").tag(TappableLinksDisplayMode.compact)
+                        Text("Never in Comments").tag(TappableLinksDisplayMode.contextual)
+                    }
+                    .pickerStyle(.menu)
+                } else {
+                    if tappableLinksDisplayMode != .disabled {
+                        Toggle(
+                            "Show Full URL",
+                            isOn: Binding(
+                                get: { tappableLinksDisplayMode != .compact },
+                                set: { tappableLinksDisplayMode = $0 ? .large : .compact }
+                            )
+                        )
+                    }
+                }
             }
         }
         .navigationTitle("Links")

--- a/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct LinkSettingsView: View {
     @Setting(\.openLinksInBrowser) var openLinksInBrowser
     @Setting(\.openLinksInReaderMode) var openLinksInReaderMode
+    @Setting(\.showTappableLinks) var showTappableLinks
     
     var body: some View {
         Form {
@@ -27,6 +28,10 @@ struct LinkSettingsView: View {
                     .disabled(openLinksInBrowser)
             } footer: {
                 Text("Automatically enable Reader for supported webpages. You can only enable this when using the in-app browser.")
+            }
+            
+            Section {
+                Toggle("Show Tappable Links", isOn: $showTappableLinks)
             }
         }
         .navigationTitle("Links")

--- a/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
@@ -43,23 +43,17 @@ struct LinkSettingsView: View {
                         }
                     )
                 )
-                if compactComments {
+                if tappableLinksDisplayMode != .disabled {
                     Picker("Show Full URL", selection: $tappableLinksDisplayMode) {
+                        Text("Automatic").tag(TappableLinksDisplayMode.contextual)
                         Text("Always").tag(TappableLinksDisplayMode.large)
                         Text("Never").tag(TappableLinksDisplayMode.compact)
-                        Text("Never in Comments").tag(TappableLinksDisplayMode.contextual)
                     }
                     .pickerStyle(.menu)
-                } else {
-                    if tappableLinksDisplayMode != .disabled {
-                        Toggle(
-                            "Show Full URL",
-                            isOn: Binding(
-                                get: { tappableLinksDisplayMode != .compact },
-                                set: { tappableLinksDisplayMode = $0 ? .large : .compact }
-                            )
-                        )
-                    }
+                }
+            } footer: {
+                if tappableLinksDisplayMode != .disabled {
+                    Text("If set to \"Automatic\", the full URL will be hidden in compact comments.")
                 }
             }
         }

--- a/Mlem/App/Views/Shared/CommentBodyView.swift
+++ b/Mlem/App/Views/Shared/CommentBodyView.swift
@@ -24,7 +24,7 @@ struct CommentBodyView: View {
                 .italic()
                 .foregroundStyle(palette.secondary)
         } else {
-            Markdown(comment.content, configuration: .default)
+            MarkdownWithLinks(comment.content)
         }
     }
 }

--- a/Mlem/App/Views/Shared/CommentBodyView.swift
+++ b/Mlem/App/Views/Shared/CommentBodyView.swift
@@ -12,6 +12,8 @@ import SwiftUI
 struct CommentBodyView: View {
     @Environment(Palette.self) var palette
     
+    @Setting(\.compactComments) var compactComments
+    
     let comment: any Comment
     
     var body: some View {
@@ -24,7 +26,7 @@ struct CommentBodyView: View {
                 .italic()
                 .foregroundStyle(palette.secondary)
         } else {
-            MarkdownWithLinks(comment.content)
+            MarkdownWithLinkList(comment.content, showLinkCaptions: !compactComments)
         }
     }
 }

--- a/Mlem/App/Views/Shared/MarkdownWithLinkList.swift
+++ b/Mlem/App/Views/Shared/MarkdownWithLinkList.swift
@@ -1,5 +1,5 @@
 //
-//  MarkdownWithLinks.swift
+//  MarkdownWithLinkList.swift
 //  Mlem
 //
 //  Created by Sjmarf on 12/10/2024.
@@ -8,11 +8,11 @@
 import LemmyMarkdownUI
 import SwiftUI
 
-struct MarkdownWithLinks: View {
+struct MarkdownWithLinkList: View {
     @Environment(Palette.self) var palette
     @Environment(\.openURL) var openURL
     
-    @Setting(\.showTappableLinks) var showTappableLinks
+    @Setting(\.tappableLinksDisplayMode) var tappableLinksDisplayMode
     
     let blocks: [BlockNode]
     let showLinkCaptions: Bool
@@ -30,8 +30,11 @@ struct MarkdownWithLinks: View {
     var body: some View {
         VStack(spacing: Constants.main.standardSpacing) {
             Markdown(blocks, configuration: .default)
-            if showTappableLinks {
-                ForEach(Array(blocks.links.enumerated()), id: \.offset) { _, link in
+            if tappableLinksDisplayMode != .disabled {
+                ForEach(
+                    Array(blocks.links.filter { !$0.insideSpoiler }.enumerated()),
+                    id: \.offset
+                ) { _, link in
                     linkView(link)
                 }
             }
@@ -46,7 +49,7 @@ struct MarkdownWithLinks: View {
                 .font(.subheadline)
                 .fontWeight(.semibold)
 
-            if showLinkCaptions {
+            if tappableLinksDisplayMode == .large || tappableLinksDisplayMode == .contextual && showLinkCaptions {
                 Text(data.url.absoluteURL.description)
                     .font(.footnote)
                     .lineLimit(1)
@@ -54,8 +57,8 @@ struct MarkdownWithLinks: View {
         }
         .foregroundStyle(palette.secondary)
         .padding(Constants.main.standardSpacing)
-        // TODO: before merge: Add OLED palette border
         .background(palette.tertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu {
             Button("Open", systemImage: Icons.browser) {
@@ -83,4 +86,8 @@ private extension LinkData {
         }
         return literal
     }
+}
+
+enum TappableLinksDisplayMode: String, Codable, CaseIterable {
+    case disabled, large, compact, contextual
 }

--- a/Mlem/App/Views/Shared/MarkdownWithLinks.swift
+++ b/Mlem/App/Views/Shared/MarkdownWithLinks.swift
@@ -12,6 +12,8 @@ struct MarkdownWithLinks: View {
     @Environment(Palette.self) var palette
     @Environment(\.openURL) var openURL
     
+    @Setting(\.showTappableLinks) var showTappableLinks
+    
     let blocks: [BlockNode]
     let showLinkCaptions: Bool
     
@@ -28,8 +30,10 @@ struct MarkdownWithLinks: View {
     var body: some View {
         VStack(spacing: Constants.main.standardSpacing) {
             Markdown(blocks, configuration: .default)
-            ForEach(Array(blocks.links.enumerated()), id: \.offset) { _, link in
-                linkView(link)
+            if showTappableLinks {
+                ForEach(Array(blocks.links.enumerated()), id: \.offset) { _, link in
+                    linkView(link)
+                }
             }
         }
     }

--- a/Mlem/App/Views/Shared/MarkdownWithLinks.swift
+++ b/Mlem/App/Views/Shared/MarkdownWithLinks.swift
@@ -1,0 +1,82 @@
+//
+//  MarkdownWithLinks.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/10/2024.
+//
+
+import LemmyMarkdownUI
+import SwiftUI
+
+struct MarkdownWithLinks: View {
+    @Environment(Palette.self) var palette
+    @Environment(\.openURL) var openURL
+    
+    let blocks: [BlockNode]
+    let showLinkCaptions: Bool
+    
+    init(_ blocks: [BlockNode], showLinkCaptions: Bool = true) {
+        self.blocks = blocks
+        self.showLinkCaptions = showLinkCaptions
+    }
+    
+    init(_ markdown: String, showLinkCaptions: Bool = true) {
+        self.blocks = .init(markdown)
+        self.showLinkCaptions = showLinkCaptions
+    }
+    
+    var body: some View {
+        VStack(spacing: Constants.main.standardSpacing) {
+            Markdown(blocks, configuration: .default)
+            ForEach(Array(blocks.links.enumerated()), id: \.offset) { _, link in
+                linkView(link)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    func linkView(_ data: LinkData) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(data.stringTitle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            if showLinkCaptions {
+                Text(data.url.absoluteURL.description)
+                    .font(.footnote)
+                    .lineLimit(1)
+            }
+        }
+        .foregroundStyle(palette.secondary)
+        .padding(Constants.main.standardSpacing)
+        // TODO: before merge: Add OLED palette border
+        .background(palette.tertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+        .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
+        .contextMenu {
+            Button("Open", systemImage: Icons.browser) {
+                openURL(data.url)
+            }
+            Button("Copy", systemImage: Icons.copy) {
+                let pasteboard = UIPasteboard.general
+                pasteboard.url = data.url
+            }
+            ShareLink(item: data.url)
+        } preview: {
+            WebView(url: data.url)
+        }
+        .onTapGesture {
+            openURL(data.url)
+        }
+    }
+}
+
+private extension LinkData {
+    var stringTitle: String {
+        let literal = title.stringLiteral
+        if literal == url.absoluteString {
+            return url.host() ?? literal
+        }
+        return literal
+    }
+}

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -796,6 +796,9 @@
     "Never" : {
 
     },
+    "Never in Comments" : {
+
+    },
     "New" : {
 
     },
@@ -1120,6 +1123,9 @@
     "Show Details" : {
 
     },
+    "Show Full URL" : {
+
+    },
     "Show Mod Names in Modlog" : {
 
     },
@@ -1136,9 +1142,6 @@
 
     },
     "Show Sidebar on App Launch" : {
-
-    },
-    "Show Tappable Links" : {
 
     },
     "Show User Avatar" : {
@@ -1251,6 +1254,9 @@
 
     },
     "Tap to show slur filter regex." : {
+
+    },
+    "Tappable Links" : {
 
     },
     "Temporary" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1123,6 +1123,9 @@
     "Show Sidebar on App Launch" : {
 
     },
+    "Show Tappable Links" : {
+
+    },
     "Show User Avatar" : {
 
     },

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -186,6 +186,9 @@
     "Auto-Bypass Image Proxy" : {
 
     },
+    "Automatic" : {
+
+    },
     "Automatically enable Reader for supported webpages. You can only enable this when using the in-app browser." : {
 
     },
@@ -607,6 +610,9 @@
     "I think I've found the bottom!" : {
 
     },
+    "If set to \"Automatic\", the full URL will be hidden in compact comments." : {
+
+    },
     "Image" : {
 
     },
@@ -794,9 +800,6 @@
 
     },
     "Never" : {
-
-    },
-    "Never in Comments" : {
 
     },
     "New" : {


### PR DESCRIPTION
Added tappable links (closes #1072)

In v1 we had an option for compact links. Is that something we'd want to keep? Personally I think that's too complicated - the whole point of tappable links is that they're large enough to tap easily. Hiding the URL and making them smaller seems to defeat that purpose. A simple on/off toggle would be better imo.