### PR TITLE
Fix "about Mlem" theming and Form button hitboxes

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Settings/AboutMlemView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AboutMlemView.swift
@@ -22,18 +22,22 @@ struct AboutMlemView: View {
             Section {
                 Link(destination: URL(string: "https://mlem.group")!) {
                     FormChevron { Label("Website", systemImage: Icons.websiteIcon) }
+                        .foregroundStyle(palette.primary)
                 }
                 .tint(palette.colorfulAccent(2))
                 Link(destination: URL(string: "https://lemmy.ml/c/mlemapp")!) {
                     FormChevron { Label("Lemmy Community", systemImage: Icons.communityFill) }
+                        .foregroundStyle(palette.primary)
                 }
                 .tint(palette.colorfulAccent(3))
                 Link(destination: URL(string: "https://matrix.to/#/#mlemappspace:matrix.org")!) {
                     FormChevron { Label("Matrix Room", image: "matrix.logo") }
+                        .foregroundStyle(palette.primary)
                 }
                 .tint(.black) // non-palette because white tint turns this into white square
                 Link(destination: URL(string: "https://github.com/mlemgroup/mlem")!) {
                     FormChevron { Label("GitHub Repository", image: "github.logo") }
+                        .foregroundStyle(palette.primary)
                 }
                 .tint(.black) // non-palette because white tint turns this into white square
             }

--- a/Mlem/App/Views/Shared/Palette Components/Button.swift
+++ b/Mlem/App/Views/Shared/Palette Components/Button.swift
@@ -13,12 +13,16 @@ struct PaletteButton: ButtonStyle {
     @Environment(\.isEnabled) var isEnabled
     
     func makeBody(configuration: Configuration) -> some View {
-        if isEnabled {
-            configuration.label
-                .foregroundStyle(.tint)
-        } else {
-            configuration.label
-                .foregroundStyle(palette.secondary)
+        Group {
+            if isEnabled {
+                configuration.label
+                    .foregroundStyle(.tint)
+            } else {
+                configuration.label
+                    .foregroundStyle(palette.secondary)
+            }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(.rect)
     }
 }


### PR DESCRIPTION
Links in the "About Mlem" page were the wrong color, and buttons in a form didn't have a full-width `.contentShape`.