### PR TITLE
Import/Export Filtered Keywords

### DIFF
--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -11,6 +11,7 @@ import UIKit
 
 /// Mirror of Settings but without any AppStorage complexity and fully optionalized.
 struct CodableSettings: Codable {
+    // MARK: Settings mirrored in AppStorage
     var a11y_markReadType: String // TODO: pending a11y mark read
     var a11y_readBarThickness: Int
     var a11y_websiteThumbnailIcon: Bool
@@ -84,6 +85,8 @@ struct CodableSettings: Codable {
     var subscriptions_sort: SubscriptionListSort
     var navigation_sidebarVisibleByDefault: Bool
     var navigation_swipeAnywhere: Bool
+    
+    var filteredKeywords: [String]
     
     // swiftlint:disable line_length function_body_length
     init(from decoder: any Decoder) throws {

--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -11,6 +11,7 @@ import UIKit
 
 /// Mirror of Settings but without any AppStorage complexity and fully optionalized.
 struct CodableSettings: Codable {
+    // MARK: Settings mirrored in AppStorage
     var a11y_readPostIndicator: ReadPostIndicator
     var a11y_readOutlineThickness: Int
     var a11y_websiteThumbnailIcon: Bool
@@ -85,6 +86,7 @@ struct CodableSettings: Codable {
     var navigation_sidebarVisibleByDefault: Bool
     var navigation_swipeAnywhere: Bool
     
+    // MARK: Settings stored in files
     var filteredKeywords: [String]
     
     // swiftlint:disable line_length function_body_length
@@ -163,11 +165,12 @@ struct CodableSettings: Codable {
         self.subscriptions_sort = try container.decodeIfPresent(SubscriptionListSort.self, forKey: .subscriptions_sort) ?? .alphabetical
         self.navigation_sidebarVisibleByDefault = try container.decodeIfPresent(Bool.self, forKey: .navigation_sidebarVisibleByDefault) ?? true
         self.navigation_swipeAnywhere = try container.decodeIfPresent(Bool.self, forKey: .navigation_swipeAnywhere) ?? false
+        self.filteredKeywords = try container.decodeIfPresent([String].self, forKey: .filteredKeywords) ?? .init()
     }
 
     // swiftlint:enable line_length
     
-    init(from settings: Settings) {
+    init(from settings: Settings, filteredKeywords: [String]) {
         self.a11y_readPostIndicator = .checkmark
         self.a11y_readOutlineThickness = 3
         self.a11y_websiteThumbnailIcon = false
@@ -241,6 +244,8 @@ struct CodableSettings: Codable {
         self.subscriptions_sort = settings.subscriptionSort
         self.navigation_sidebarVisibleByDefault = settings.sidebarVisibleByDefault
         self.navigation_swipeAnywhere = settings.swipeAnywhereToNavigate
+        
+        self.filteredKeywords = filteredKeywords
     }
     // swiftlint:enable function_body_length
 }

--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -11,7 +11,7 @@ import UIKit
 
 /// Mirror of Settings but without any AppStorage complexity and fully optionalized.
 struct CodableSettings: Codable {
-    // MARK: Settings mirrored in AppStorage
+    // MARK: Settings saved in AppStorage
     var a11y_readPostIndicator: ReadPostIndicator
     var a11y_readOutlineThickness: Int
     var a11y_websiteThumbnailIcon: Bool
@@ -86,7 +86,7 @@ struct CodableSettings: Codable {
     var navigation_sidebarVisibleByDefault: Bool
     var navigation_swipeAnywhere: Bool
     
-    // MARK: Settings stored in files
+    // MARK: Settings saved in files
     var filteredKeywords: Set<String>
     
     // swiftlint:disable line_length function_body_length

--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -87,7 +87,7 @@ struct CodableSettings: Codable {
     var navigation_swipeAnywhere: Bool
     
     // MARK: Settings stored in files
-    var filteredKeywords: [String]
+    var filteredKeywords: Set<String>
     
     // swiftlint:disable line_length function_body_length
     init(from decoder: any Decoder) throws {
@@ -165,12 +165,12 @@ struct CodableSettings: Codable {
         self.subscriptions_sort = try container.decodeIfPresent(SubscriptionListSort.self, forKey: .subscriptions_sort) ?? .alphabetical
         self.navigation_sidebarVisibleByDefault = try container.decodeIfPresent(Bool.self, forKey: .navigation_sidebarVisibleByDefault) ?? true
         self.navigation_swipeAnywhere = try container.decodeIfPresent(Bool.self, forKey: .navigation_swipeAnywhere) ?? false
-        self.filteredKeywords = try container.decodeIfPresent([String].self, forKey: .filteredKeywords) ?? .init()
+        self.filteredKeywords = try container.decodeIfPresent(Set<String>.self, forKey: .filteredKeywords) ?? .init()
     }
 
     // swiftlint:enable line_length
     
-    init(from settings: Settings, filteredKeywords: [String]) {
+    init(from settings: Settings, filteredKeywords: Set<String>) {
         self.a11y_readPostIndicator = .checkmark
         self.a11y_readOutlineThickness = 3
         self.a11y_websiteThumbnailIcon = false

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -159,10 +159,8 @@ class Settings: ObservableObject {
         readPostIndicator = settings.a11y_readPostIndicator
         readOutlineThickness = settings.a11y_readOutlineThickness
         
-        print("DEBUG \(settings.filteredKeywords)")
-        FiltersTracker.main.filteredKeywords = .init(settings.filteredKeywords)
-        
         Task {
+            await FiltersTracker.main.resetFilteredKeywords(settings.filteredKeywords)
             do {
                 try await persistenceRepository.saveSystemSettings(settings, setting: .v2)
             } catch {

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -87,7 +87,7 @@ class Settings: ObservableObject {
     @AppStorage("menus.moderatorActionGrouping") var moderatorActionGrouping: ModeratorActionGrouping = .divider
     @AppStorage("menus.allModActions") var showAllModActions: Bool = false
     
-    var codable: CodableSettings { .init(from: self, filteredKeywords: .init(FiltersTracker.main.filteredKeywords)) }
+    var codable: CodableSettings { .init(from: self, filteredKeywords: FiltersTracker.main.filteredKeywords) }
     
     @MainActor
     func restore(from systemSetting: SystemSetting) {
@@ -160,7 +160,7 @@ class Settings: ObservableObject {
         readOutlineThickness = settings.a11y_readOutlineThickness
         
         Task {
-            await FiltersTracker.main.resetFilteredKeywords(settings.filteredKeywords)
+            await FiltersTracker.main.resetFilteredKeywords(to: settings.filteredKeywords)
             do {
                 try await persistenceRepository.saveSystemSettings(settings, setting: .v2)
             } catch {

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -87,7 +87,7 @@ class Settings: ObservableObject {
     @AppStorage("menus.moderatorActionGrouping") var moderatorActionGrouping: ModeratorActionGrouping = .divider
     @AppStorage("menus.allModActions") var showAllModActions: Bool = false
     
-    var codable: CodableSettings { .init(from: self) }
+    var codable: CodableSettings { .init(from: self, filteredKeywords: .init(FiltersTracker.main.filteredKeywords)) }
     
     @MainActor
     func restore(from systemSetting: SystemSetting) {
@@ -110,6 +110,7 @@ class Settings: ObservableObject {
     
     /// Re-initializes all values from the given CodableSettings object.
     @MainActor
+    // swiftlint:disable:next function_body_length
     func reinit(from settings: CodableSettings) {
         postSize = settings.post_size
         defaultPostSort = settings.post_defaultSort
@@ -157,5 +158,16 @@ class Settings: ObservableObject {
         showAllModActions = settings.menus_allModActions
         readPostIndicator = settings.a11y_readPostIndicator
         readOutlineThickness = settings.a11y_readOutlineThickness
+        
+        print("DEBUG \(settings.filteredKeywords)")
+        FiltersTracker.main.filteredKeywords = .init(settings.filteredKeywords)
+        
+        Task {
+            do {
+                try await persistenceRepository.saveSystemSettings(settings, setting: .v2)
+            } catch {
+                handleError(error)
+            }
+        }
     }
 }

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -12,9 +12,11 @@ import Observation
 
 @Observable
 class FiltersTracker {
+    @ObservationIgnored @Dependency(\.persistenceRepository) var persistenceRepository
+    
     var isAdmin: Bool
     var moderatedCommunityActorIds: Set<URL>
-    var filteredKeywords: Set<String>
+    private(set) var filteredKeywords: Set<String>
     
     var filterContext: FilterContext {
         .init(isAdmin: isAdmin, moderatedCommunityActorIds: moderatedCommunityActorIds, filteredKeywords: filteredKeywords)
@@ -35,9 +37,54 @@ class FiltersTracker {
         self.filteredKeywords = persistenceRepository.loadFilteredKeywords()
     }
     
+    @MainActor
+    func setFilteredKeywords(to filteredKeywords: Set<String>) {
+        self.filteredKeywords = filteredKeywords
+    }
+    
+    func addFilteredKeyword(_ keyword: String) async {
+        do {
+            try await setFilteredKeywords(to: persistenceRepository.saveFilteredKeywords(filteredKeywords.union([keyword])))
+        } catch {
+            handleError(error)
+        }
+    }
+    
+    func removeFilteredKeyword(_ keyword: String) async {
+        assert(filteredKeywords.contains(keyword), "Filtered keywords does not contain \(keyword)")
+        do {
+            try await setFilteredKeywords(to: persistenceRepository.saveFilteredKeywords(filteredKeywords.subtracting([keyword])))
+        } catch {
+            handleError(error)
+        }
+    }
+    
+    func resetFilteredKeywords(_ filteredKeywords: Set<String>) async {
+        do {
+            try await setFilteredKeywords(to: persistenceRepository.saveFilteredKeywords(filteredKeywords))
+        } catch {
+            handleError(error)
+        }
+    }
+    
     func postWouldBeFiltered(_ post: any Post) -> Bool {
         post.title.lowercased().containsWordsIn(filteredKeywords)
     }
     
     static var main: FiltersTracker = .init()
+}
+
+// The persisted file serves as the source of truth for filters. Since it's much more convenient to use FiltersTracker,
+// all access to the file is proxied through FiltersTracker so that FiltersTracker and the persistent file remain in sync
+// and the rest of the app can treat FiltersTracker as a source of truth.
+private extension PersistenceRepository {
+    func loadFilteredKeywords() -> Set<String> {
+        load(Set<String>.self, from: PersistencePath.filteredKeywords) ?? .init()
+    }
+    
+    @discardableResult
+    func saveFilteredKeywords(_ value: Set<String>) async throws -> Set<String> {
+        try await save(value, to: PersistencePath.filteredKeywords)
+        return value
+    }
 }

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -76,7 +76,13 @@ class FiltersTracker {
 
 // The persisted file serves as the source of truth for filters. Since it's much more convenient to use FiltersTracker,
 // all access to the file is proxied through FiltersTracker so that FiltersTracker and the persistent file remain in sync
-// and the rest of the app can treat FiltersTracker as a source of truth.
+// and the rest of the app can treat FiltersTracker as a source of truth. Access to filters persistence is therefore
+// restricted to FiltersTracker.
+
+private extension PersistencePath {
+    static var filteredKeywords = root.appendingPathComponent("Blocked Keywords", conformingTo: .json)
+}
+
 private extension PersistenceRepository {
     func loadFilteredKeywords() -> Set<String> {
         load(Set<String>.self, from: PersistencePath.filteredKeywords) ?? .init()

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -59,7 +59,7 @@ class FiltersTracker {
         }
     }
     
-    func resetFilteredKeywords(_ filteredKeywords: Set<String>) async {
+    func resetFilteredKeywords(to filteredKeywords: Set<String>) async {
         do {
             try await setFilteredKeywords(to: persistenceRepository.saveFilteredKeywords(filteredKeywords))
         } catch {

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -183,15 +183,15 @@ class PersistenceRepository {
         try await save(value, to: Path.pinnedSortTypes)
     }
     
-    /// Saves the given user settings
-    func saveUserSettings(_ settings: CodableSettings, name: String) async throws {
-        try await save(settings, to: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
-    }
-    
-    /// Loads given user settings, if present
-    func loadUserSettings(name: String) -> CodableSettings? {
-        load(CodableSettings.self, from: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
-    }
+//    /// Saves the given user settings
+//    func saveUserSettings(_ settings: CodableSettings, name: String) async throws {
+//        try await save(settings, to: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
+//    }
+//    
+//    /// Loads given user settings, if present
+//    func loadUserSettings(name: String) -> CodableSettings? {
+//        load(CodableSettings.self, from: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
+//    }
     
     /// Returns true if the given system settings exist, false otherwise
     func systemSettingsExists(_ setting: SystemSetting) -> Bool {

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -11,7 +11,7 @@ import Foundation
 import MlemMiddleware
 
 enum PersistencePath {
-    private static var root = {
+    static var root = {
         guard let path = try? FileManager.default.url(
             for: .applicationSupportDirectory,
             in: .userDomainMask,
@@ -26,7 +26,6 @@ enum PersistencePath {
 
     static var userAccounts = root.appendingPathComponent("Saved Accounts", conformingTo: .json)
     static var guestAccounts = root.appendingPathComponent("Guest Accounts", conformingTo: .json)
-    static var filteredKeywords = root.appendingPathComponent("Blocked Keywords", conformingTo: .json)
     static var favoriteCommunities = root.appendingPathComponent("Favorite Communities", conformingTo: .json)
     static var recentSearches = root.appendingPathComponent("Recent Searches", conformingTo: .json)
     static var easterFlags = root.appendingPathComponent("Easter eggs flags", conformingTo: .json)

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -183,15 +183,15 @@ class PersistenceRepository {
         try await save(value, to: Path.pinnedSortTypes)
     }
     
-//    /// Saves the given user settings
-//    func saveUserSettings(_ settings: CodableSettings, name: String) async throws {
-//        try await save(settings, to: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
-//    }
-//    
-//    /// Loads given user settings, if present
-//    func loadUserSettings(name: String) -> CodableSettings? {
-//        load(CodableSettings.self, from: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
-//    }
+    /// Saves the given user settings
+    func saveUserSettings(_ settings: CodableSettings, name: String) async throws {
+        try await save(settings, to: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
+    }
+    
+    /// Loads given user settings, if present
+    func loadUserSettings(name: String) -> CodableSettings? {
+        load(CodableSettings.self, from: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
+    }
     
     /// Returns true if the given system settings exist, false otherwise
     func systemSettingsExists(_ setting: SystemSetting) -> Bool {

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -10,7 +10,7 @@ import Dependencies
 import Foundation
 import MlemMiddleware
 
-private enum Path {
+enum PersistencePath {
     private static var root = {
         guard let path = try? FileManager.default.url(
             for: .applicationSupportDirectory,
@@ -84,8 +84,8 @@ class PersistenceRepository {
         
         // set up settings directories--if this fails, something has gone _terribly_ wrong
         do {
-            try FileManager.default.createDirectory(at: Path.systemSettings, withIntermediateDirectories: true)
-            try FileManager.default.createDirectory(at: Path.userSettings, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: PersistencePath.systemSettings, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: PersistencePath.userSettings, withIntermediateDirectories: true)
         } catch {
             fatalError("Could not create settings directories")
         }
@@ -94,19 +94,19 @@ class PersistenceRepository {
     // MARK: - Public methods
     
     func loadUserAccounts() -> [UserAccount] {
-        load([UserAccount].self, from: Path.userAccounts) ?? []
+        load([UserAccount].self, from: PersistencePath.userAccounts) ?? []
     }
     
     func saveUserAccounts(_ value: [UserAccount]) async throws {
-        try await save(value, to: Path.userAccounts)
+        try await save(value, to: PersistencePath.userAccounts)
     }
     
     func loadGuestAccounts() -> [GuestAccount] {
-        load([GuestAccount].self, from: Path.guestAccounts) ?? []
+        load([GuestAccount].self, from: PersistencePath.guestAccounts) ?? []
     }
     
     func saveGuestAccounts(_ value: [GuestAccount]) async throws {
-        try await save(value, to: Path.guestAccounts)
+        try await save(value, to: PersistencePath.guestAccounts)
     }
 
 //
@@ -138,21 +138,21 @@ class PersistenceRepository {
 //    }
 
     func loadInteractionBarConfigurations() -> InteractionBarConfigurations {
-        load(InteractionBarConfigurations.self, from: Path.layoutWidgets) ?? .default
+        load(InteractionBarConfigurations.self, from: PersistencePath.layoutWidgets) ?? .default
     }
     
     func saveInteractionBarConfigurations(_ value: InteractionBarConfigurations) async throws {
-        try await save(value, to: Path.layoutWidgets)
+        try await save(value, to: PersistencePath.layoutWidgets)
     }
     
     func loadPinnedSortTypes() -> Set<ApiSortType> {
-        load(Set<ApiSortType>.self, from: Path.pinnedSortTypes) ?? [
+        load(Set<ApiSortType>.self, from: PersistencePath.pinnedSortTypes) ?? [
             .hot, .new, .topSixHour, .topDay, .topWeek, .topMonth, .topYear, .topAll
         ]
     }
     
     func savePinnedSortTypes(_ value: Set<ApiSortType>) async throws {
-        try await save(value, to: Path.pinnedSortTypes)
+        try await save(value, to: PersistencePath.pinnedSortTypes)
     }
     
 //    /// Saves the given user settings
@@ -174,51 +174,18 @@ class PersistenceRepository {
     
     /// Saves the given system settings
     func saveSystemSettings(_ settings: CodableSettings, setting: SystemSetting) async throws {
-        print("DEBUG saving to \(setting), \(settings.filteredKeywords)")
-        try await save(settings, to: Path.systemSettings.appendingPathComponent(setting.path, conformingTo: .json))
+        try await save(settings, to: PersistencePath.systemSettings.appendingPathComponent(setting.path, conformingTo: .json))
     }
     
     /// Loads given system settings, if present
     func loadSystemSettings(_ setting: SystemSetting) -> CodableSettings? {
-        load(CodableSettings.self, from: Path.systemSettings.appendingPathComponent(setting.path, conformingTo: .json))
-    }
-    
-    func loadFilteredKeywords(for setting: SystemSetting = .v2) -> Set<String> {
-        let settings = loadSystemSettings(setting)
-        print("DEBUG loading filtered keywords \(settings?.filteredKeywords ?? [])")
-        return .init(settings?.filteredKeywords ?? [])
-    }
-    
-    /// Saves the given keyword and returns the updated set of filtered keywords
-    func saveFilteredKeyword(_ value: String, to setting: SystemSetting = .v2) async throws -> Set<String> {
-        var settings = Settings.main.codable
-        settings.filteredKeywords.append(value)
-        try await saveSystemSettings(settings, setting: setting)
-        return .init(settings.filteredKeywords)
-//        var keywords = loadFilteredKeywords(for: setting)
-//        keywords.insert(value)
-//        try await saveFilteredKeywords(.init(keywords), to: setting)
-//        return keywords
-    }
-    
-    /// Removes the given keyword and returns the updated set of filtered keywords
-    func removeFilteredKeyword(_ value: String, from setting: SystemSetting = .v2) async throws -> Set<String> {
-        var keywords = loadFilteredKeywords(for: setting)
-        keywords.remove(value)
-        try await saveFilteredKeywords(.init(keywords), to: setting)
-        return keywords
-    }
-    
-    func saveFilteredKeywords(_ value: [String], to setting: SystemSetting = .v2) async throws {
-        var settings = Settings.main.codable
-        settings.filteredKeywords = value
-        try await saveSystemSettings(settings, setting: setting)
+        load(CodableSettings.self, from: PersistencePath.systemSettings.appendingPathComponent(setting.path, conformingTo: .json))
     }
     
     // DEV ONLY
     func deleteAllSystemSettings() throws {
-        try FileManager.default.removeItem(at: Path.systemSettings)
-        try FileManager.default.createDirectory(at: Path.systemSettings, withIntermediateDirectories: true)
+        try FileManager.default.removeItem(at: PersistencePath.systemSettings)
+        try FileManager.default.createDirectory(at: PersistencePath.systemSettings, withIntermediateDirectories: true)
     }
 
 //
@@ -238,9 +205,9 @@ class PersistenceRepository {
 //        try await save(timestamped, to: Path.instanceMetadata)
 //    }
     
-    // MARK: Private methods
+    // MARK: Loading methods
     
-    private func load<T: Decodable>(_ model: T.Type, from path: URL) -> T? {
+    func load<T: Decodable>(_ model: T.Type, from path: URL) -> T? {
         do {
             let data = try read(path)
             
@@ -269,7 +236,7 @@ class PersistenceRepository {
         }
     }
     
-    private func save(_ value: some Encodable, to path: URL) async throws {
+    func save(_ value: some Encodable, to path: URL) async throws {
         do {
             let data = try JSONEncoder().encode(value)
             try await write(data, path)

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -155,15 +155,15 @@ class PersistenceRepository {
         try await save(value, to: PersistencePath.pinnedSortTypes)
     }
     
-//    /// Saves the given user settings
-//    func saveUserSettings(_ settings: CodableSettings, name: String) async throws {
-//        try await save(settings, to: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
-//    }
-//    
-//    /// Loads given user settings, if present
-//    func loadUserSettings(name: String) -> CodableSettings? {
-//        load(CodableSettings.self, from: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
-//    }
+    /// Saves the given user settings
+    func saveUserSettings(_ settings: CodableSettings, name: String) async throws {
+        try await save(settings, to: PersistencePath.userSettings.appendingPathComponent(name, conformingTo: .json))
+    }
+    
+    /// Loads given user settings, if present
+    func loadUserSettings(name: String) -> CodableSettings? {
+        load(CodableSettings.self, from: PersistencePath.userSettings.appendingPathComponent(name, conformingTo: .json))
+    }
     
     /// Returns true if the given system settings exist, false otherwise
     func systemSettingsExists(_ setting: SystemSetting) -> Bool {

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -136,35 +136,7 @@ class PersistenceRepository {
 //    func saveEasterFlags(_ value: Set<EasterFlag>) async throws {
 //        try await save(value, to: Path.easterFlags)
 //    }
-    
-    func loadFilteredKeywords() -> Set<String> {
-        Set(load([String].self, from: Path.filteredKeywords) ?? [])
-    }
-    
-    /// Saves the given keyword and returns the updated set of filtered keywords
-    func saveFilteredKeyword(_ value: String) async throws -> Set<String> {
-        var keywords = loadFilteredKeywords()
-        keywords.insert(value)
-        try await saveFilteredKeywords(.init(keywords))
-        return keywords
-    }
-    
-    /// Removes the given keyword and returns the updated set of filtered keywords
-    func removeFilteredKeyword(_ value: String) async throws -> Set<String> {
-        var keywords = loadFilteredKeywords()
-        keywords.remove(value)
-        try await saveFilteredKeywords(.init(keywords))
-        return keywords
-    }
-    
-    func saveFilteredKeywords(_ value: [String]) async throws {
-        try await save(value, to: Path.filteredKeywords)
-    }
-    
-    func getFilteredKeywordsPath() -> URL {
-        Path.filteredKeywords
-    }
-    
+
     func loadInteractionBarConfigurations() -> InteractionBarConfigurations {
         load(InteractionBarConfigurations.self, from: Path.layoutWidgets) ?? .default
     }
@@ -183,15 +155,15 @@ class PersistenceRepository {
         try await save(value, to: Path.pinnedSortTypes)
     }
     
-    /// Saves the given user settings
-    func saveUserSettings(_ settings: CodableSettings, name: String) async throws {
-        try await save(settings, to: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
-    }
-    
-    /// Loads given user settings, if present
-    func loadUserSettings(name: String) -> CodableSettings? {
-        load(CodableSettings.self, from: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
-    }
+//    /// Saves the given user settings
+//    func saveUserSettings(_ settings: CodableSettings, name: String) async throws {
+//        try await save(settings, to: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
+//    }
+//    
+//    /// Loads given user settings, if present
+//    func loadUserSettings(name: String) -> CodableSettings? {
+//        load(CodableSettings.self, from: Path.userSettings.appendingPathComponent(name, conformingTo: .json))
+//    }
     
     /// Returns true if the given system settings exist, false otherwise
     func systemSettingsExists(_ setting: SystemSetting) -> Bool {
@@ -202,12 +174,45 @@ class PersistenceRepository {
     
     /// Saves the given system settings
     func saveSystemSettings(_ settings: CodableSettings, setting: SystemSetting) async throws {
+        print("DEBUG saving to \(setting), \(settings.filteredKeywords)")
         try await save(settings, to: Path.systemSettings.appendingPathComponent(setting.path, conformingTo: .json))
     }
     
     /// Loads given system settings, if present
     func loadSystemSettings(_ setting: SystemSetting) -> CodableSettings? {
         load(CodableSettings.self, from: Path.systemSettings.appendingPathComponent(setting.path, conformingTo: .json))
+    }
+    
+    func loadFilteredKeywords(for setting: SystemSetting = .v2) -> Set<String> {
+        let settings = loadSystemSettings(setting)
+        print("DEBUG loading filtered keywords \(settings?.filteredKeywords ?? [])")
+        return .init(settings?.filteredKeywords ?? [])
+    }
+    
+    /// Saves the given keyword and returns the updated set of filtered keywords
+    func saveFilteredKeyword(_ value: String, to setting: SystemSetting = .v2) async throws -> Set<String> {
+        var settings = Settings.main.codable
+        settings.filteredKeywords.append(value)
+        try await saveSystemSettings(settings, setting: setting)
+        return .init(settings.filteredKeywords)
+//        var keywords = loadFilteredKeywords(for: setting)
+//        keywords.insert(value)
+//        try await saveFilteredKeywords(.init(keywords), to: setting)
+//        return keywords
+    }
+    
+    /// Removes the given keyword and returns the updated set of filtered keywords
+    func removeFilteredKeyword(_ value: String, from setting: SystemSetting = .v2) async throws -> Set<String> {
+        var keywords = loadFilteredKeywords(for: setting)
+        keywords.remove(value)
+        try await saveFilteredKeywords(.init(keywords), to: setting)
+        return keywords
+    }
+    
+    func saveFilteredKeywords(_ value: [String], to setting: SystemSetting = .v2) async throws {
+        var settings = Settings.main.codable
+        settings.filteredKeywords = value
+        try await saveSystemSettings(settings, setting: setting)
     }
     
     // DEV ONLY

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -14,13 +14,10 @@ struct FiltersSettingsView: View {
     @Environment(Palette.self) var palette
     @Environment(FiltersTracker.self) var filtersTracker
     
-    @State var filteredKeywords: [String]
     @State var newKeyword: String = ""
     
     init() {
         @Dependency(\.persistenceRepository) var persistenceRepository
-        
-        _filteredKeywords = .init(wrappedValue: .init(persistenceRepository.loadFilteredKeywords()))
     }
     
     var body: some View {
@@ -46,7 +43,7 @@ struct FiltersSettingsView: View {
                 saveNewKeyword()
             }
         
-        ForEach(filteredKeywords, id: \.self) { filter in
+        ForEach(filtersTracker.filteredKeywords.sorted(by: <), id: \.self) { filter in
             HStack {
                 Text(filter)
                 
@@ -68,28 +65,18 @@ struct FiltersSettingsView: View {
         let cleanedKeyword = newKeyword.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
         
         Task {
-            do {
-                let newFilteredKeywords = try await persistenceRepository.saveFilteredKeyword(cleanedKeyword)
-                filteredKeywords = .init(newFilteredKeywords)
-                newKeyword = ""
-                filtersTracker.filteredKeywords = newFilteredKeywords
-            } catch {
-                handleError(error)
-            }
+            await filtersTracker.addFilteredKeyword(cleanedKeyword)
+            newKeyword = ""
         }
     }
     
     func deleteKeyword(_ keyword: String) {
-        assert(filteredKeywords.contains(keyword), "Filtered keywords does not contain \(keyword)")
+        guard filtersTracker.filteredKeywords.contains(keyword) else {
+            return
+        }
         
         Task {
-            do {
-                let newFilteredKeywords = try await persistenceRepository.removeFilteredKeyword(keyword)
-                filteredKeywords = .init(newFilteredKeywords)
-                filtersTracker.filteredKeywords = newFilteredKeywords
-            } catch {
-                handleError(error)
-            }
+            await filtersTracker.removeFilteredKeyword(keyword)
         }
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #1533 

# Pull Request Information

This PR enhances the existing import/export settings feature to also include keyword filters. This is done instead of making filters independently exportable because filters are presented as settings and so it doesn't make much sense to handle them as a special case; this also makes the common case of moving settings from one device to another smooth.

Since filters are stored in a file and other settings in AppStorage, this requires some slight architectural rearranging to make smooth:
- All filter-related persistence now happens in a private extension of `PersistenceRepository` available only to `FiltersTracker`. This makes `FiltersTracker` a reliable source of truth for the current persisted filters state.
- When settings are exported, the `CodableSettings` object is instantiated with the current state of `FiltersTracker`
- When settings are imported, `FiltersTracker` is updated with the imported keywords and the underlying file is automatically updated