### PR TITLE
Accessible Mark Read Indicator

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = B104A6DB2A59BF3C00B3E725 /* NukeUI */; };
 		B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */ = {isa = PBXBuildFile; productRef = B104A6DD2A59BF3C00B3E725 /* NukeVideo */; };
 		B1B78D642A51D53900F72485 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B78D632A51D53900F72485 /* AppDelegate.swift */; };
+		CD03742A2D1DBFD2001E85FA /* ReadCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0374292D1DBFCF001E85FA /* ReadCheck.swift */; };
 		CD0507732C6AA0C8008B1505 /* FeedSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0507722C6AA0C8008B1505 /* FeedSelection.swift */; };
 		CD09BA7F2CB4698E00C93926 /* OledPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD09BA7E2CB4698600C93926 /* OledPalette.swift */; };
 		CD0E06F72C0E739F00445849 /* PostType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0E06F62C0E739F00445849 /* PostType+Extensions.swift */; };
@@ -733,6 +734,7 @@
 		AD1B0D362A5F7A260006F554 /* Licenses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Licenses.swift; sourceTree = "<group>"; };
 		B104A6E12A5AFC9F00B3E725 /* Mlem.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Mlem.entitlements; sourceTree = "<group>"; };
 		B1B78D632A51D53900F72485 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		CD0374292D1DBFCF001E85FA /* ReadCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadCheck.swift; sourceTree = "<group>"; };
 		CD0507722C6AA0C8008B1505 /* FeedSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSelection.swift; sourceTree = "<group>"; };
 		CD09BA7E2CB4698600C93926 /* OledPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OledPalette.swift; sourceTree = "<group>"; };
 		CD0E06F62C0E739F00445849 /* PostType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostType+Extensions.swift"; sourceTree = "<group>"; };
@@ -1536,6 +1538,7 @@
 		CD4D58A82B86BE4C00B82964 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				CD0374292D1DBFCF001E85FA /* ReadCheck.swift */,
 				CDAA02E42C82236200D75633 /* Palette Components */,
 				03B431C32C45BA45001A1EB5 /* AccountPickerMenu.swift */,
 				CD4D58AB2B86BE6100B82964 /* Accounts */,
@@ -2522,6 +2525,7 @@
 				033FCB282C5E3933007B7CD1 /* AlternateIcon.swift in Sources */,
 				038028F62CB096960091A8A2 /* SearchView+FilterModels.swift in Sources */,
 				033FCB292C5E3933007B7CD1 /* IconSettingsView.swift in Sources */,
+				CD03742A2D1DBFD2001E85FA /* ReadCheck.swift in Sources */,
 				035394932CA1AE2C00795AA5 /* UptimeData.swift in Sources */,
 				036ED6832D0C483B0018E5EA /* Profile2Providing+Extensions.swift in Sources */,
 				033FCB2A2C5E3933007B7CD1 /* AlternateIconCell.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -395,6 +395,8 @@
 		CDBFCB6A2C04EFFE008CD468 /* PostSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBFCB692C04EFFE008CD468 /* PostSettingsView.swift */; };
 		CDBFCB6C2C054AA7008CD468 /* TilePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBFCB6B2C054AA7008CD468 /* TilePostView.swift */; };
 		CDC199EA2BE449790077B4F1 /* Interactable1Providing+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC199E92BE449790077B4F1 /* Interactable1Providing+Extensions.swift */; };
+		CDC44A342D1CBBD30030F01C /* AccessibilitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC44A332D1CBBCC0030F01C /* AccessibilitySettingsView.swift */; };
+		CDC44A362D1CBC280030F01C /* ReadPostIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC44A352D1CBC200030F01C /* ReadPostIndicator.swift */; };
 		CDCA44952C17658000C092B3 /* View+QuickSwipes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCA44942C17658000C092B3 /* View+QuickSwipes.swift */; };
 		CDCA44972C17666C00C092B3 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCA44962C17666C00C092B3 /* HapticManager.swift */; };
 		CDCA449B2C1766CF00C092B3 /* Failure.ahap in Resources */ = {isa = PBXBuildFile; fileRef = CDCA449A2C1766CF00C092B3 /* Failure.ahap */; };
