### PR TITLE
show save icon in compact post

### DIFF
--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -64,6 +64,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
         case upvote
         case downvote
         case comment
+        case saved
         
         var appearance: MockReadoutAppearance {
             switch self {
@@ -72,6 +73,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             case .upvote: .init(icon: Icons.upvoteSquare, label: "9")
             case .downvote: .init(icon: Icons.downvoteSquare, label: "2")
             case .comment: .init(icon: Icons.replies, label: "1")
+            case .saved: .init(icon: Icons.save, label: "")
             }
         }
         

--- a/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
@@ -249,4 +249,14 @@ extension Interactable1Providing {
             valueColor: Palette.main.positive
         )
     }
+    
+    var savedReadout: Readout {
+        let isOn = saved_ ?? false
+        return .init(
+            id: "saved\(uid)",
+            label: nil,
+            icon: isOn ? Icons.saveFill : Icons.save,
+            color: isOn ? Palette.main.save : nil
+        )
+    }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -227,6 +227,7 @@ extension Post1Providing {
         case .upvote: upvoteReadout
         case .downvote: downvoteReadout
         case .comment: commentReadout
+        case .saved: savedReadout
         }
     }
     

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
@@ -73,7 +73,7 @@ struct CompactPostView: View {
                         .font(.caption)
                 }
                 
-                InfoStackView(post: post, readouts: [.created, .score, .comment], showColor: true)
+                InfoStackView(post: post, readouts: [.created, .score, .comment, post.saved_ ?? false ? .saved : nil], showColor: true)
             }
             .frame(maxWidth: .infinity)
             

--- a/Mlem/App/Views/Shared/InfoStackView.swift
+++ b/Mlem/App/Views/Shared/InfoStackView.swift
@@ -54,8 +54,11 @@ struct ReadoutView: View {
 }
 
 extension InfoStackView {
-    init(post: any Post1Providing, readouts: [PostBarConfiguration.ReadoutType], showColor: Bool) {
-        self.readouts = readouts.map { post.readout(type: $0) }
+    init(post: any Post1Providing, readouts: [PostBarConfiguration.ReadoutType?], showColor: Bool) {
+        self.readouts = readouts.compactMap {
+            if let readoutType = $0 { return post.readout(type: readoutType) }
+            return nil
+        }
         self.showColor = showColor
     }
     


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #1403 

# Pull Request Information

Adds saved status to compact post. We don't want to show the empty icon if not saved in compact mode, but we _do_ want it in larger modes if the user adds it to the info stack, so I've also updated the InfoStackView's post convenience init to accept `nil` array values.
