### PR TITLE
Image upload fix

### DIFF
--- a/Mlem/App/Models/ErrorDetails.swift
+++ b/Mlem/App/Models/ErrorDetails.swift
@@ -19,6 +19,32 @@ struct ErrorDetails: Hashable {
     var refresh: (() async -> Bool)?
     var autoRefresh: Bool = false
     
+    init(
+        title: String? = nil,
+        body: String? = nil,
+        error: Error? = nil,
+        systemImage: String? = nil,
+        buttonText: String? = nil,
+        refresh: (() -> Bool)? = nil,
+        autoRefresh: Bool = false
+    ) {
+        self.title = title
+        self.body = body
+        self.error = error
+        self.systemImage = systemImage
+        self.buttonText = buttonText
+        self.refresh = refresh
+        self.autoRefresh = autoRefresh
+        if let error {
+            switch error {
+            case ApiClientError.imageTooLarge:
+                self.title = self.title ?? "Image too large"
+            default:
+                break
+            }
+        }
+    }
+    
     func hash(into hasher: inout Hasher) {
         hasher.combine(title)
         hasher.combine(body)

--- a/Mlem/App/Models/ImageUploadManager.swift
+++ b/Mlem/App/Models/ImageUploadManager.swift
@@ -85,8 +85,15 @@ class ImageUploadManager: Hashable {
     }
     
     func upload(data: Data, api: ApiClient) async throws {
-        let image = try await api.uploadImage(data, onProgress: { self.state = .uploading(progress: $0) })
-        state = .done(image)
+        do {
+            let image = try await api.uploadImage(data, onProgress: {
+                self.state = .uploading(progress: $0)
+            })
+            state = .done(image)
+        } catch {
+            state = .idle
+            throw error
+        }
     }
     
     func hash(into hasher: inout Hasher) {

--- a/Mlem/App/Views/Pages/PostEditor/PostEditorTargetView.swift
+++ b/Mlem/App/Views/Pages/PostEditor/PostEditorTargetView.swift
@@ -50,7 +50,7 @@ struct PostEditorTargetView: View {
                 callback: { target.community = .init($0) }
             ))
         } label: {
-            var singleAccount = AccountsTracker.main.userAccounts.count == 1
+            let singleAccount = AccountsTracker.main.userAccounts.count == 1
             HStack(spacing: 0) {
                 if let community = target.community as? any Community {
                     FullyQualifiedLabelView(


### PR DESCRIPTION
- Fixed a bug in which "Uploading..." continued to be shown in the toolbar if an image upload fails.
- It now shows "Image too large" instead of "error" if image is too large

Closes #1465, #1422