### PR TITLE
Fix settings import

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsPage.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsPage.swift
@@ -33,22 +33,17 @@ struct ImportExportSettingsPage: View {
                 isPresented: $importingSettingsFile,
                 allowedContentTypes: [.json]
             ) { result in
-                var fileUrl: URL?
                 do {
-                    fileUrl = try result.get()
-                    if let fileUrl, fileUrl.startAccessingSecurityScopedResource() {
-                        let fileData = try Data(contentsOf: fileUrl, options: .mappedIfSafe)
-                        fileUrl.stopAccessingSecurityScopedResource()
-                        
+                    let fileUrl = try result.get()
+                    if let fileData = readSettings(from: fileUrl) {
                         let importedSettings = try JSONDecoder().decode(CodableSettings.self, from: fileData)
                         Settings.main.reinit(from: importedSettings)
                         ToastModel.main.add(.success("Imported Settings"))
                     } else {
-                        assertionFailure("Failed to access requested file")
+                        assertionFailure("Failed to import settings")
                         ToastModel.main.add(.failure("Failed to Import Settings"))
                     }
                 } catch {
-                    fileUrl?.stopAccessingSecurityScopedResource()
                     handleError(error)
                 }
             }
@@ -109,6 +104,24 @@ struct ImportExportSettingsPage: View {
                     }
                 }
             #endif
+        }
+    }
+    
+    func readSettings(from fileUrl: URL) -> Data? {
+        let accessing = fileUrl.startAccessingSecurityScopedResource()
+        
+        // ensure we relinquish access
+        defer {
+            if accessing {
+                fileUrl.stopAccessingSecurityScopedResource()
+            }
+        }
+        
+        do {
+            return try Data(contentsOf: fileUrl, options: .mappedIfSafe)
+        } catch {
+            handleError(error)
+            return nil
         }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsPage.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsPage.swift
@@ -34,10 +34,18 @@ struct ImportExportSettingsPage: View {
                 allowedContentTypes: [.json]
             ) { result in
                 do {
-                    let fileData = try Data(contentsOf: result.get(), options: .mappedIfSafe)
-                    let importedSettings = try JSONDecoder().decode(CodableSettings.self, from: fileData)
-                    Settings.main.reinit(from: importedSettings)
-                    ToastModel.main.add(.success("Imported Settings"))
+                    let fileUrl = try result.get()
+                    if fileUrl.startAccessingSecurityScopedResource() {
+                        let fileData = try Data(contentsOf: fileUrl, options: .mappedIfSafe)
+                        fileUrl.stopAccessingSecurityScopedResource()
+                        
+                        let importedSettings = try JSONDecoder().decode(CodableSettings.self, from: fileData)
+                        Settings.main.reinit(from: importedSettings)
+                        ToastModel.main.add(.success("Imported Settings"))
+                    } else {
+                        assertionFailure("Failed to access requested file")
+                        ToastModel.main.add(.failure("Failed to Import Settings"))
+                    }
                 } catch {
                     handleError(error)
                 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsPage.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsPage.swift
@@ -33,9 +33,10 @@ struct ImportExportSettingsPage: View {
                 isPresented: $importingSettingsFile,
                 allowedContentTypes: [.json]
             ) { result in
+                var fileUrl: URL?
                 do {
-                    let fileUrl = try result.get()
-                    if fileUrl.startAccessingSecurityScopedResource() {
+                    fileUrl = try result.get()
+                    if let fileUrl, fileUrl.startAccessingSecurityScopedResource() {
                         let fileData = try Data(contentsOf: fileUrl, options: .mappedIfSafe)
                         fileUrl.stopAccessingSecurityScopedResource()
                         
@@ -47,6 +48,7 @@ struct ImportExportSettingsPage: View {
                         ToastModel.main.add(.failure("Failed to Import Settings"))
                     }
                 } catch {
+                    fileUrl?.stopAccessingSecurityScopedResource()
                     handleError(error)
                 }
             }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -461,6 +461,9 @@
     "Failed to delete post!" : {
 
     },
+    "Failed to Import Settings" : {
+
+    },
     "Failed to lock post" : {
 
     },


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #1373 

# Pull Request Information

Fixes an issue where settings could not be imported unless created explicitly by Mlem

**Repro (on-device)**
- Export settings
- Duplicate the settings file
- Try to import the duplicated file
- Import fails: "the file couldn't be opened because you don't have permission"

**Resolution**
Properly request access as defined [in the docs](https://developer.apple.com/documentation/foundation/url/1779698-startaccessingsecurityscopedreso)
