### PR TITLE
Fix second render on sheet dismissal

### DIFF
--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -63,7 +63,10 @@ struct ContentView: View {
                         try await (appState.firstSession as? UserSession)?.unreadCount?.refresh()
                     }
                 }
-                .navigationSheetModifiers(nextLayer: navigationModel.layers.first, model: navigationModel)
+                .navigationSheetModifiers(
+                    nextLayer: navigationModel.layers.first,
+                    contentPickerTracker: navigationModel.contentPickerTracker
+                )
                 .tint(palette.accent)
                 .environment(palette)
                 .environment(tabReselectTracker)

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -9,7 +9,7 @@ import MlemMiddleware
 import SwiftUI
 
 @Observable
-class NavigationLayer {
+class NavigationLayer: Identifiable {
     struct ShareInfo {
         let url: URL
         let activities: [ShareActivity]
@@ -30,6 +30,8 @@ class NavigationLayer {
             }
         }
     }
+    
+    var id: ObjectIdentifier { .init(self) }
     
     weak var model: NavigationModel?
     var index: Int
@@ -125,7 +127,7 @@ class NavigationLayer {
     
     @MainActor
     func showPhotosPicker(for imageUploadManager: ImageUploadManager, api: ApiClient) {
-        model?.photosPickerCallback = { photo in
+        model?.contentPickerTracker.photosPickerCallback = { photo in
             Task {
                 do {
                     guard let data = try await photo.loadTransferable(type: Data.self) else {
@@ -145,8 +147,8 @@ class NavigationLayer {
     
     @MainActor
     func showFilePicker(for imageUploadManager: ImageUploadManager, api: ApiClient) {
-        model?.showingFilePicker = true
-        model?.filePickerCallback = { url in
+        model?.contentPickerTracker.showingFilePicker = true
+        model?.contentPickerTracker.filePickerCallback = { url in
             Task {
                 do {
                     guard url.startAccessingSecurityScopedResource() else {

--- a/Mlem/App/Views/Shared/Navigation/NavigationModel.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationModel.swift
@@ -14,14 +14,19 @@ class NavigationModel {
     
     private(set) var layers: [NavigationLayer] = .init()
     
-    var photosPickerCallback: ((PhotosPickerItem) -> Void)?
+    @Observable
+    class ContentPickerTracker {
+        var photosPickerCallback: ((PhotosPickerItem) -> Void)?
+        
+        // This needs two values unlike `photosPickerCallback` because
+        // `fileImporter` sets `isPresented` to `false` before calling
+        // `onCompletion`, which makes it impossible to call the callback
+        // before setting it to `nil`.
+        var showingFilePicker: Bool = false
+        var filePickerCallback: ((URL) -> Void)?
+    }
     
-    // This needs two values unlike `photosPickerCallback` because
-    // `fileImporter` sets `isPresented` to `false` before calling
-    // `onCompletion`, which makes it impossible to call the callback
-    // before setting it to `nil`.
-    var showingFilePicker: Bool = false
-    var filePickerCallback: ((URL) -> Void)?
+    var contentPickerTracker: ContentPickerTracker = .init()
     
     var mediaUrl: URL?
     

--- a/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
+++ b/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
@@ -7,73 +7,116 @@
 
 import SwiftUI
 
+private struct NavigationSheetModifier: ViewModifier {
+    let nextLayer: NavigationLayer?
+    let contentPickerTracker_: () -> NavigationModel.ContentPickerTracker?
+    
+    init(
+        nextLayer: NavigationLayer?,
+        // This tomfoolery exists to prevent this view being subject to NavigationModel view updates, which caused #1492
+        contentPickerTracker: @escaping () -> NavigationModel.ContentPickerTracker?
+    ) {
+        self.nextLayer = nextLayer
+        self.contentPickerTracker_ = contentPickerTracker
+    }
+    
+    // DO NOT access this in the view body; see #1492
+    var contentPickerTracker: NavigationModel.ContentPickerTracker? {
+        contentPickerTracker_()
+    }
+    
+    func body(content: Content) -> some View {
+        content
+            .sheet(isPresented: Binding(
+                get: { !(nextLayer?.isFullScreenCover ?? true) },
+                set: { newValue in
+                    if !newValue, let nextLayer, let model = nextLayer.model {
+                        model.closeSheets(aboveIndex: nextLayer.index)
+                    }
+                }
+            )) {
+                if let nextLayer {
+                    NavigationLayerView(layer: nextLayer, hasSheetModifiers: true)
+                }
+            }
+            .fullScreenCover(isPresented: Binding(
+                get: { nextLayer?.isFullScreenCover ?? false },
+                set: { newValue in
+                    if !newValue, let nextLayer, let model = nextLayer.model {
+                        model.closeSheets(aboveIndex: nextLayer.index)
+                    }
+                }
+            )) {
+                if let nextLayer {
+                    NavigationLayerView(layer: nextLayer, hasSheetModifiers: true)
+                }
+            }
+            .photosPicker(
+                isPresented: .init(
+                    get: { nextLayer == nil && contentPickerTracker?.photosPickerCallback != nil },
+                    set: { contentPickerTracker?.photosPickerCallback = $0 ? contentPickerTracker?.photosPickerCallback : nil }
+                ),
+                selection: .init(get: { nil }, set: { photo in
+                    if let photo {
+                        contentPickerTracker?.photosPickerCallback?(photo)
+                        contentPickerTracker?.photosPickerCallback = nil
+                    }
+                }),
+                matching: .images
+            )
+            .fileImporter(
+                isPresented: .init(
+                    get: { nextLayer == nil && (contentPickerTracker?.showingFilePicker ?? false) },
+                    set: { contentPickerTracker?.showingFilePicker = $0 }
+                ),
+                allowedContentTypes: [.image],
+                onCompletion: { result in
+                    do {
+                        try contentPickerTracker?.filePickerCallback?(result.get())
+                    } catch {
+                        handleError(error)
+                    }
+                }
+            )
+    }
+}
+
+private struct ComputeNextLayerModifier: ViewModifier {
+    let layer: NavigationLayer
+    
+    // This exists to prevent the view from being subject to NavigationModel state updates, which caused #1492
+    @State var nextLayer: NavigationLayer?
+    
+    func body(content: Content) -> some View {
+        Group {
+            content.navigationSheetModifiers(
+                nextLayer: nextLayer,
+                contentPickerTracker: layer.model?.contentPickerTracker
+            )
+        }.onChange(of: computeNextLayer()?.id, initial: true) {
+            nextLayer = computeNextLayer()
+        }
+    }
+    
+    func computeNextLayer() -> NavigationLayer? {
+        if let model = layer.model {
+            (layer.index < model.layers.count - 1) ? model.layers[layer.index + 1] : nil
+        } else {
+            nil
+        }
+    }
+}
+
 extension View {
     @ViewBuilder func navigationSheetModifiers(for layer: NavigationLayer) -> some View {
-        if let model = layer.model {
-            navigationSheetModifiers(
-                nextLayer: (layer.index < model.layers.count - 1) ? model.layers[layer.index + 1] : nil,
-                model: model
-            )
-        } else {
-            self
-        }
+        modifier(ComputeNextLayerModifier(layer: layer))
     }
         
     // swiftlint:disable:next function_body_length
     @ViewBuilder func navigationSheetModifiers(
         nextLayer: NavigationLayer?,
-        model: NavigationModel
+        contentPickerTracker: @autoclosure @escaping () -> NavigationModel.ContentPickerTracker?
     ) -> some View {
-        sheet(isPresented: Binding(
-            get: { !(nextLayer?.isFullScreenCover ?? true) },
-            set: { newValue in
-                if !newValue, let nextLayer {
-                    model.closeSheets(aboveIndex: nextLayer.index)
-                }
-            }
-        )) {
-            if let nextLayer {
-                NavigationLayerView(layer: nextLayer, hasSheetModifiers: true)
-            }
-        }
-        .fullScreenCover(isPresented: Binding(
-            get: { nextLayer?.isFullScreenCover ?? false },
-            set: { newValue in
-                if !newValue, let nextLayer {
-                    model.closeSheets(aboveIndex: nextLayer.index)
-                }
-            }
-        )) {
-            if let nextLayer {
-                NavigationLayerView(layer: nextLayer, hasSheetModifiers: true)
-            }
-        }
-        .photosPicker(
-            isPresented: .init(
-                get: { nextLayer == nil && model.photosPickerCallback != nil },
-                set: { model.photosPickerCallback = $0 ? model.photosPickerCallback : nil }
-            ),
-            selection: .init(get: { nil }, set: { photo in
-                if let photo {
-                    model.photosPickerCallback?(photo)
-                    model.photosPickerCallback = nil
-                }
-            }),
-            matching: .images
-        )
-        .fileImporter(
-            isPresented: .init(
-                get: { nextLayer == nil && model.showingFilePicker },
-                set: { model.showingFilePicker = $0 }
-            ),
-            allowedContentTypes: [.image],
-            onCompletion: { result in
-                do {
-                    try model.filePickerCallback?(result.get())
-                } catch {
-                    handleError(error)
-                }
-            }
-        )
+        modifier(NavigationSheetModifier(nextLayer: nextLayer, contentPickerTracker: contentPickerTracker))
     }
 }

--- a/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
+++ b/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
@@ -29,10 +29,8 @@ private struct NavigationSheetModifier: ViewModifier {
         content
             .sheet(isPresented: Binding(
                 get: { !(nextLayer?.isFullScreenCover ?? true) },
-                set: { newValue in
-                    if !newValue, let nextLayer, let model = nextLayer.model {
-                        model.closeSheets(aboveIndex: nextLayer.index)
-                    }
+                set: {
+                    if !$0 { closeSheet() }
                 }
             )) {
                 if let nextLayer {
@@ -41,10 +39,8 @@ private struct NavigationSheetModifier: ViewModifier {
             }
             .fullScreenCover(isPresented: Binding(
                 get: { nextLayer?.isFullScreenCover ?? false },
-                set: { newValue in
-                    if !newValue, let nextLayer, let model = nextLayer.model {
-                        model.closeSheets(aboveIndex: nextLayer.index)
-                    }
+                set: {
+                    if !$0 { closeSheet() }
                 }
             )) {
                 if let nextLayer {
@@ -79,6 +75,12 @@ private struct NavigationSheetModifier: ViewModifier {
                 }
             )
     }
+    
+    func closeSheet() {
+        if let nextLayer, let model = nextLayer.model {
+            model.closeSheets(aboveIndex: nextLayer.index)
+        }
+    }
 }
 
 private struct ComputeNextLayerModifier: ViewModifier {
@@ -112,7 +114,6 @@ extension View {
         modifier(ComputeNextLayerModifier(layer: layer))
     }
         
-    // swiftlint:disable:next function_body_length
     @ViewBuilder func navigationSheetModifiers(
         nextLayer: NavigationLayer?,
         contentPickerTracker: @autoclosure @escaping () -> NavigationModel.ContentPickerTracker?


### PR DESCRIPTION
Closes #1492
Closes #1593

Because the view body to which the `.sheet` modifier was attached accessed properties from `NavigationModel`, changing a `NavigationModel` property would cause the view body to be evaluated again. I've refactored it to avoid being dependent on `NavigationModel`.