### PR TITLE
OLED theme tweaks

### DIFF
--- a/Mlem/App/Views/Pages/CommentEditor/CommentEditorView.swift
+++ b/Mlem/App/Views/Pages/CommentEditor/CommentEditorView.swift
@@ -157,10 +157,12 @@ struct CommentEditorView: View {
                 )
                 .padding(.vertical, Constants.main.standardSpacing)
                 .background(palette.secondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+                .paletteBorder(cornerRadius: Constants.main.standardSpacing)
                 .padding(.horizontal, Constants.main.standardSpacing)
                 contextView
                     .padding(Constants.main.standardSpacing)
                     .background(palette.secondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+                    .paletteBorder(cornerRadius: Constants.main.standardSpacing)
                     .padding(.horizontal, Constants.main.standardSpacing)
             }
             .animation(.easeOut(duration: 0.2), value: resolutionState == .notFound)

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -146,6 +146,7 @@ struct CommunityView: View {
                 Markdown(description, configuration: .default)
                     .padding(Constants.main.standardSpacing)
                     .background(palette.secondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+                    .paletteBorder(cornerRadius: Constants.main.standardSpacing)
             }
         }
         .padding([.horizontal, .bottom], Constants.main.standardSpacing)

--- a/Mlem/App/Views/Pages/Instance/FediseerOpinionListView.swift
+++ b/Mlem/App/Views/Pages/Instance/FediseerOpinionListView.swift
@@ -24,8 +24,6 @@ struct FediseerOpinionListView: View {
                 
                 ForEach(items, id: \.domain) { opinion in
                     FediseerOpinionView(opinion: opinion)
-                        .background(palette.secondaryGroupedBackground)
-                        .cornerRadius(Constants.main.standardSpacing)
                 }
             }
             .padding(16)

--- a/Mlem/App/Views/Pages/Instance/FediseerOpinionView.swift
+++ b/Mlem/App/Views/Pages/Instance/FediseerOpinionView.swift
@@ -45,6 +45,9 @@ struct FediseerOpinionView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 10)
         .font(.callout)
+        .background(palette.secondaryGroupedBackground)
+        .cornerRadius(Constants.main.standardSpacing)
+        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Pages/Instance/InstanceSafetyView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceSafetyView.swift
@@ -104,7 +104,7 @@ struct InstanceSafetyView: View {
                             destination: items.count > 5 ? destination : nil
                         )
                         ForEach(items.prefix(5), id: \.domain) { item in
-                            section { FediseerOpinionView(opinion: item) }
+                            FediseerOpinionView(opinion: item)
                                 .padding(.bottom, 9)
                         }
                     }
@@ -121,6 +121,7 @@ struct InstanceSafetyView: View {
             .frame(maxWidth: .infinity)
             .background(palette.secondaryGroupedBackground)
             .cornerRadius(Constants.main.standardSpacing)
+            .paletteBorder(cornerRadius: Constants.main.standardSpacing)
         }
     }
     

--- a/Mlem/App/Views/Pages/Instance/InstanceUptimeView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceUptimeView.swift
@@ -90,10 +90,7 @@ struct InstanceUptimeView: View {
                     .padding(.leading, 12)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, 10)
-                    .background(
-                        RoundedRectangle(cornerRadius: Constants.main.standardSpacing)
-                            .fill(palette.secondaryGroupedBackground)
-                    )
+                    .background(palette.secondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
             }
             .buttonStyle(EmptyButtonStyle())
             
@@ -218,6 +215,7 @@ struct InstanceUptimeView: View {
             .frame(maxWidth: .infinity)
             .background(palette.secondaryGroupedBackground)
             .cornerRadius(Constants.main.standardSpacing)
+            .paletteBorder(cornerRadius: Constants.main.standardSpacing)
         }
     }
     

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -104,6 +104,7 @@ struct InstanceView: View {
                     Markdown(description, configuration: .default)
                         .padding(Constants.main.standardSpacing)
                         .background(palette.secondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+                        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
                         .padding([.horizontal, .bottom], Constants.main.standardSpacing)
                 }
             case .details:

--- a/Mlem/App/Views/Root/Tabs/Settings/SortingSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SortingSettingsView.swift
@@ -9,6 +9,8 @@ import MlemMiddleware
 import SwiftUI
 
 struct SortingSettingsView: View {
+    @Environment(Palette.self) var palette
+    
     @Setting(\.defaultPostSort) var defaultPostSort
     @Setting(\.fallbackPostSort) var fallbackPostSort
     @Setting(\.commentSort) var commentSort
@@ -20,6 +22,7 @@ struct SortingSettingsView: View {
                     Text("Posts")
                     Spacer()
                     FeedSortPicker(sort: $defaultPostSort)
+                        .foregroundStyle(palette.accent)
                         .frame(minHeight: 50)
                         .buttonStyle(.bordered)
                 }
@@ -28,6 +31,7 @@ struct SortingSettingsView: View {
                         Text("Fallback")
                         Spacer()
                         FeedSortPicker(sort: $fallbackPostSort, filters: [.alwaysAvailable])
+                            .foregroundStyle(palette.accent)
                             .frame(minHeight: 50)
                             .buttonStyle(.bordered)
                     }
@@ -50,6 +54,7 @@ struct SortingSettingsView: View {
                             }
                         }
                     }
