### PR TITLE
Actor Feed Loaders

### DIFF
--- a/.github/workflows/ci_build_16.yml
+++ b/.github/workflows/ci_build_16.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   Build:
     permissions: write-all
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/ci_build_16.yml
+++ b/.github/workflows/ci_build_16.yml
@@ -23,5 +23,5 @@ jobs:
       uses: "./.github/actions/ci_xcodebuild"
       with:
         xcode_version: "16.0"
-        xcodebuild_destination: "platform=iOS Simulator,name=iPhone 15,OS=18.0"
+        xcodebuild_destination: "platform=iOS Simulator,name=iPhone 16,OS=18.1"
         xcodebuild_action: "build"

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -128,8 +128,8 @@
 		037331A42C9CB12D00C826E1 /* EnvironmentValues+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037331A32C9CB12D00C826E1 /* EnvironmentValues+Extensions.swift */; };
 		037386472BDAFE81007492B5 /* LemmyMarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 037386462BDAFE81007492B5 /* LemmyMarkdownUI */; };
 		037658DF2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037658DE2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift */; };
-		037DE07A2CE108D9007F7B92 /* FooterLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037DE0792CE108D9007F7B92 /* FooterLinkView.swift */; };
 		037DE0752CE023E3007F7B92 /* BlockListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037DE0742CE023E3007F7B92 /* BlockListView.swift */; };
+		037DE07A2CE108D9007F7B92 /* FooterLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037DE0792CE108D9007F7B92 /* FooterLinkView.swift */; };
 		038028D32CAB3D2D0091A8A2 /* ShareActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038028D22CAB3D2D0091A8A2 /* ShareActivity.swift */; };
 		038028D52CAB479D0091A8A2 /* PostEditorView+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038028D42CAB479D0091A8A2 /* PostEditorView+Views.swift */; };
 		038028D82CACAB960091A8A2 /* ModeratorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038028D72CACAB960091A8A2 /* ModeratorSettingsView.swift */; };
@@ -539,8 +539,8 @@
 		036CC3AE2B8145C30098B6A1 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		037331A32C9CB12D00C826E1 /* EnvironmentValues+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+Extensions.swift"; sourceTree = "<group>"; };
 		037658DE2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Community1Providing+Extensions.swift"; sourceTree = "<group>"; };
-		037DE0792CE108D9007F7B92 /* FooterLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FooterLinkView.swift; sourceTree = "<group>"; };
 		037DE0742CE023E3007F7B92 /* BlockListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockListView.swift; sourceTree = "<group>"; };
+		037DE0792CE108D9007F7B92 /* FooterLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FooterLinkView.swift; sourceTree = "<group>"; };
 		038028D22CAB3D2D0091A8A2 /* ShareActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareActivity.swift; sourceTree = "<group>"; };
 		038028D42CAB479D0091A8A2 /* PostEditorView+Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+Views.swift"; sourceTree = "<group>"; };
 		038028D72CACAB960091A8A2 /* ModeratorSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeratorSettingsView.swift; sourceTree = "<group>"; };
@@ -2883,8 +2883,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
 			requirement = {
-				branch = "eric/actor-feed-loaders";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.47.0;
 			};
 		};
 		CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -201,12 +201,12 @@
 		03AFD0E52C3C14D50054B8AD /* InstanceStubProviding+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFD0E42C3C14D50054B8AD /* InstanceStubProviding+Extensions.swift */; };
 		03B04FC02C5FC32300824128 /* SimpleAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B04FBF2C5FC32300824128 /* SimpleAvatarView.swift */; };
 		03B0EB6F2C87827A00F79FDF /* ExpandedPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B0EB6E2C87827A00F79FDF /* ExpandedPostView.swift */; };
-		03B25B3B2CC44FFF00EB6DF5 /* UploadConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B3A2CC44FFF00EB6DF5 /* UploadConfirmationView.swift */; };
 		03B25B2F2CC43F8600EB6DF5 /* InstanceSafetyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B2E2CC43F8600EB6DF5 /* InstanceSafetyView.swift */; };
 		03B25B312CC4403500EB6DF5 /* Fediseer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B302CC4403500EB6DF5 /* Fediseer.swift */; };
 		03B25B332CC440A600EB6DF5 /* FediseerOpinionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B322CC440A600EB6DF5 /* FediseerOpinionView.swift */; };
 		03B25B352CC4446400EB6DF5 /* FediseerOpinionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B342CC4446400EB6DF5 /* FediseerOpinionListView.swift */; };
 		03B25B372CC4478600EB6DF5 /* FediseerInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B362CC4478600EB6DF5 /* FediseerInfoView.swift */; };
