### PR TITLE
Improve animated webp detection

### DIFF
--- a/Mlem/App/Views/Shared/Images/Helpers/NukeWebpBridgeDecoder.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/NukeWebpBridgeDecoder.swift
@@ -11,30 +11,49 @@ import SDWebImageSwiftUI
 import SDWebImageWebPCoder
 import UIKit
 
-/// Raw values of "ANMF", which we can use to identify whether a webp is animated or not without decoding it
-/// https://stackoverflow.com/questions/45190469/how-to-identify-whether-webp-image-is-static-or-animated
-let animatedWebpHeader: [UInt8] = [65, 78, 77, 70]
-
 /// Custom Nuke decoder that processes the image using SDWebImage. The resulting ImageContainer will have the following properties:
 /// `image`: the first frame of the decoded webp
 /// `type`: `.webp`
 /// `data`: the raw webp data if the webp is animated, nil otherwise
 struct NukeWebpBridgeDecoder: ImageDecoding {
     public init?(context: ImageDecodingContext) {
-        guard let type = AssetType(context.data), type == .webp else { return nil }
+        guard
+            let type = AssetType(context.data),
+            type == .webp,
+            context.data.isAnimatedWebp() // only use this for animated webp, fall back on Nuke default for non-animated
+        else { return nil }
     }
     
     func decode(_ data: Data) throws -> ImageContainer {
         // decode the first frame to use as thumbnail
         let decoded = SDImageWebPCoder().decodedImage(with: data, options: [.decodeFirstFrameOnly: true])
         
-        // use magic numbers to check if animated
-        let animated = data.contains(animatedWebpHeader)
-        
         if let ret = decoded?.cgImage {
-            return .init(image: .init(cgImage: ret), type: .webp, data: animated ? data : nil)
+            return .init(image: .init(cgImage: ret), type: .webp, data: data)
         } else {
             return .init(image: UIImage.blank)
         }
+    }
+}
+
+/// Raw values of "ANIM", which we can use to identify whether a webp is animated or not without decoding it
+/// https://stackoverflow.com/questions/45190469/how-to-identify-whether-webp-image-is-static-or-animated
+private let animHeader: Data = Data([65, 78, 73, 77])
+
+private extension Data {
+    /// If the given data is a webp, returns true if that webp is animated and false otherwise.
+    /// - Warning: This function's behavior is undefined if the provided data is not an animated webp
+    func isAnimatedWebp() -> Bool {
+        // This function is built to run fast, banking on the fact that it's being passed in after Nuke checks that
+        // the image is a webp to guarantee safety. The check itself therefore only targets the bytes that, if the
+        // data is a webp, indicate an animated webp; it is assumed that the data is long enough and correctly formatted.
+        
+        // Sanity checks that the data conforms to the webp spec
+        assert(self.count >= 33,"Invalid data (too short)")
+        assert(self[..<4] == Data([82, 73, 70, 70]), "Invalid data (no RIFF header)")
+        assert(self[8..<12] == Data([87, 69, 66, 80]), "Invalid data (no WEBP header)")
+        assert(self[12..<15] == Data([86, 80, 56]), "Invalid data (no VP8X header)")
+        
+        return self[30..<34] == animHeader
     }
 }

--- a/Mlem/App/Views/Shared/Images/Helpers/NukeWebpBridgeDecoder.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/NukeWebpBridgeDecoder.swift
@@ -49,7 +49,7 @@ private extension Data {
         // data is a webp, indicate an animated webp; it is assumed that the data is long enough and correctly formatted.
         
         // Sanity checks that the data conforms to the webp spec
-        assert(self.count >= 33,"Invalid data (too short)")
+        assert(self.count >= 33, "Invalid data (too short)")
         assert(self[..<4] == Data([82, 73, 70, 70]), "Invalid data (no RIFF header)")
         assert(self[8..<12] == Data([87, 69, 66, 80]), "Invalid data (no WEBP header)")
         assert(self[12..<15] == Data([86, 80, 56]), "Invalid data (no VP8X header)")


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - Hopefully deals with #1509

# Pull Request Information

This PR improves how webp images are handled. Previously, every webp would go through the `NukeWebpBridgeDecoder`, which would both decode the image and, if the image was animated, populate the `animated` field. This had multiple problems:
- The `BridgeDecoder` was scanning the entire data to find the `ANMF` header
- The `BridgeDecoder` was therefore very slow, even for static images, and because the check was so slow it couldn't defer to the standard Nuke decoder for static images
- The `BridgeDecoder` was poorly optimized for static images, since it was built to handle animated images
- The `BridgeDecoder` could throw a false positive if `ANMF` happened to appear in the body of the image's data

This PR implements a much more efficient method of checking whether a webp is animated; it now scans only the critical bytes, rather than the whole data. This allows the `NukeWebpBridgeDecoder` to check at `init` whether a webp is animated and defer to the more efficient Nuke default decoder for static images.

Hopefully using Nuke for the static webps fixes the lagginess, which I believe may have been caused by the custom decoding. It may just be good luck, but I haven't encountered lag on this branch.