### PR TITLE
Add and Remove Administrators

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -331,7 +331,6 @@
 		CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */; };
 		CD317D4C2BE97FED008F63E2 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4B2BE97FED008F63E2 /* Palette.swift */; };
 		CD317D4F2BE983ED008F63E2 /* MonochromePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4E2BE983ED008F63E2 /* MonochromePalette.swift */; };
-		CD32680C2D308CEC0072AC1C /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD32680B2D308CEC0072AC1C /* MlemMiddleware */; };
 		CD332D792CA7175500A53988 /* PlayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D782CA7175200A53988 /* PlayButton.swift */; };
 		CD332D7C2CA71E6F00A53988 /* GifView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D7B2CA71E6E00A53988 /* GifView.swift */; };
 		CD332D7E2CA7486000A53988 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D7D2CA7485D00A53988 /* String+Extensions.swift */; };
@@ -392,6 +391,7 @@
 		CD9CFA302C2E22F600739BBC /* FeedDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9CFA2F2C2E22F600739BBC /* FeedDescription.swift */; };
 		CD9CFA372C306DAB00739BBC /* PostGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9CFA362C306DAB00739BBC /* PostGridView.swift */; };
 		CD9D243D2CC1DF59006E5F3F /* AccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9D243C2CC1DF55006E5F3F /* AccountType.swift */; };
+		CDA38A6F2D31C4E6000C5B20 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CDA38A6E2D31C4E6000C5B20 /* MlemMiddleware */; };
 		CDA683F82C77E577000C4486 /* NsfwBlurBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA683F72C77E577000C4486 /* NsfwBlurBehavior.swift */; };
 		CDAA02DB2C810DB200D75633 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02DA2C810DB200D75633 /* Calendar+Extensions.swift */; };
 		CDAA02DD2C81792500D75633 /* SolarizedPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02DC2C81792500D75633 /* SolarizedPalette.swift */; };
@@ -918,7 +918,7 @@
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CDE4AC452CA370E000981010 /* SDWebImageSwiftUI in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
-				CD32680C2D308CEC0072AC1C /* MlemMiddleware in Frameworks */,
+				CDA38A6F2D31C4E6000C5B20 /* MlemMiddleware in Frameworks */,
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
@@ -2083,7 +2083,7 @@
 				CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */,
 				CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */,
 				CD64A9192CA37E8D007CA7E6 /* Gifu */,
-				CD32680B2D308CEC0072AC1C /* MlemMiddleware */,
+				CDA38A6E2D31C4E6000C5B20 /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -2171,7 +2171,7 @@
 				CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
 				CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */,
-				CD32680A2D308CE20072AC1C /* XCLocalSwiftPackageReference "../MlemMiddleware" */,
+				CDA38A6D2D31C4DD000C5B20 /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -3033,13 +3033,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		CD32680A2D308CE20072AC1C /* XCLocalSwiftPackageReference "../MlemMiddleware" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../MlemMiddleware;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -3102,6 +3095,14 @@
 			repositoryURL = "https://github.com/kaishin/Gifu";
 			requirement = {
 				branch = master;
+				kind = branch;
+			};
+		};
+		CDA38A6D2D31C4DD000C5B20 /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
+			requirement = {
+				branch = "eric/add-admin";
 				kind = branch;
 			};
 		};
@@ -3169,11 +3170,6 @@
 			package = B104A6D62A59BF3C00B3E725 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeVideo;
 		};
-		CD32680B2D308CEC0072AC1C /* MlemMiddleware */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CD32680A2D308CE20072AC1C /* XCLocalSwiftPackageReference "../MlemMiddleware" */;
-			productName = MlemMiddleware;
-		};
 		CD4368C02AE23FD400BD8BD1 /* Semaphore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */;
@@ -3183,6 +3179,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */;
 			productName = Gifu;
+		};
+		CDA38A6E2D31C4E6000C5B20 /* MlemMiddleware */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CDA38A6D2D31C4DD000C5B20 /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
+			productName = MlemMiddleware;
 		};
 		CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -331,6 +331,7 @@
 		CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */; };
 		CD317D4C2BE97FED008F63E2 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4B2BE97FED008F63E2 /* Palette.swift */; };
 		CD317D4F2BE983ED008F63E2 /* MonochromePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4E2BE983ED008F63E2 /* MonochromePalette.swift */; };
+		CD32680C2D308CEC0072AC1C /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD32680B2D308CEC0072AC1C /* MlemMiddleware */; };
 		CD332D792CA7175500A53988 /* PlayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D782CA7175200A53988 /* PlayButton.swift */; };
 		CD332D7C2CA71E6F00A53988 /* GifView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D7B2CA71E6E00A53988 /* GifView.swift */; };
 		CD332D7E2CA7486000A53988 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D7D2CA7485D00A53988 /* String+Extensions.swift */; };
@@ -396,7 +397,6 @@
 		CDAA02DD2C81792500D75633 /* SolarizedPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02DC2C81792500D75633 /* SolarizedPalette.swift */; };
 		CDAA02E12C817AAB00D75633 /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02E02C817AAB00D75633 /* Color+Extensions.swift */; };
 		CDAA02E32C821C9100D75633 /* Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02E22C821C9100D75633 /* Divider.swift */; };
