### PR TITLE
Mix Audio

### DIFF
--- a/Mlem/App/Views/Root/MlemApp.swift
+++ b/Mlem/App/Views/Root/MlemApp.swift
@@ -34,7 +34,7 @@ struct MlemApp: App {
         
         // set up audio
         do {
-            try AVAudioSession.sharedInstance().setCategory(.playback)
+            try AVAudioSession.sharedInstance().setCategory(.playback, options: [.mixWithOthers])
         } catch {
             handleError(error)
         }

--- a/Mlem/App/Views/Shared/Images/Helpers/AnimationControlLayer.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/AnimationControlLayer.swift
@@ -57,7 +57,6 @@ private struct AnimationControlLayer: ViewModifier {
             }
     }
     
-    
     @ViewBuilder
     var muteButton: some View {
         if let muted {

--- a/Mlem/App/Views/Shared/Images/Helpers/AnimationControlLayer.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/AnimationControlLayer.swift
@@ -56,9 +56,9 @@ private struct AnimationControlLayer: ViewModifier {
                         .padding([.top, .trailing], 5)
                         .padding([.bottom, .leading], 15)
                         .contentShape(.rect)
-                        .onTapGesture {
+                        .highPriorityGesture(TapGesture().onEnded {
                             muted.wrappedValue = !muted.wrappedValue
-                        }
+                        })
                 }
             }
             .onChange(of: blurred, initial: true) {

--- a/Mlem/App/Views/Shared/Images/Helpers/AnimationControlLayer.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/AnimationControlLayer.swift
@@ -45,21 +45,7 @@ private struct AnimationControlLayer: ViewModifier {
                 }
             }
             .overlay(alignment: .bottomTrailing) {
-                if let muted {
-                    Image(systemName: muted.wrappedValue ? Icons.muted : Icons.unmuted)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 15, height: 15)
-                        .padding(5)
-                        .background(.ultraThinMaterial, in: .circle)
-                        .foregroundStyle(.white)
-                        .padding([.top, .trailing], 5)
-                        .padding([.bottom, .leading], 15)
-                        .contentShape(.rect)
-                        .highPriorityGesture(TapGesture().onEnded {
-                            muted.wrappedValue = !muted.wrappedValue
-                        })
-                }
+                muteButton
             }
             .onChange(of: blurred, initial: true) {
                 if blurred {
@@ -69,6 +55,26 @@ private struct AnimationControlLayer: ViewModifier {
                     showControls = true
                 }
             }
+    }
+    
+    
+    @ViewBuilder
+    var muteButton: some View {
+        if let muted {
+            Image(systemName: muted.wrappedValue ? Icons.muted : Icons.unmuted)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 15, height: 15)
+                .padding(5)
+                .background(.ultraThinMaterial, in: .circle)
+                .foregroundStyle(.white)
+                .padding([.bottom, .trailing], 5)
+                .padding([.top, .leading], 15)
+                .contentShape(.rect)
+                .highPriorityGesture(TapGesture().onEnded {
+                    muted.wrappedValue = !muted.wrappedValue
+                })
+        }
     }
 }
 


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

# Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have described what this PR contains
- [x] If this PR alters the UI, I have attached pictures/videos
- [x] This PR addresses one or more open issues that were assigned to me:
      - progress towards #1389

# Pull Request Information

Audio now mixes with other sessions instead of turning them off. Also fixes a bug where the mute button wasn't tappable, and lightly refactors `animationControlLayer`.

I tried to make this duck background sessions and un-duck them when the audio stopped playing, but ran into main thread hangs that I couldn't fix. That work is up on `eric/audio-mix`.