### PR TITLE
Fix "data could not be read because it is missing"

### DIFF
--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -173,7 +173,7 @@ struct CodableSettings: Codable {
         self.post_thumbnailLocation = try container.decodeIfPresent(ThumbnailLocation.self, forKey: .post_thumbnailLocation) ?? .left
         self.post_webPreview_showHost = try container.decodeIfPresent(Bool.self, forKey: .post_webPreview_showHost) ?? true
         self.post_webPreview_showIcon = try container.decodeIfPresent(Bool.self, forKey: .post_webPreview_showIcon) ?? true
-        self.privacy_autoBypassImageProxy = try container.decode(Bool.self, forKey: .privacy_autoBypassImageProxy)
+        self.privacy_autoBypassImageProxy = try container.decodeIfPresent(Bool.self, forKey: .privacy_autoBypassImageProxy) ?? false
         self.profile_showBanner = try container.decodeIfPresent(Bool.self, forKey: .profile_showBanner) ?? true
         self.safety_blurNsfw = try container.decodeIfPresent(NsfwBlurBehavior.self, forKey: .safety_blurNsfw) ?? .always
         self.safety_enableModlogWarning = try container.decodeIfPresent(Bool.self, forKey: .safety_enableModlogWarning) ?? true

--- a/Mlem/App/Globals/Definitions/ErrorsTracker.swift
+++ b/Mlem/App/Globals/Definitions/ErrorsTracker.swift
@@ -22,7 +22,7 @@ class ErrorsTracker {
         var ret = ""
         
         for details in errors {
-            let description = details.error?.localizedDescription ?? "No Description"
+            let description = String(describing: details.error)
             ret += "\(details.when.formatted(.iso8601))\t\(details.title ?? "Error")\t\(description)\n"
         }
         

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -213,7 +213,7 @@ class PersistenceRepository {
     
     // MARK: Loading methods
     
-    func load<T: Decodable>(_ model: T.Type, from path: URL, ignoringError: Bool = false) -> T? {
+    func load<T: Decodable>(_ model: T.Type, from path: URL) -> T? {
         do {
             let data = try read(path)
             

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -213,7 +213,7 @@ class PersistenceRepository {
     
     // MARK: Loading methods
     
-    func load<T: Decodable>(_ model: T.Type, from path: URL) -> T? {
+    func load<T: Decodable>(_ model: T.Type, from path: URL, ignoringError: Bool = false) -> T? {
         do {
             let data = try read(path)
             

--- a/Mlem/App/Models/ErrorDetails.swift
+++ b/Mlem/App/Models/ErrorDetails.swift
@@ -67,7 +67,7 @@ struct ErrorDetails: Hashable {
         if let error = error as? ApiClientError {
             output = error.description
         } else {
-            output = error?.localizedDescription ?? ""
+            output = String(describing: error)
         }
         for account in AccountsTracker.main.userAccounts {
             if let token = account.api.token {


### PR DESCRIPTION
Closes #1445

Also replaced cases where we print an error using `error.localizedDescription` with `String(describing: error)` instead - this seems to give a more descriptive error message