### PR TITLE
Add/Remove Moderators

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -327,6 +327,8 @@
 		CD1446272A5B36DA00610EF1 /* EULA.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1446262A5B36DA00610EF1 /* EULA.swift */; };
 		CD17B24B2C19109A001E174B /* SwipeConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD17B24A2C19108B001E174B /* SwipeConfiguration.swift */; };
 		CD1B2E212C7F84160075C7EA /* View+MarkReadOnScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1B2E202C7F84160075C7EA /* View+MarkReadOnScroll.swift */; };
+		CD1C64152D3428710006B3C1 /* CommunityView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1C64142D34286E0006B3C1 /* CommunityView+Logic.swift */; };
+		CD1C64172D342ABE0006B3C1 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD1C64162D342ABE0006B3C1 /* MlemMiddleware */; };
 		CD1D31832C56D742001B434B /* View+WidthReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1D31822C56D742001B434B /* View+WidthReader.swift */; };
 		CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */; };
 		CD317D4C2BE97FED008F63E2 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4B2BE97FED008F63E2 /* Palette.swift */; };
@@ -396,7 +398,6 @@
 		CDAA02DD2C81792500D75633 /* SolarizedPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02DC2C81792500D75633 /* SolarizedPalette.swift */; };
 		CDAA02E12C817AAB00D75633 /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02E02C817AAB00D75633 /* Color+Extensions.swift */; };
 		CDAA02E32C821C9100D75633 /* Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02E22C821C9100D75633 /* Divider.swift */; };
-		CDB190B22D2CB4130044B05B /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CDB190B12D2CB4130044B05B /* MlemMiddleware */; };
 		CDB2EC7D2BFADAB300DBC0EF /* CompactPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC7C2BFADAB300DBC0EF /* CompactPostView.swift */; };
 		CDB2EC7F2BFADACC00DBC0EF /* HeadlinePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC7E2BFADACC00DBC0EF /* HeadlinePostView.swift */; };
 		CDB2EC812BFADADF00DBC0EF /* LargePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC802BFADADF00DBC0EF /* LargePostView.swift */; };
@@ -784,6 +785,7 @@
 		CD1446262A5B36DA00610EF1 /* EULA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EULA.swift; sourceTree = "<group>"; };
 		CD17B24A2C19108B001E174B /* SwipeConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeConfiguration.swift; sourceTree = "<group>"; };
 		CD1B2E202C7F84160075C7EA /* View+MarkReadOnScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+MarkReadOnScroll.swift"; sourceTree = "<group>"; };
+		CD1C64142D34286E0006B3C1 /* CommunityView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommunityView+Logic.swift"; sourceTree = "<group>"; };
 		CD1D31822C56D742001B434B /* View+WidthReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+WidthReader.swift"; sourceTree = "<group>"; };
 		CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+LoadFeed.swift"; sourceTree = "<group>"; };
 		CD317D4B2BE97FED008F63E2 /* Palette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Palette.swift; sourceTree = "<group>"; };
@@ -918,7 +920,7 @@
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CDE4AC452CA370E000981010 /* SDWebImageSwiftUI in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
-				CDB190B22D2CB4130044B05B /* MlemMiddleware in Frameworks */,
+				CD1C64172D342ABE0006B3C1 /* MlemMiddleware in Frameworks */,
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
@@ -1080,6 +1082,7 @@
 		033FCAF22C598435007B7CD1 /* Community */ = {
 			isa = PBXGroup;
 			children = (
+				CD1C64142D34286E0006B3C1 /* CommunityView+Logic.swift */,
 				033FCAF32C59843E007B7CD1 /* CommunityView.swift */,
 				03049A212C650B2C00FF6889 /* CommunityDetailsView.swift */,
 				0397D4632C676CA8002C6CDC /* FeedSortPicker.swift */,
@@ -2083,7 +2086,7 @@
 				CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */,
 				CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */,
 				CD64A9192CA37E8D007CA7E6 /* Gifu */,
-				CDB190B12D2CB4130044B05B /* MlemMiddleware */,
+				CD1C64162D342ABE0006B3C1 /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -2171,7 +2174,7 @@
 				CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
 				CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */,
-				CDB190B02D2CB4090044B05B /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
+				CD1C64132D3424AA0006B3C1 /* XCLocalSwiftPackageReference "../MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -2483,6 +2486,7 @@
 				03D3A1EF2BB9CA1D009DE55E /* MenuButton.swift in Sources */,
 				CD0507732C6AA0C8008B1505 /* FeedSelection.swift in Sources */,
 				039F58862C7A810100C61658 /* ExpandedPostView+Logic.swift in Sources */,
+				CD1C64152D3428710006B3C1 /* CommunityView+Logic.swift in Sources */,
 				031E2D512BEF961D0003BC45 /* SubscriptionListView.swift in Sources */,
 				CDD4A09E2C8B69FC0001AD1A /* Button.swift in Sources */,
 				038028DA2CACACD30091A8A2 /* PostEllipsisMenus.swift in Sources */,
@@ -3033,6 +3037,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		CD1C64132D3424AA0006B3C1 /* XCLocalSwiftPackageReference "../MlemMiddleware" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../MlemMiddleware;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -3096,14 +3107,6 @@
 			requirement = {
 				branch = master;
 				kind = branch;
-			};
-		};
-		CDB190B02D2CB4090044B05B /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.61.0;
 			};
 		};
 		CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
@@ -3170,6 +3173,11 @@
 			package = B104A6D62A59BF3C00B3E725 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeVideo;
 		};
+		CD1C64162D342ABE0006B3C1 /* MlemMiddleware */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD1C64132D3424AA0006B3C1 /* XCLocalSwiftPackageReference "../MlemMiddleware" */;
+			productName = MlemMiddleware;
+		};
 		CD4368C02AE23FD400BD8BD1 /* Semaphore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */;
@@ -3179,11 +3187,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */;
 			productName = Gifu;
-		};
-		CDB190B12D2CB4130044B05B /* MlemMiddleware */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CDB190B02D2CB4090044B05B /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
-			productName = MlemMiddleware;
 		};
 		CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -331,7 +331,6 @@
 		CD17B24B2C19109A001E174B /* SwipeConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD17B24A2C19108B001E174B /* SwipeConfiguration.swift */; };
 		CD1B2E212C7F84160075C7EA /* View+MarkReadOnScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1B2E202C7F84160075C7EA /* View+MarkReadOnScroll.swift */; };
 		CD1C64152D3428710006B3C1 /* CommunityView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1C64142D34286E0006B3C1 /* CommunityView+Logic.swift */; };