@@ -831,6 +833,8 @@
 		CDBFCB692C04EFFE008CD468 /* PostSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSettingsView.swift; sourceTree = "<group>"; };
 		CDBFCB6B2C054AA7008CD468 /* TilePostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TilePostView.swift; sourceTree = "<group>"; };
 		CDC199E92BE449790077B4F1 /* Interactable1Providing+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Interactable1Providing+Extensions.swift"; sourceTree = "<group>"; };
+		CDC44A332D1CBBCC0030F01C /* AccessibilitySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySettingsView.swift; sourceTree = "<group>"; };
+		CDC44A352D1CBC200030F01C /* ReadPostIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadPostIndicator.swift; sourceTree = "<group>"; };
 		CDCA44942C17658000C092B3 /* View+QuickSwipes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+QuickSwipes.swift"; sourceTree = "<group>"; };
 		CDCA44962C17666C00C092B3 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		CDCA449A2C1766CF00C092B3 /* Failure.ahap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Failure.ahap; sourceTree = "<group>"; };
@@ -935,6 +939,7 @@
 		03134A492BEACF46002662CC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				CDC44A332D1CBBCC0030F01C /* AccessibilitySettingsView.swift */,
 				CD45CB0C2D1880E3008BC729 /* FiltersSettingsView.swift */,
 				0397D4982C6EA68A002C6CDC /* InteractionBarEditor */,
 				031E2D5C2BEFCC630003BC45 /* SettingsView.swift */,