-		CDB190B22D2CB4130044B05B /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CDB190B12D2CB4130044B05B /* MlemMiddleware */; };
 		CDB2EC7D2BFADAB300DBC0EF /* CompactPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC7C2BFADAB300DBC0EF /* CompactPostView.swift */; };
 		CDB2EC7F2BFADACC00DBC0EF /* HeadlinePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC7E2BFADACC00DBC0EF /* HeadlinePostView.swift */; };
 		CDB2EC812BFADADF00DBC0EF /* LargePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC802BFADADF00DBC0EF /* LargePostView.swift */; };
@@ -918,7 +918,7 @@
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CDE4AC452CA370E000981010 /* SDWebImageSwiftUI in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
-				CDB190B22D2CB4130044B05B /* MlemMiddleware in Frameworks */,
+				CD32680C2D308CEC0072AC1C /* MlemMiddleware in Frameworks */,
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
@@ -2083,7 +2083,7 @@
 				CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */,
 				CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */,
 				CD64A9192CA37E8D007CA7E6 /* Gifu */,
-				CDB190B12D2CB4130044B05B /* MlemMiddleware */,
+				CD32680B2D308CEC0072AC1C /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -2171,7 +2171,7 @@
 				CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
 				CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */,
-				CDB190B02D2CB4090044B05B /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
+				CD32680A2D308CE20072AC1C /* XCLocalSwiftPackageReference "../MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -3033,6 +3033,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		CD32680A2D308CE20072AC1C /* XCLocalSwiftPackageReference "../MlemMiddleware" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../MlemMiddleware;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -3096,14 +3103,6 @@
 			requirement = {
 				branch = master;
 				kind = branch;
-			};
-		};
-		CDB190B02D2CB4090044B05B /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.61.0;
 			};
 		};
 		CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
@@ -3170,6 +3169,11 @@
 			package = B104A6D62A59BF3C00B3E725 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeVideo;
 		};
+		CD32680B2D308CEC0072AC1C /* MlemMiddleware */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD32680A2D308CE20072AC1C /* XCLocalSwiftPackageReference "../MlemMiddleware" */;
+			productName = MlemMiddleware;
+		};
 		CD4368C02AE23FD400BD8BD1 /* Semaphore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */;
@@ -3179,11 +3183,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */;
 			productName = Gifu;
-		};
-		CDB190B12D2CB4130044B05B /* MlemMiddleware */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CDB190B02D2CB4090044B05B /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
-			productName = MlemMiddleware;
 		};
 		CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3102,8 +3102,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
 			requirement = {
-				branch = "eric/add-admin";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.62.0;
 			};
 		};
 		CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
