### PR TITLE
Use MainActor for NavigationModel mutation

### DIFF
--- a/Mlem/App/Logic/HandleError.swift
+++ b/Mlem/App/Logic/HandleError.swift
@@ -49,7 +49,9 @@ private func _handleError(
     switch error {
     // TODO: Modify MlemMiddleware to attach the ApiClient throwing the error to ApiClientError.invalidSession, so that we can access the relevant UserStub in a multi-account context
     case ApiClientError.invalidSession:
-        showReauthSheet()
+        Task { @MainActor in
+            showReauthSheet()
+        }
         return true
     case ApiClientError.cancelled, is CancellationError:
         print("Cancellation error")
@@ -59,6 +61,7 @@ private func _handleError(
     }
 }
 
+@MainActor
 private func showReauthSheet() {
     if let user = AppState.main.firstSession.account as? UserAccount {
         for layer in NavigationModel.main.layers {

--- a/Mlem/App/Models/Action/BasicAction.swift
+++ b/Mlem/App/Models/Action/BasicAction.swift
@@ -15,7 +15,7 @@ struct BasicAction: Action {
     let confirmationPrompt: String?
 
     /// If this is nil, the BasicAction is disabled
-    var callback: (() -> Void)?
+    var callback: (@MainActor () -> Void)?
     
     var disabled: Bool { callback == nil }
     
@@ -26,7 +26,7 @@ struct BasicAction: Action {
         appearance: ActionAppearance,
         confirmationPrompt: String? = nil,
         enabled: Bool = true,
-        callback: (() -> Void)? = nil
+        callback: (@MainActor () -> Void)? = nil
     ) {
         self.id = id
         self.appearance = appearance
@@ -34,6 +34,7 @@ struct BasicAction: Action {
         self.callback = enabled ? callback : nil
     }
     
+    @MainActor
     func callbackWithConfirmation(popupModel: PopupAnchorModel) {
         if let callback {
             if let confirmationPrompt {

--- a/Mlem/App/Models/Action/ShareActivity.swift
+++ b/Mlem/App/Models/Action/ShareActivity.swift
@@ -9,9 +9,9 @@ import UIKit
 
 class ShareActivity: UIActivity {
     let appearance: ActionAppearance
-    let action: () -> Void
+    let action: @MainActor () -> Void
     
-    init(appearance: ActionAppearance, performAction: @escaping () -> Void) {
+    init(appearance: ActionAppearance, performAction: @escaping @MainActor () -> Void) {
         self.appearance = appearance
         self.action = performAction
         super.init()
@@ -37,6 +37,7 @@ class ShareActivity: UIActivity {
         true
     }
     
+    @MainActor
     override func perform() {
         action()
         activityDidFinish(true)

--- a/Mlem/App/Models/Session/UserSession.swift
+++ b/Mlem/App/Models/Session/UserSession.swift
@@ -38,7 +38,7 @@ class UserSession: Session {
                 try await self.api.fetchSiteVersion(task: Task {
                     let (person, instance, blocks) = try await self.api.getMyPerson()
                     if let person {
-                        await self.account.update(person: person, instance: instance)
+                        self.account.update(person: person, instance: instance)
                         self.person = person
                     }
                     self.blocks = blocks

--- a/Mlem/App/Utility/Extensions/Content Models/ActorIdentifiable+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/ActorIdentifiable+Extensions.swift
@@ -14,7 +14,7 @@ extension ActorIdentifiable {
     }
     
     func openInstanceAction(navigation: NavigationLayer?) -> BasicAction {
-        let callback: (() -> Void)?
+        let callback: (@MainActor () -> Void)?
         if let navigation {
             callback = { navigation.push(.instance(hostOf: self)) }
         } else {

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -17,6 +17,7 @@ extension Comment1Providing {
         (creator_?.shouldHideInFeed ?? false) || purged
     }
     
+    @MainActor
     func showEditSheet() {
         if let self = self as? any Comment2Providing {
             NavigationModel.main.openSheet(.editComment(self.comment2, context: nil))
@@ -170,13 +171,13 @@ extension Comment1Providing {
         .init(
             id: "edit\(uid)",
             appearance: .edit(),
-            callback: api.canInteract ? { self.showEditSheet() } : nil
+            callback: api.canInteract ? { @MainActor in self.showEditSheet() } : nil
         )
     }
     
     func viewVotesAction() -> BasicAction {
         let enabled = canModerate && (api.isAdmin || (api.fetchedVersion ?? .infinity) > .v19_4)
-        let callback: (() -> Void)?
+        let callback: (@MainActor () -> Void)?
         if let self2, enabled {
             callback = {
                 NavigationModel.main.openSheet(.votesList(.comment(self2)))

--- a/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
@@ -19,6 +19,7 @@ extension Community1Providing {
     
     // MARK: Operations
     
+    @MainActor
     func showNewPostSheet() {
         NavigationModel.main.openSheet(.createPost(community: self))
     }
@@ -174,7 +175,7 @@ extension Community1Providing {
                 swipeIcon1: isOn ? Icons.unsubscribePerson : Icons.subscribePerson,
                 swipeIcon2: isOn ? Icons.unsubscribePersonFill : Icons.subscribePersonFill
             ),
-            callback: api.canInteract ? { self.self2?.toggleSubscribe(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.self2?.toggleSubscribe(feedback: feedback) } : nil
         )
     }
     
@@ -191,7 +192,7 @@ extension Community1Providing {
                 swipeIcon1: isOn ? Icons.unfavorite : Icons.favorite,
                 swipeIcon2: isOn ? Icons.unfavoriteFill : Icons.favoriteFill
             ),
-            callback: api.canInteract ? { self.self2?.toggleFavorite(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.self2?.toggleFavorite(feedback: feedback) } : nil
         )
     }
     
@@ -200,7 +201,7 @@ extension Community1Providing {
             id: "block\(uid)",
             appearance: .block(isOn: blocked),
             confirmationPrompt: (!blocked && showConfirmation) ? "Really block this community?" : nil,
-            callback: api.canInteract ? { self.toggleBlocked(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.toggleBlocked(feedback: feedback) } : nil
         )
     }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/DeletableProviding+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/DeletableProviding+Extensions.swift
@@ -45,7 +45,7 @@ extension DeletableProviding {
                 icon: deleted ? Icons.undelete : Icons.delete
             ),
             confirmationPrompt: deleted ? nil : "Really delete?",
-            callback: api.canInteract ? { self.toggleDeleted(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.toggleDeleted(feedback: feedback) } : nil
         )
     }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/InboxItemProviding+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/InboxItemProviding+Extensions.swift
@@ -19,7 +19,7 @@ extension InboxItemProviding {
         .init(
             id: "markRead\(uid)",
             appearance: .markRead(isOn: read),
-            callback: api.canInteract ? { self.toggleRead(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.toggleRead(feedback: feedback) } : nil
         )
     }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/InstanceStubProviding+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/InstanceStubProviding+Extensions.swift
@@ -45,6 +45,7 @@ extension InstanceStubProviding {
         self.toggleBlocked()
     }
     
+    @MainActor
     func visit() {
         if let account = try? GuestAccount.getGuestAccount(url: actorId) {
             AppState.main.changeAccount(to: account)
@@ -52,10 +53,12 @@ extension InstanceStubProviding {
         }
     }
     
+    @MainActor
     func openLoginSheet() {
         NavigationModel.main.openSheet(.logIn(.instance(self)))
     }
     
+    @MainActor
     func openSignUpSheet() {
         NavigationModel.main.openSheet(.signUp(self))
     }

--- a/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
@@ -12,6 +12,7 @@ extension Interactable1Providing {
     private var self2: (any Interactable2Providing)? { self as? any Interactable2Providing }
     private var inboxItem: (any InboxItemProviding)? { self as? any InboxItemProviding }
     
+    @MainActor
     func showReplySheet(commentTreeTracker: CommentTreeTracker? = nil) {
         if let responseContext {
             NavigationModel.main.openSheet(.createComment(responseContext, commentTreeTracker: commentTreeTracker))
@@ -127,7 +128,7 @@ extension Interactable1Providing {
         .init(
             id: "upvote\(uid)",
             appearance: .upvote(isOn: self2?.votes.myVote ?? .none == .upvote),
-            callback: api.canInteract ? { self.self2?.toggleUpvoted(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.self2?.toggleUpvoted(feedback: feedback) } : nil
         )
     }
     
@@ -136,7 +137,7 @@ extension Interactable1Providing {
         return .init(
             id: "downvote\(uid)",
             appearance: .downvote(isOn: self2?.votes.myVote ?? .none == .downvote),
-            callback: enabled ? { self.self2?.toggleDownvoted(feedback: feedback) } : nil
+            callback: enabled ? { @MainActor in self.self2?.toggleDownvoted(feedback: feedback) } : nil
         )
     }
     
@@ -144,7 +145,7 @@ extension Interactable1Providing {
         .init(
             id: "save\(uid)",
             appearance: .save(isOn: self2?.saved ?? false),
-            callback: api.canInteract ? { self.self2?.toggleSaved(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.self2?.toggleSaved(feedback: feedback) } : nil
         )
     }
     
@@ -152,7 +153,7 @@ extension Interactable1Providing {
         .init(
             id: "reply\(uid)",
             appearance: .reply(),
-            callback: api.canInteract ? { self.showReplySheet(commentTreeTracker: commentTreeTracker) } : nil
+            callback: api.canInteract ? { @MainActor in self.showReplySheet(commentTreeTracker: commentTreeTracker) } : nil
         )
     }
     
@@ -161,7 +162,7 @@ extension Interactable1Providing {
             id: "blockCreator\(uid)",
             appearance: .blockCreator(),
             confirmationPrompt: showConfirmation ? "Really block this user?" : nil,
-            callback: api.canInteract ? { self.self2?.creator.toggleBlocked(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.self2?.creator.toggleBlocked(feedback: feedback) } : nil
         )
     }
     

--- a/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
@@ -87,7 +87,7 @@ extension Message1Providing {
         .init(
             id: "blockCreator\(uid)",
             appearance: .blockCreator(),
-            callback: api.canInteract ? { self.self2?.creator.toggleBlocked(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.self2?.creator.toggleBlocked(feedback: feedback) } : nil
         )
     }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
@@ -88,9 +88,9 @@ extension Message1Providing {
     // These actions are also defined in Interactable1Providing... another protocol for these may be a good idea
        
     func replyAction(navigation: NavigationLayer) -> BasicAction {
-        var callback: (() -> Void)?
+        var callback: (@MainActor () -> Void)?
         if let creator = creator_, api.canInteract {
-            callback = { navigation.push(.messageFeed(creator, focusTextField: true)) }
+            callback = { @MainActor in navigation.push(.messageFeed(creator, focusTextField: true)) }
         }
         return .init(
             id: "reply\(uid)",

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -53,6 +53,7 @@ extension Person1Providing {
         return output.sorted { $0.sortVal < $1.sortVal }
     }
     
+    @MainActor
     func showBanSheet(community: (any Community)?, isBannedFromCommunity: Bool, shouldBan: Bool) {
         NavigationModel.main.openSheet(
             .ban(self, isBannedFromCommunity: isBannedFromCommunity, shouldBan: shouldBan, community: community)
@@ -114,7 +115,7 @@ extension Person1Providing {
         .init(
             id: "block\(uid)",
             appearance: .block(isOn: blocked),
-            callback: api.canInteract ? { self.toggleBlocked(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.toggleBlocked(feedback: feedback) } : nil
         )
     }
     
@@ -153,7 +154,7 @@ extension Person1Providing {
         .init(
             id: "banFromInstance\(uid)",
             appearance: .banFromInstance(isOn: bannedFromInstance, withUserLabel: withUserLabel),
-            callback: api.canInteract && api.isAdmin ? {
+            callback: api.canInteract && api.isAdmin ? { @MainActor in
                 self.showBanSheet(
                     community: nil,
                     isBannedFromCommunity: false,
@@ -165,7 +166,7 @@ extension Person1Providing {
     
     func banFromCommunityAction(community: any Community, withUserLabel: Bool = false) -> BasicAction {
         let isBanned = isBannedFromCommunity(community)
-        let callback: (() -> Void)?
+        let callback: (@MainActor () -> Void)?
         if let isBanned, api.canInteract, community.canModerate {
             callback = {
                 self.showBanSheet(

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -22,6 +22,7 @@ extension Post1Providing {
         api.myPerson?.moderates(communityId: communityId) ?? false || api.isAdmin
     }
     
+    @MainActor
     func showEditSheet() {
         if let self = self as? any Post2Providing {
             NavigationModel.main.openSheet(.editPost(self.post2))
@@ -342,7 +343,7 @@ extension Post1Providing {
         return .init(
             id: "hide\(uid)",
             appearance: .hide(isOn: hidden),
-            callback: available ? { self.self2?.toggleHidden(feedback: feedback) } : nil
+            callback: available ? { @MainActor in self.self2?.toggleHidden(feedback: feedback) } : nil
         )
     }
     
@@ -374,7 +375,7 @@ extension Post1Providing {
                 icon: Icons.block
             ),
             confirmationPrompt: showConfirmation ? "Really block this community?" : nil,
-            callback: api.canInteract ? { self.self2?.community.toggleBlocked(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.self2?.community.toggleBlocked(feedback: feedback) } : nil
         )
     }
     
@@ -382,7 +383,7 @@ extension Post1Providing {
         .init(
             id: "edit\(uid)",
             appearance: .edit(),
-            callback: api.canInteract ? { self.showEditSheet() } : nil
+            callback: api.canInteract ? showEditSheet : nil
         )
     }
     
@@ -391,7 +392,7 @@ extension Post1Providing {
             id: "lock\(uid)",
             appearance: .lock(isOn: locked, isInProgress: !lockedManager.isInSync),
             confirmationPrompt: locked ? "Really unlock this post?" : "Really lock this post?",
-            callback: api.canInteract && canModerate ? { self.self2?.toggleLocked(feedback: feedback) } : nil
+            callback: api.canInteract && canModerate ? { @MainActor in self.self2?.toggleLocked(feedback: feedback) } : nil
         )
     }
     
@@ -438,7 +439,7 @@ extension Post1Providing {
                 isOn: isOn, isInProgress: !pinnedCommunityManager.isInSync
             ),
             confirmationPrompt: prompt,
-            callback: api.canInteract && canModerate ? { self.togglePinnedCommunity(feedback: feedback) } : nil
+            callback: api.canInteract && canModerate ? { @MainActor in self.togglePinnedCommunity(feedback: feedback) } : nil
         )
     }
     
@@ -458,7 +459,7 @@ extension Post1Providing {
             id: "pinToInstance\(uid)",
             appearance: .pinToInstance(isOn: isOn, isInProgress: !pinnedInstanceManager.isInSync),
             confirmationPrompt: prompt,
-            callback: api.canInteract && api.isAdmin ? { self.togglePinnedInstance(feedback: feedback) } : nil
+            callback: api.canInteract && api.isAdmin ? { @MainActor in self.togglePinnedInstance(feedback: feedback) } : nil
         )
     }
     
@@ -467,7 +468,7 @@ extension Post1Providing {
         return .init(
             id: "viewVotes\(uid)",
             appearance: .viewVotes(),
-            callback: enabled ? { navigation.push(.votesList(.post(self))) } : nil
+            callback: enabled ? { @MainActor in navigation.push(.votesList(.post(self))) } : nil
         )
     }
     // swiftlint:disable:next file_length

--- a/Mlem/App/Utility/Extensions/Content Models/PurgableProviding+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/PurgableProviding+Extensions.swift
@@ -9,6 +9,7 @@ import Foundation
 import MlemMiddleware
 
 extension PurgableProviding {
+    @MainActor
     func showPurgeSheet() {
         NavigationModel.main.openSheet(.purge(self))
     }

--- a/Mlem/App/Utility/Extensions/Content Models/RemovableProviding+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/RemovableProviding+Extensions.swift
@@ -8,6 +8,7 @@
 import MlemMiddleware
 
 extension RemovableProviding {
+    @MainActor
     func showRemoveSheet() {
         NavigationModel.main.openSheet(.remove(self))
     }

--- a/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
@@ -85,7 +85,7 @@ extension Reply1Providing {
     // MARK: Actions
     
     func selectTextAction() -> BasicAction {
-        let callback: (() -> Void)?
+        let callback: (@MainActor () -> Void)?
         if let comment = comment_ {
             callback = comment.showTextSelectionSheet
         } else {

--- a/Mlem/App/Utility/Extensions/Content Models/Report+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Report+Extensions.swift
@@ -31,7 +31,7 @@ extension Report {
                 icon: resolved ? Icons.failureCircle : Icons.successCircle,
                 swipeIcon2: resolved ? Icons.failureCircleFill : Icons.successCircleFill
             ),
-            callback: api.canInteract ? { self.toggleResolved(feedback: feedback) } : nil
+            callback: api.canInteract ? { @MainActor in self.toggleResolved(feedback: feedback) } : nil
         )
     }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/ReportableProviding+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/ReportableProviding+Extensions.swift
@@ -8,6 +8,7 @@
 import MlemMiddleware
 
 extension ReportableProviding {
+    @MainActor
     func showReportSheet(communityContext: (any CommunityStubProviding)? = nil) {
         NavigationModel.main.openSheet(.report(self, community: communityContext))
     }
@@ -16,7 +17,7 @@ extension ReportableProviding {
         .init(
             id: "report\(uid)",
             appearance: .report(),
-            callback: api.canInteract ? { self.showReportSheet(communityContext: communityContext) } : nil
+            callback: api.canInteract ? { @MainActor in self.showReportSheet(communityContext: communityContext) } : nil
         )
     }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/SelectableContentProviding+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/SelectableContentProviding+Extensions.swift
@@ -8,6 +8,7 @@
 import MlemMiddleware
 
 extension SelectableContentProviding {
+    @MainActor
     func showTextSelectionSheet() {
         NavigationModel.main.openSheet(.selectText(selectableContent ?? ""))
     }

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -59,6 +59,7 @@ class NavigationLayer {
         self.canDisplayToasts = canDisplayToasts
     }
     
+    @MainActor
     func push(_ page: NavigationPage) {
         if hasNavigationStack {
             path.append(page)
@@ -67,6 +68,7 @@ class NavigationLayer {
         }
     }
 
+    @MainActor
     func pop() {
         if !path.isEmpty {
             path.removeLast()
@@ -76,6 +78,7 @@ class NavigationLayer {
         }
     }
     
+    @MainActor
     func dismissSheet() {
         model?.closeSheets(aboveIndex: index)
     }
@@ -95,6 +98,7 @@ class NavigationLayer {
     }
     
     /// Open a new sheet, optionally with navigation enabled. If `nil` is specified for `hasNavigationStack`, the value of `page.hasNavigationStack` will be used.
+    @MainActor
     func openSheet(_ page: NavigationPage, hasNavigationStack: Bool? = nil) {
         model?.openSheet(
             page,
@@ -103,6 +107,7 @@ class NavigationLayer {
     }
     
     /// Open a new sheet, optionally with navigation enabled. If `nil` is specified for `hasNavigationStack`, the value of `page.hasNavigationStack` will be used.
+    @MainActor
     func showFullScreenCover(_ page: NavigationPage, hasNavigationStack: Bool? = nil) {
         model?.showFullScreenCover(
             page,
@@ -110,6 +115,7 @@ class NavigationLayer {
         )
     }
     
+    @MainActor
     func showPhotosPicker(for imageUploadManager: ImageUploadManager, api: ApiClient) {
         model?.photosPickerCallback = { photo in
             Task {
@@ -129,6 +135,7 @@ class NavigationLayer {
         }
     }
     
+    @MainActor
     func showFilePicker(for imageUploadManager: ImageUploadManager, api: ApiClient) {
         model?.showingFilePicker = true
         model?.filePickerCallback = { url in
@@ -153,7 +160,7 @@ class NavigationLayer {
     }
     
     func uploadImageFromClipboard(for imageUploadManager: ImageUploadManager, api: ApiClient) {
-        Task {
+        Task { @MainActor in
             do {
                 if UIPasteboard.general.hasImages, let content = UIPasteboard.general.image {
                     if let data = content.pngData() {

--- a/Mlem/App/Views/Shared/Navigation/NavigationModel.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationModel.swift
@@ -25,6 +25,7 @@ class NavigationModel {
     
     var mediaUrl: URL?
     
+    @MainActor
     private func openSheet(_ page: NavigationPage, hasNavigationStack: Bool? = nil, isFullScreenCover: Bool) {
         layers.append(
             .init(
@@ -38,11 +39,13 @@ class NavigationModel {
         )
     }
     
+    @MainActor
     func addLayer(_ navigationLayer: NavigationLayer) {
         layers.append(navigationLayer)
     }
     
     // Closes all sheets above and including the given index
+    @MainActor
     func closeSheets(aboveIndex index: Int) {
         for layer in layers.dropFirst(index) {
             layer.model = nil
@@ -50,15 +53,18 @@ class NavigationModel {
         layers.removeLast(max(0, layers.count - index))
     }
     
+    @MainActor
     func clear() {
         layers.forEach { $0.model = nil }
         layers = []
     }
     
+    @MainActor
     func openSheet(_ page: NavigationPage, hasNavigationStack: Bool? = nil) {
         openSheet(page, hasNavigationStack: hasNavigationStack, isFullScreenCover: false)
     }
     
+    @MainActor
     func showFullScreenCover(_ page: NavigationPage, hasNavigationStack: Bool? = nil) {
         openSheet(page, hasNavigationStack: hasNavigationStack, isFullScreenCover: true)
     }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -145,7 +145,9 @@ enum NavigationPage: Hashable {
     static func signUp() -> NavigationPage {
         .instancePicker(callback: { instance, navigation in
             if let stub = instance.instanceStub {
-                navigation.push(.signUp(stub))
+                Task { @MainActor in
+                    navigation.push(.signUp(stub))
+                }
             }
         })
     }
@@ -156,7 +158,9 @@ enum NavigationPage: Hashable {
     ) -> NavigationPage {
         communityPicker(api: api, callback: .init(wrappedValue: { value, navigation in
             callback(value)
-            navigation.dismissSheet()
+            Task { @MainActor in
+                navigation.dismissSheet()
+            }
         }))
     }
     
@@ -166,7 +170,9 @@ enum NavigationPage: Hashable {
     ) -> NavigationPage {
         personPicker(api: api, callback: .init(wrappedValue: { value, navigation in
             callback(value)
-            navigation.dismissSheet()
+            Task { @MainActor in
+                navigation.dismissSheet()
+            }
         }))
     }
     
@@ -177,7 +183,9 @@ enum NavigationPage: Hashable {
         assert((minimumVersion ?? .infinity) > Constants.main.minimumLemmyVersion)
         return instancePicker(callback: .init(wrappedValue: { value, navigation in
             callback(value)
-            navigation.dismissSheet()
+            Task { @MainActor in
+                navigation.dismissSheet()
+            }
         }), minimumVersion: minimumVersion)
     }
     


### PR DESCRIPTION
There's a TF crash related to mutating `NavigationModel.layers` on a background thread; this should hopefully fix it