@@ -1645,6 +1650,7 @@
 		CD4D58C62B86DCE500B82964 /* Enums */ = {
 			isa = PBXGroup;
 			children = (
+				CDC44A352D1CBC200030F01C /* ReadPostIndicator.swift */,
 				CD4D58C72B86DCED00B82964 /* AvatarType.swift */,
 				03CBD18C2C6120F600E870BC /* PersonFlair.swift */,
 				03AF91E62C1C65AE00E56644 /* Interaction */,
@@ -2254,6 +2260,7 @@
 				03D2A6372C00F92400ED4FF2 /* Session.swift in Sources */,
 				03AF91DD2C1B23E500E56644 /* ImageViewer.swift in Sources */,
 				CD13CC592C583C7A001AF428 /* WebsitePreviewView.swift in Sources */,
+				CDC44A342D1CBBD30030F01C /* AccessibilitySettingsView.swift in Sources */,
 				CD869FCE2C15F90C00FC8B5B /* ChildSizeReader.swift in Sources */,
 				035EDEF12C2DE94B00F51144 /* DefaultTextInputType.swift in Sources */,
 				039F588C2C7B574E00C61658 /* AdvancedSettingsView.swift in Sources */,
@@ -2498,6 +2505,7 @@
 				033F84C32C2B12AA002E3EDF /* InstanceSummary.swift in Sources */,
 				0369B3532BFA514B001EFEDF /* ToastLocation.swift in Sources */,
 				036ED6792D0AF3740018E5EA /* PinnedSortTracker.swift in Sources */,
+				CDC44A362D1CBC280030F01C /* ReadPostIndicator.swift in Sources */,
 				0353948D2CA080EB00795AA5 /* FeedWelcomeView.swift in Sources */,
 				03049A202C650A8100FF6889 /* FormReadout.swift in Sources */,
 				030050D32D109B7E002B1E99 /* ReportView.swift in Sources */,

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
-        "revision" : "064dbc65be21977113207067c563155ee859f485",
-        "version" : "0.56.0"
+        "revision" : "da33c0b616559921a8dd895c843aaf8abf2d85db",
+        "version" : "0.57.0"
       }
     },
     {

--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -11,8 +11,8 @@ import UIKit
 
 /// Mirror of Settings but without any AppStorage complexity and fully optionalized.
 struct CodableSettings: Codable {
-    var a11y_markReadType: String // TODO: pending a11y mark read
-    var a11y_readBarThickness: Int
+    var a11y_readPostIndicator: ReadPostIndicator
+    var a11y_readOutlineThickness: Int
     var a11y_websiteThumbnailIcon: Bool
     var accounts_defaultId: Int?
     var accounts_grouped: Bool
@@ -88,8 +88,8 @@ struct CodableSettings: Codable {
     // swiftlint:disable line_length function_body_length
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.a11y_markReadType = try container.decodeIfPresent(String.self, forKey: .a11y_markReadType) ?? "bar"
-        self.a11y_readBarThickness = try container.decodeIfPresent(Int.self, forKey: .a11y_readBarThickness) ?? 3
+        self.a11y_readPostIndicator = try container.decodeIfPresent(ReadPostIndicator.self, forKey: .a11y_readPostIndicator) ?? .outline
+        self.a11y_readOutlineThickness = try container.decodeIfPresent(Int.self, forKey: .a11y_readOutlineThickness) ?? 3
         self.a11y_websiteThumbnailIcon = try container.decodeIfPresent(Bool.self, forKey: .a11y_websiteThumbnailIcon) ?? false
         self.accounts_defaultId = try container.decodeIfPresent(Int?.self, forKey: .accounts_defaultId) ?? nil
         self.accounts_grouped = try container.decodeIfPresent(Bool.self, forKey: .accounts_grouped) ?? false
@@ -166,8 +166,8 @@ struct CodableSettings: Codable {
     // swiftlint:enable line_length
     
     init(from settings: Settings) {
-        self.a11y_markReadType = "bar"
-        self.a11y_readBarThickness = 3
+        self.a11y_readPostIndicator = .outline
+        self.a11y_readOutlineThickness = 3
         self.a11y_websiteThumbnailIcon = false
         self.accounts_defaultId = nil
         self.accounts_grouped = settings.groupAccountSort

--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -88,7 +88,7 @@ struct CodableSettings: Codable {
     // swiftlint:disable line_length function_body_length
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.a11y_readPostIndicator = try container.decodeIfPresent(ReadPostIndicator.self, forKey: .a11y_readPostIndicator) ?? .outline
+        self.a11y_readPostIndicator = try container.decodeIfPresent(ReadPostIndicator.self, forKey: .a11y_readPostIndicator) ?? .checkmark
         self.a11y_readOutlineThickness = try container.decodeIfPresent(Int.self, forKey: .a11y_readOutlineThickness) ?? 3
         self.a11y_websiteThumbnailIcon = try container.decodeIfPresent(Bool.self, forKey: .a11y_websiteThumbnailIcon) ?? false
         self.accounts_defaultId = try container.decodeIfPresent(Int?.self, forKey: .accounts_defaultId) ?? nil
@@ -166,7 +166,7 @@ struct CodableSettings: Codable {
     // swiftlint:enable line_length
     
     init(from settings: Settings) {
-        self.a11y_readPostIndicator = .outline
+        self.a11y_readPostIndicator = .checkmark
         self.a11y_readOutlineThickness = 3
         self.a11y_websiteThumbnailIcon = false
         self.accounts_defaultId = nil

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -18,6 +18,9 @@ class Settings: ObservableObject {
     /// Default initializer. Will take current AppStorage values.
     init() {}
 
+    @AppStorage("a11y.readPostIndicator") var readPostIndicator: ReadPostIndicator = .none
+    @AppStorage("a11y.readOutlineThickness") var readOutlineThickness: Int = 3
+
     @AppStorage("post.size") var postSize: PostSize = .compact
     @AppStorage("post.defaultSort") var defaultPostSort: ApiSortType = .hot
     @AppStorage("post.fallbackSort") var fallbackPostSort: ApiSortType = .hot
@@ -152,5 +155,7 @@ class Settings: ObservableObject {
         swipeAnywhereToNavigate = settings.navigation_swipeAnywhere
         moderatorActionGrouping = settings.menus_modActionGrouping
         showAllModActions = settings.menus_allModActions
+        readPostIndicator = settings.a11y_readPostIndicator
+        readOutlineThickness = settings.a11y_readOutlineThickness
     }
 }

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -18,7 +18,7 @@ class Settings: ObservableObject {
     /// Default initializer. Will take current AppStorage values.
     init() {}
 
-    @AppStorage("a11y.readPostIndicator") var readPostIndicator: ReadPostIndicator = .none
+    @AppStorage("a11y.readPostIndicator") var readPostIndicator: ReadPostIndicator = .checkmark
     @AppStorage("a11y.readOutlineThickness") var readOutlineThickness: Int = 3
 
     @AppStorage("post.size") var postSize: PostSize = .compact

--- a/Mlem/App/Enums/ReadPostIndicator.swift
+++ b/Mlem/App/Enums/ReadPostIndicator.swift
@@ -1,0 +1,20 @@
+//
+//  ReadPostIndicator.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-12-25.
+//
+
+import Foundation
+
+enum ReadPostIndicator: String, CaseIterable, Codable {
+    case outline, checkmark, none
+    
+    var label: LocalizedStringResource {
+        switch self {
+        case .outline: "Outline"
+        case .checkmark: "Checkmark"
+        case .none: "None"
+        }
+    }
+}

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
@@ -12,9 +12,11 @@ import SwiftUI
 struct CompactPostView: View {
     @Setting(\.thumbnailLocation) var thumbnailLocation
     @Setting(\.blurNsfw) var blurNsfw
+    @Setting(\.readPostIndicator) var readPostIndicator
     
     @Environment(\.communityContext) var communityContext: (any Community1Providing)?
     @Environment(Palette.self) var palette: Palette
+    @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor
     
     let post: any Post1Providing
     
@@ -52,6 +54,10 @@ struct CompactPostView: View {
                         FullyQualifiedLinkView(entity: post.community_, labelStyle: .small, showAvatar: false)
                     }
                     Spacer()
+
+                    if differentiateWithoutColor, readPostIndicator == .checkmark, post.read_ ?? false {
+                        ReadCheck()
+                    }
                     
                     if post.nsfw {
                         Image(Icons.nsfwTag)

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
@@ -18,12 +18,18 @@ struct FeedPostView<EmbeddedContent: View>: View {
     
     @State var obscured: Bool
     
-    @Setting(\.postSize) private var postSize
+    @Setting(\.postSize) private var settingsPostSize
+    @Setting(\.readPostIndicator) var readPostIndicator
+    @Setting(\.readOutlineThickness) var readOutlineThickness
     
     let post: any Post1Providing
     let favoredLink: PostViewNavigationLink?
     let overridePostSize: PostSize?
     
+    var postSize: PostSize {
+        overridePostSize ?? settingsPostSize
+    }
+
     @ViewBuilder let embeddedContent: () -> EmbeddedContent
     
     init(
@@ -50,7 +56,14 @@ struct FeedPostView<EmbeddedContent: View>: View {
                     }
             } else {
                 content
-                    .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
+                    .overlay(alignment: .topLeading) {
+                        if !(post.read_ ?? false), readPostIndicator == .outline {
+                            RoundedRectangle(cornerRadius: postSize.swipeBehavior.cornerRadius)
+                                .stroke(lineWidth: .init(readOutlineThickness))
+                                .foregroundStyle(palette.secondary)
+                        }
+                    }
+                    .contentShape(.contextMenuPreview, .rect(cornerRadius: postSize.swipeBehavior.cornerRadius))
                     .quickSwipes(post.swipeActions(behavior: postSize.swipeBehavior))
                     .contextMenu { post.allMenuActions(
                         showAllActions: false,
@@ -79,7 +92,7 @@ struct FeedPostView<EmbeddedContent: View>: View {
     
     @ViewBuilder
     var content: some View {
-        switch overridePostSize ?? postSize {
+        switch postSize {
         case .compact:
             CompactPostView(post: post)
         case .tile:

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
@@ -15,6 +15,7 @@ struct FeedPostView<EmbeddedContent: View>: View {
     @Environment(NavigationLayer.self) private var navigation
     @Environment(Palette.self) private var palette
     @Environment(FiltersTracker.self) var filtersTracker
+    @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor
     
     @State var obscured: Bool
     
@@ -29,7 +30,7 @@ struct FeedPostView<EmbeddedContent: View>: View {
     var postSize: PostSize {
         overridePostSize ?? settingsPostSize
     }
-
+    
     @ViewBuilder let embeddedContent: () -> EmbeddedContent
     
     init(
@@ -57,7 +58,7 @@ struct FeedPostView<EmbeddedContent: View>: View {
             } else {
                 content
                     .overlay(alignment: .topLeading) {
-                        if !(post.read_ ?? false), readPostIndicator == .outline {
+                        if differentiateWithoutColor, !(post.read_ ?? false), readPostIndicator == .outline {
                             RoundedRectangle(cornerRadius: postSize.swipeBehavior.cornerRadius)
                                 .stroke(lineWidth: .init(readOutlineThickness))
                                 .foregroundStyle(palette.secondary)

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/HeadlinePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/HeadlinePostView.swift
@@ -13,10 +13,12 @@ struct HeadlinePostView<EmbeddedContent: View>: View {
     @Setting(\.showPostCreator) var alwaysShowCreator
     @Setting(\.showPersonAvatar) var showPersonAvatar
     @Setting(\.showCommunityAvatar) var showCommunityAvatar
+    @Setting(\.readPostIndicator) var readPostIndicator
     
     @Environment(CommentTreeTracker.self) private var commentTreeTracker: CommentTreeTracker?
     @Environment(Palette.self) var palette: Palette
     @Environment(\.communityContext) var communityContext: (any Community1Providing)?
+    @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor
     
     let post: any Post1Providing
     let embeddedContent: EmbeddedContent
@@ -53,6 +55,10 @@ struct HeadlinePostView<EmbeddedContent: View>: View {
                 }
                 
                 Spacer()
+                
+                if differentiateWithoutColor, readPostIndicator == .checkmark, post.read_ ?? false {
+                    ReadCheck()
+                }
                 
                 if post.nsfw {
                     Image(Icons.nsfwTag)

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostView.swift
@@ -14,10 +14,12 @@ struct LargePostView: View {
     @Setting(\.showPersonAvatar) private var showPersonAvatar
     @Setting(\.showCommunityAvatar) private var showCommunityAvatar
     @Setting(\.blurNsfw) var blurNsfw
+    @Setting(\.readPostIndicator) var readPostIndicator
     
     @Environment(Palette.self) private var palette: Palette
     @Environment(CommentTreeTracker.self) private var commentTreeTracker: CommentTreeTracker?
     @Environment(\.communityContext) private var communityContext
+    @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor
     
     let post: any Post1Providing
     let isPostPage: Bool
@@ -63,11 +65,15 @@ struct LargePostView: View {
                 
                 Spacer()
                 
+                if !isPostPage, differentiateWithoutColor, readPostIndicator == .checkmark, post.read_ ?? false {
+                    ReadCheck()
+                }
+                
                 if post.nsfw {
                     Image(Icons.nsfwTag)
                         .foregroundStyle(palette.warning)
                 }
-
+                
                 if !isPostPage {
                     PostEllipsisMenus(post: post)
                 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/TilePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/TilePostView.swift
@@ -12,11 +12,14 @@ import NukeUI
 import SwiftUI
 
 struct TilePostView: View {
+    @Setting(\.readPostIndicator) var readPostIndicator
+    
     @Environment(CommentTreeTracker.self) private var commentTreeTracker: CommentTreeTracker?
     @Environment(NavigationLayer.self) var navigation
     @Environment(Palette.self) var palette: Palette
     @Environment(\.communityContext) var communityContext: (any Community1Providing)?
     @Environment(\.parentFrameWidth) var parentFrameWidth: CGFloat
+    @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor
     
     let post: any Post1Providing
 
@@ -87,6 +90,10 @@ struct TilePostView: View {
             }
             
             Spacer()
+            
+            if differentiateWithoutColor, readPostIndicator == .checkmark, post.read_ ?? false {
+                ReadCheck(tiled: true)
+            }
             
             score
         }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct AccessibilitySettingsView: View {
     
+    @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor
+    
     @Setting(\.readPostIndicator) var readPostIndicator
     @Setting(\.readOutlineThickness) var readOutlineThickness
     
@@ -49,6 +51,8 @@ struct AccessibilitySettingsView: View {
                         }
                     }
                 }
+            } footer: {
+                Text("These settings control how Mlem behaves when the system-wide \"Differentiate Without Color\" option is enabled.")
             }
         }
     }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -41,9 +41,9 @@ struct AccessibilitySettingsView: View {
                         ) {
                             Text("Outline Thickness")
                         } minimumValueLabel: {
-                            Text("1")
+                            Text(verbatim: "1")
                         } maximumValueLabel: {
-                            Text("5")
+                            Text(verbatim: "5")
                         } onEditingChanged: { editing in
                             if !editing {
                                 readOutlineThickness = Int(readBarThicknessSlider)

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -1,0 +1,55 @@
+//
+//  AccessibilitySettingsView.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-12-25.
+//
+
+import SwiftUI
+
+struct AccessibilitySettingsView: View {
+    
+    @Setting(\.readPostIndicator) var readPostIndicator
+    @Setting(\.readOutlineThickness) var readOutlineThickness
+    
+    @State var readBarThicknessSlider: Double
+    
+    init() {
+        @Setting(\.readOutlineThickness) var readOutlineThickness
+        self._readBarThicknessSlider = .init(wrappedValue: Double(readOutlineThickness))
+    }
+    
+    var body: some View {
+        List {
+            Section("Differentiate Without Color") {
+                Picker("Read Post Indicator", selection: $readPostIndicator) {
+                    ForEach(ReadPostIndicator.allCases, id: \.self) { item in
+                        Text(item.label)
+                    }
+                }
+                
+                if readPostIndicator == .outline {
+                    VStack(alignment: .leading) {
+                        Text("Outline Thickness")
+                        
+                        Slider(
+                            value: $readBarThicknessSlider,
+                            in: 1 ... 5,
+                            step: 1
+                        ) {
+                            Text("Outline Thickness")
+                        } minimumValueLabel: {
+                            Text("1")
+                        } maximumValueLabel: {
+                            Text("5")
+                        } onEditingChanged: { editing in
+                            if !editing {
+                                readOutlineThickness = Int(readBarThicknessSlider)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -29,7 +29,7 @@ struct SettingsView: View {
                 NavigationLink("General", systemImage: "gear", destination: .settings(.general))
                     .tint(palette.neutralAccent)
                 NavigationLink("Accessibility", systemImage: "hand.point.up.braille.fill", destination: .settings(.accessibility))
-                    .tint(palette.accent)
+                    .tint(palette.colorfulAccent(2))
                 NavigationLink("Links", systemImage: Icons.websiteAddress, destination: .settings(.links))
                     .tint(palette.colorfulAccent(6))
                 NavigationLink("Sorting", systemImage: "arrow.up.and.down.text.horizontal", destination: .settings(.sorting))

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -28,6 +28,8 @@ struct SettingsView: View {
             Section {
                 NavigationLink("General", systemImage: "gear", destination: .settings(.general))
                     .tint(palette.neutralAccent)
+                NavigationLink("Accessibility", systemImage: "hand.point.up.braille.fill", destination: .settings(.accessibility))
+                    .tint(palette.accent)
                 NavigationLink("Links", systemImage: Icons.websiteAddress, destination: .settings(.links))
                     .tint(palette.colorfulAccent(6))
                 NavigationLink("Sorting", systemImage: "arrow.up.and.down.text.horizontal", destination: .settings(.sorting))

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -12,7 +12,7 @@ enum SettingsPage: Hashable {
     case root
     case accounts, account
     case profile, accountGeneral, accountAdvanced, accountSignIn, accountChangeEmail, accountLocal
-    case general, links, sorting, filters
+    case general, accessibility, links, sorting, filters
     case importExportSettings
     case theme, icon
     case post, comment, inbox, subscriptionList
@@ -27,6 +27,8 @@ enum SettingsPage: Hashable {
         switch self {
         case .root:
             SettingsView()
+        case .accessibility:
+            AccessibilitySettingsView()
         case .account:
             AccountSettingsView()
         case .profile:

--- a/Mlem/App/Views/Shared/ReadCheck.swift
+++ b/Mlem/App/Views/Shared/ReadCheck.swift
@@ -1,0 +1,27 @@
+//
+//  ReadCheck.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-12-26.
+//
+
+import SwiftUI
+
+struct ReadCheck: View {
+    
+    @Environment(Palette.self) var palette
+    
+    let dimension: CGFloat
+    
+    init(tiled: Bool = false) {
+        dimension = tiled ? 10 : 12
+    }
+    
+    var body: some View {
+        Image(systemName: Icons.success)
+            .resizable()
+            .scaledToFit()
+            .frame(width: dimension, height: dimension)
+            .foregroundColor(palette.secondary)
+    }
+}

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1591,6 +1591,9 @@
     "These options are stored locally in Mlem and not on your Lemmy account." : {
 
     },
+    "These settings control how Mlem behaves when the system-wide \"Differentiate Without Color\" option is enabled." : {
+
+    },
     "This account has %lld favorite communities." : {
       "localizations" : {
         "en" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -97,12 +97,6 @@
     "%lld on your instance" : {
 
     },
-    "1" : {
-
-    },
-    "5" : {
-
-    },
     "A censure signifies that an instance disapproves of another instance. Like an endorsement, it is completely subjective and a reason does not have to be given." : {
 
     },

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -97,6 +97,12 @@
     "%lld on your instance" : {
 
     },
+    "1" : {
+
+    },
+    "5" : {
+
+    },
     "A censure signifies that an instance disapproves of another instance. Like an endorsement, it is completely subjective and a reason does not have to be given." : {
 
     },
@@ -110,6 +116,9 @@
 
     },
     "Abuse" : {
+
+    },
+    "Accessibility" : {
 
     },
     "Account" : {
@@ -327,6 +336,9 @@
         }
       }
     },
+    "Checkmark" : {
+
+    },
     "Choose a community..." : {
 
     },
@@ -483,6 +495,9 @@
 
     },
     "Diagnosing..." : {
+
+    },
+    "Differentiate Without Color" : {
 
     },
     "Disabled" : {
@@ -1036,6 +1051,12 @@
     "Other" : {
 
     },
+    "Outline" : {
+
+    },
+    "Outline Thickness" : {
+
+    },
     "Outside NSFW Communities" : {
 
     },
@@ -1136,6 +1157,9 @@
 
     },
     "Ranks posts based on the post score and creation time." : {
+
+    },
+    "Read Post Indicator" : {
 
     },
     "Readouts:" : {


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #1448 

# Pull Request Information

Adds an accessible read post indicator. There are two options:
- Outline: unread posts are outlined. Thickness is configurable from 1 to 5px
- Checkmark: read posts show a checkmark next to the ellipsis menu

These markers should only be visible when the system-wide "differentiate without color" option is enabled.
