### PR TITLE
"Swipe anywhere to Navigate" setting

### DIFF
--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -80,6 +80,7 @@ struct CodableSettings: Codable {
     var subscriptions_instanceLocation: InstanceLocation
     var subscriptions_sort: SubscriptionListSort
     var navigation_sidebarVisibleByDefault: Bool
+    var navigation_swipeAnywhere: Bool
     
     // swiftlint:disable line_length function_body_length
     init(from decoder: any Decoder) throws {
@@ -153,6 +154,7 @@ struct CodableSettings: Codable {
         self.subscriptions_instanceLocation = try container.decodeIfPresent(InstanceLocation.self, forKey: .subscriptions_instanceLocation) ?? (UIDevice.isPad ? .bottom : .trailing)
         self.subscriptions_sort = try container.decodeIfPresent(SubscriptionListSort.self, forKey: .subscriptions_sort) ?? .alphabetical
         self.navigation_sidebarVisibleByDefault = try container.decodeIfPresent(Bool.self, forKey: .navigation_sidebarVisibleByDefault) ?? true
+        self.navigation_swipeAnywhere = try container.decodeIfPresent(Bool.self, forKey: .navigation_swipeAnywhere) ?? false
     }
 
     // swiftlint:enable line_length
@@ -227,6 +229,7 @@ struct CodableSettings: Codable {
         self.subscriptions_instanceLocation = settings.subscriptionInstanceLocation
         self.subscriptions_sort = settings.subscriptionSort
         self.navigation_sidebarVisibleByDefault = settings.sidebarVisibleByDefault
+        self.navigation_swipeAnywhere = settings.swipeAnywhereToNavigate
     }
     // swiftlint:enable function_body_length
 }

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -74,6 +74,7 @@ class Settings: ObservableObject {
     @AppStorage("tip.feedWelcomePrompt") var showFeedWelcomePrompt: Bool = true
     
     @AppStorage("navigation.sidebarVisibleByDefault") var sidebarVisibleByDefault: Bool = true
+    @AppStorage("navigation.swipeAnywhere") var swipeAnywhereToNavigate: Bool = false
     
     @AppStorage("menus.moderatorActionGrouping") var moderatorActionGrouping: ModeratorActionGrouping = .divider
     
@@ -136,5 +137,6 @@ class Settings: ObservableObject {
         bypassImageProxyShown = settings.status_bypassImageProxyShown
         autoBypassImageProxy = settings.privacy_autoBypassImageProxy
         sidebarVisibleByDefault = settings.navigation_sidebarVisibleByDefault
+        swipeAnywhereToNavigate = settings.navigation_swipeAnywhere
     }
 }

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/Quick Swipes/View+QuickSwipes.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/Quick Swipes/View+QuickSwipes.swift
@@ -54,17 +54,18 @@ struct QuickSwipeView: ViewModifier {
                         }
                 }
             }
-            .clipShape(RoundedRectangle(cornerRadius: config.behavior.cornerRadius)) // clip slidable card
+            .clipShape(.rect(cornerRadius: config.behavior.cornerRadius)) // clip slidable card
             .background(shadowBackground)
             .geometryGroup()
             .offset(x: dragPosition) // using dragPosition so we can apply withAnimation() to it
             .background(iconBackground)
             // disables links from highlighting when tapped
             .buttonStyle(.empty)
