### PR TITLE
Show post context for comments in feeds

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		037331A42C9CB12D00C826E1 /* EnvironmentValues+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037331A32C9CB12D00C826E1 /* EnvironmentValues+Extensions.swift */; };
 		037386472BDAFE81007492B5 /* LemmyMarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 037386462BDAFE81007492B5 /* LemmyMarkdownUI */; };
 		037658DF2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037658DE2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift */; };
+		037DE07A2CE108D9007F7B92 /* FooterLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037DE0792CE108D9007F7B92 /* FooterLinkView.swift */; };
 		038028D32CAB3D2D0091A8A2 /* ShareActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038028D22CAB3D2D0091A8A2 /* ShareActivity.swift */; };
 		038028D52CAB479D0091A8A2 /* PostEditorView+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038028D42CAB479D0091A8A2 /* PostEditorView+Views.swift */; };
 		038028D82CACAB960091A8A2 /* ModeratorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038028D72CACAB960091A8A2 /* ModeratorSettingsView.swift */; };
@@ -537,6 +538,7 @@
 		036CC3AE2B8145C30098B6A1 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		037331A32C9CB12D00C826E1 /* EnvironmentValues+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+Extensions.swift"; sourceTree = "<group>"; };
 		037658DE2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Community1Providing+Extensions.swift"; sourceTree = "<group>"; };
+		037DE0792CE108D9007F7B92 /* FooterLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FooterLinkView.swift; sourceTree = "<group>"; };
 		038028D22CAB3D2D0091A8A2 /* ShareActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareActivity.swift; sourceTree = "<group>"; };
 		038028D42CAB479D0091A8A2 /* PostEditorView+Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+Views.swift"; sourceTree = "<group>"; };
 		038028D72CACAB960091A8A2 /* ModeratorSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeratorSettingsView.swift; sourceTree = "<group>"; };
@@ -1508,6 +1510,7 @@
 				03AF91DE2C1B243D00E56644 /* ZoomableContainer.swift */,
 				CD635E1A2C94DACD00864F75 /* BypassProxyWarningSheet.swift */,
 				03AB484E2CBAE33500567FF9 /* MarkdownWithLinkList.swift */,
+				037DE0792CE108D9007F7B92 /* FooterLinkView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -2350,6 +2353,7 @@
 				034B94812C09306D00039AF4 /* CommunityOrPersonStub+Extensions.swift in Sources */,
 				0320B6692C93506300D38548 /* SearchView+Logic.swift in Sources */,
 				039F58932C7B616600C61658 /* CommentSettingsView.swift in Sources */,
