### PR TITLE
Image Control Tweaks

### DIFF
--- a/Mlem/App/Views/Pages/ImageViewer.swift
+++ b/Mlem/App/Views/Pages/ImageViewer.swift
@@ -91,6 +91,8 @@ struct ImageViewer: View {
             animateOpacityUpdate(1.0)
         }
         .onChange(of: dragState) {
+            guard !isZoomed else { return }
+            
             if dragState {
                 // drag gesture conflicts with control tap, so we disable it for a brief window after detecting a drag
                 enableControlTap = false
@@ -181,8 +183,8 @@ struct ImageViewer: View {
     private func handleOffsetUpdate(_ newOffset: CGFloat) {
         let absOffset = abs(newOffset)
         offset = newOffset
-        controlOffset = absOffset
-        controlOpacity = 1.0 - (absOffset / maxControlOffset)
+        controlOffset = absOffset / 3
+        controlOpacity = 1.0 - (controlOffset / maxControlOffset)
         opacity = 1.0 - (absOffset / screenHeight)
     }
     


### PR DESCRIPTION
Minor changes to the image controls:
- Fixed a bug where zooming in and then dragging would cause the controls to appear
- When interactively dismissing, the controls now move at 1/3 the speed of the image--this feels smoother to me