-            .clipShape(RoundedRectangle(cornerRadius: config.behavior.cornerRadius)) // clip entire view
+            .clipShape(.rect(cornerRadius: config.behavior.cornerRadius)) // clip entire view
             .popupAnchor(model: popupModel)
         } else {
             content
+                .clipShape(.rect(cornerRadius: config.behavior.cornerRadius)) // clip entire view
         }
     }
     

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -82,16 +82,9 @@ struct GeneralSettingsView: View {
             
             Section("Gestures") {
                 Toggle("Swipe Actions", isOn: $swipeActionsEnabled)
-                    .onChange(of: swipeActionsEnabled) {
-                        if swipeActionsEnabled {
-                            swipeAnywhereToNavigate = false
-                        }
-                    }
-                Toggle("Swipe Anywhere to Navigate", isOn: .init(
-                    get: { !swipeActionsEnabled && swipeAnywhereToNavigate },
-                    set: { swipeAnywhereToNavigate = $0 }
-                ))
-                .disabled(swipeActionsEnabled)
+                    .disabled(swipeAnywhereToNavigate)
+                Toggle("Swipe Anywhere to Navigate", isOn: $swipeAnywhereToNavigate)
+                    .disabled(swipeActionsEnabled)
             }
             
             NavigationLink("Import/Export Settings", destination: .settings(.importExportSettings))

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -83,10 +83,30 @@ struct GeneralSettingsView: View {
             }
             
             Section("Gestures") {
-                Toggle("Swipe Actions", isOn: $swipeActionsEnabled)
-                    .disabled(swipeAnywhereToNavigate)
-                Toggle("Swipe Anywhere to Navigate", isOn: $swipeAnywhereToNavigate)
-                    .disabled(swipeActionsEnabled)
+                Toggle(
+                    "Swipe Actions",
+                    isOn: .init(
+                        get: { swipeActionsEnabled },
+                        set: {
+                            swipeActionsEnabled = $0
+                            if $0 {
+                                swipeAnywhereToNavigate = false
+                            }
+                        }
+                    )
+                )
+                Toggle(
+                    "Swipe Anywhere to Navigate",
+                    isOn: .init(
+                        get: { swipeAnywhereToNavigate },
+                        set: {
+                            swipeAnywhereToNavigate = $0
+                            if $0 {
+                                swipeActionsEnabled = false
+                            }
+                        }
+                    )
+                )
             }
             
             NavigationLink("Import/Export Settings", destination: .settings(.importExportSettings))

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -18,7 +18,6 @@ struct GeneralSettingsView: View {
     
     // behavior
     @Setting(\.upvoteOnSave) var upvoteOnSave
-    @Setting(\.quickSwipesEnabled) var swipeActionsEnabled
     @Setting(\.jumpButton) var jumpButton
     @Setting(\.markReadOnScroll) var markReadOnScroll
     @Setting(\.autoplayMedia) var autoplayMedia
@@ -26,6 +25,10 @@ struct GeneralSettingsView: View {
     @Setting(\.sidebarVisibleByDefault) var sidebarVisibleByDefault
     @Setting(\.hapticLevel) var hapticLevel
     @Setting(\.wrapCodeBlockLines) var wrapCodeBlockLines
+    
+    // Gestures
+    @Setting(\.quickSwipesEnabled) var swipeActionsEnabled
+    @Setting(\.swipeAnywhereToNavigate) var swipeAnywhereToNavigate
     
     var body: some View {
         Form {
@@ -62,7 +65,6 @@ struct GeneralSettingsView: View {
                 }
                 Toggle("Mark Read on Scroll", isOn: $markReadOnScroll)
                 Toggle("Upvote on Save", isOn: $upvoteOnSave)
-                Toggle("Swipe Actions", isOn: $swipeActionsEnabled)
                 Picker("Jump Button", selection: $jumpButton) {
                     ForEach(CommentJumpButtonLocation.allCases, id: \.self) { item in
                         Text(item.label)
@@ -76,6 +78,20 @@ struct GeneralSettingsView: View {
                 Toggle("Wrap Code Block Lines", isOn: $wrapCodeBlockLines)
             } header: {
                 Text("Behavior")
+            }
+            
+            Section("Gestures") {
+                Toggle("Swipe Actions", isOn: $swipeActionsEnabled)
+                    .onChange(of: swipeActionsEnabled) {
+                        if swipeActionsEnabled {
+                            swipeAnywhereToNavigate = false
+                        }
+                    }
+                Toggle("Swipe Anywhere to Navigate", isOn: .init(
+                    get: { !swipeActionsEnabled && swipeAnywhereToNavigate },
+                    set: { swipeAnywhereToNavigate = $0 }
+                ))
+                .disabled(swipeActionsEnabled)
             }
             
             NavigationLink("Import/Export Settings", destination: .settings(.importExportSettings))

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
@@ -6,10 +6,14 @@
 //
 
 import SwiftUI
+import SwiftUIIntrospect
+import UIKit
 
 struct NavigationLayerView: View {
     @Bindable var layer: NavigationLayer
     let hasSheetModifiers: Bool
+    
+    private let fullWidthGestureRecognizerDelegate: FullWidthGestureRecognizerDelegate = .init()
     
     var body: some View {
         Group {
@@ -21,6 +25,22 @@ struct NavigationLayerView: View {
                             $0.view()
                                 .environment(\.isRootView, false)
                         }
+                }
+                .introspect(.navigationStack, on: .iOS(.v17, .v18)) { controller in
+                    // This is for the "Swipe anywhere to navigate" setting
+                    // https://stackoverflow.com/questions/20714595/extend-default-interactivepopgesturerecognizer-beyond-screen-edge
+                    guard
+                        let interactivePopGestureRecognizer = controller.interactivePopGestureRecognizer,
+                        let targets = interactivePopGestureRecognizer.value(forKey: "targets")
+                    else {
+                        return
+                    }
+                    
+                    let fullWidthBackGestureRecognizer = UIPanGestureRecognizer()
+                    fullWidthBackGestureRecognizer.setValue(targets, forKey: "targets")
+                    fullWidthGestureRecognizerDelegate.navigationController = controller
+                    fullWidthBackGestureRecognizer.delegate = fullWidthGestureRecognizerDelegate
+                    controller.view.addGestureRecognizer(fullWidthBackGestureRecognizer)
                 }
                
             } else {
@@ -87,5 +107,16 @@ private struct SharingViewController: UIViewControllerRepresentable {
         if isPresenting {
             uiViewController.present(content(), animated: true, completion: { isPresenting = false })
         }
+    }
+}
+
+private class FullWidthGestureRecognizerDelegate: NSObject, UIGestureRecognizerDelegate {
+    var navigationController: UINavigationController?
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        if !Settings.main.swipeAnywhereToNavigate { return false }
+        let isSystemSwipeToBackEnabled = navigationController?.interactivePopGestureRecognizer?.isEnabled == true
+        let isThereStackedViewControllers = (navigationController?.viewControllers.count ?? 0) > 1
+        return isSystemSwipeToBackEnabled && isThereStackedViewControllers
     }
 }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -596,6 +596,9 @@
     "General" : {
 
     },
+    "Gestures" : {
+
+    },
     "GitHub Repository" : {
 
     },
@@ -1318,6 +1321,9 @@
 
     },
     "Swipe Actions" : {
+
+    },
+    "Swipe Anywhere to Navigate" : {
 
     },
     "Switch Account" : {


### PR DESCRIPTION
If `General` -> `Swipe anywhere to Navigate` is enabled, you can swipe anywhere on the screen to go back rather than only at the edges.

Also fixed a bug in which feed post corners weren't clipped if Swipe Actions were turned off.

Closes #130 