### PR TITLE
Markdown Tweaks

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2764,7 +2764,7 @@
 			repositoryURL = "https://github.com/mlemgroup/LemmyMarkdownUI";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.7;
+				minimumVersion = 0.5.2;
 			};
 		};
 		0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/LemmyMarkdownUI",
       "state" : {
-        "revision" : "9b3b11ba95e3b4c262177956a81fb262fabb5da4",
-        "version" : "0.4.7"
+        "revision" : "b42b1e301194fd56a144cf199ab2b807a0413a97",
+        "version" : "0.5.2"
       }
     },
     {

--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -21,6 +21,7 @@ struct CodableSettings: Codable {
     var appearance_interfaceStyle: UIUserInterfaceStyle
     var appearance_palette: PaletteOption
     var appearance_showSettingsIcons: Bool
+    var markdown_wrapCodeBlockLines: Bool
     var behavior_biometricUnlock: Bool
     var behavior_confirmImageUploads: Bool
     var behavior_enableQuickSwipes: Bool
@@ -93,6 +94,7 @@ struct CodableSettings: Codable {
         self.appearance_interfaceStyle = try container.decodeIfPresent(UIUserInterfaceStyle.self, forKey: .appearance_interfaceStyle) ?? .unspecified
         self.appearance_palette = try container.decodeIfPresent(PaletteOption.self, forKey: .appearance_palette) ?? .standard
         self.appearance_showSettingsIcons = try container.decodeIfPresent(Bool.self, forKey: .appearance_showSettingsIcons) ?? true
+        self.markdown_wrapCodeBlockLines = try container.decodeIfPresent(Bool.self, forKey: .markdown_wrapCodeBlockLines) ?? true
         self.behavior_biometricUnlock = try container.decodeIfPresent(Bool.self, forKey: .behavior_biometricUnlock) ?? false
         self.behavior_confirmImageUploads = try container.decodeIfPresent(Bool.self, forKey: .behavior_confirmImageUploads) ?? true
         self.behavior_enableQuickSwipes = try container.decodeIfPresent(Bool.self, forKey: .behavior_enableQuickSwipes) ?? true
@@ -166,6 +168,7 @@ struct CodableSettings: Codable {
         self.appearance_interfaceStyle = settings.interfaceStyle
         self.appearance_palette = settings.colorPalette
         self.appearance_showSettingsIcons = true
+        self.markdown_wrapCodeBlockLines = settings.wrapCodeBlockLines
         self.behavior_biometricUnlock = false
         self.behavior_confirmImageUploads = true
         self.behavior_enableQuickSwipes = settings.quickSwipesEnabled

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -38,6 +38,8 @@ class Settings: ObservableObject {
     @AppStorage("appearance.interfaceStyle") var interfaceStyle: UIUserInterfaceStyle = .unspecified
     @AppStorage("appearance.palette") var colorPalette: PaletteOption = .standard
     
+    @AppStorage("markdown.wrapCodeBlockLines") var wrapCodeBlockLines: Bool = true
+    
     @AppStorage("dev.developerMode") var developerMode: Bool = false
     
     @AppStorage("safety.blurNsfw") var blurNsfw: NsfwBlurBehavior = .always
@@ -113,6 +115,7 @@ class Settings: ObservableObject {
         groupAccountSort = settings.accounts_grouped
         interfaceStyle = settings.appearance_interfaceStyle
         colorPalette = settings.appearance_palette
+        wrapCodeBlockLines = settings.markdown_wrapCodeBlockLines
         developerMode = settings.dev_developerMode
         blurNsfw = settings.safety_blurNsfw
         showNsfwCommunityWarning = settings.safety_enableNsfwCommunityWarning

--- a/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
@@ -10,36 +10,48 @@ import Nuke
 import SwiftUI
 
 extension MarkdownConfiguration {
-    static let defaultBlurred: Self = .init(
+    static var defaultBlurred: MarkdownConfiguration { .init(
         inlineImageLoader: loadInlineImage,
         imageBlockView: {
             imageView($0, shouldBlur: true)
         },
-        primaryColor: Palette.main.primary,
-        secondaryColor: Palette.main.secondary
-    )
-    
-    static let `default`: Self = .init(
-        inlineImageLoader: loadInlineImage,
-        imageBlockView: { imageView($0, shouldBlur: false) },
-        primaryColor: Palette.main.primary,
-        secondaryColor: Palette.main.secondary
-    )
-    
-    static let dimmed: Self = .init(
-        inlineImageLoader: { _ in },
-        imageBlockView: { imageView($0, shouldBlur: false) },
-        primaryColor: Palette.main.secondary,
-        secondaryColor: Palette.main.tertiary
-    )
-    
-    static let caption: Self = .init(
-        inlineImageLoader: { _ in },
-        imageBlockView: { imageView($0, shouldBlur: false) },
+        wrapCodeBlockLines: Settings.main.wrapCodeBlockLines,
         primaryColor: Palette.main.primary,
         secondaryColor: Palette.main.secondary,
-        font: .caption1
-    )
+        codeBackgroundColor: Palette.main.tertiaryGroupedBackground,
+        codeFontScaleFactor: 0.9
+    ) }
+    
+    static var `default`: MarkdownConfiguration { .init(
+        inlineImageLoader: loadInlineImage,
+        imageBlockView: { imageView($0, shouldBlur: false) },
+        wrapCodeBlockLines: Settings.main.wrapCodeBlockLines,
+        primaryColor: Palette.main.primary,
+        secondaryColor: Palette.main.secondary,
+        codeBackgroundColor: Palette.main.tertiaryGroupedBackground,
+        codeFontScaleFactor: 0.9
+    ) }
+    
+    static var dimmed: MarkdownConfiguration { .init(
+        inlineImageLoader: { _ in },
+        imageBlockView: { imageView($0, shouldBlur: false) },
+        wrapCodeBlockLines: Settings.main.wrapCodeBlockLines,
+        primaryColor: Palette.main.secondary,
+        secondaryColor: Palette.main.tertiary,
+        codeBackgroundColor: Palette.main.tertiaryGroupedBackground,
+        codeFontScaleFactor: 0.9
+    ) }
+    
+    static var caption: MarkdownConfiguration { .init(
+        inlineImageLoader: { _ in },
+        imageBlockView: { imageView($0, shouldBlur: false) },
+        wrapCodeBlockLines: Settings.main.wrapCodeBlockLines,
+        primaryColor: Palette.main.primary,
+        secondaryColor: Palette.main.secondary,
+        codeBackgroundColor: Palette.main.tertiaryGroupedBackground,
+        font: .caption1,
+        codeFontScaleFactor: 0.9
+    ) }
 }
 
 private func imageView(_ inlineImage: InlineImage, shouldBlur: Bool) -> AnyView {

--- a/Mlem/App/Utility/Extensions/[BlockNode]+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/[BlockNode]+Extensions.swift
@@ -63,8 +63,8 @@ extension [BlockNode] {
                     isProbableRuleList = true
                     continue loop
                 }
-            case .bulletedList(isTight: _, items: let items, truncatedRows: _),
-                 .numberedList(isTight: _, start: _, items: let items, truncatedRows: _):
+            case .bulletedList(isTight: _, items: let items),
+                 .numberedList(isTight: _, start: _, items: let items):
                 if isProbableRuleList {
                     output.append(contentsOf: items.map(\.blocks))
                 }

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -25,6 +25,7 @@ struct GeneralSettingsView: View {
     @Setting(\.defaultFeed) var defaultFeed
     @Setting(\.sidebarVisibleByDefault) var sidebarVisibleByDefault
     @Setting(\.hapticLevel) var hapticLevel
+    @Setting(\.wrapCodeBlockLines) var wrapCodeBlockLines
     
     var body: some View {
         Form {
@@ -72,6 +73,7 @@ struct GeneralSettingsView: View {
                         Text(item.label)
                     }
                 }
+                Toggle("Wrap Code Block Lines", isOn: $wrapCodeBlockLines)
             } header: {
                 Text("Behavior")
             }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1517,6 +1517,9 @@
     "What is Federation?" : {
 
     },
+    "Wrap Code Block Lines" : {
+
+    },
     "Year" : {
 
     },


### PR DESCRIPTION
- Made the code block font a little smaller
- Added a "wrap code block lines" setting under "General" (on by default)
- Fixed some bugs related to duplicate `ForEach` ids