+		03B25B3B2CC44FFF00EB6DF5 /* UploadConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B3A2CC44FFF00EB6DF5 /* UploadConfirmationView.swift */; };
 		03B431B22C44409D001A1EB5 /* CommentEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B12C44409D001A1EB5 /* CommentEditorView.swift */; };
 		03B431B42C4481C3001A1EB5 /* MarkdownTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B32C4481C3001A1EB5 /* MarkdownTextEditor.swift */; };
 		03B431B62C454D49001A1EB5 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */; };
@@ -341,12 +341,12 @@
 		CD9CFA302C2E22F600739BBC /* FeedDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9CFA2F2C2E22F600739BBC /* FeedDescription.swift */; };
 		CD9CFA372C306DAB00739BBC /* PostGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9CFA362C306DAB00739BBC /* PostGridView.swift */; };
 		CD9D243D2CC1DF59006E5F3F /* AccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9D243C2CC1DF55006E5F3F /* AccountType.swift */; };
-		CD9D24402CC1E38C006E5F3F /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD9D243F2CC1E38C006E5F3F /* MlemMiddleware */; };
 		CDA683F82C77E577000C4486 /* NsfwBlurBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA683F72C77E577000C4486 /* NsfwBlurBehavior.swift */; };
 		CDAA02DB2C810DB200D75633 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02DA2C810DB200D75633 /* Calendar+Extensions.swift */; };
 		CDAA02DD2C81792500D75633 /* SolarizedPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02DC2C81792500D75633 /* SolarizedPalette.swift */; };
 		CDAA02E12C817AAB00D75633 /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02E02C817AAB00D75633 /* Color+Extensions.swift */; };
 		CDAA02E32C821C9100D75633 /* Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02E22C821C9100D75633 /* Divider.swift */; };
+		CDB09F2B2CCE99D300581E88 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CDB09F2A2CCE99D300581E88 /* MlemMiddleware */; };
 		CDB2EC7D2BFADAB300DBC0EF /* CompactPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC7C2BFADAB300DBC0EF /* CompactPostView.swift */; };
 		CDB2EC7F2BFADACC00DBC0EF /* HeadlinePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC7E2BFADACC00DBC0EF /* HeadlinePostView.swift */; };
 		CDB2EC812BFADADF00DBC0EF /* LargePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC802BFADADF00DBC0EF /* LargePostView.swift */; };
@@ -606,12 +606,12 @@
 		03AFD0E42C3C14D50054B8AD /* InstanceStubProviding+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InstanceStubProviding+Extensions.swift"; sourceTree = "<group>"; };
 		03B04FBF2C5FC32300824128 /* SimpleAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleAvatarView.swift; sourceTree = "<group>"; };
 		03B0EB6E2C87827A00F79FDF /* ExpandedPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedPostView.swift; sourceTree = "<group>"; };
-		03B25B3A2CC44FFF00EB6DF5 /* UploadConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadConfirmationView.swift; sourceTree = "<group>"; };
 		03B25B2E2CC43F8600EB6DF5 /* InstanceSafetyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceSafetyView.swift; sourceTree = "<group>"; };
 		03B25B302CC4403500EB6DF5 /* Fediseer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fediseer.swift; sourceTree = "<group>"; };
 		03B25B322CC440A600EB6DF5 /* FediseerOpinionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FediseerOpinionView.swift; sourceTree = "<group>"; };
 		03B25B342CC4446400EB6DF5 /* FediseerOpinionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FediseerOpinionListView.swift; sourceTree = "<group>"; };
 		03B25B362CC4478600EB6DF5 /* FediseerInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FediseerInfoView.swift; sourceTree = "<group>"; };
+		03B25B3A2CC44FFF00EB6DF5 /* UploadConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadConfirmationView.swift; sourceTree = "<group>"; };
 		03B431B12C44409D001A1EB5 /* CommentEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentEditorView.swift; sourceTree = "<group>"; };
 		03B431B32C4481C3001A1EB5 /* MarkdownTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextEditor.swift; sourceTree = "<group>"; };
 		03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
@@ -810,7 +810,7 @@
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CDE4AC452CA370E000981010 /* SDWebImageSwiftUI in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
-				CD9D24402CC1E38C006E5F3F /* MlemMiddleware in Frameworks */,
+				CDB09F2B2CCE99D300581E88 /* MlemMiddleware in Frameworks */,
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
@@ -1905,7 +1905,7 @@
 				CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */,
 				CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */,
 				CD64A9192CA37E8D007CA7E6 /* Gifu */,
