### PR TITLE
Hide "Select Text" and "Report" actions for deleted posts/comments

### DIFF
--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -78,14 +78,18 @@ extension Comment1Providing {
             downvoteAction(feedback: feedback)
             saveAction(feedback: feedback)
             replyAction(commentTreeTracker: commentTreeTracker)
-            selectTextAction()
+            if !deleted {
+                selectTextAction()
+            }
             shareAction()
             
             if isOwnComment {
                 editAction()
                 deleteAction(feedback: feedback)
             } else {
-                reportAction()
+                if !canModerate, !deleted {
+                    reportAction()
+                }
                 blockCreatorAction(feedback: feedback)
             }
         }

--- a/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
@@ -29,7 +29,9 @@ extension Message1Providing {
             replyAction()
             markReadAction(feedback: feedback)
         }
-        selectTextAction()
+        if !deleted {
+            selectTextAction()
+        }
         if isOwnMessage {
             deleteAction(feedback: feedback)
         } else {

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -154,7 +154,9 @@ extension Post1Providing {
             downvoteAction(feedback: feedback)
             saveAction(feedback: feedback)
             replyAction(commentTreeTracker: commentTreeTracker)
-            selectTextAction()
+            if !deleted {
+                selectTextAction()
+            }
             shareAction()
 
             if isOwnPost {
@@ -167,7 +169,7 @@ extension Post1Providing {
                 if (api.fetchedVersion ?? .zero) >= .v19_4 {
                     hideAction(feedback: feedback)
                 }
-                if !canModerate {
+                if !canModerate, !deleted {
                     reportAction()
                 }
                 blockAction(feedback: feedback)

--- a/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
@@ -39,10 +39,14 @@ extension Reply1Providing {
             replyAction()
             markReadAction(feedback: feedback)
             if let comment = self2?.comment {
-                comment.selectTextAction()
+                if !comment.deleted {
+                    comment.selectTextAction()
+                }
                 comment.shareAction()
+                if !comment.deleted {
+                    reportAction()
+                }
             }
-            reportAction()
             blockCreatorAction(feedback: feedback)
         }
     }


### PR DESCRIPTION
Also hid the "report" action on comments that you can moderate. We already do this for posts.

Closes #1486