### PR TITLE
Don't wipe all accounts if keychain token cannot be found

### DIFF
--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -43,9 +43,7 @@ class UserAccount: Account, CommunityOrPersonStub {
         case id, username, storedNickname, instanceLink, siteVersion, avatarUrl, lastUsed, favorites, accountType
     }
     
-    enum DecodingError: Error {
-        case cannotModifyPathComponents, noTokenInKeychain
-    }
+    enum DecodingError: Error { case cannotModifyPathComponents }
     
     required init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
@@ -73,9 +71,11 @@ class UserAccount: Account, CommunityOrPersonStub {
         self.actorId = actorId
         
         // retrive token and initialize ApiClient
-        guard let token = Constants.main.keychain[getKeychainId(actorId: actorId)] ?? Constants.main.keychain[getKeychainId(id: id)] else {
-            throw DecodingError.noTokenInKeychain
-        }
+        // Fallback to "cannotRetrieveFromKeychain" if a token cannot be found,
+        // rather than throwing an error. This will cause Mlem to ask for the user's password again
+        let token = Constants.main.keychain[getKeychainId(actorId: actorId)]
+            ?? Constants.main.keychain[getKeychainId(id: id)]
+            ?? "cannotRetrieveFromKeychain"
         self.api = ApiClient.getApiClient(for: instanceLink, with: token)
     }
     


### PR DESCRIPTION
Previously if a token wasn't found in the keychain Mlem would reset the JSON account list file. Instead of resetting the JSON file, I've made it fallback to setting an arbitrary string as the token. This will cause Mlem to pick up on the token being invalid when it tries to perform an authenticated request, and show the re-auth sheet.

In normal circumstances, a token should always be present in the keychain. However, in #1416 an account's token is consistently missing from the keychain. I haven't been able to reproduce this exact issue myself yet. 