-				CD9D243F2CC1E38C006E5F3F /* MlemMiddleware */,
+				CDB09F2A2CCE99D300581E88 /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -1993,7 +1993,7 @@
 				CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
 				CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */,
-				CD9D243E2CC1E380006E5F3F /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
+				CDB09F292CCE99C400581E88 /* XCLocalSwiftPackageReference "../MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -2802,6 +2802,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		CDB09F292CCE99C400581E88 /* XCLocalSwiftPackageReference "../MlemMiddleware" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../MlemMiddleware;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -2865,14 +2872,6 @@
 			requirement = {
 				branch = master;
 				kind = branch;
-			};
-		};
-		CD9D243E2CC1E380006E5F3F /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.45.0;
 			};
 		};
 		CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
@@ -2949,9 +2948,9 @@
 			package = CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */;
 			productName = Gifu;
 		};
-		CD9D243F2CC1E38C006E5F3F /* MlemMiddleware */ = {
+		CDB09F2A2CCE99D300581E88 /* MlemMiddleware */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = CD9D243E2CC1E380006E5F3F /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
+			package = CDB09F292CCE99C400581E88 /* XCLocalSwiftPackageReference "../MlemMiddleware" */;
 			productName = MlemMiddleware;
 		};
 		CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -316,6 +316,7 @@
 		CD4E386D2C836F8C009B24F2 /* UIUserInterfaceStyle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4E386C2C836F8C009B24F2 /* UIUserInterfaceStyle+Extensions.swift */; };
 		CD4ED8472BF110FA00EFA0A2 /* TabReselectTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED8462BF110FA00EFA0A2 /* TabReselectTracker.swift */; };
 		CD4ED84A2BF1113800EFA0A2 /* View+TabReselectConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4ED8492BF1113800EFA0A2 /* View+TabReselectConsumer.swift */; };
+		CD555F822CE56CBE00E763E7 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD555F812CE56CBE00E763E7 /* MlemMiddleware */; };
 		CD5581DE2C7B8B820043FAC3 /* ImageFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5581DD2C7B8B820043FAC3 /* ImageFunctions.swift */; };
 		CD635E1B2C94DACD00864F75 /* BypassProxyWarningSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD635E1A2C94DACD00864F75 /* BypassProxyWarningSheet.swift */; };
 		CD64A91A2CA37E8D007CA7E6 /* Gifu in Frameworks */ = {isa = PBXBuildFile; productRef = CD64A9192CA37E8D007CA7E6 /* Gifu */; };
@@ -346,7 +347,6 @@
 		CDAA02DD2C81792500D75633 /* SolarizedPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02DC2C81792500D75633 /* SolarizedPalette.swift */; };
 		CDAA02E12C817AAB00D75633 /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02E02C817AAB00D75633 /* Color+Extensions.swift */; };
 		CDAA02E32C821C9100D75633 /* Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02E22C821C9100D75633 /* Divider.swift */; };
-		CDB09F2B2CCE99D300581E88 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CDB09F2A2CCE99D300581E88 /* MlemMiddleware */; };
 		CDB2EC7D2BFADAB300DBC0EF /* CompactPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC7C2BFADAB300DBC0EF /* CompactPostView.swift */; };
 		CDB2EC7F2BFADACC00DBC0EF /* HeadlinePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC7E2BFADACC00DBC0EF /* HeadlinePostView.swift */; };
 		CDB2EC812BFADADF00DBC0EF /* LargePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC802BFADADF00DBC0EF /* LargePostView.swift */; };
@@ -810,7 +810,7 @@
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CDE4AC452CA370E000981010 /* SDWebImageSwiftUI in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
-				CDB09F2B2CCE99D300581E88 /* MlemMiddleware in Frameworks */,
+				CD555F822CE56CBE00E763E7 /* MlemMiddleware in Frameworks */,
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
@@ -1905,7 +1905,7 @@
 				CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */,
 				CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */,
 				CD64A9192CA37E8D007CA7E6 /* Gifu */,