-        "branch" : "eric/add-admin",
-        "revision" : "982389cb3334931053255367e8b6b0cdeae69223"
+        "revision" : "90b96295c7ba49f54c2adae7f3c553d6ef1e2594",
+        "version" : "0.62.0"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e91c2cec61691543665fad5843f30eafc5288bb40fc3a60d50c7d7e9194f3135",
+  "originHash" : "7fe183dcbb4acc6bb34fdc0842377273418aa1caa6335cd2926051ef29f2a665",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -44,15 +44,6 @@
       "state" : {
         "revision" : "b2b1d20a90b14d11f6ef4241da6b81c1d3f171e4",
         "version" : "1.3.2"
-      }
-    },
-    {
-      "identity" : "mlemmiddleware",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlemgroup/MlemMiddleware",
-      "state" : {
-        "revision" : "ebe24bf4b5471d8d961a84e27e8856a1646110f9",
-        "version" : "0.61.0"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -52,7 +52,7 @@
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
         "branch" : "eric/add-admin",
-        "revision" : "efeb2d7cdb25ed8f52332d3018fbaa02aecc4244"
+        "revision" : "982389cb3334931053255367e8b6b0cdeae69223"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7fe183dcbb4acc6bb34fdc0842377273418aa1caa6335cd2926051ef29f2a665",
+  "originHash" : "e91c2cec61691543665fad5843f30eafc5288bb40fc3a60d50c7d7e9194f3135",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "b2b1d20a90b14d11f6ef4241da6b81c1d3f171e4",
         "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "mlemmiddleware",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mlemgroup/MlemMiddleware",
+      "state" : {
+        "branch" : "eric/add-admin",
+        "revision" : "4e87744cbb5d24b8ece58101df1cb74fdb419f62"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -52,7 +52,7 @@
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
         "branch" : "eric/add-admin",
-        "revision" : "4e87744cbb5d24b8ece58101df1cb74fdb419f62"
+        "revision" : "efeb2d7cdb25ed8f52332d3018fbaa02aecc4244"
       }
     },
     {

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -254,6 +254,7 @@ enum Icons {
     static let select: String = "selection.pin.in.out"
     static let crossPost: String = "shuffle"
     static let chooseFile: String = "folder"
+    static let add: String = "plus"
     
     // settings
     static let upvoteOnSave: String = "arrow.up.heart"

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -44,12 +44,14 @@ enum Icons {
     static let markUnreadFill: String = "envelope.fill"
     
     // moderation
+    static let administration: String = "crown"
     static let moderation: String = "shield"
     static let moderationFill: String = "shield.fill"
     static let demoteModerator: String = "shield.slash"
     static let moderationReport: String = "flag"
     static let modlog: String = "book.pages"
     static let transferCommunity: String = "arrow.right"
+    static let removeAdministrator: String = "arrow.down"
     
     // inbox
     static let mention: String = "quote.bubble"

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -204,6 +204,13 @@ extension ActionAppearance {
         )
     }
     
+    static func removeAdmin() -> Self {
+        .init(label: "Remove from Administrators",
+              isDestructive: true,
+              color: Palette.main.warning,
+              icon: "arrow.down")
+    }
+    
     static func purge(isInProgress: Bool = false) -> Self {
         .init(
             label: "Purge",

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -204,11 +204,13 @@ extension ActionAppearance {
         )
     }
     
-    static func removeAdmin() -> Self {
-        .init(label: "Remove Administrator",
-              isDestructive: true,
-              color: Palette.main.warning,
-              icon: "arrow.down")
+    /// Adds or removes a user as administrator
+    /// - Parameter isOn: true when user is admin, false otherwise
+    static func addAdmin(isOn: Bool) -> Self {
+        .init(label: isOn ? "Remove Administrator" : "Appoint Administrator",
+              isDestructive: isOn,
+              color: isOn ? Palette.main.negative : Palette.main.positive,
+              icon: isOn ? "arrow.down" : "crown") // TODO: NOW icons
     }
     
     static func purge(isInProgress: Bool = false) -> Self {

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -210,7 +210,7 @@ extension ActionAppearance {
         .init(label: isOn ? "Remove Administrator" : "Appoint Administrator",
               isDestructive: isOn,
               color: isOn ? Palette.main.negative : Palette.main.positive,
-              icon: isOn ? "arrow.down" : "crown") // TODO: NOW icons
+              icon: isOn ? Icons.removeAdministrator : Icons.administration)
     }
     
     static func purge(isInProgress: Bool = false) -> Self {

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -205,7 +205,7 @@ extension ActionAppearance {
     }
     
     static func removeAdmin() -> Self {
-        .init(label: "Remove from Administrators",
+        .init(label: "Remove Administrator",
               isDestructive: true,
               color: Palette.main.warning,
               icon: "arrow.down")

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -223,6 +223,9 @@ extension Person1Providing {
         return .init(
             id: "addAdmin\(uid)",
             appearance: .addAdmin(isOn: isOn),
+            confirmationPrompt: isOn
+            ? "Really remove \(displayName) from administrators of \(instance.displayName)?"
+            : "Really appoint \(displayName) as administrator of \(instance.displayName)?",
             callback: callback
         )
     }

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -224,8 +224,8 @@ extension Person1Providing {
             id: "addAdmin\(uid)",
             appearance: .addAdmin(isOn: isOn),
             confirmationPrompt: isOn
-            ? "Really remove \(displayName) from administrators of \(instance.displayName)?"
-            : "Really appoint \(displayName) as administrator of \(instance.displayName)?",
+            ? "Really remove administrator \(displayName) from \(instance.displayName)?"
+            : "Really appoint \(displayName) as an administrator of \(instance.displayName)?",
             callback: callback
         )
     }

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -112,7 +112,7 @@ extension Person1Providing {
             if api.isAdmin {
                 purgeAction()
             }
-            if local, api.isAdmin, let myInstance = api.myInstance {
+            if apiIsLocal, api.isAdmin, let myInstance = api.myInstance {
                 if api.isHigherAdmin(than: self) {
                     addAdminAction(instance: myInstance, isOn: true)
                 } else if !(self.isAdmin_ ?? false) {

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -112,7 +112,7 @@ extension Person1Providing {
             if api.isAdmin {
                 purgeAction()
             }
-            if api.isAdmin, let myInstance = api.myInstance {
+            if local, api.isAdmin, let myInstance = api.myInstance {
                 if api.isHigherAdmin(than: self) {
                     addAdminAction(instance: myInstance, isOn: true)
                 } else if !(self.isAdmin_ ?? false) {

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -112,8 +112,12 @@ extension Person1Providing {
             if api.isAdmin {
                 purgeAction()
             }
-            if api.isHigherAdmin(than: self), let myInstance = api.myInstance {
-                removeAdminAction(instance: myInstance)
+            if api.isAdmin, let myInstance = api.myInstance {
+                if api.isHigherAdmin(than: self) {
+                    addAdminAction(instance: myInstance, isOn: true)
+                } else if !(self.isAdmin_ ?? false) {
+                    addAdminAction(instance: myInstance, isOn: false)
+                }
             }
         }
     }
@@ -201,11 +205,15 @@ extension Person1Providing {
         )
     }
     
-    func removeAdminAction(instance: any Instance3Providing) -> BasicAction {
+    /// Action to add/remove admin
+    /// - Parameters:
+    ///   - instance: instance to add the admin to
+    ///   - isOn: true if the user is already an admin, false otherwise
+    func addAdminAction(instance: any Instance3Providing, isOn: Bool) -> BasicAction {
         let callback: (@MainActor () -> Void) = {
             Task {
                 do {
-                    try await instance.addAdmin(personId: self.id, added: false)
+                    try await instance.addAdmin(personId: self.id, added: !isOn)
                 } catch {
                     handleError(error)
                 }
@@ -213,8 +221,8 @@ extension Person1Providing {
         }
         
         return .init(
-            id: "removeAdmin\(uid)",
-            appearance: .removeAdmin(),
+            id: "addAdmin\(uid)",
+            appearance: .addAdmin(isOn: isOn),
             callback: callback
         )
     }

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -213,7 +213,7 @@ extension Person1Providing {
         let callback: (@MainActor () -> Void) = {
             Task {
                 do {
-                    try await instance.addAdmin(personId: self.id, added: !isOn)
+                    try await instance.addAdmin(person: self, added: !isOn)
                 } catch {
                     handleError(error)
                 }

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -213,7 +213,7 @@ extension Person1Providing {
         let callback: (@MainActor () -> Void) = {
             Task {
                 do {
-                    try await instance.addAdmin(person: self, added: !isOn)
+                    try await instance.addAdmin(self, added: !isOn)
                 } catch {
                     handleError(error)
                 }

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -112,6 +112,9 @@ extension Person1Providing {
             if api.isAdmin {
                 purgeAction()
             }
+            if api.isHigherAdmin(than: self), let myInstance = api.myInstance {
+                removeAdminAction(instance: myInstance)
+            }
         }
     }
     
@@ -194,6 +197,24 @@ extension Person1Providing {
         return .init(
             id: "banFromCommunity\(uid)",
             appearance: .banFromCommunity(isOn: isBanned ?? false, withUserLabel: withUserLabel),
+            callback: callback
+        )
+    }
+    
+    func removeAdminAction(instance: any Instance3Providing) -> BasicAction {
+        let callback: (@MainActor () -> Void) = {
+            Task {
+                do {
+                    try await instance.addAdmin(personId: self.id, added: false)
+                } catch {
+                    handleError(error)
+                }
+            }
+        }
+        
+        return .init(
+            id: "removeAdmin\(uid)",
+            appearance: .removeAdmin(),
             callback: callback
         )
     }

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -43,7 +43,7 @@ extension InstanceView {
             return
         }
         guard newAdmin.apiIsLocal else {
-            ToastModel.main.add(.error(.init(title: "Admin must be local")))
+            ToastModel.main.add(.error(.init(title: "Cannot appoint non-local user as administrator")))
             return
         }
         Task {

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -28,22 +28,37 @@ extension InstanceView {
         }
     }
     
-    func addAdmin(personId: Int, added: Bool) async {
-        do {
-            let myInstance: Instance3
-            if let apiInstance = appState.firstApi.myInstance {
-                myInstance = apiInstance
-            } else {
-                myInstance = try await appState.firstApi.getMyInstance()
+    func openAddAdminSheet() {
+        navigation.openSheet(.personPicker(filter: .local) { person in
+            newAdmin = person
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                showingConfirmation = true
             }
-            
-            Task { @MainActor in
-                self.instance = myInstance
+        })
+    }
+    
+    func addNewAdmin() {
+        guard let newAdmin else {
+            assertionFailure("newAdmin cannot be nil")
+            return
+        }
+        Task {
+            do {
+                let myInstance: Instance3
+                if let apiInstance = appState.firstApi.myInstance {
+                    myInstance = apiInstance
+                } else {
+                    myInstance = try await appState.firstApi.getMyInstance()
+                }
+                
+                Task { @MainActor in
+                    self.instance = myInstance
+                }
+                
+                try await myInstance.addAdmin(personId: newAdmin.id, added: true)
+            } catch {
+                handleError(error)
             }
-            
-            try await myInstance.addAdmin(personId: personId, added: added)
-        } catch {
-            handleError(error)
         }
     }
     

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -42,6 +42,10 @@ extension InstanceView {
             assertionFailure("newAdmin cannot be nil")
             return
         }
+        guard newAdmin.apiIsLocal else {
+            ToastModel.main.add(.error(.init(title: "Admin must be local")))
+            return
+        }
         Task {
             do {
                 let myInstance: Instance3

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -28,7 +28,7 @@ extension InstanceView {
         }
     }
     
-    func addAdmin(_ person: any Person, added: Bool) async {
+    func addAdmin(personId: Int, added: Bool) async {
         do {
             let myInstance: Instance3
             if let apiInstance = appState.firstApi.myInstance {
@@ -41,7 +41,7 @@ extension InstanceView {
                 self.instance = myInstance
             }
             
-            try await myInstance.addAdmin(person: person, added: added)
+            try await myInstance.addAdmin(personId: personId, added: added)
         } catch {
             handleError(error)
         }

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -28,6 +28,25 @@ extension InstanceView {
         }
     }
     
+    func addAdmin(_ personId: Int, added: Bool) async {
+        do {
+            let myInstance: Instance3
+            if let apiInstance = appState.firstApi.myInstance {
+                myInstance = apiInstance
+            } else {
+                myInstance = try await appState.firstApi.getMyInstance()
+            }
+            
+            Task { @MainActor in
+                self.instance = myInstance
+            }
+            
+            try await myInstance.addAdmin(personId: personId, added: added)
+        } catch {
+            handleError(error)
+        }
+    }
+    
     func attemptToLoadUptimeData() {
         print("Fetching uptime data...")
         if let url = instance.uptimeDataUrl {

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -28,7 +28,7 @@ extension InstanceView {
         }
     }
     
-    func addAdmin(_ personId: Int, added: Bool) async {
+    func addAdmin(_ person: any Person, added: Bool) async {
         do {
             let myInstance: Instance3
             if let apiInstance = appState.firstApi.myInstance {
@@ -41,7 +41,7 @@ extension InstanceView {
                 self.instance = myInstance
             }
             
-            try await myInstance.addAdmin(personId: personId, added: added)
+            try await myInstance.addAdmin(person: person, added: added)
         } catch {
             handleError(error)
         }

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -50,13 +50,6 @@ struct InstanceView: View {
     @State var selectedTab: Tab = .about
     @State var isAtTop: Bool = true
     
-    var admins: [Person2] { instance.administrators_ ?? [] }
-    
-    var adminIndex: Int? {
-        guard let firstPerson = appState.firstPerson?.person2 else { return nil }
-        return admins.firstIndex(of: firstPerson)
-    }
-    
     init(instance: any InstanceStubProviding, visitContext: VisitHistory.VisitContext?) {
         self._instance = .init(wrappedValue: instance)
         self.visitContext = visitContext
@@ -139,13 +132,13 @@ struct InstanceView: View {
     func administrationTab(instance: any Instance) -> some View {
         VStack(spacing: Constants.main.halfSpacing) {
             ModlogButtonView(community: nil)
-            ForEach(admins) { person in
+            ForEach(instance.administrators_ ?? []) { person in
                 PersonListRow(person)
             }
             
-            if adminIndex != nil {
+            if appState.firstApi.isAdmin {
                 Button("Add Administrator", systemImage: Icons.add) {
-                    navigation.openSheet(.personPicker { person in
+                    navigation.openSheet(.personPicker(filter: .local) { person in
                         Task { await addAdmin(person.id, added: true) }
                     })
                 }

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -146,14 +146,14 @@ struct InstanceView: View {
                 Button("Add Administrator", systemImage: Icons.add, action: openAddAdminSheet)
                     .buttonStyle(.capsule)
                     .padding(.bottom, Constants.main.halfSpacing)
-                    .confirmationDialog("", isPresented: $showingConfirmation) {
+                    .confirmationDialog("Add Administrator", isPresented: $showingConfirmation) {
                         Button("Yes", action: addNewAdmin)
                     } message: {
-    if let displayName = newAdmin?.displayName {
-        Text("Really appoint \(displayName) as an administrator of \(instance.displayName)?")
-    } else {
-        Text("Really appoint this user as an administrator of \(instance.displayName)?")
-    }
+                        if let displayName = newAdmin?.displayName {
+                            Text("Really appoint \(displayName) as an administrator of \(instance.displayName)?")
+                        } else {
+                            Text("Really appoint this user as an administrator of \(instance.displayName)?")
+                        }
                     }
             }
         }

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -139,7 +139,7 @@ struct InstanceView: View {
             if appState.firstApi.isAdmin {
                 Button("Add Administrator", systemImage: Icons.add) {
                     navigation.openSheet(.personPicker(filter: .local) { person in
-                        Task { await addAdmin(person, added: true) }
+                        Task { await addAdmin(personId: person.id, added: true) }
                     })
                 }
                 .buttonStyle(.capsule)

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -149,7 +149,11 @@ struct InstanceView: View {
                     .confirmationDialog("", isPresented: $showingConfirmation) {
                         Button("Yes", action: addNewAdmin)
                     } message: {
-                        Text("Really appoint \(newAdmin?.displayName ?? "this user") as administrator of \(instance.displayName)?")
+    if let displayName = newAdmin?.displayName {
+        Text("Really appoint \(displayName) as an administrator of \(instance.displayName)?")
+    } else {
+        Text("Really appoint this user as an administrator of \(instance.displayName)?")
+    }
                     }
             }
         }

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -139,7 +139,7 @@ struct InstanceView: View {
             if appState.firstApi.isAdmin {
                 Button("Add Administrator", systemImage: Icons.add) {
                     navigation.openSheet(.personPicker(filter: .local) { person in
-                        Task { await addAdmin(person.id, added: true) }
+                        Task { await addAdmin(person, added: true) }
                     })
                 }
                 .buttonStyle(.capsule)

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -50,6 +50,9 @@ struct InstanceView: View {
     @State var selectedTab: Tab = .about
     @State var isAtTop: Bool = true
     
+    @State var showingConfirmation: Bool = false
+    @State var newAdmin: Person2?
+    
     init(instance: any InstanceStubProviding, visitContext: VisitHistory.VisitContext?) {
         self._instance = .init(wrappedValue: instance)
         self.visitContext = visitContext
@@ -130,20 +133,24 @@ struct InstanceView: View {
     
     @ViewBuilder
     func administrationTab(instance: any Instance) -> some View {
-        VStack(spacing: Constants.main.halfSpacing) {
+        VStack(spacing: Constants.main.standardSpacing) {
             ModlogButtonView(community: nil)
-            ForEach(instance.administrators_ ?? []) { person in
-                PersonListRow(person)
+            
+            VStack(spacing: Constants.main.halfSpacing) {
+                ForEach(instance.administrators_ ?? []) { person in
+                    PersonListRow(person)
+                }
             }
             
             if appState.firstApi.isAdmin {
-                Button("Add Administrator", systemImage: Icons.add) {
-                    navigation.openSheet(.personPicker(filter: .local) { person in
-                        Task { await addAdmin(personId: person.id, added: true) }
-                    })
-                }
-                .buttonStyle(.capsule)
-                .padding(.top, Constants.main.halfSpacing)
+                Button("Add Administrator", systemImage: Icons.add, action: openAddAdminSheet)
+                    .buttonStyle(.capsule)
+                    .padding(.bottom, Constants.main.halfSpacing)
+                    .confirmationDialog("", isPresented: $showingConfirmation) {
+                        Button("Yes", action: addNewAdmin)
+                    } message: {
+                        Text("Really appoint \(newAdmin?.displayName ?? "this user") as administrator of \(instance.displayName)?")
+                    }
             }
         }
         .padding([.horizontal, .bottom], Constants.main.standardSpacing)

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -34,6 +34,7 @@ struct InstanceView: View {
     var uptimeRefreshTimer = Timer.publish(every: 30, tolerance: 0.5, on: .main, in: .common)
         .autoconnect()
     
+    @Environment(NavigationLayer.self) var navigation
     @Environment(Palette.self) var palette
     @Environment(AppState.self) var appState
     @Environment(\.colorScheme) var colorScheme
@@ -48,6 +49,13 @@ struct InstanceView: View {
     
     @State var selectedTab: Tab = .about
     @State var isAtTop: Bool = true
+    
+    var admins: [Person2] { instance.administrators_ ?? [] }
+    
+    var adminIndex: Int? {
+        guard let firstPerson = appState.firstPerson?.person2 else { return nil }
+        return admins.firstIndex(of: firstPerson)
+    }
     
     init(instance: any InstanceStubProviding, visitContext: VisitHistory.VisitContext?) {
         self._instance = .init(wrappedValue: instance)
@@ -131,8 +139,18 @@ struct InstanceView: View {
     func administrationTab(instance: any Instance) -> some View {
         VStack(spacing: Constants.main.halfSpacing) {
             ModlogButtonView(community: nil)
-            ForEach(instance.administrators_ ?? []) { person in
+            ForEach(admins) { person in
                 PersonListRow(person)
+            }
+            
+            if adminIndex != nil {
+                Button("Add Administrator", systemImage: Icons.add) {
+                    navigation.openSheet(.personPicker { person in
+                        Task { await addAdmin(person.id, added: true) }
+                    })
+                }
+                .buttonStyle(.capsule)
+                .padding(.top, Constants.main.halfSpacing)
             }
         }
         .padding([.horizontal, .bottom], Constants.main.standardSpacing)

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -10,6 +10,7 @@ import LemmyMarkdownUI
 import MlemMiddleware
 import SwiftUI
 
+// swiftlint:disable:next type_body_length
 struct PersonView: View {
     enum Tab: String, CaseIterable, Identifiable {
         case overview, comments, posts, communities
@@ -41,6 +42,7 @@ struct PersonView: View {
     @State private var isAtTop: Bool = true
     @State var feedLoader: PersonContentFeedLoader?
     @State var isAdmin: Bool
+    @State var upgraded: Bool = false
     let isProfileTab: Bool
     
     init(
@@ -75,6 +77,12 @@ struct PersonView: View {
                 case .comments: selectedContentType = .comments
                 case .posts: selectedContentType = .posts
                 default: selectedContentType = .all
+                }
+            }
+            .onChange(of: person.wrappedValue.isAdmin_, initial: false) {
+                // track changes to the upgraded model while ignoring upgrade-related state changes
+                if upgraded {
+                    isAdmin = person.wrappedValue.isAdmin_ ?? isAdmin
                 }
             }
             .environment(\.feedContext, .person)
@@ -137,6 +145,8 @@ struct PersonView: View {
             if model.wrappedValue.isAdmin_ ?? false {
                 isAdmin = true
             }
+            
+            upgraded = true
         }
         .navigationTitle(isAtTop ? "" : (person.wrappedValue.displayName_ ?? person.wrappedValue.name))
         .navigationBarTitleDisplayMode(.inline)

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -235,7 +235,7 @@ struct PersonView: View {
             default:
                 if let feedLoader {
                     if isProfileTab, selectedTab == .overview || selectedTab == .posts {
-                        Button("New Post", systemImage: "plus") {
+                        Button("New Post", systemImage: Icons.add) {
                             navigation.openSheet(.createPost(community: nil, feedLoader: feedLoader))
                         }
                         .buttonStyle(.capsule)

--- a/Mlem/App/Views/Pages/PostEditor/PostEditorView+Toolbar.swift
+++ b/Mlem/App/Views/Pages/PostEditor/PostEditorView+Toolbar.swift
@@ -16,7 +16,7 @@ extension PostEditorView {
             }
         }
         ToolbarItemGroup(placement: .topBarTrailing) {
-            Menu("Add", systemImage: "plus") {
+            Menu("Add", systemImage: Icons.add) {
                 Toggle(
                     "Link",
                     systemImage: Icons.websiteAddress,

--- a/Mlem/App/Views/Shared/Accounts/AccountListView.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView.swift
@@ -99,7 +99,7 @@ struct AccountListView: View {
     var addAccountButton: some View {
         Section {
             Button { isShowingAddAccountDialogue = true } label: {
-                Label("Add Account", systemImage: "plus")
+                Label("Add Account", systemImage: Icons.add)
             }
             .confirmationDialog("Choose Account Type", isPresented: $isShowingAddAccountDialogue) {
                 Button("Log In") {

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -108,8 +108,8 @@ extension NavigationPage {
                         .background(Palette.main.secondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
                 }
             }
-        case let .personPicker(api: api, callback: callback):
-            SearchSheetView(api: api) { (person: Person2, navigation: NavigationLayer) in
+        case let .personPicker(api: api, filter: filter, callback: callback):
+            SearchSheetView(api: api, filter: filter) { (person: Person2, navigation: NavigationLayer) in
                 Button {
                     callback.wrappedValue(person, navigation)
                 } label: {

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -33,7 +33,7 @@ enum NavigationPage: Hashable {
     case externalApiInfo(api: ApiClient, actorId: URL)
     case imageViewer(_ url: URL)
     case communityPicker(api: ApiClient?, callback: HashWrapper<(Community2, NavigationLayer) -> Void>)
-    case personPicker(api: ApiClient?, callback: HashWrapper<(Person2, NavigationLayer) -> Void>)
+    case personPicker(api: ApiClient?, filter: ApiListingType, callback: HashWrapper<(Person2, NavigationLayer) -> Void>)
     case instancePicker(callback: HashWrapper<(InstanceSummary, NavigationLayer) -> Void>, minimumVersion: SiteVersion? = nil)
     case selectText(_ string: String)
     case subscriptionList
@@ -166,9 +166,10 @@ enum NavigationPage: Hashable {
     
     static func personPicker(
         api: ApiClient? = nil,
+        filter: ApiListingType = .all,
         callback: @escaping (Person2, NavigationLayer) -> Void
     ) -> NavigationPage {
-        personPicker(api: api, callback: .init(wrappedValue: callback))
+        personPicker(api: api, filter: filter, callback: .init(wrappedValue: callback))
     }
     
     static func instancePicker(
@@ -203,9 +204,10 @@ enum NavigationPage: Hashable {
     
     static func personPicker(
         api: ApiClient? = nil,
+        filter: ApiListingType = .all,
         callback: @escaping (Person2) -> Void
     ) -> NavigationPage {
-        personPicker(api: api, callback: .init(wrappedValue: { value, navigation in
+        personPicker(api: api, filter: filter, callback: .init(wrappedValue: { value, navigation in
             callback(value)
             Task { @MainActor in
                 navigation.dismissSheet()

--- a/Mlem/App/Views/Shared/Search/SearchSheetView.swift
+++ b/Mlem/App/Views/Shared/Search/SearchSheetView.swift
@@ -20,6 +20,7 @@ struct SearchSheetView<Item: Searchable, Content: View>: View {
     
     @ViewBuilder let content: ([Item], NavigationLayer) -> Content
     let api: ApiClient
+    let filter: ApiListingType
     let closeButtonLabel: CloseButtonLabel
     
     @State var query: String = ""
@@ -31,10 +32,12 @@ struct SearchSheetView<Item: Searchable, Content: View>: View {
     /// If `api` is `nil`, the active ApiClient will be used.
     init(
         api: ApiClient? = nil,
+        filter: ApiListingType? = nil,
         closeButtonLabel: CloseButtonLabel = .cancel,
         @ViewBuilder content: @escaping ([Item], NavigationLayer) -> Content
     ) {
         self.api = api ?? AppState.main.firstApi
+        self.filter = filter ?? .all
         self.content = content
         self.closeButtonLabel = closeButtonLabel
     }
@@ -70,7 +73,8 @@ struct SearchSheetView<Item: Searchable, Content: View>: View {
                     api: api,
                     query: query,
                     page: 1,
-                    limit: 20
+                    limit: 20,
+                    filter: filter
                 )
                 Task { @MainActor in
                     results = response
@@ -88,10 +92,12 @@ struct SearchSheetView<Item: Searchable, Content: View>: View {
 extension SearchSheetView {
     init<RowContent: View>(
         api: ApiClient? = nil,
+        filter: ApiListingType? = nil,
         closeButtonLabel: CloseButtonLabel = .cancel,
         @ViewBuilder content: @escaping (Item, NavigationLayer) -> RowContent
     ) where Content == SearchResultsView<Item, RowContent> {
         self.api = api ?? AppState.main.firstApi
+        self.filter = filter ?? .all
         self.closeButtonLabel = closeButtonLabel
         self.content = { (results: [Item], navigation: NavigationLayer) in
             SearchResultsView(results: results) { item in
@@ -102,11 +108,13 @@ extension SearchSheetView {
     
     init<RowContent: View, HeaderContent: View>(
         api: ApiClient? = nil,
+        filter: ApiListingType? = nil,
         closeButtonLabel: CloseButtonLabel = .cancel,
         @ViewBuilder content: @escaping (Item, NavigationLayer) -> RowContent,
         @ViewBuilder header: @escaping () -> HeaderContent
     ) where Content == VStack<TupleView<(HeaderContent, SearchResultsView<Item, RowContent>)>> {
         self.api = api ?? AppState.main.firstApi
+        self.filter = filter ?? .all
         self.closeButtonLabel = closeButtonLabel
         self.content = { (results: [Item], dismiss: NavigationLayer) in
             VStack(alignment: .leading, spacing: 0) {

--- a/Mlem/App/Views/Shared/Search/Searchable.swift
+++ b/Mlem/App/Views/Shared/Search/Searchable.swift
@@ -8,25 +8,30 @@
 import MlemMiddleware
 
 protocol Searchable: Identifiable {
-    static func search(api: ApiClient, query: String, page: Int, limit: Int) async throws -> [Self]
+    static func search(api: ApiClient, query: String, page: Int, limit: Int, filter: ApiListingType) async throws -> [Self]
 }
 
 extension Community2: Searchable {
-    static func search(api: ApiClient, query: String, page: Int, limit: Int) async throws -> [Community2] {
-        try await api.searchCommunities(query: query, page: page, limit: limit)
+    static func search(api: ApiClient, query: String, page: Int, limit: Int, filter: ApiListingType) async throws -> [Community2] {
+        try await api.searchCommunities(query: query, page: page, limit: limit, filter: filter)
     }
 }
 
 extension Person2: Searchable {
-    static func search(api: ApiClient, query: String, page: Int, limit: Int) async throws -> [Person2] {
-        try await api.searchPeople(query: query, page: page, limit: limit)
+    static func search(api: ApiClient, query: String, page: Int, limit: Int, filter: ApiListingType) async throws -> [Person2] {
+        try await api.searchPeople(query: query, page: page, limit: limit, filter: filter)
     }
 }
 
 extension InstanceSummary: Searchable, Identifiable {
     var id: String { host }
     
-    static func search(api _: ApiClient, query: String, page _: Int, limit _: Int) async throws -> [InstanceSummary] {
-        try await MlemStats.main.searchInstances(query: query)
-    }
+    static func search(
+        api _: ApiClient,
+        query: String,
+        page _: Int,
+        limit _: Int,
+        filter _: ApiListingType) async throws -> [InstanceSummary] {
+            try await MlemStats.main.searchInstances(query: query)
+        }
 }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1413,10 +1413,10 @@
     "Remove" : {
 
     },
-    "Remove Content" : {
+    "Remove Administrator" : {
 
     },
-    "Remove from Administrators" : {
+    "Remove Content" : {
 
     },
     "Removed: %@" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -219,6 +219,9 @@
     "Add Account" : {
 
     },
+    "Add Administrator" : {
+
+    },
     "Add Guest" : {
 
     },
@@ -1411,6 +1414,9 @@
 
     },
     "Remove Content" : {
+
+    },
+    "Remove from Administrators" : {
 
     },
     "Removed: %@" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1,9 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "" : {
-
-    },
     "**%@** and **%@** chose to defederate from one another." : {
       "localizations" : {
         "en" : {
@@ -1362,15 +1359,18 @@
     "Really apply configuration to all?" : {
 
     },
-    "Really appoint %@ as administrator of %@?" : {
+    "Really appoint %@ as an administrator of %@?" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Really appoint %1$@ as administrator of %2$@?"
+            "value" : "Really appoint %1$@ as an administrator of %2$@?"
           }
         }
       }
+    },
+    "Really appoint this user as an administrator of %@?" : {
+
     },
     "Really delete %@?" : {
 

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "" : {
+
+    },
     "**%@** and **%@** chose to defederate from one another." : {
       "localizations" : {
         "en" : {
@@ -1358,6 +1361,16 @@
     },
     "Really apply configuration to all?" : {
 
+    },
+    "Really appoint %@ as administrator of %@?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Really appoint %1$@ as administrator of %2$@?"
+          }
+        }
+      }
     },
     "Really delete %@?" : {
 

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -285,6 +285,9 @@
     "Apply to All Interaction Bars" : {
 
     },
+    "Appoint Administrator" : {
+
+    },
     "Appointed: %@" : {
 
     },


### PR DESCRIPTION
> [!NOTE]
> Depends on [this MlemMiddleware PR](https://github.com/mlemgroup/MlemMiddleware/pull/94)

<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #965 

# Pull Request Information

Administrators can now be appointed from the "Administration" tab of the instance view or appointed/removed from `Person1Providing` menus.

Also updates the `SearchSheetView` so it can be opened with a filter applied. Note that this **does not work** on locally hosted instances (at least, not on mine). To test it properly, you can remove the admin check at `InstanceView:139` and open the sheet using the "Add Administrator" button on a real instance.