-		CD1C64172D342ABE0006B3C1 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD1C64162D342ABE0006B3C1 /* MlemMiddleware */; };
 		CD1D31832C56D742001B434B /* View+WidthReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1D31822C56D742001B434B /* View+WidthReader.swift */; };
 		CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */; };
 		CD317D4C2BE97FED008F63E2 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4B2BE97FED008F63E2 /* Palette.swift */; };
@@ -381,6 +380,7 @@
 		CD79281F2C73B52A00FA712D /* EndOfFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD79281E2C73B52A00FA712D /* EndOfFeedView.swift */; };
 		CD7928232C73CBA400FA712D /* TileScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7928222C73CBA400FA712D /* TileScoreView.swift */; };
 		CD7928262C73E73400FA712D /* PersonView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7928252C73E73400FA712D /* PersonView+Logic.swift */; };
+		CD7A696A2D3453D200100DFC /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD7A69692D3453D200100DFC /* MlemMiddleware */; };
 		CD7BF9322D18F4ED0020F2C5 /* FiltersTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7BF9312D18F4EB0020F2C5 /* FiltersTracker.swift */; };
 		CD7DB9712C49C17200DCC542 /* PersonContentGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7DB9702C49C17200DCC542 /* PersonContentGridView.swift */; };
 		CD7DB9732C4AEDDE00DCC542 /* TileCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7DB9722C4AEDDE00DCC542 /* TileCommentView.swift */; };
@@ -396,7 +396,6 @@
 		CD9CFA302C2E22F600739BBC /* FeedDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9CFA2F2C2E22F600739BBC /* FeedDescription.swift */; };
 		CD9CFA372C306DAB00739BBC /* PostGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9CFA362C306DAB00739BBC /* PostGridView.swift */; };
 		CD9D243D2CC1DF59006E5F3F /* AccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9D243C2CC1DF55006E5F3F /* AccountType.swift */; };
-		CDA38A6F2D31C4E6000C5B20 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CDA38A6E2D31C4E6000C5B20 /* MlemMiddleware */; };
 		CDA683F82C77E577000C4486 /* NsfwBlurBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA683F72C77E577000C4486 /* NsfwBlurBehavior.swift */; };
 		CDAA02DB2C810DB200D75633 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02DA2C810DB200D75633 /* Calendar+Extensions.swift */; };
 		CDAA02DD2C81792500D75633 /* SolarizedPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA02DC2C81792500D75633 /* SolarizedPalette.swift */; };
