### PR TITLE
Fix play button bad behavior

### DIFF
--- a/Mlem/App/Views/Pages/ImageViewer.swift
+++ b/Mlem/App/Views/Pages/ImageViewer.swift
@@ -90,7 +90,6 @@ struct ImageViewer: View {
     }
     
     private func updateOpacity(_ newOpacity: CGFloat, callback: (() -> Void)? = nil) {
-        print("DEBUG updating opacity to \(newOpacity)")
         withAnimation(.easeOut(duration: duration)) {
             opacity = newOpacity
         }

--- a/Mlem/App/Views/Pages/ImageViewer.swift
+++ b/Mlem/App/Views/Pages/ImageViewer.swift
@@ -52,7 +52,7 @@ struct ImageViewer: View {
                 .padding(Constants.main.standardSpacing)
             }
         }
-        .simultaneousGesture(DragGesture(minimumDistance: 0.0)
+        .simultaneousGesture(DragGesture(minimumDistance: 1.0)
             .updating($dragState) { value, state, _ in
                 state = true
                 if !isZoomed, !isDismissing {
@@ -90,6 +90,7 @@ struct ImageViewer: View {
     }
     
     private func updateOpacity(_ newOpacity: CGFloat, callback: (() -> Void)? = nil) {
+        print("DEBUG updating opacity to \(newOpacity)")
         withAnimation(.easeOut(duration: duration)) {
             opacity = newOpacity
         }

--- a/Mlem/App/Views/Shared/Images/Core/FixedImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Core/FixedImageView.swift
@@ -22,6 +22,7 @@ struct FixedImageView: View {
     let fallback: Fallback
     let showProgress: Bool
     let blurred: Bool
+    let showPlayButton: Bool
     
     /// Enumeration of placeholder images to use if image loading fails
     enum Fallback {
@@ -44,12 +45,14 @@ struct FixedImageView: View {
         size: CGSize,
         fallback: Fallback,
         showProgress: Bool,
-        blurred: Bool = false
+        blurred: Bool = false,
+        showPlayButton: Bool = true
     ) {
         self.fallback = fallback
         self.showProgress = showProgress
         self._loader = .init(wrappedValue: .init(url: url, size: size))
         self.blurred = blurred
+        self.showPlayButton = showPlayButton
     }
     
     var isMovie: Bool { loader.url?.proxyAwarePathExtension?.isMovieExtension ?? false }
@@ -79,7 +82,7 @@ struct FixedImageView: View {
             || (loader.loading == .loading && !showProgress) {
             fallbackImage
                 .overlay {
-                    if loader.isAnimated {
+                    if loader.isAnimated, showPlayButton {
                         PlayButton(postSize: postSize)
                     }
                 }
@@ -92,7 +95,7 @@ struct FixedImageView: View {
                     .scaledToFill()
                     .dynamicBlur(blurred: blurred)
                     .overlay {
-                        if loader.isAnimated {
+                        if loader.isAnimated, showPlayButton {
                             PlayButton(postSize: postSize)
                         }
                     }

--- a/Mlem/App/Views/Shared/Images/Wrappers/CircleCroppedImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Wrappers/CircleCroppedImageView.swift
@@ -37,7 +37,8 @@ struct CircleCroppedImageView: View {
             size: .init(width: frame, height: frame),
             fallback: fallback,
             showProgress: showProgress,
-            blurred: blurred
+            blurred: blurred,
+            showPlayButton: false
         )
         .clipShape(Circle())
         .geometryGroup()

--- a/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
@@ -101,9 +101,9 @@ struct ThumbnailImageView: View {
                 url: url,
                 size: frame,
                 fallback: url.proxyAwarePathExtension?.isMovieExtension ?? false ? .movie : .image,
-                showProgress: true
+                showProgress: true,
+                blurred: blurred && loading == .done
             )
-            .dynamicBlur(blurred: blurred && loading == .done)
             .clipShape(RoundedRectangle(cornerRadius: Constants.main.smallItemCornerRadius))
             .onPreferenceChange(MediaLoadingPreferenceKey.self, perform: { loading = $0 })
         } else {
@@ -125,9 +125,9 @@ struct ThumbnailImageView: View {
                 url: url,
                 size: frame,
                 fallback: .image,
-                showProgress: true
+                showProgress: true,
+                blurred: blurred && loading == .done
             )
-            .dynamicBlur(blurred: blurred)
             .onPreferenceChange(MediaLoadingPreferenceKey.self, perform: { loading = $0 })
         } else {
             Image(systemName: post.placeholderImageName)


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [ ] This PR addresses one or more open issues that were assigned to me:
      - closes #issue
      - progress towards #issue

# Pull Request Information

This PR fixes a couple minor issues with the play button on animated media:
- Fixed button being blurred along with the image for NSFW images
- Fixed play button being rendered on avatars. This is implemented by disabling it on any `CircleCroppedImageView`, since everywhere we use that view is non-interactable. Down the line we should animate avatars properly, but that's a pretty bad time/payoff ratio. I've opened #1511 to track this.

This PR also fixes an issue where the image viewer X button would not trigger the fade effect properly due to the `DragGesture` also triggering.