### PR TITLE
Fix user-created comments not always being inserted into the comment tree

### DIFF
--- a/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
@@ -80,9 +80,9 @@ private func loadInlineImage(inlineImage: InlineImage) async {
     // with tooltips are displayed inline. I haven't found a better way to test for
     // a custom emoji.
     if inlineImage.tooltip == nil {
-        Task { @MainActor in
+        _ = await Task { @MainActor in
             inlineImage.renderFullWidth = true
-        }
+        }.result
         return
     }
     

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
@@ -36,7 +36,7 @@ struct FeedCommentView<EmbeddedContent: View>: View {
         content
             .contentShape(.interaction, .rect)
             .quickSwipes(comment.swipeActions(behavior: postSize.swipeBehavior, commentTreeTracker: commentTreeTracker))
-            .contextMenu { comment.allMenuActions(report: reportContext) }
+            .contextMenu { comment.allMenuActions(commentTreeTracker: commentTreeTracker, report: reportContext) }
             .paletteBorder(cornerRadius: postSize.swipeBehavior.cornerRadius)
     }
     

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -178,7 +178,13 @@ struct ExpandedPostView<Content: View>: View {
             if isLoading || post.shouldShowLoadingSymbol() {
                 ProgressView()
             } else {
-                ToolbarEllipsisMenu(post.allMenuActions(expanded: true, navigation: navigation))
+                ToolbarEllipsisMenu(
+                    post.allMenuActions(
+                        expanded: true,
+                        navigation: navigation,
+                        commentTreeTracker: tracker
+                    )
+                )
             }
         }
         .environment(tracker)


### PR DESCRIPTION
Also added a possible fix for #1470, haven't spent that long trying to reproduce it though. I'll close that issue later if I think it's fixed