@@ -927,7 +926,7 @@
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CDE4AC452CA370E000981010 /* SDWebImageSwiftUI in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
-				CD1C64172D342ABE0006B3C1 /* MlemMiddleware in Frameworks */,
+				CD7A696A2D3453D200100DFC /* MlemMiddleware in Frameworks */,
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
@@ -2096,7 +2095,7 @@
 				CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */,
 				CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */,
 				CD64A9192CA37E8D007CA7E6 /* Gifu */,
-				CD1C64162D342ABE0006B3C1 /* MlemMiddleware */,
+				CD7A69692D3453D200100DFC /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -2184,7 +2183,7 @@
 				CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
 				CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */,
-				CD1C64132D3424AA0006B3C1 /* XCLocalSwiftPackageReference "../MlemMiddleware" */,
+				CD7A69682D3453CB00100DFC /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -3050,13 +3049,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		CD1C64132D3424AA0006B3C1 /* XCLocalSwiftPackageReference "../MlemMiddleware" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../MlemMiddleware;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -3119,6 +3111,14 @@
 			repositoryURL = "https://github.com/kaishin/Gifu";
 			requirement = {
 				branch = master;
+				kind = branch;
+			};
+		};
+		CD7A69682D3453CB00100DFC /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
+			requirement = {
+				branch = "eric/add-mod";
 				kind = branch;
 			};
 		};
@@ -3186,11 +3186,6 @@
 			package = B104A6D62A59BF3C00B3E725 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeVideo;
 		};
-		CD1C64162D342ABE0006B3C1 /* MlemMiddleware */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CD1C64132D3424AA0006B3C1 /* XCLocalSwiftPackageReference "../MlemMiddleware" */;
-			productName = MlemMiddleware;
-		};
 		CD4368C02AE23FD400BD8BD1 /* Semaphore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */;
@@ -3200,6 +3195,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */;
 			productName = Gifu;
+		};
+		CD7A69692D3453D200100DFC /* MlemMiddleware */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD7A69682D3453CB00100DFC /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
+			productName = MlemMiddleware;
 		};
 		CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		CD17B24B2C19109A001E174B /* SwipeConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD17B24A2C19108B001E174B /* SwipeConfiguration.swift */; };
 		CD1B2E212C7F84160075C7EA /* View+MarkReadOnScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1B2E202C7F84160075C7EA /* View+MarkReadOnScroll.swift */; };
 		CD1C64152D3428710006B3C1 /* CommunityView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1C64142D34286E0006B3C1 /* CommunityView+Logic.swift */; };
+		CD1CEDD22D35D157006BB0BB /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD1CEDD12D35D157006BB0BB /* MlemMiddleware */; };
 		CD1D31832C56D742001B434B /* View+WidthReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1D31822C56D742001B434B /* View+WidthReader.swift */; };
 		CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */; };
 		CD317D4C2BE97FED008F63E2 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4B2BE97FED008F63E2 /* Palette.swift */; };
@@ -380,7 +381,6 @@
 		CD79281F2C73B52A00FA712D /* EndOfFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD79281E2C73B52A00FA712D /* EndOfFeedView.swift */; };
 		CD7928232C73CBA400FA712D /* TileScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7928222C73CBA400FA712D /* TileScoreView.swift */; };
 		CD7928262C73E73400FA712D /* PersonView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7928252C73E73400FA712D /* PersonView+Logic.swift */; };
-		CD7A696A2D3453D200100DFC /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD7A69692D3453D200100DFC /* MlemMiddleware */; };
 		CD7BF9322D18F4ED0020F2C5 /* FiltersTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7BF9312D18F4EB0020F2C5 /* FiltersTracker.swift */; };
 		CD7DB9712C49C17200DCC542 /* PersonContentGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7DB9702C49C17200DCC542 /* PersonContentGridView.swift */; };
 		CD7DB9732C4AEDDE00DCC542 /* TileCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7DB9722C4AEDDE00DCC542 /* TileCommentView.swift */; };
@@ -926,7 +926,7 @@
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CDE4AC452CA370E000981010 /* SDWebImageSwiftUI in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
-				CD7A696A2D3453D200100DFC /* MlemMiddleware in Frameworks */,
+				CD1CEDD22D35D157006BB0BB /* MlemMiddleware in Frameworks */,
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
@@ -2095,7 +2095,7 @@
 				CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */,
 				CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */,
 				CD64A9192CA37E8D007CA7E6 /* Gifu */,
-				CD7A69692D3453D200100DFC /* MlemMiddleware */,
+				CD1CEDD12D35D157006BB0BB /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -2183,7 +2183,7 @@
 				CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
 				CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */,
-				CD7A69682D3453CB00100DFC /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
+				CD5F8A9E2D35D0E7007FAB56 /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -3106,19 +3106,19 @@
 				minimumVersion = 0.0.8;
 			};
 		};