+                    .foregroundStyle(palette.accent)
                     .frame(minHeight: 50)
                     .buttonStyle(.bordered)
                 }

--- a/Mlem/App/Views/Shared/FooterLinkView.swift
+++ b/Mlem/App/Views/Shared/FooterLinkView.swift
@@ -12,13 +12,15 @@ struct FooterLinkView: View {
     
     let title: String
     let subtitle: String?
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             Text(title)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .font(.subheadline)
                 .fontWeight(.semibold)
+                .multilineTextAlignment(.leading)
+                .lineLimit(2)
 
             if let subtitle {
                 Text(subtitle)

--- a/Mlem/App/Views/Shared/Form/FormSection.swift
+++ b/Mlem/App/Views/Shared/Form/FormSection.swift
@@ -20,6 +20,7 @@ struct FormSection<Content: View>: View {
         content
             .frame(maxWidth: .infinity)
             .background(palette.secondaryGroupedBackground)
-            .clipShape(.rect(cornerRadius: 10))
+            .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
+            .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
 }

--- a/Mlem/App/Views/Shared/Palette Components/Form.swift
+++ b/Mlem/App/Views/Shared/Palette Components/Form.swift
@@ -22,9 +22,9 @@ struct Form<Content: View>: View {
                 .tint(palette.accent)
                 .buttonStyle(PaletteButton())
         }
-        .listStyle(InsetListStyle())
+        .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
         .background(palette.groupedBackground)
-        .shadow(color: palette.primary.opacity(palette.bordered ? 0.2 : 0.0), radius: 5)
+        .shadow(color: palette.primary.opacity(palette.bordered ? 0.4 : 0.0), radius: 1)
     }
 }

--- a/Mlem/App/Views/Shared/Search/Results/CommunityListRow.swift
+++ b/Mlem/App/Views/Shared/Search/Results/CommunityListRow.swift
@@ -50,5 +50,6 @@ struct CommunityListRow<Content2: View>: View {
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu { community.menuActions(navigation: navigation) }
         .quickSwipes(community.swipeActions(behavior: .standard))
+        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
 }

--- a/Mlem/App/Views/Shared/Search/Results/InstanceListRow.swift
+++ b/Mlem/App/Views/Shared/Search/Results/InstanceListRow.swift
@@ -59,5 +59,6 @@ struct InstanceListRow<Content2: View>: View {
         .contextMenu {
             instanceStub?.menuActions(allowExternalBlocking: true) ?? []
         }
+        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
 }

--- a/Mlem/App/Views/Shared/Search/Results/PersonListRow.swift
+++ b/Mlem/App/Views/Shared/Search/Results/PersonListRow.swift
@@ -49,5 +49,6 @@ struct PersonListRow<Content2: View>: View {
         .background(palette.secondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu { person.menuActions(navigation: navigation) }
+        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
 }

--- a/Mlem/App/Views/Shared/Search/SearchResultsView.swift
+++ b/Mlem/App/Views/Shared/Search/SearchResultsView.swift
@@ -23,7 +23,6 @@ struct SearchResultsView<Item: Identifiable, Content: View>: View {
     var body: some View {
         ForEach(results) { item in
             content(item)
-                .paletteBorder(cornerRadius: Constants.main.standardSpacing)
                 .padding(.horizontal, Constants.main.standardSpacing)
                 .padding(.bottom, Constants.main.halfSpacing)
         }


### PR DESCRIPTION
- Changed the form shadow radius to 1px so that it looks like a solid border
- Added missing `.paletteBorder` cases
- Fixed tappable link text alignment (closes #1462)