-				CDB09F2A2CCE99D300581E88 /* MlemMiddleware */,
+				CD555F812CE56CBE00E763E7 /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -1993,7 +1993,7 @@
 				CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
 				CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */,
-				CDB09F292CCE99C400581E88 /* XCLocalSwiftPackageReference "../MlemMiddleware" */,
+				CD555F802CE56CB200E763E7 /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -2802,13 +2802,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		CDB09F292CCE99C400581E88 /* XCLocalSwiftPackageReference "../MlemMiddleware" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../MlemMiddleware;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -2864,6 +2857,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.0.8;
+			};
+		};
+		CD555F802CE56CB200E763E7 /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
+			requirement = {
+				branch = "eric/actor-feed-loaders";
+				kind = branch;
 			};
 		};
 		CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */ = {
@@ -2943,15 +2944,15 @@
 			package = CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */;
 			productName = Semaphore;
 		};
+		CD555F812CE56CBE00E763E7 /* MlemMiddleware */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD555F802CE56CB200E763E7 /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
+			productName = MlemMiddleware;
+		};
 		CD64A9192CA37E8D007CA7E6 /* Gifu */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */;
 			productName = Gifu;
-		};
-		CDB09F2A2CCE99D300581E88 /* MlemMiddleware */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CDB09F292CCE99C400581E88 /* XCLocalSwiftPackageReference "../MlemMiddleware" */;
-			productName = MlemMiddleware;
 		};
 		CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -52,7 +52,7 @@
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
         "branch" : "eric/actor-feed-loaders",
-        "revision" : "7ca87aa05093420df3ad4aba509f5072ba749198"
+        "revision" : "e2c37cd61df89617a6e759308b7311605ccf9621"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
-        "branch" : "eric/actor-feed-loaders",
-        "revision" : "c62070aa7e65342005dc5d62503f5a665a493acd"
+        "revision" : "4ba5f4702c33954ff46fc0275e412e078b816fbd",
+        "version" : "0.47.0"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dbb3f4a3491e755efbaa3d420a53d720cf7832bc30be35000cee5f9dbf3d87fa",
+  "originHash" : "741161cefb0674ba95c43c14afc8238177d21974f95f4e66fe76b72259069ef1",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "b2b1d20a90b14d11f6ef4241da6b81c1d3f171e4",
         "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "mlemmiddleware",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mlemgroup/MlemMiddleware",