+		CD5F8A9E2D35D0E7007FAB56 /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.64.1;
+			};
+		};
 		CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kaishin/Gifu";
 			requirement = {
 				branch = master;
-				kind = branch;
-			};
-		};
-		CD7A69682D3453CB00100DFC /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
-			requirement = {
-				branch = "eric/add-mod";
 				kind = branch;
 			};
 		};
@@ -3186,6 +3186,11 @@
 			package = B104A6D62A59BF3C00B3E725 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeVideo;
 		};
+		CD1CEDD12D35D157006BB0BB /* MlemMiddleware */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD5F8A9E2D35D0E7007FAB56 /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
+			productName = MlemMiddleware;
+		};
 		CD4368C02AE23FD400BD8BD1 /* Semaphore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */;
@@ -3195,11 +3200,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */;
 			productName = Gifu;
-		};
-		CD7A69692D3453D200100DFC /* MlemMiddleware */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CD7A69682D3453CB00100DFC /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
-			productName = MlemMiddleware;
 		};
 		CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dbb3f4a3491e755efbaa3d420a53d720cf7832bc30be35000cee5f9dbf3d87fa",
+  "originHash" : "741161cefb0674ba95c43c14afc8238177d21974f95f4e66fe76b72259069ef1",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "b2b1d20a90b14d11f6ef4241da6b81c1d3f171e4",
         "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "mlemmiddleware",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mlemgroup/MlemMiddleware",
