### PR TITLE
Fix flair assertion failure

### DIFF
--- a/Mlem/App/Views/Shared/Labels/FullyQualifiedLabelView.swift
+++ b/Mlem/App/Views/Shared/Labels/FullyQualifiedLabelView.swift
@@ -88,9 +88,20 @@ struct FullyQualifiedLabelView: View {
     var flairs: [PersonFlair] {
         guard let person = entity as? any Person else { return [] }
         return person.flairs(
-            interactableContext: (commentContext as? any Comment2Providing) ?? (postContext as? any Post2Providing),
+            interactableContext: interactableContext,
             communityContext: communityContext
         )
+    }
+    
+    var interactableContext: (any Interactable2Providing)? {
+        guard let person = entity as? any Person else { return nil }
+        if let commentContext2 = commentContext as? any Comment2Providing, commentContext2.creator.actorId == person.actorId {
+            return commentContext2
+        }
+        if let postContext2 = postContext as? any Post2Providing, postContext2.creator.actorId == person.actorId {
+            return postContext2
+        }
+        return nil
     }
     
     var accessibilityLabel: String {


### PR DESCRIPTION
The `assert` on `Person1Providing+Extensions` line 41 would occasionally fail. 

This seems to be because somehow the wrong `Comment` models ends up being put in the `commentContext` environment for `FullyQualifiedLabelView`. Looking at the code, this mismatch shouldn't be possible - I think it's a SwiftUI bug. I wasn't able to directly fix the issue, so instead have made `FullyQualifiedLabelView` ignore the `commentContext` if the comment creator doesn't match the `person` it was given.

The wrong environment appears to only occur momentarily when the view appears, and then fixes itself shortly after. So I don't think the bug causes any visual issues.