+      "state" : {
+        "branch" : "eric/actor-feed-loaders",
+        "revision" : "1f6808f5524962e2ea9bc53ca519d726ccb7b649"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e91c2cec61691543665fad5843f30eafc5288bb40fc3a60d50c7d7e9194f3135",
+  "originHash" : "7fe183dcbb4acc6bb34fdc0842377273418aa1caa6335cd2926051ef29f2a665",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -44,15 +44,6 @@
       "state" : {
         "revision" : "b2b1d20a90b14d11f6ef4241da6b81c1d3f171e4",
         "version" : "1.3.2"
-      }
-    },
-    {
-      "identity" : "mlemmiddleware",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlemgroup/MlemMiddleware",
-      "state" : {
-        "revision" : "3221dd333c93e98ab3a3b8df996ecd7b4dc6ab9b",
-        "version" : "0.45.0"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7fe183dcbb4acc6bb34fdc0842377273418aa1caa6335cd2926051ef29f2a665",
+  "originHash" : "dbb3f4a3491e755efbaa3d420a53d720cf7832bc30be35000cee5f9dbf3d87fa",
   "pins" : [
     {
       "identity" : "combine-schedulers",

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -52,7 +52,7 @@
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
         "branch" : "eric/actor-feed-loaders",
-        "revision" : "e2c37cd61df89617a6e759308b7311605ccf9621"
+        "revision" : "c62070aa7e65342005dc5d62503f5a665a493acd"
       }
     },
     {

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+LoadFeed.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+LoadFeed.swift
@@ -17,7 +17,7 @@ private struct LoadFeed: ViewModifier {
     func body(content: Content) -> some View {
         content
             .onChange(of: feedLoader == nil, initial: true) {
-                if let feedLoader, feedLoader.items.isEmpty, feedLoader.loadingState == .idle {
+                if let feedLoader, feedLoader.items.isEmpty {
                     // wrapping this in a Task instead of using .task prevents cancellation errors from the parent view de-rendering
                     Task {
                         do {

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -25,6 +25,7 @@ struct PersonView: View {
     }
     
     @Setting(\.postSize) var postSize
+    @Setting(\.internetSpeed) var internetSpeed
     
     @Environment(AppState.self) var appState
     @Environment(Palette.self) var palette
@@ -44,6 +45,7 @@ struct PersonView: View {
         if let person1 = person.wrappedValue as? any Person1Providing, person1.api === AppState.main.firstApi {
             self._feedLoader = .init(wrappedValue: .init(
                 api: AppState.main.firstApi,
+                pageSize: internetSpeed.pageSize,
                 userId: person1.id,
                 sortType: .new,
                 savedOnly: false,
@@ -95,6 +97,7 @@ struct PersonView: View {
                     if feedLoader == nil {
                         feedLoader = .init(
                             api: AppState.main.firstApi,
+                            pageSize: internetSpeed.pageSize,
                             userId: response.person.id,
                             sortType: .new,
                             savedOnly: false,
@@ -103,7 +106,7 @@ struct PersonView: View {
                         preheatFeedLoader()
                     } else if let feedLoader, feedLoader.api !== entity.api {
                         Task {
-                            await feedLoader.switchUser(api: entity.api, userId: entity.id)
+                            await feedLoader.changeUser(api: entity.api, userId: entity.id)
                         }
                     }
                     

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -114,7 +114,6 @@ struct FeedsView: View {
                 if appState.firstApi.canInteract, let firstUser = appState.firstAccount as? UserAccount {
                     if let savedFeedLoader {
                         Task {
-                            print("DEBUG changing savedFeedLoader api")
                             await savedFeedLoader.changeUser(api: appState.firstApi, userId: firstUser.id)
                         }
                     } else {

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -130,7 +130,8 @@ struct FeedsView: View {
                 // ensure we always are showing an appropriate feed
                 Task {
                     if !FeedSelection.cases(for: appState.firstAccount.accountType).contains(feedSelection) {
-                        postFeedLoader?.sortType = try await appState.initialFeedSortType
+                        // sortType = try await appState.initialFeedSortType
+                        try await postFeedLoader?.changeSortType(to: appState.initialFeedSortType)
                         feedSelection = appState.firstAccount.accountType == .user ? .subscribed : .all
                     }
                 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -109,7 +109,6 @@ struct FeedsView: View {
                 scrollToTopTrigger.toggle()
             }
             .onChange(of: appState.firstApi, initial: false) {
-                // postFeedLoader?.api = appState.firstApi // TODO: handle better
                 postFeedLoader?.changeApi(to: appState.firstApi)
                 
                 if appState.firstApi.canInteract, let firstUser = appState.firstAccount as? UserAccount {
@@ -134,7 +133,6 @@ struct FeedsView: View {
                 // ensure we always are showing an appropriate feed
                 Task {
                     if !FeedSelection.cases(for: appState.firstAccount.accountType).contains(feedSelection) {
-                        // sortType = try await appState.initialFeedSortType
                         try await postFeedLoader?.changeSortType(to: appState.initialFeedSortType)
                         feedSelection = appState.firstAccount.accountType == .user ? .subscribed : .all
                     }

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -129,7 +129,6 @@ struct FeedsView: View {
                 
                 // ensure we always are showing an appropriate feed
                 Task {
-                    print("DEBUG dummy")
                     if !FeedSelection.cases(for: appState.firstAccount.accountType).contains(feedSelection) {
                         postFeedLoader?.sortType = try await appState.initialFeedSortType
                         feedSelection = appState.firstAccount.accountType == .user ? .subscribed : .all

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -129,6 +129,7 @@ struct FeedsView: View {
                 
                 // ensure we always are showing an appropriate feed
                 Task {
+                    print("DEBUG dummy")
                     if !FeedSelection.cases(for: appState.firstAccount.accountType).contains(feedSelection) {
                         postFeedLoader?.sortType = try await appState.initialFeedSortType
                         feedSelection = appState.firstAccount.accountType == .user ? .subscribed : .all

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -14,6 +14,7 @@ struct FeedsView: View {
     @Setting(\.postSize) var postSize
     @Setting(\.showReadInFeed) var showRead
     @Setting(\.showFeedWelcomePrompt) var showWelcomePrompt
+    @Setting(\.internetSpeed) var internetSpeed
     
     @Environment(AppState.self) var appState
     @Environment(Palette.self) var palette
@@ -31,7 +32,7 @@ struct FeedsView: View {
                         await postFeedLoader?.clear()
                         try await savedFeedLoader?.refresh(clearBeforeRefresh: true)
                     } else {
-                        savedFeedLoader?.clear()
+                        await savedFeedLoader?.clear()
                         try await postFeedLoader?.changeFeedType(to: feedSelection.associatedApiType)
                     }
                 } catch {
@@ -75,6 +76,7 @@ struct FeedsView: View {
         if let firstUser = AppState.main.firstAccount as? UserAccount {
             _savedFeedLoader = .init(wrappedValue: .init(
                 api: AppState.main.firstApi,
+                pageSize: internetSpeed.pageSize,
                 userId: firstUser.id,
                 sortType: .new,
                 savedOnly: true,
@@ -107,16 +109,18 @@ struct FeedsView: View {
                 scrollToTopTrigger.toggle()
             }
             .onChange(of: appState.firstApi, initial: false) {
-                postFeedLoader?.api = appState.firstApi // TODO: handle better
+                // postFeedLoader?.api = appState.firstApi // TODO: handle better
+                postFeedLoader?.changeApi(to: appState.firstApi)
                 
                 if appState.firstApi.canInteract, let firstUser = appState.firstAccount as? UserAccount {
                     if let savedFeedLoader {
                         Task {
-                            await savedFeedLoader.switchUser(api: appState.firstApi, userId: firstUser.id)
+                            await savedFeedLoader.changeUser(api: appState.firstApi, userId: firstUser.id)
                         }
                     } else {
                         savedFeedLoader = .init(
                             api: appState.firstApi,
+                            pageSize: internetSpeed.pageSize,
                             userId: firstUser.id,
                             sortType: .new,
                             savedOnly: true,

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -107,7 +107,7 @@ struct FeedsView: View {
                 scrollToTopTrigger.toggle()
             }
             .onChange(of: appState.firstApi, initial: false) {
-                postFeedLoader?.api = appState.firstApi
+                postFeedLoader?.api = appState.firstApi // TODO: handle better
                 
                 if appState.firstApi.canInteract, let firstUser = appState.firstAccount as? UserAccount {
                     if let savedFeedLoader {

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -114,6 +114,7 @@ struct FeedsView: View {
                 if appState.firstApi.canInteract, let firstUser = appState.firstAccount as? UserAccount {
                     if let savedFeedLoader {
                         Task {
+                            print("DEBUG changing savedFeedLoader api")
                             await savedFeedLoader.changeUser(api: appState.firstApi, userId: firstUser.id)
                         }
                     } else {

--- a/Mlem/App/Views/Shared/EndOfFeedView.swift
+++ b/Mlem/App/Views/Shared/EndOfFeedView.swift
@@ -33,13 +33,19 @@ struct EndOfFeedView: View {
     @Environment(Palette.self) var palette
     
     let loadingState: LoadingState
+    let loadMore: (() -> Void)?
     let viewType: EndOfFeedViewType
     
     var body: some View {
         Group {
             switch loadingState {
             case .idle:
-                EmptyView()
+                if let loadMore {
+                    Button("Load More") {
+                        loadMore()
+                    }
+                    .buttonStyle(.bordered)
+                }
             case .loading:
                 ProgressView()
             case .done:

--- a/Mlem/App/Views/Shared/PersonContentGridView.swift
+++ b/Mlem/App/Views/Shared/PersonContentGridView.swift
@@ -83,7 +83,8 @@ struct PersonContentGridView: View {
                         .padding(.horizontal, postSize.tiled ? Constants.main.halfSpacing : 10)
                         .onAppear {
                             do {
-                                try feedLoader.loadIfThreshold(item, asChild: contentType != .all)
+                                // try feedLoader.loadIfThreshold(item, asChild: contentType != .all)
+                                try feedLoader.loadIfThreshold(item)
                             } catch {
                                 // TODO: is postFeedLoader.loadIfThreshold throws 400, this line is not executed
                                 handleError(error)

--- a/Mlem/App/Views/Shared/PersonContentGridView.swift
+++ b/Mlem/App/Views/Shared/PersonContentGridView.swift
@@ -83,8 +83,7 @@ struct PersonContentGridView: View {
                         .padding(.horizontal, postSize.tiled ? Constants.main.halfSpacing : 10)
                         .onAppear {
                             do {
-                                // try feedLoader.loadIfThreshold(item, asChild: contentType != .all)
-                                try feedLoader.loadIfThreshold(item)
+                                try feedLoader.loadIfThreshold(item, asChild: contentType != .all)
                             } catch {
                                 // TODO: is postFeedLoader.loadIfThreshold throws 400, this line is not executed
                                 handleError(error)

--- a/Mlem/App/Views/Shared/PersonContentGridView.swift
+++ b/Mlem/App/Views/Shared/PersonContentGridView.swift
@@ -91,7 +91,7 @@ struct PersonContentGridView: View {
                         }
                 }
             }
-            EndOfFeedView(loadingState: loadingState, viewType: .hobbit)
+            EndOfFeedView(loadingState: loadingState, loadMore: nil, viewType: .hobbit)
         }
     }
     

--- a/Mlem/App/Views/Shared/PostGridView.swift
+++ b/Mlem/App/Views/Shared/PostGridView.swift
@@ -108,6 +108,18 @@ struct PostGridView: View {
             }
         
             EndOfFeedView(loadingState: postFeedLoader.loadingState, viewType: .hobbit)
+            
+            if postFeedLoader.loadingState == .idle {
+                Button("Load More") {
+                    Task {
+                        do {
+                            try await postFeedLoader.loadMoreItems()
+                        } catch {
+                            handleError(error)
+                        }
+                    }
+                }
+            }
         }
     }
     

--- a/Mlem/App/Views/Shared/PostGridView.swift
+++ b/Mlem/App/Views/Shared/PostGridView.swift
@@ -107,19 +107,7 @@ struct PostGridView: View {
                 }
             }
         
-            EndOfFeedView(loadingState: postFeedLoader.loadingState, viewType: .hobbit)
-            
-            if postFeedLoader.loadingState == .idle {
-                Button("Load More") {
-                    Task {
-                        do {
-                            try await postFeedLoader.loadMoreItems()
-                        } catch {
-                            handleError(error)
-                        }
-                    }
-                }
-            }
+            EndOfFeedView(loadingState: postFeedLoader.loadingState, loadMore: loadMore, viewType: .hobbit)
         }
     }
     
@@ -137,6 +125,16 @@ struct PostGridView: View {
             }
         } label: {
             Label("Post Size", systemImage: Icons.postSizeSetting)
+        }
+    }
+    
+    func loadMore() {
+        Task {
+            do {
+                try await postFeedLoader.loadMoreItems()
+            } catch {
+                handleError(error)
+            }
         }
     }
 }

--- a/Mlem/App/Views/Shared/Search/SearchView+Logic.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView+Logic.swift
@@ -72,21 +72,21 @@ extension SearchView {
     
     private func refreshPosts(clearBeforeRefresh: Bool) async throws {
         guard !query.isEmpty else { return }
-        postLoader.searchPostFetchProvider.setApi(getRefreshApi(for: postFilters.location))
-        postLoader.searchPostFetchProvider.setSortType(postFilters.sort)
-        postLoader.searchPostFetchProvider.query = query
-        postLoader.searchPostFetchProvider.creatorId = postFilters.creator?.id
-        postLoader.searchPostFetchProvider.communityId = nil
-        postLoader.searchPostFetchProvider.listing = .all
+        postLoader.searchPostFetcher.setApi(getRefreshApi(for: postFilters.location))
+        postLoader.searchPostFetcher.setSortType(postFilters.sort)
+        postLoader.searchPostFetcher.query = query
+        postLoader.searchPostFetcher.creatorId = postFilters.creator?.id
+        postLoader.searchPostFetcher.communityId = nil
+        postLoader.searchPostFetcher.listing = .all
         switch postFilters.location {
         case .subscribed:
-            postLoader.searchPostFetchProvider.listing = .subscribed
+            postLoader.searchPostFetcher.listing = .subscribed
         case .moderated:
-            postLoader.searchPostFetchProvider.listing = .moderatorView
+            postLoader.searchPostFetcher.listing = .moderatorView
         case .localInstance, .instance:
-            postLoader.searchPostFetchProvider.listing = .local
+            postLoader.searchPostFetcher.listing = .local
         case let .community(community):
-            postLoader.searchPostFetchProvider.communityId = community.id
+            postLoader.searchPostFetcher.communityId = community.id
         default:
             break
         }

--- a/Mlem/App/Views/Shared/Search/SearchView+Logic.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView+Logic.swift
@@ -27,7 +27,7 @@ extension SearchView {
                 try await Task.sleep(for: .seconds(0.2))
             }
             if clearBeforeRefresh {
-                await setInstances(.init())
+                setInstances(.init())
             }
             switch selectedTab {
             case .communities:
@@ -72,21 +72,21 @@ extension SearchView {
     
     private func refreshPosts(clearBeforeRefresh: Bool) async throws {
         guard !query.isEmpty else { return }
-        postLoader.api = getRefreshApi(for: postFilters.location)
-        postLoader.query = query
-        postLoader.sortType = postFilters.sort
-        postLoader.creatorId = postFilters.creator?.id
-        postLoader.communityId = nil
-        postLoader.listing = .all
+        postLoader.searchPostFetchProvider.setApi(getRefreshApi(for: postFilters.location))
+        postLoader.searchPostFetchProvider.setSortType(postFilters.sort)
+        postLoader.searchPostFetchProvider.query = query
+        postLoader.searchPostFetchProvider.creatorId = postFilters.creator?.id
+        postLoader.searchPostFetchProvider.communityId = nil
+        postLoader.searchPostFetchProvider.listing = .all
         switch postFilters.location {
         case .subscribed:
-            postLoader.listing = .subscribed
+            postLoader.searchPostFetchProvider.listing = .subscribed
         case .moderated:
-            postLoader.listing = .moderatorView
+            postLoader.searchPostFetchProvider.listing = .moderatorView
         case .localInstance, .instance:
-            postLoader.listing = .local
+            postLoader.searchPostFetchProvider.listing = .local
         case let .community(community):
-            postLoader.communityId = community.id
+            postLoader.searchPostFetchProvider.communityId = community.id
         default:
             break
         }

--- a/Mlem/App/Views/Shared/Search/SearchView.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView.swift
@@ -161,7 +161,7 @@ struct SearchView: View {
                                 }
                             }
                     }
-                    EndOfFeedView(loadingState: communityLoader.loadingState, viewType: .hobbit)
+                    EndOfFeedView(loadingState: communityLoader.loadingState, loadMore: nil, viewType: .hobbit)
                 }
             case .users:
                 LazyVStack(spacing: 0) {
@@ -175,14 +175,14 @@ struct SearchView: View {
                                 }
                             }
                     }
-                    EndOfFeedView(loadingState: personLoader.loadingState, viewType: .hobbit)
+                    EndOfFeedView(loadingState: personLoader.loadingState, loadMore: nil, viewType: .hobbit)
                 }
             case .instances:
                 LazyVStack(spacing: 0) {
                     SearchResultsView(results: instances) { instance in
                         InstanceListRow(instance, readout: .users)
                     }
-                    EndOfFeedView(loadingState: .done, viewType: .hobbit)
+                    EndOfFeedView(loadingState: .done, loadMore: nil, viewType: .hobbit)
                 }
             case .posts:
                 if postLoader.loadingState == .idle, postLoader.items.isEmpty {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -770,6 +770,9 @@
     "Load directly from %@" : {
 
     },
+    "Load More" : {
+
+    },
     "Load This Image Directly" : {
 
     },


### PR DESCRIPTION
Frontend changes for [the real PR](https://github.com/mlemgroup/MlemMiddleware/pull/70).

Contains two minor changes of note:
- `EndOfFeedView` can now take in an optional `loadMore` callback; if available, a "Load More" button will be rendered at the bottom of the feed if the `loadingState` is `idle`. Sometimes hiding read posts creates a feed that won't trigger the infinite load; this handles that case without needing to do weird threshold hacks. This will also make implementing #832 trivial.
- `loadFeed` now triggers if the loader is empty regardless of `loadingState`. The middleware PR changes the initial `loadingState` to be `.loading`, which in turn results in a spinner being immediately rendered when an empty feed is opened.