+      "state" : {
+        "branch" : "eric/add-mod",
+        "revision" : "eccf9cc323c1a2e983c24543c60a3a585f5b9ef4"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7fe183dcbb4acc6bb34fdc0842377273418aa1caa6335cd2926051ef29f2a665",
+  "originHash" : "dbb3f4a3491e755efbaa3d420a53d720cf7832bc30be35000cee5f9dbf3d87fa",
   "pins" : [
     {
       "identity" : "combine-schedulers",

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e91c2cec61691543665fad5843f30eafc5288bb40fc3a60d50c7d7e9194f3135",
+  "originHash" : "7fe183dcbb4acc6bb34fdc0842377273418aa1caa6335cd2926051ef29f2a665",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -44,15 +44,6 @@
       "state" : {
         "revision" : "b2b1d20a90b14d11f6ef4241da6b81c1d3f171e4",
         "version" : "1.3.2"
-      }
-    },
-    {
-      "identity" : "mlemmiddleware",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlemgroup/MlemMiddleware",
-      "state" : {
-        "revision" : "ebe24bf4b5471d8d961a84e27e8856a1646110f9",
-        "version" : "0.61.0"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "741161cefb0674ba95c43c14afc8238177d21974f95f4e66fe76b72259069ef1",
+  "originHash" : "e91c2cec61691543665fad5843f30eafc5288bb40fc3a60d50c7d7e9194f3135",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
-        "branch" : "eric/add-mod",
-        "revision" : "eccf9cc323c1a2e983c24543c60a3a585f5b9ef4"
+        "revision" : "da122ffdc03c7b2d4b4cbd963a15ca46653aeae9",
+        "version" : "0.64.1"
       }
     },
     {

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -47,6 +47,7 @@ enum Icons {
     static let moderation: String = "shield"
     static let moderationFill: String = "shield.fill"
     static let demoteModerator: String = "shield.slash"
+    static let demoteModeratorFill: String = "shield.slash.fill"
     static let moderationReport: String = "flag"
     static let modlog: String = "book.pages"
     static let transferCommunity: String = "arrow.right"

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -53,7 +53,8 @@ enum Icons {
     static let moderationReport: String = "flag"
     static let modlog: String = "book.pages"
     static let transferCommunity: String = "arrow.right"
-    static let removeAdministrator: String = "arrow.down"
+    static let removeAdministrator: String = "arrowshape.down"
+    static let removeAdministratorFill: String = "arrowshape.down.fill"
     
     // inbox
     static let mention: String = "quote.bubble"

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -210,7 +210,10 @@ extension ActionAppearance {
         .init(label: isOn ? "Remove Administrator" : "Appoint Administrator",
               isDestructive: isOn,
               color: isOn ? Palette.main.negative : Palette.main.positive,
-              icon: isOn ? Icons.removeAdministrator : Icons.administration)
+              icon: isOn ? Icons.removeAdministrator : Icons.administration,
+              swipeIcon1: isOn ? Icons.removeAdministrator : Icons.administration,
+              swipeIcon2: isOn ? Icons.removeAdministratorFill : Icons.administrationFill
+        )
     }
     
     /// Adds or removes a user as moderator

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -216,10 +216,13 @@ extension ActionAppearance {
     /// Adds or removes a user as moderator
     /// - Parameter isOn: true when user is moderator, false otherwise
     static func addMod(isOn: Bool) -> Self {
-        .init(label: isOn ? "Remove Moderator" : "Appoint Moderator",
-              isDestructive: isOn,
-              color: isOn ? Palette.main.negative : Palette.main.positive,
-              icon: isOn ? Icons.demoteModerator : Icons.moderation)
+        .init(
+            label: isOn ? "Remove Moderator" : "Appoint Moderator",
+            color: isOn ? Palette.main.negative : Palette.main.positive,
+            icon: isOn ? Icons.demoteModerator : Icons.moderation,
+            swipeIcon1: isOn ? Icons.demoteModerator : Icons.moderation,
+            swipeIcon2: isOn ? Icons.demoteModeratorFill : Icons.moderationFill
+        )
     }
     
     static func purge(isInProgress: Bool = false) -> Self {

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -228,7 +228,7 @@ extension Person1Providing {
         }
         
         return .init(
-            id: "appointAdmin\(uid)",
+            id: "addAdmin\(uid)",
             appearance: .addAdmin(isOn: isOn),
             confirmationPrompt: isOn
             ? "Really remove administrator \(displayName) from \(instance.displayName)?"

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/Quick Swipes/SwipeConfiguration.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/Quick Swipes/SwipeConfiguration.swift
@@ -40,6 +40,11 @@ public struct SwipeConfiguration {
             trailingActions: trailingActions()
         )
     }
+    
+    static func none() -> SwipeConfiguration {
+        // need to supply at least one parameter or the compiler can't pick an initializer
+        return .init(leadingActions: [])
+    }
 }
 
 struct SwipeBehavior {

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/Quick Swipes/SwipeConfiguration.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/Quick Swipes/SwipeConfiguration.swift
@@ -15,6 +15,12 @@ public struct SwipeConfiguration {
     
     let behavior: SwipeBehavior
     
+    init() {
+        self.behavior = .standard
+        self.leadingActions = .init()
+        self.trailingActions = .init()
+    }
+    
     init(
         behavior: SwipeBehavior = .standard,
         leadingActions: [any Action] = [],
@@ -39,11 +45,6 @@ public struct SwipeConfiguration {
             leadingActions: leadingActions(),
             trailingActions: trailingActions()
         )
-    }
-    
-    static func none() -> SwipeConfiguration {
-        // need to supply at least one parameter or the compiler can't pick an initializer
-        return .init(leadingActions: [])
     }
 }
 

--- a/Mlem/App/Views/Pages/Community/CommunityView+Logic.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView+Logic.swift
@@ -45,26 +45,7 @@ extension CommunityView {
             return .none()
         }
         
-        let removeModeratorAction: BasicAction = .init(
-            id: "removeModerator\(person.id)",
-            appearance: .init(
-                label: "Remove Moderator",
-                color: palette.negative,
-                icon: Icons.demoteModerator,
-                swipeIcon1: Icons.demoteModerator,
-                swipeIcon2: Icons.demoteModeratorFill),
-            confirmationPrompt: "Really remove moderator \(person.displayName) from \(community.displayName)?",
-            enabled: true) {
-                Task {
-                    do {
-                        try await community.addModerator(person, added: false)
-                    } catch {
-                        handleError(error)
-                    }
-                }
-            }
-        
-        return .init(trailingActions: [removeModeratorAction])
+        return .init(trailingActions: [person.addModAction(community: community, isOn: true)])
     }
     
     func setupFeedLoader(community: any Community) {

--- a/Mlem/App/Views/Pages/Community/CommunityView+Logic.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView+Logic.swift
@@ -1,0 +1,98 @@
+//
+//  CommunityView+Logic.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2025-01-12.
+//
+
+import MlemMiddleware
+import Foundation
+
+extension CommunityView {
+    func openAddModSheet() {
+        navigation.openSheet(.personPicker { person in
+            newMod = person
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                showingConfirmation = true
+            }
+        })
+    }
+    
+    func addNewMod() {
+        guard let newMod else {
+            assertionFailure("newMod cannot be nil")
+            return
+        }
+        
+        guard let community = community.wrappedValue as? any Community else {
+            assertionFailure("Community not loaded yet")
+            return
+        }
+
+        Task {
+            do {
+                try await community.addModerator(newMod, added: true)
+            } catch {
+                handleError(error)
+            }
+        }
+    }
+    
+    func moderatorQuickSwipes(community: any Community, person: any Person) -> SwipeConfiguration {
+        guard appState.firstApi.myPerson?.moderates(community: community) ?? false else {
+            return .none()
+        }
+        
+        let removeModeratorAction: BasicAction = .init(
+            id: "removeModerator\(person.id)",
+            appearance: .init(
+                label: "Remove Moderator",
+                color: palette.negative,
+                icon: Icons.demoteModerator,
+                swipeIcon1: Icons.demoteModerator,
+                swipeIcon2: Icons.demoteModeratorFill),
+            confirmationPrompt: "Really remove moderator \(person.displayName) from \(community.displayName)?",
+            enabled: true) {
+                Task {
+                    do {
+                        try await community.addModerator(person, added: false)
+                    } catch {
+                        handleError(error)
+                    }
+                }
+            }
+        
+        return .init(trailingActions: [removeModeratorAction])
+    }
+    
+    func setupFeedLoader(community: any Community) {
+        if postFeedLoader == nil {
+            Task { @MainActor in
+                @Setting(\.internetSpeed) var internetSpeed
+                @Setting(\.showReadInFeed) var showReadInFeed
+                
+                postFeedLoader = try await .init(
+                    pageSize: internetSpeed.pageSize,
+                    sortType: appState.initialFeedSortType,
+                    showReadPosts: showReadInFeed,
+                    filterContext: filtersTracker.filterContext,
+                    prefetchingConfiguration: .forPostSize(postSize),
+                    urlCache: Constants.main.urlCache,
+                    community: community
+                )
+            }
+        } else if postFeedLoader?.community.api != community.api {
+            postFeedLoader?.community = community
+        }
+    }
+    
+    func logVisit(_ community: Community2) {
+        if let session = (appState.firstSession as? UserSession), let visitHistory = session.visitHistory {
+            guard session.api === community.api else { return }
+            visitHistory.addCommunity(community, context: visitContext)
+            Task(priority: .background) {
+                try await session.saveVisitHistory()
+            }
+        }
+    }
+}

--- a/Mlem/App/Views/Pages/Community/CommunityView+Logic.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView+Logic.swift
@@ -42,7 +42,7 @@ extension CommunityView {
         guard let community = community as? any Community3Providing,
               let myPerson = appState.firstPerson,
               myPerson.canModerate(person, in: community) else {
-            return .none()
+            return .init()
         }
         
         return .init(trailingActions: [person.addModAction(community: community, isOn: true)])

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -193,7 +193,8 @@ struct CommunityView: View {
                 }
             }
             
-            if appState.firstApi.myPerson?.moderates(community: community) ?? false {
+            if let firstPerson = appState.firstPerson,
+               firstPerson.isAdmin || firstPerson.moderates(community: community) {
                 Button("Add Moderator", systemImage: "plus", action: openAddModSheet) // TODO: NOW icons
                     .buttonStyle(.capsule)
                     .confirmationDialog("Add Moderator", isPresented: $showingConfirmation) {

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -46,6 +46,9 @@ struct CommunityView: View {
     
     @State var isAtTop: Bool = true
     
+    @State var showingConfirmation: Bool = false
+    @State var newMod: Person2?
+    
     init(
         community: AnyCommunity,
         visitContext: VisitHistory.VisitContext
@@ -180,9 +183,27 @@ struct CommunityView: View {
     
     @ViewBuilder
     func moderationTab(community: any Community) -> some View {
-        VStack(spacing: Constants.main.halfSpacing) {
-            ForEach(community.moderators_ ?? []) { person in
-                PersonListRow(person)
+        VStack(spacing: Constants.main.standardSpacing) {
+            VStack(spacing: Constants.main.halfSpacing) {
+                ForEach(community.moderators_ ?? []) { person in
+                    PersonListRow(person)
+                        .quickSwipes(moderatorQuickSwipes(community: community, person: person))
+                }
+            }
+            
+            if appState.firstApi.myPerson?.moderates(community: community) ?? false {
+                Button("Add Moderator", systemImage: "plus", action: openAddModSheet) // TODO: NOW icons
+                    .buttonStyle(.capsule)
+                    .confirmationDialog("Add Moderator", isPresented: $showingConfirmation) {
+                         Button("Yes", action: addNewMod)
+                     } message: {
+                         if let displayName = newMod?.displayName {
+                             Text("Really appoint \(displayName) as a moderator of \(community.displayName)?")
+                         } else {
+                             Text("Really appoint this user as a moderator of \(community.displayName)?")
+                         }
+                     }
+                
             }
         }
         .padding([.horizontal, .bottom], Constants.main.standardSpacing)
@@ -218,36 +239,5 @@ struct CommunityView: View {
             output.insert(.about, at: 1)
         }
         return output
-    }
-    
-    func setupFeedLoader(community: any Community) {
-        if postFeedLoader == nil {
-            Task { @MainActor in
-                @Setting(\.internetSpeed) var internetSpeed
-                @Setting(\.showReadInFeed) var showReadInFeed
-                
-                postFeedLoader = try await .init(
-                    pageSize: internetSpeed.pageSize,
-                    sortType: appState.initialFeedSortType,
-                    showReadPosts: showReadInFeed,
-                    filterContext: filtersTracker.filterContext,
-                    prefetchingConfiguration: .forPostSize(postSize),
-                    urlCache: Constants.main.urlCache,
-                    community: community
-                )
-            }
-        } else if postFeedLoader?.community.api != community.api {
-            postFeedLoader?.community = community
-        }
-    }
-    
-    func logVisit(_ community: Community2) {
-        if let session = (appState.firstSession as? UserSession), let visitHistory = session.visitHistory {
-            guard session.api === community.api else { return }
-            visitHistory.addCommunity(community, context: visitContext)
-            Task(priority: .background) {
-                try await session.saveVisitHistory()
-            }
-        }
     }
 }

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -195,7 +195,7 @@ struct CommunityView: View {
             
             if let firstPerson = appState.firstPerson,
                firstPerson.isAdmin || firstPerson.moderates(community: community) {
-                Button("Add Moderator", systemImage: "plus", action: openAddModSheet) // TODO: NOW icons
+                Button("Add Moderator", systemImage: Icons.add, action: openAddModSheet)
                     .buttonStyle(.capsule)
                     .confirmationDialog("Add Moderator", isPresented: $showingConfirmation) {
                          Button("Yes", action: addNewMod)

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -69,7 +69,7 @@ extension InstanceView {
               myPerson.api.isHigherAdmin(than: person),
               let myInstance = appState.firstApi.myInstance,
               let isAdmin = person.isAdmin_ else {
-            return .none()
+            return .init()
         }
         
         return .init(trailingActions: [person.addAdminAction(instance: myInstance, isOn: isAdmin)])

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -46,24 +46,31 @@ extension InstanceView {
             ToastModel.main.add(.error(.init(title: "Cannot appoint non-local user as administrator")))
             return
         }
-        Task {
-            do {
-                let myInstance: Instance3
-                if let apiInstance = appState.firstApi.myInstance {
-                    myInstance = apiInstance
-                } else {
-                    myInstance = try await appState.firstApi.getMyInstance()
-                }
-                
-                Task { @MainActor in
-                    self.instance = myInstance
-                }
-                
-                try await myInstance.addAdmin(personId: newAdmin.id, added: true)
-            } catch {
-                handleError(error)
-            }
+        addAdminHelper(personId: newAdmin.id)
+    }
+    
+    func administratorQuickSwipes(person: any Person) -> SwipeConfiguration {
+        guard let myPerson = appState.firstPerson,
+              myPerson.api.isHigherAdmin(than: person) else {
+            return .none()
         }
+        
+        let instanceName: String = instance.displayName_ ?? "this instance"
+        
+        let removeAdministratorAction: BasicAction = .init(
+            id: "removeAdministrator\(person.id)",
+            appearance: .init(
+                label: "Remove Administrator",
+                color: palette.negative,
+                icon: Icons.removeAdministrator,
+                swipeIcon1: Icons.removeAdministrator,
+                swipeIcon2: Icons.removeAdministratorFill),
+            confirmationPrompt: "Really remove administrator \(person.displayName) from \(instanceName)?",
+            enabled: true) {
+                addAdminHelper(personId: person.id)
+            }
+        
+        return .init(trailingActions: [removeAdministratorAction])
     }
     
     func attemptToLoadUptimeData() {
@@ -131,6 +138,27 @@ extension InstanceView {
                 } catch {
                     handleError(error)
                 }
+            }
+        }
+    }
+    
+    private func addAdminHelper(personId: Int) {
+        Task {
+            do {
+                let myInstance: Instance3
+                if let apiInstance = appState.firstApi.myInstance {
+                    myInstance = apiInstance
+                } else {
+                    myInstance = try await appState.firstApi.getMyInstance()
+                }
+                
+                Task { @MainActor in
+                    self.instance = myInstance
+                }
+                
+                try await myInstance.addAdmin(personId: personId, added: true)
+            } catch {
+                handleError(error)
             }
         }
     }

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -46,31 +46,33 @@ extension InstanceView {
             ToastModel.main.add(.error(.init(title: "Cannot appoint non-local user as administrator")))
             return
         }
-        addAdminHelper(personId: newAdmin.id)
+        guard let instance3 = instance as? any Instance3Providing else {
+            assertionFailure("Instance is not upgraded")
+            return
+        }
+        guard instance.local || instance.host == "localhost" else {
+            assertionFailure("Instance is not local")
+            return
+        }
+        
+        Task {
+            do {
+                try await instance3.addAdmin(personId: newAdmin.id, added: true)
+            } catch {
+                handleError(error)
+            }
+        }
     }
     
     func administratorQuickSwipes(person: any Person) -> SwipeConfiguration {
         guard let myPerson = appState.firstPerson,
-              myPerson.api.isHigherAdmin(than: person) else {
+              myPerson.api.isHigherAdmin(than: person),
+              let myInstance = appState.firstApi.myInstance,
+              let isAdmin = person.isAdmin_ else {
             return .none()
         }
         
-        let instanceName: String = instance.displayName_ ?? "this instance"
-        
-        let removeAdministratorAction: BasicAction = .init(
-            id: "removeAdministrator\(person.id)",
-            appearance: .init(
-                label: "Remove Administrator",
-                color: palette.negative,
-                icon: Icons.removeAdministrator,
-                swipeIcon1: Icons.removeAdministrator,
-                swipeIcon2: Icons.removeAdministratorFill),
-            confirmationPrompt: "Really remove administrator \(person.displayName) from \(instanceName)?",
-            enabled: true) {
-                addAdminHelper(personId: person.id)
-            }
-        
-        return .init(trailingActions: [removeAdministratorAction])
+        return .init(trailingActions: [person.addAdminAction(instance: myInstance, isOn: isAdmin)])
     }
     
     func attemptToLoadUptimeData() {
@@ -138,27 +140,6 @@ extension InstanceView {
                 } catch {
                     handleError(error)
                 }
-            }
-        }
-    }
-    
-    private func addAdminHelper(personId: Int) {
-        Task {
-            do {
-                let myInstance: Instance3
-                if let apiInstance = appState.firstApi.myInstance {
-                    myInstance = apiInstance
-                } else {
-                    myInstance = try await appState.firstApi.getMyInstance()
-                }
-                
-                Task { @MainActor in
-                    self.instance = myInstance
-                }
-                
-                try await myInstance.addAdmin(personId: personId, added: true)
-            } catch {
-                handleError(error)
             }
         }
     }

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -85,6 +85,24 @@ struct InstanceView: View {
                 handleError(error)
             }
         }
+        .task {
+            if instance.local {
+                do {
+                    let myInstance: Instance3
+                    if let apiInstance = appState.firstApi.myInstance {
+                        myInstance = apiInstance
+                    } else {
+                        myInstance = try await appState.firstApi.getMyInstance()
+                    }
+                    
+                    Task { @MainActor in
+                        self.instance = myInstance
+                    }
+                } catch {
+                    handleError(error)
+                }
+            }
+        }
         .isAtTopSubscriber(isAtTop: $isAtTop)
         .navigationBarTitleDisplayMode(.inline)
         .background(palette.groupedBackground)

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -139,6 +139,7 @@ struct InstanceView: View {
             VStack(spacing: Constants.main.halfSpacing) {
                 ForEach(instance.administrators_ ?? []) { person in
                     PersonListRow(person)
+                        .quickSwipes(administratorQuickSwipes(person: person))
                 }
             }
             

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -222,6 +222,9 @@
     "Add Guest" : {
 
     },
+    "Add Moderator" : {
+
+    },
     "Administration" : {
 
     },
@@ -1353,6 +1356,19 @@
     "Really apply configuration to all?" : {
 
     },
+    "Really appoint %@ as a moderator of %@?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Really appoint %1$@ as a moderator of %2$@?"
+          }
+        }
+      }
+    },
+    "Really appoint this user as a moderator of %@?" : {
+
+    },
     "Really delete %@?" : {
 
     },
@@ -1411,6 +1427,9 @@
 
     },
     "Remove Content" : {
+
+    },
+    "Remove Moderator" : {
 
     },
     "Removed: %@" : {


### PR DESCRIPTION
> [!NOTE]
> Depends on [this MlemMiddleware PR](https://github.com/mlemgroup/MlemMiddleware/pull/96)

<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - closes #1455 

# Pull Request Information

This PR enables adding and removing moderators from the Moderation tab of a community.

It also tweaks some add/remove admin behavior:
- Admins can now be removed using a quick swipe action
- When the local instance, `InstanceView.instance` is now immediately set to `appState.firstApi.myInstance` (this previously happened immediately before adding an admin)
- Admin actions are disabled if `instance.local` is false
- Remove admin icon is now `arrowshape.down` because it plays nice with swipe actions