+				037DE07A2CE108D9007F7B92 /* FooterLinkView.swift in Sources */,
 				03D3A1E52BB8B7A3009DE55E /* ActionType.swift in Sources */,
 				0320B6542C8B65EB00D38548 /* Captcha+Extensions.swift in Sources */,
 				0397D4A42C6FBC04002C6CDC /* ActionAppearance+StaticValues.swift in Sources */,

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -83,7 +83,9 @@ struct CommentView: View {
                     CommentBodyView(comment: comment)
                         .padding(.trailing, 2)
                     if inFeed, let post = comment.post_ {
-                        FooterLinkView(title: post.title, subtitle: comment.community_?.fullNameWithPrefix)
+                        NavigationLink(.post(post)) {
+                            FooterLinkView(title: post.title, subtitle: comment.community_?.fullNameWithPrefix)
+                        }
                     }
                     if !compactComments {
                         InteractionBarView(

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -82,6 +82,9 @@ struct CommentView: View {
                 if !collapsed {
                     CommentBodyView(comment: comment)
                         .padding(.trailing, 2)
+                    if inFeed, let post = comment.post_ {
+                        FooterLinkView(title: post.title, subtitle: comment.community_?.fullNameWithPrefix)
+                    }
                     if !compactComments {
                         InteractionBarView(
                             comment: comment,

--- a/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
@@ -145,6 +145,7 @@ class CommentTreeTracker: Hashable {
         }
     }
     
+    @MainActor
     private func buildCommentTree(comments newComments: [Comment2]) async {
         var output: [CommentWrapper] = []
         var commentsKeyedById: [Int: CommentWrapper] = [:]

--- a/Mlem/App/Views/Shared/FooterLinkView.swift
+++ b/Mlem/App/Views/Shared/FooterLinkView.swift
@@ -1,0 +1,35 @@
+//
+//  MarkdownFooterLinkView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2024-11-10.
+//
+
+import SwiftUI
+
+struct FooterLinkView: View {
+    @Environment(Palette.self) var palette
+    
+    let title: String
+    let subtitle: String?
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            if let subtitle {
+                Text(subtitle)
+                    .font(.footnote)
+                    .lineLimit(1)
+            }
+        }
+        .foregroundStyle(palette.secondary)
+        .padding(Constants.main.standardSpacing)
+        .background(palette.tertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
+        .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
+    }
+}

--- a/Mlem/App/Views/Shared/MarkdownWithLinkList.swift
+++ b/Mlem/App/Views/Shared/MarkdownWithLinkList.swift
@@ -27,6 +27,10 @@ struct MarkdownWithLinkList: View {
         self.showLinkCaptions = showLinkCaptions
     }
     
+    var showSubtitle: Bool {
+        tappableLinksDisplayMode == .large || tappableLinksDisplayMode == .contextual && showLinkCaptions
+    }
+    
     var body: some View {
         VStack(spacing: Constants.main.standardSpacing) {
             Markdown(blocks, configuration: .default)
@@ -43,23 +47,10 @@ struct MarkdownWithLinkList: View {
     
     @ViewBuilder
     func linkView(_ data: LinkData) -> some View {
-        VStack(alignment: .leading, spacing: 5) {
-            Text(data.stringTitle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .font(.subheadline)
-                .fontWeight(.semibold)
-
-            if tappableLinksDisplayMode == .large || tappableLinksDisplayMode == .contextual && showLinkCaptions {
-                Text(data.url.absoluteURL.description)
-                    .font(.footnote)
-                    .lineLimit(1)
-            }
-        }
-        .foregroundStyle(palette.secondary)
-        .padding(Constants.main.standardSpacing)
-        .background(palette.tertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
-        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
-        .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
+        FooterLinkView(
+            title: data.stringTitle,
+            subtitle: showSubtitle ? data.url.absoluteURL.description : nil
+        )
         .contextMenu {
             Button("Open", systemImage: Icons.browser) {
                 openURL(data.url)

--- a/Mlem/App/Views/Shared/MessageView.swift
+++ b/Mlem/App/Views/Shared/MessageView.swift
@@ -31,7 +31,7 @@ struct MessageView: View {
                     .italic()
                     .foregroundStyle(palette.secondary)
             } else {
-                Markdown(message.content, configuration: .default)
+                MarkdownWithLinkList(message.content)
             }
             Group {
                 if message.isOwnMessage {

--- a/Mlem/App/Views/Shared/ReplyView.swift
+++ b/Mlem/App/Views/Shared/ReplyView.swift
@@ -27,7 +27,8 @@ struct ReplyView: View {
                     .frame(height: 10)
             }
           
-            Markdown(reply.comment.content, configuration: .default)
+            MarkdownWithLinkList(reply.comment.content)
+            FooterLinkView(title: reply.post.title, subtitle: reply.community.fullNameWithPrefix)
             InteractionBarView(
                 reply: reply,
                 configuration: InteractionBarTracker.main.replyInteractionBar

--- a/Mlem/App/Views/Shared/ReplyView.swift
+++ b/Mlem/App/Views/Shared/ReplyView.swift
@@ -28,7 +28,9 @@ struct ReplyView: View {
             }
           
             MarkdownWithLinkList(reply.comment.content)
-            FooterLinkView(title: reply.post.title, subtitle: reply.community.fullNameWithPrefix)
+            NavigationLink(.post(reply.post)) {
+                FooterLinkView(title: reply.post.title, subtitle: reply.community.fullNameWithPrefix)
+            }
             InteractionBarView(
                 reply: reply,
                 configuration: InteractionBarTracker.main.replyInteractionBar


### PR DESCRIPTION
Closes #1390

<img src="https://github.com/user-attachments/assets/797ae884-9b60-492d-8fb9-f8c645f8aa6c" width=50%>

Do you think tapping the link should open the `CommentPage` (current behavior) or the parent `PostPage`? I'm not sure.

