### PR TITLE
Settings Icons

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -260,9 +260,9 @@
 		03B62C402CE811CB0077E9C8 /* PersonBanEditorView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B62C3F2CE811CB0077E9C8 /* PersonBanEditorView+Logic.swift */; };
 		03B72B672C2888EE0023A6C4 /* View+ContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B72B662C2888EE0023A6C4 /* View+ContextMenu.swift */; };
 		03B72B6B2C28A0190023A6C4 /* SubscriptionListSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B72B6A2C28A0190023A6C4 /* SubscriptionListSettingsView.swift */; };
+		03BF11C32D3D135D00CC1F66 /* SearchView+CreatorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BF11C22D3D135D00CC1F66 /* SearchView+CreatorPicker.swift */; };
 		03BF11C52D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BF11C42D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift */; };
 		03BF11C72D3D634A00CC1F66 /* AccessibilitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BF11C62D3D634A00CC1F66 /* AccessibilitySettingsView.swift */; };
-		03BF11C32D3D135D00CC1F66 /* SearchView+CreatorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BF11C22D3D135D00CC1F66 /* SearchView+CreatorPicker.swift */; };
 		03C0EAEF2CA8288A00B4B2A5 /* CapsuleButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C0EAEE2CA8288A00B4B2A5 /* CapsuleButtonStyle.swift */; };
 		03C93CF02BEFFB1A00327BFE /* LoginCredentialsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C93CEF2BEFFB1A00327BFE /* LoginCredentialsView.swift */; };
 		03CBD18D2C6120F600E870BC /* PersonFlair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CBD18C2C6120F600E870BC /* PersonFlair.swift */; };
@@ -467,6 +467,7 @@
 		CDEE15542D22364B00EB9D7B /* ErrorLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEE15532D22364500EB9D7B /* ErrorLogView.swift */; };
 		CDF9EF332AB2845C003F885B /* Icons.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF9EF322AB2845C003F885B /* Icons.swift */; };
 		CDFB8C692C7796020070845F /* View+DynamicBlur.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFB8C682C7796020070845F /* View+DynamicBlur.swift */; };
+		CDFF11712D3D93DC00386B71 /* ConditionalIconLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFF11702D3D93D900386B71 /* ConditionalIconLabelStyle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -739,9 +740,9 @@
 		03B62C3F2CE811CB0077E9C8 /* PersonBanEditorView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonBanEditorView+Logic.swift"; sourceTree = "<group>"; };
 		03B72B662C2888EE0023A6C4 /* View+ContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ContextMenu.swift"; sourceTree = "<group>"; };
 		03B72B6A2C28A0190023A6C4 /* SubscriptionListSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionListSettingsView.swift; sourceTree = "<group>"; };
+		03BF11C22D3D135D00CC1F66 /* SearchView+CreatorPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchView+CreatorPicker.swift"; sourceTree = "<group>"; };
 		03BF11C42D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReadIndicatorSettingsView.swift; sourceTree = "<group>"; };
 		03BF11C62D3D634A00CC1F66 /* AccessibilitySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySettingsView.swift; sourceTree = "<group>"; };
-		03BF11C22D3D135D00CC1F66 /* SearchView+CreatorPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchView+CreatorPicker.swift"; sourceTree = "<group>"; };
 		03C0EAEE2CA8288A00B4B2A5 /* CapsuleButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsuleButtonStyle.swift; sourceTree = "<group>"; };
 		03C93CEF2BEFFB1A00327BFE /* LoginCredentialsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCredentialsView.swift; sourceTree = "<group>"; };
 		03CBD18C2C6120F600E870BC /* PersonFlair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonFlair.swift; sourceTree = "<group>"; };
@@ -940,6 +941,7 @@
 		CDEE15532D22364500EB9D7B /* ErrorLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorLogView.swift; sourceTree = "<group>"; };
 		CDF9EF322AB2845C003F885B /* Icons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icons.swift; sourceTree = "<group>"; };
 		CDFB8C682C7796020070845F /* View+DynamicBlur.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+DynamicBlur.swift"; sourceTree = "<group>"; };
+		CDFF11702D3D93D900386B71 /* ConditionalIconLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalIconLabelStyle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1317,6 +1319,7 @@
 		039F588D2C7B598000C61658 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				CDFF11702D3D93D900386B71 /* ConditionalIconLabelStyle.swift */,
 				039F58872C7B531800C61658 /* SquircleLabelStyle.swift */,
 				039F588E2C7B599800C61658 /* ThemeLabel.swift */,
 				0325B93D2D3AAE9E00E28B97 /* SettingsHeaderView.swift */,
@@ -2681,6 +2684,7 @@
 				033FCAEC2C57DCCD007B7CD1 /* ApiListingType+Extensions.swift in Sources */,
 				033FCB272C5E3933007B7CD1 /* AlternateIconLabel.swift in Sources */,
 				033FCB282C5E3933007B7CD1 /* AlternateIcon.swift in Sources */,
+				CDFF11712D3D93DC00386B71 /* ConditionalIconLabelStyle.swift in Sources */,
 				038028F62CB096960091A8A2 /* SearchView+FilterModels.swift in Sources */,
 				033FCB292C5E3933007B7CD1 /* IconSettingsView.swift in Sources */,
 				CD03742A2D1DBFD2001E85FA /* ReadCheck.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -449,7 +449,7 @@
 		CDCA44B62C176C5000C092B3 /* View+EdgeBorders.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCA44B52C176C5000C092B3 /* View+EdgeBorders.swift */; };
 		CDD4A09C2C8A122F0001AD1A /* CodableSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD4A09B2C8A122F0001AD1A /* CodableSettings.swift */; };
 		CDD4A09E2C8B69FC0001AD1A /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD4A09D2C8B69FC0001AD1A /* Button.swift */; };
-		CDD4A0A02C8B985D0001AD1A /* ImportExportSettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD4A09F2C8B985D0001AD1A /* ImportExportSettingsPage.swift */; };
+		CDD4A0A02C8B985D0001AD1A /* ImportExportSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD4A09F2C8B985D0001AD1A /* ImportExportSettingsView.swift */; };
 		CDD8B94C2C8234BC00510EBB /* Form.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD8B94B2C8234BC00510EBB /* Form.swift */; };
 		CDD99C3C2C73F3FF0010367F /* DeleteAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD99C3B2C73F3FF0010367F /* DeleteAccountView.swift */; };
 		CDD99C3E2C73F4380010367F /* WarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD99C3D2C73F4380010367F /* WarningView.swift */; };
@@ -925,7 +925,7 @@
 		CDCA44B52C176C5000C092B3 /* View+EdgeBorders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+EdgeBorders.swift"; sourceTree = "<group>"; };
 		CDD4A09B2C8A122F0001AD1A /* CodableSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableSettings.swift; sourceTree = "<group>"; };
 		CDD4A09D2C8B69FC0001AD1A /* Button.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
-		CDD4A09F2C8B985D0001AD1A /* ImportExportSettingsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportExportSettingsPage.swift; sourceTree = "<group>"; };
+		CDD4A09F2C8B985D0001AD1A /* ImportExportSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportExportSettingsView.swift; sourceTree = "<group>"; };
 		CDD8B94B2C8234BC00510EBB /* Form.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Form.swift; sourceTree = "<group>"; };
 		CDD99C3B2C73F3FF0010367F /* DeleteAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountView.swift; sourceTree = "<group>"; };
 		CDD99C3D2C73F4380010367F /* WarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningView.swift; sourceTree = "<group>"; };
@@ -1015,42 +1015,42 @@
 		03134A492BEACF46002662CC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				CDEE15532D22364500EB9D7B /* ErrorLogView.swift */,
-				CD45CB0C2D1880E3008BC729 /* FiltersSettingsView.swift */,
-				0397D4982C6EA68A002C6CDC /* InteractionBarEditor */,
-				031E2D5C2BEFCC630003BC45 /* SettingsView.swift */,
-				039F58892C7B54FE00C61658 /* GeneralSettingsView.swift */,
-				039F588B2C7B574E00C61658 /* AdvancedSettingsView.swift */,
-				0353948E2CA088E600795AA5 /* DeveloperSettingsView.swift */,
-				038028D72CACAB960091A8A2 /* ModeratorSettingsView.swift */,
 				039F58962C7B68F100C61658 /* AboutMlemView.swift */,
-				0397D46B2C67E583002C6CDC /* SortingSettingsView.swift */,
-				03267D832BED49CE009D6268 /* AccountSettingsView.swift */,
-				037DE0742CE023E3007F7B92 /* BlockListView.swift */,
-				03AB48512CBC042E00567FF9 /* AccountGeneralSettingsView.swift */,
-				0391E0F82CFF17AE0040CCA8 /* ProfileSettingsView.swift */,
+				03BF11C62D3D634A00CC1F66 /* AccessibilitySettingsView.swift */,
 				03AB48542CBC0B8000567FF9 /* AccountAdvancedSettingsView.swift */,
-				03AB48562CBC0DFC00567FF9 /* AccountSignInSettingsView.swift */,
 				03AB48582CBC14CE00567FF9 /* AccountEmailSettingsView.swift */,
+				03AB48512CBC042E00567FF9 /* AccountGeneralSettingsView.swift */,
+				03134A572BEC1C46002662CC /* AccountListSettingsView.swift */,
 				03AD0A812CFDBFA0001EF9F7 /* AccountLocalSettingsView.swift */,
 				03AD0A832CFDC557001EF9F7 /* AccountNicknameFieldView.swift */,
-				03134A572BEC1C46002662CC /* AccountListSettingsView.swift */,
-				031E2D5A2BEFC9460003BC45 /* ThemeSettingsView.swift */,
-				03B72B6A2C28A0190023A6C4 /* SubscriptionListSettingsView.swift */,
-				03D284052D2AEE3A00A6659B /* TabBarSettingsView.swift */,
-				0325B9392D3A9E8100E28B97 /* InboxBadgeSettingsView.swift */,
-				CDBFCB692C04EFFE008CD468 /* PostSettingsView.swift */,
-				037F78442D3C25AB00D4E180 /* PostSubscriptionIndicatorSettingsView.swift */,
-				03BF11C42D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift */,
-				03BF11C62D3D634A00CC1F66 /* AccessibilitySettingsView.swift */,
-				037F78422D3C129B00D4E180 /* PostThumbnailSettingsView.swift */,
-				037F783E2D3BD05500D4E180 /* PostSettingsView+PostSizePicker.swift */,
+				03267D832BED49CE009D6268 /* AccountSettingsView.swift */,
+				03AB48562CBC0DFC00567FF9 /* AccountSignInSettingsView.swift */,
+				039F588B2C7B574E00C61658 /* AdvancedSettingsView.swift */,
+				037DE0742CE023E3007F7B92 /* BlockListView.swift */,
 				039F58922C7B616600C61658 /* CommentSettingsView.swift */,
+				0353948E2CA088E600795AA5 /* DeveloperSettingsView.swift */,
+				CDEE15532D22364500EB9D7B /* ErrorLogView.swift */,
+				CD45CB0C2D1880E3008BC729 /* FiltersSettingsView.swift */,
+				039F58892C7B54FE00C61658 /* GeneralSettingsView.swift */,
+				CDD4A09F2C8B985D0001AD1A /* ImportExportSettingsView.swift */,
+				0325B9392D3A9E8100E28B97 /* InboxBadgeSettingsView.swift */,
 				039F58942C7B618F00C61658 /* InboxSettingsView.swift */,
 				03531EEB2C2D81DC004A3464 /* LinkSettingsView.swift */,
-				033FCB262C5E3933007B7CD1 /* Icon */,
+				038028D72CACAB960091A8A2 /* ModeratorSettingsView.swift */,
+				03BF11C42D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift */,
+				CDBFCB692C04EFFE008CD468 /* PostSettingsView.swift */,
+				037F783E2D3BD05500D4E180 /* PostSettingsView+PostSizePicker.swift */,
+				037F78442D3C25AB00D4E180 /* PostSubscriptionIndicatorSettingsView.swift */,
+				037F78422D3C129B00D4E180 /* PostThumbnailSettingsView.swift */,
+				0391E0F82CFF17AE0040CCA8 /* ProfileSettingsView.swift */,
+				031E2D5C2BEFCC630003BC45 /* SettingsView.swift */,
+				0397D46B2C67E583002C6CDC /* SortingSettingsView.swift */,
+				03B72B6A2C28A0190023A6C4 /* SubscriptionListSettingsView.swift */,
+				03D284052D2AEE3A00A6659B /* TabBarSettingsView.swift */,
+				031E2D5A2BEFC9460003BC45 /* ThemeSettingsView.swift */,
 				039F588D2C7B598000C61658 /* Components */,
-				CDD4A09F2C8B985D0001AD1A /* ImportExportSettingsPage.swift */,
+				033FCB262C5E3933007B7CD1 /* Icon */,
+				0397D4982C6EA68A002C6CDC /* InteractionBarEditor */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -2433,7 +2433,7 @@
 				0305EBB22D35C1B70066E5AD /* RegistrationApplicationView.swift in Sources */,
 				037658DF2BE7D9EF00F4DD4D /* Community1Providing+Extensions.swift in Sources */,
 				032C32182C36F70300595286 /* ReplyBarConfiguration.swift in Sources */,
-				CDD4A0A02C8B985D0001AD1A /* ImportExportSettingsPage.swift in Sources */,
+				CDD4A0A02C8B985D0001AD1A /* ImportExportSettingsView.swift in Sources */,
 				03B431B62C454D49001A1EB5 /* UIImage+Extensions.swift in Sources */,
 				CD1446212A5B328E00610EF1 /* Privacy Policy.swift in Sources */,
 				03AFD0E32C3C0C540054B8AD /* InstanceView.swift in Sources */,

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -291,6 +291,9 @@ enum Icons {
     static let swipeActions: String = "inset.filled.leadinghalf.rectangle"
     static let swipeAnywhere: String = "arrow.left"
     static let importSettings: String = "folder.badge.gearshape"
+    static let inApp: String = "house"
+    static let reader: String = "text.page"
+    static let keywordFilter: String = "rectangle.and.text.magnifyingglass"
     
     // fediseer
     static let fediseer: String = "shield.checkered"

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -285,6 +285,12 @@ enum Icons {
     static let unbanFromCommunity: String = "checkmark.shield"
     static let logIn: String = "person.text.rectangle"
     static let signUp: String = "pencil.and.list.clipboard"
+    static let sidebar: String = "sidebar.left"
+    static let infiniteScroll: String = "infinity"
+    static let confirmImageUploads: String = "photo.badge.checkmark"
+    static let swipeActions: String = "inset.filled.leadinghalf.rectangle"
+    static let swipeAnywhere: String = "arrow.left"
+    static let importSettings: String = "folder.badge.gearshape"
     
     // fediseer
     static let fediseer: String = "shield.checkered"
@@ -296,6 +302,7 @@ enum Icons {
     
     // media
     static let play: String = "play.fill"
+    static let playCircle: String = "play.circle"
     static let muted: String = "speaker.slash.fill"
     static let unmuted: String = "speaker.wave.2.fill"
     

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -297,6 +297,9 @@ enum Icons {
     static let saveSettings: String = "document.badge.gearshape"
     static let restoreSettings: String = "gearshape.arrow.trianglehead.2.clockwise.rotate.90"
     static let menuItems: String = "filemenu.and.selection"
+    static let systemMode: String = "circle.lefthalf.filled"
+    static let lightMode: String = "sun.max"
+    static let darkMode: String = "moon"
     
     // fediseer
     static let fediseer: String = "shield.checkered"

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -294,6 +294,9 @@ enum Icons {
     static let inApp: String = "house"
     static let reader: String = "text.page"
     static let keywordFilter: String = "rectangle.and.text.magnifyingglass"
+    static let saveSettings: String = "document.badge.gearshape"
+    static let restoreSettings: String = "gearshape.arrow.trianglehead.2.clockwise.rotate.90"
+    static let menuItems: String = "filemenu.and.selection"
     
     // fediseer
     static let fediseer: String = "shield.checkered"

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -278,7 +278,6 @@ enum Icons {
     static let developerMode: String = "wrench.adjustable.fill"
     static let limitImageHeightSetting: String = "rectangle.compress.vertical"
     static let appLockSettings: String = "lock.app.dashed"
-    static let collapseComments: String = "arrow.down.and.line.horizontal.and.arrow.up"
     static let banFromInstance: String = "xmark.circle"
     static let unbanFromInstance: String = "checkmark.circle"
     static let banFromCommunity: String = "xmark.shield"
@@ -300,6 +299,10 @@ enum Icons {
     static let systemMode: String = "circle.lefthalf.filled"
     static let lightMode: String = "sun.max"
     static let darkMode: String = "moon"
+    static let compactComments: String = "rectangle.compress.vertical"
+    static let interactionBar: String = "square.and.line.vertical.and.square.fill"
+    static let commentDepth: String = "text.append"
+    static let qualifiedLabel: String = "at"
     
     // fediseer
     static let fediseer: String = "shield.checkered"

--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -15,6 +15,7 @@ struct CodableSettings: Codable {
 
     var a11y_readPostIndicator: ReadPostIndicator
     var a11y_readOutlineThickness: Int
+    var a11y_showSettingsIcons: Bool
     var a11y_websiteThumbnailIcon: Bool
     var accounts_defaultId: Int?
     var accounts_grouped: Bool
@@ -22,7 +23,6 @@ struct CodableSettings: Codable {
     var accounts_keepPlace: Bool
     var appearance_interfaceStyle: UIUserInterfaceStyle
     var appearance_palette: PaletteOption
-    var appearance_showSettingsIcons: Bool
     var markdown_wrapCodeBlockLines: Bool
     var behavior_biometricUnlock: Bool
     var behavior_confirmImageUploads: Bool
@@ -100,6 +100,7 @@ struct CodableSettings: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.a11y_readPostIndicator = try container.decodeIfPresent(ReadPostIndicator.self, forKey: .a11y_readPostIndicator) ?? .checkmark
         self.a11y_readOutlineThickness = try container.decodeIfPresent(Int.self, forKey: .a11y_readOutlineThickness) ?? 3
+        self.a11y_showSettingsIcons = try container.decodeIfPresent(Bool.self, forKey: .a11y_showSettingsIcons) ?? true
         self.a11y_websiteThumbnailIcon = try container.decodeIfPresent(Bool.self, forKey: .a11y_websiteThumbnailIcon) ?? false
         self.accounts_defaultId = try container.decodeIfPresent(Int?.self, forKey: .accounts_defaultId) ?? nil
         self.accounts_grouped = try container.decodeIfPresent(Bool.self, forKey: .accounts_grouped) ?? false
@@ -107,7 +108,6 @@ struct CodableSettings: Codable {
         self.accounts_keepPlace = try container.decodeIfPresent(Bool.self, forKey: .accounts_keepPlace) ?? false
         self.appearance_interfaceStyle = try container.decodeIfPresent(UIUserInterfaceStyle.self, forKey: .appearance_interfaceStyle) ?? .unspecified
         self.appearance_palette = try container.decodeIfPresent(PaletteOption.self, forKey: .appearance_palette) ?? .standard
-        self.appearance_showSettingsIcons = try container.decodeIfPresent(Bool.self, forKey: .appearance_showSettingsIcons) ?? true
         self.markdown_wrapCodeBlockLines = try container.decodeIfPresent(Bool.self, forKey: .markdown_wrapCodeBlockLines) ?? true
         self.behavior_biometricUnlock = try container.decodeIfPresent(Bool.self, forKey: .behavior_biometricUnlock) ?? false
         self.behavior_confirmImageUploads = try container.decodeIfPresent(Bool.self, forKey: .behavior_confirmImageUploads) ?? true
@@ -199,6 +199,7 @@ struct CodableSettings: Codable {
     init(from settings: Settings, filteredKeywords: Set<String>) {
         self.a11y_readPostIndicator = settings.readPostIndicator
         self.a11y_readOutlineThickness = settings.readOutlineThickness
+        self.a11y_showSettingsIcons = true
         self.a11y_websiteThumbnailIcon = settings.websiteThumbnailIcon
         self.accounts_defaultId = nil
         self.accounts_grouped = settings.groupAccountSort
@@ -206,7 +207,6 @@ struct CodableSettings: Codable {
         self.accounts_keepPlace = settings.keepPlaceOnAccountSwitch
         self.appearance_interfaceStyle = settings.interfaceStyle
         self.appearance_palette = settings.colorPalette
-        self.appearance_showSettingsIcons = true
         self.markdown_wrapCodeBlockLines = settings.wrapCodeBlockLines
         self.behavior_biometricUnlock = false
         self.behavior_confirmImageUploads = settings.confirmImageUploads

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -20,6 +20,7 @@ class Settings: ObservableObject {
 
     @AppStorage("a11y.readPostIndicator") var readPostIndicator: ReadPostIndicator = .checkmark
     @AppStorage("a11y.readOutlineThickness") var readOutlineThickness: Int = 3
+    @AppStorage("a11y.showSettingsIcons") var showSettingsIcons: Bool = false
     @AppStorage("a11y.websiteThumbnailIcon") var websiteThumbnailIcon: Bool = false
 
     @AppStorage("post.size") var postSize: PostSize = .compact
@@ -178,6 +179,7 @@ class Settings: ObservableObject {
         tabProfileShowAvatar = settings.tab_profile_showAvatar
         tabInboxBadgeIncludedTypes = settings.tab_inbox_badgeIncludedTypes
         websiteThumbnailIcon = settings.a11y_websiteThumbnailIcon
+        showSettingsIcons = settings.a11y_showSettingsIcons
         
         Task {
             await FiltersTracker.main.resetFilteredKeywords(to: settings.filteredKeywords)

--- a/Mlem/App/Models/Settings/Options/ThumbnailLocation.swift
+++ b/Mlem/App/Models/Settings/Options/ThumbnailLocation.swift
@@ -12,7 +12,7 @@ enum ThumbnailLocation: String, CaseIterable, Codable {
     
     var label: LocalizedStringResource {
         switch self {
-        case .none: "Hidden"
+        case .none: "None"
         case .left: "Left"
         case .right: "Right"
         }

--- a/Mlem/App/Models/Settings/Options/ThumbnailLocation.swift
+++ b/Mlem/App/Models/Settings/Options/ThumbnailLocation.swift
@@ -12,9 +12,9 @@ enum ThumbnailLocation: String, CaseIterable, Codable {
     
     var label: LocalizedStringResource {
         switch self {
+        case .none: "Hidden"
         case .left: "Left"
         case .right: "Right"
-        case .none: "Hidden"
         }
     }
 }

--- a/Mlem/App/Utility/Extensions/UIUserInterfaceStyle+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/UIUserInterfaceStyle+Extensions.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import UIKit
+import SwiftUICore
 
 extension UIUserInterfaceStyle: Codable {
     var label: String {
@@ -19,6 +20,15 @@ extension UIUserInterfaceStyle: Codable {
             "Dark"
         default:
             "Unknown"
+        }
+    }
+    
+    var systemImage: String {
+        switch self {
+        case .unspecified: "circle.lefthalf.filled"
+        case .light: "circle"
+        case .dark: "circle.fill"
+        default: "circle.lefthalf.filled"
         }
     }
     

--- a/Mlem/App/Utility/Extensions/UIUserInterfaceStyle+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/UIUserInterfaceStyle+Extensions.swift
@@ -25,10 +25,10 @@ extension UIUserInterfaceStyle: Codable {
     
     var systemImage: String {
         switch self {
-        case .unspecified: "circle.lefthalf.filled"
-        case .light: "circle"
-        case .dark: "circle.fill"
-        default: "circle.lefthalf.filled"
+        case .unspecified: Icons.systemMode
+        case .light: Icons.lightMode
+        case .dark: Icons.darkMode
+        default: Icons.systemMode
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Views/NavigationLink+NavigationPage.swift
+++ b/Mlem/App/Utility/Extensions/Views/NavigationLink+NavigationPage.swift
@@ -20,13 +20,15 @@ extension NavigationLink where Destination == Never {
         _ titleKey: LocalizedStringResource,
         value: String,
         fallbackValue: String,
+        systemImage: String? = nil,
         destination: NavigationPage
     ) where Label == NavigationLinkPickerLabelView {
         self.init(destination) {
             NavigationLinkPickerLabelView(
                 title: .init(localized: titleKey),
                 value: value,
-                fallbackValue: fallbackValue
+                fallbackValue: fallbackValue,
+                systemImage: systemImage
             )
         }
     }
@@ -51,11 +53,19 @@ struct NavigationLinkPickerLabelView: View {
     let title: String
     let value: String
     let fallbackValue: String
+    let systemImage: String?
     
     var body: some View {
         HStack {
-            Text(title)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            Group {
+                if let systemImage {
+                    Label(title, systemImage: systemImage)
+                } else {
+                    Text(title)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
             ViewThatFits {
                 Text(value)
                 Text(fallbackValue)

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -29,8 +29,8 @@ struct AccessibilitySettingsView: View {
                 Toggle("Website Thumbnail Indicator", systemImage: Icons.browser, isOn: $websiteThumbnailIcon)
                 Toggle("Settings Icons", systemImage: Icons.icon, isOn: $showSettingsIcons)
             }
-            .labelStyle(ConditionalIconLabelStyle())
         }
+        .labelStyle(.conditional)
         .navigationTitle("Accessibility")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -12,6 +12,9 @@ struct AccessibilitySettingsView: View {
 
     @Setting(\.readPostIndicator) var readPostIndicator
     @Setting(\.websiteThumbnailIcon) var websiteThumbnailIcon
+    @Setting(\.showSettingsIcons) var showSettingsIcons
+    
+    // var labelStyle: any LabelStyle { showSettingsIcons ? .titleAndIcon : .titleOnly }
     
     var body: some View {
         Form {
@@ -25,8 +28,10 @@ struct AccessibilitySettingsView: View {
             }
             
             Section {
-                Toggle("Website Thumbnail Indicator", isOn: $websiteThumbnailIcon)
+                Toggle("Website Thumbnail Indicator", systemImage: Icons.browser, isOn: $websiteThumbnailIcon)
+                Toggle("Settings Icons", systemImage: Icons.icon, isOn: $showSettingsIcons)
             }
+            .labelStyle(ConditionalIconLabelStyle())
         }
         .navigationTitle("Accessibility")
     }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -14,8 +14,6 @@ struct AccessibilitySettingsView: View {
     @Setting(\.websiteThumbnailIcon) var websiteThumbnailIcon
     @Setting(\.showSettingsIcons) var showSettingsIcons
     
-    // var labelStyle: any LabelStyle { showSettingsIcons ? .titleAndIcon : .titleOnly }
-    
     var body: some View {
         Form {
             if differentiateWithoutColor {

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountAdvancedSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountAdvancedSettingsView.swift
@@ -37,7 +37,7 @@ struct AccountAdvancedSettingsView: View {
                 Text("Bot accounts are unable to vote.")
             }
         }
-        .labelStyle(ConditionalIconLabelStyle())
+        .labelStyle(.conditional)
         .navigationTitle("Advanced")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountAdvancedSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountAdvancedSettingsView.swift
@@ -21,7 +21,7 @@ struct AccountAdvancedSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("Bot Account", isOn: $isBot)
+                Toggle("Bot Account", systemImage: Icons.botFlair, isOn: $isBot)
                     .tint(palette.colorfulAccent(5))
                     .onChange(of: isBot) {
                         Task {
@@ -37,6 +37,7 @@ struct AccountAdvancedSettingsView: View {
                 Text("Bot accounts are unable to vote.")
             }
         }
+        .labelStyle(ConditionalIconLabelStyle())
         .navigationTitle("Advanced")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountGeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountGeneralSettingsView.swift
@@ -74,7 +74,7 @@ struct AccountGeneralSettingsView: View {
                 }
             }
         }
-        .labelStyle(ConditionalIconLabelStyle())
+        .labelStyle(.conditional)
         .navigationTitle("Content & Notifications")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountGeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountGeneralSettingsView.swift
@@ -25,7 +25,7 @@ struct AccountGeneralSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("Show NSFW Content", isOn: $showNsfw)
+                Toggle("Show NSFW Content", systemImage: Icons.blurNsfw, isOn: $showNsfw)
                     .tint(palette.warning)
                     .onChange(of: showNsfw) {
                         Task {
@@ -41,7 +41,7 @@ struct AccountGeneralSettingsView: View {
                 Text("Show content flagged as Not Safe For Work.")
             }
             Section {
-                Toggle("Show Bot Accounts", isOn: $showBotAccounts)
+                Toggle("Show Bot Accounts", systemImage: Icons.botFlair, isOn: $showBotAccounts)
                     .onChange(of: showBotAccounts) {
                         Task {
                             do {
@@ -54,7 +54,7 @@ struct AccountGeneralSettingsView: View {
                     }
             }
             Section {
-                Toggle("Send Notifications to Email", isOn: $sendNotificationsToEmail)
+                Toggle("Send Notifications to Email", systemImage: Icons.email, isOn: $sendNotificationsToEmail)
                     .onChange(of: sendNotificationsToEmail) {
                         Task {
                             do {
@@ -74,6 +74,7 @@ struct AccountGeneralSettingsView: View {
                 }
             }
         }
+        .labelStyle(ConditionalIconLabelStyle())
         .navigationTitle("Content & Notifications")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
@@ -23,7 +23,7 @@ struct AccountListSettingsView: View {
                 Toggle("Reload on Switch", systemImage: Icons.accountSwitchReload, isOn: $keepPlace.invert())
             }
         }
-        .labelStyle(ConditionalIconLabelStyle())
+        .labelStyle(.conditional)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountListSettingsView.swift
@@ -20,9 +20,10 @@ struct AccountListSettingsView: View {
             headerView
             AccountListView()
             Section {
-                Toggle("Reload on Switch", isOn: $keepPlace.invert())
+                Toggle("Reload on Switch", systemImage: Icons.accountSwitchReload, isOn: $keepPlace.invert())
             }
         }
+        .labelStyle(ConditionalIconLabelStyle())
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
@@ -29,7 +29,7 @@ struct CommentSettingsView: View {
             }
             maxDepthSection
         }
-        .labelStyle(ConditionalIconLabelStyle())
+        .labelStyle(.conditional)
         .navigationTitle("Comments")
     }
     

--- a/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
@@ -17,18 +17,19 @@ struct CommentSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("Compact Comments", isOn: $compactComments)
-                Toggle("Tap to Collapse", isOn: $tapCommentsToCollapse)
+                Toggle("Compact Comments", systemImage: Icons.compactComments, isOn: $compactComments)
+                Toggle("Tap to Collapse", systemImage: Icons.collapseComment, isOn: $tapCommentsToCollapse)
             }
             Section {
                 NavigationLink(
                     "Customize Interaction Bar",
-                    systemImage: "square.and.line.vertical.and.square.fill",
+                    systemImage: Icons.interactionBar,
                     destination: .settings(.commentInteractionBar)
                 )
             }
             maxDepthSection
         }
+        .labelStyle(ConditionalIconLabelStyle())
         .navigationTitle("Comments")
     }
     
@@ -36,7 +37,7 @@ struct CommentSettingsView: View {
     var maxDepthSection: some View {
         Section {
             HStack {
-                Text("Maximum Comment Depth")
+                Label("Maximum Comment Depth", systemImage: Icons.commentDepth)
                 Spacer()
                 Text(String(maxCommentDepth))
                     .foregroundStyle(palette.secondary)

--- a/Mlem/App/Views/Root/Tabs/Settings/Components/ConditionalIconLabelStyle.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/Components/ConditionalIconLabelStyle.swift
@@ -22,3 +22,7 @@ struct ConditionalIconLabelStyle: LabelStyle {
         }
     }
 }
+
+extension LabelStyle where Self == ConditionalIconLabelStyle {
+    static var conditional: ConditionalIconLabelStyle { .init() }
+}

--- a/Mlem/App/Views/Root/Tabs/Settings/Components/ConditionalIconLabelStyle.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/Components/ConditionalIconLabelStyle.swift
@@ -1,0 +1,26 @@
+//
+//  ConditionalIconLabelStyle.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2025-01-19.
+//
+
+import SwiftUI
+
+struct ConditionalIconLabelStyle: LabelStyle {
+    @Environment(Palette.self) var palette
+    
+    @Setting(\.showSettingsIcons) var showSettingsIcons
+    
+    func makeBody(configuration: Configuration) -> some View {
+        if showSettingsIcons {
+            HStack {
+                configuration.icon.foregroundStyle(palette.accent)
+                configuration.title
+            }
+        } else {
+            Label(configuration)
+                .labelStyle(.titleOnly)
+        }
+    }
+}

--- a/Mlem/App/Views/Root/Tabs/Settings/Components/ConditionalIconLabelStyle.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/Components/ConditionalIconLabelStyle.swift
@@ -13,14 +13,12 @@ struct ConditionalIconLabelStyle: LabelStyle {
     @Setting(\.showSettingsIcons) var showSettingsIcons
     
     func makeBody(configuration: Configuration) -> some View {
-        if showSettingsIcons {
-            HStack {
+        Label {
+            configuration.title
+        } icon: {
+            if showSettingsIcons {
                 configuration.icon.foregroundStyle(palette.accent)
-                configuration.title
             }
-        } else {
-            Label(configuration)
-                .labelStyle(.titleOnly)
         }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -35,8 +35,8 @@ struct FiltersSettingsView: View {
                 Text("Posts with these keywords in their titles will be hidden. If you are a moderator or administrator of a matching post, it will appear in your feed but require you to tap to view its content.")
             }
         }
+        .labelStyle(.conditional)
         .navigationTitle("Filters")
-        .labelStyle(ConditionalIconLabelStyle())
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -25,7 +25,7 @@ struct FiltersSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("Enable Keyword Filters", isOn: $keywordFilterEnabled)
+                Toggle("Enable Keyword Filters", systemImage: Icons.keywordFilter, isOn: $keywordFilterEnabled)
             }
             
             Section {
@@ -36,6 +36,7 @@ struct FiltersSettingsView: View {
             }
         }
         .navigationTitle("Filters")
+        .labelStyle(ConditionalIconLabelStyle())
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -37,53 +37,51 @@ struct GeneralSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Picker(selection: $blurNsfw) {
+                Picker("Blur NSFW", systemImage: Icons.blurNsfw, selection: $blurNsfw) {
                     ForEach(NsfwBlurBehavior.allCases, id: \.self) { behavior in
                         Text(behavior.label)
                     }
-                } label: {
-                    Text("Blur NSFW")
                 }
-                Toggle("Warn When Opening NSFW Community", isOn: $showNsfwCommunityWarning)
-                Toggle("Warn When Opening Modlog", isOn: $showModlogWarning)
+                Toggle("Warn When Opening NSFW Community", systemImage: Icons.warning, isOn: $showNsfwCommunityWarning)
+                Toggle("Warn When Opening Modlog", systemImage: Icons.warning, isOn: $showModlogWarning)
             } header: {
                 Text("Safety")
             }
             
             Section {
-                Toggle("Auto-Bypass Image Proxy", isOn: $bypassImageProxy)
+                Toggle("Auto-Bypass Image Proxy", systemImage: Icons.proxy, isOn: $bypassImageProxy)
             } header: {
                 Text("Privacy")
             }
             
             Section {
-                Picker("Default Feed", selection: $defaultFeed) {
+                Picker("Default Feed", systemImage: Icons.feeds, selection: $defaultFeed) {
                     ForEach(FeedSelection.allCases, id: \.self) { item in
                         Text(item.rawValue.capitalized)
                     }
                 }
                 if UIDevice.isPad {
-                    Toggle("Show Sidebar on App Launch", isOn: $sidebarVisibleByDefault)
+                    Toggle("Show Sidebar on App Launch", systemImage: Icons.sidebar, isOn: $sidebarVisibleByDefault)
                 }
                 if #available(iOS 18.0, *) {
-                    Toggle("Autoplay Media", isOn: $autoplayMedia)
+                    Toggle("Autoplay Media", systemImage: Icons.playCircle, isOn: $autoplayMedia)
                 }
-                Toggle("Mute Videos", isOn: $muteVideos)
-                Toggle("Mark Read on Scroll", isOn: $markReadOnScroll)
-                Toggle("Infinite Scroll", isOn: $infiniteScroll)
-                Toggle("Upvote on Save", isOn: $upvoteOnSave)
-                Picker("Jump Button", selection: $jumpButton) {
+                Toggle("Mute Videos", systemImage: Icons.muted, isOn: $muteVideos)
+                Toggle("Mark Read on Scroll", systemImage: Icons.read, isOn: $markReadOnScroll)
+                Toggle("Infinite Scroll", systemImage: Icons.infiniteScroll, isOn: $infiniteScroll)
+                Toggle("Upvote on Save", systemImage: Icons.upvoteOnSave, isOn: $upvoteOnSave)
+                Picker("Jump Button", systemImage: Icons.jumpButtonCircle, selection: $jumpButton) {
                     ForEach(CommentJumpButtonLocation.allCases, id: \.self) { item in
                         Text(item.label)
                     }
                 }
-                Toggle("Confirm Image Uploads", isOn: $confirmImageUploads)
-                Picker("Haptic Level", selection: $hapticLevel) {
+                Toggle("Confirm Image Uploads", systemImage: Icons.confirmImageUploads, isOn: $confirmImageUploads)
+                Picker("Haptic Level", systemImage: Icons.haptics, selection: $hapticLevel) {
                     ForEach(HapticPriority.allCases, id: \.self) { item in
                         Text(item.label)
                     }
                 }
-                Toggle("Wrap Code Block Lines", isOn: $wrapCodeBlockLines)
+                Toggle("Wrap Code Block Lines", systemImage: Icons.inlineCode, isOn: $wrapCodeBlockLines)
             } header: {
                 Text("Behavior")
             }
@@ -91,6 +89,7 @@ struct GeneralSettingsView: View {
             Section("Gestures") {
                 Toggle(
                     "Swipe Actions",
+                    systemImage: Icons.swipeActions,
                     isOn: .init(
                         get: { swipeActionsEnabled },
                         set: {
@@ -103,6 +102,7 @@ struct GeneralSettingsView: View {
                 )
                 Toggle(
                     "Swipe Anywhere to Navigate",
+                    systemImage: Icons.swipeAnywhere,
                     isOn: .init(
                         get: { swipeAnywhereToNavigate },
                         set: {
@@ -115,8 +115,9 @@ struct GeneralSettingsView: View {
                 )
             }
             
-            NavigationLink("Import/Export Settings", destination: .settings(.importExportSettings))
+            NavigationLink("Import/Export Settings", systemImage: Icons.importSettings, destination: .settings(.importExportSettings))
         }
+        .labelStyle(ConditionalIconLabelStyle())
         .navigationTitle("General")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -117,7 +117,7 @@ struct GeneralSettingsView: View {
             
             NavigationLink("Import/Export Settings", systemImage: Icons.importSettings, destination: .settings(.importExportSettings))
         }
-        .labelStyle(ConditionalIconLabelStyle())
+        .labelStyle(.conditional)
         .navigationTitle("General")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsView.swift
@@ -60,15 +60,6 @@ struct ImportExportSettingsView: View {
                     }
                 }
                 
-                // dev use only: saves the current settings under v1 to easily test migration behavior
-                #if DEBUG
-                Button("Save V1 Settings", systemImage: Icons.saveSettings) {
-                    Task {
-                        await Settings.main.save(to: .v1)
-                    }
-                }
-                #endif
-                
                 Button("Restore Settings", systemImage: Icons.restoreSettings) {
                     Task { @MainActor in
                         Settings.main.restore(from: .v2)
@@ -93,6 +84,16 @@ struct ImportExportSettingsView: View {
                     importingSettingsFile = true
                 }
             }
+            
+            #if DEBUG
+            Section("Debug") {
+                Button("Save V1 Settings", systemImage: Icons.saveSettings) {
+                    Task {
+                        await Settings.main.save(to: .v1)
+                    }
+                }
+            }
+            #endif
         }
     }
     

--- a/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsView.swift
@@ -25,7 +25,7 @@ struct ImportExportSettingsView: View {
     
     var body: some View {
         content
-            .labelStyle(ConditionalIconLabelStyle())
+            .labelStyle(.conditional)
             .onAppear {
                 v1SettingsExist = persistenceRepository.systemSettingsExists(.v1)
                 v2SettingsExist = persistenceRepository.systemSettingsExists(.v2)

--- a/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsView.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftUI
 
 // DO NOT use Picker in this page! It refuses to change the theme until it gets re-rendered. All other components pick up theme changes correctly.
-struct ImportExportSettingsPage: View {
+struct ImportExportSettingsView: View {
     @Dependency(\.persistenceRepository) var persistenceRepository
     
     @Environment(NavigationLayer.self) var navigation
@@ -25,6 +25,7 @@ struct ImportExportSettingsPage: View {
     
     var body: some View {
         content
+            .labelStyle(ConditionalIconLabelStyle())
             .onAppear {
                 v1SettingsExist = persistenceRepository.systemSettingsExists(.v1)
                 v2SettingsExist = persistenceRepository.systemSettingsExists(.v2)
@@ -51,8 +52,8 @@ struct ImportExportSettingsPage: View {
     
     var content: some View {
         Form {
-            Section {
-                Button("Save Settings") {
+            Section("Save and Restore") {
+                Button("Save Settings", systemImage: Icons.saveSettings) {
                     Task {
                         await Settings.main.save(to: .v2)
                         v2SettingsExist = persistenceRepository.systemSettingsExists(.v2)
@@ -61,23 +62,25 @@ struct ImportExportSettingsPage: View {
                 
                 // dev use only: saves the current settings under v1 to easily test migration behavior
                 #if DEBUG
-                    Button("Save V1 Settings") {
-                        Task {
-                            await Settings.main.save(to: .v1)
-                        }
+                Button("Save V1 Settings", systemImage: Icons.saveSettings) {
+                    Task {
+                        await Settings.main.save(to: .v1)
                     }
+                }
                 #endif
                 
-                Button("Restore Settings") {
+                Button("Restore Settings", systemImage: Icons.restoreSettings) {
                     Task { @MainActor in
                         Settings.main.restore(from: .v2)
                     }
                 }
                 .disabled(!v2SettingsExist)
+            } footer: {
+                Text("Save the current settings and restore them later.")
             }
             
             Section {
-                Button("Export Settings") {
+                Button("Export Settings", systemImage: Icons.share) {
                     Task {
                         let data = try JSONEncoder().encode(Settings.main.codable)
                         let fileUrl = FileManager.default.temporaryDirectory.appending(path: "settings.json")
@@ -86,7 +89,7 @@ struct ImportExportSettingsPage: View {
                     }
                 }
                 
-                Button("Import Settings") {
+                Button("Import Settings", systemImage: Icons.import) {
                     importingSettingsFile = true
                 }
             }

--- a/Mlem/App/Views/Root/Tabs/Settings/InboxBadgeSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InboxBadgeSettingsView.swift
@@ -32,7 +32,7 @@ struct InboxBadgeSettingsView: View {
             }
         }
         .contentMargins(.top, 16, for: .scrollContent)
-        .labelStyle(ConditionalIconLabelStyle())
+        .labelStyle(.conditional)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Settings/InboxBadgeSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InboxBadgeSettingsView.swift
@@ -32,6 +32,7 @@ struct InboxBadgeSettingsView: View {
             }
         }
         .contentMargins(.top, 16, for: .scrollContent)
+        .labelStyle(ConditionalIconLabelStyle())
     }
     
     @ViewBuilder
@@ -59,7 +60,7 @@ struct InboxBadgeSettingsView: View {
     
     @ViewBuilder
     func toggle(forType type: InboxItemType) -> some View {
-        Toggle(isOn: .init(
+        Toggle(String(localized: type.label), systemImage: type.systemImage, isOn: .init(
             get: { tabInboxBadgeIncludedTypes.contains(type) },
             set: {
                 if $0 {
@@ -68,13 +69,6 @@ struct InboxBadgeSettingsView: View {
                     tabInboxBadgeIncludedTypes.remove(type)
                 }
             }
-        )) {
-            Label {
-                Text(type.label)
-            } icon: {
-                Image(systemName: type.systemImage)
-                    .foregroundStyle(palette.secondary)
-            }
-        }
+        ))
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
@@ -29,7 +29,7 @@ struct InboxSettingsView: View {
                 )
             }
         }
-        .labelStyle(ConditionalIconLabelStyle())
+        .labelStyle(.conditional)
         .navigationTitle("Inbox")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
@@ -15,7 +15,7 @@ struct InboxSettingsView: View {
             Section {
                 NavigationLink(
                     "Customize Interaction Bar",
-                    systemImage: "square.and.line.vertical.and.square.fill",
+                    systemImage: Icons.interactionBar,
                     destination: .settings(.replyInteractionBar)
                 )
             }
@@ -24,10 +24,12 @@ struct InboxSettingsView: View {
                     "Notification Badge",
                     value: tabInboxBadgeIncludedTypes.label(accountType: AccountsTracker.main.highestLevelAccountType),
                     fallbackValue: .init(localized: "Some"),
+                    systemImage: Icons.unreadBadge,
                     destination: .settings(.inboxBadge)
                 )
             }
         }
+        .labelStyle(ConditionalIconLabelStyle())
         .navigationTitle("Inbox")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
@@ -58,7 +58,7 @@ struct LinkSettingsView: View {
                 }
             }
         }
+        .labelStyle(.conditional)
         .navigationTitle("Links")
-        .labelStyle(ConditionalIconLabelStyle())
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
@@ -17,15 +17,15 @@ struct LinkSettingsView: View {
         Form {
             Section("Open External Links") {
                 Picker("Open External Links", selection: $openLinksInBrowser) {
-                    Text("In-App").tag(false)
-                    Text("In Default Browser").tag(true)
+                    Label("In-App", systemImage: Icons.inApp).tag(false)
+                    Label("In Default Browser", systemImage: Icons.browser).tag(true)
                 }
                 .pickerStyle(.inline)
                 .labelsHidden()
             }
             
             Section {
-                Toggle("Open in Reader", isOn: $openLinksInReaderMode)
+                Toggle("Open in Reader", systemImage: Icons.reader, isOn: $openLinksInReaderMode)
                     .disabled(openLinksInBrowser)
             } footer: {
                 Text("Automatically enable Reader for supported webpages. You can only enable this when using the in-app browser.")
@@ -34,6 +34,7 @@ struct LinkSettingsView: View {
             Section {
                 Toggle(
                     "Tappable Links",
+                    systemImage: Icons.websiteAddress,
                     isOn: Binding(
                         get: { tappableLinksDisplayMode != .disabled },
                         set: { newValue in
@@ -44,7 +45,7 @@ struct LinkSettingsView: View {
                     )
                 )
                 if tappableLinksDisplayMode != .disabled {
-                    Picker("Show Full URL", selection: $tappableLinksDisplayMode) {
+                    Picker("Show Full URL", systemImage: Icons.inlineCode, selection: $tappableLinksDisplayMode) {
                         Text("Automatic").tag(TappableLinksDisplayMode.contextual)
                         Text("Always").tag(TappableLinksDisplayMode.large)
                         Text("Never").tag(TappableLinksDisplayMode.compact)
@@ -58,5 +59,6 @@ struct LinkSettingsView: View {
             }
         }
         .navigationTitle("Links")
+        .labelStyle(ConditionalIconLabelStyle())
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ModeratorSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ModeratorSettingsView.swift
@@ -15,7 +15,7 @@ struct ModeratorSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Picker("Group actions using", selection: $moderatorActionGrouping) {
+                Picker("Separate Actions Using", systemImage: Icons.menuItems, selection: $moderatorActionGrouping) {
                     Text("Divider")
                         .tag(ModeratorActionGrouping.divider)
                     Text("Disclosure Group")
@@ -23,14 +23,9 @@ struct ModeratorSettingsView: View {
                     Text("Separate Menu")
                         .tag(ModeratorActionGrouping.separateMenu)
                 }
-                .pickerStyle(.inline)
-                .labelsHidden()
-            } header: {
-                Text("Separate moderator actions using...")
-                    .textCase(nil)
             }
             Section {
-                Toggle("Show All Actions in Feed", isOn: $showAllModActions)
+                Toggle("Show All Actions in Feed", systemImage: Icons.menuCircle, isOn: $showAllModActions)
             } footer: {
                 Text("When disabled, some moderator actions will only be accessible from the post page.")
             }
@@ -39,11 +34,13 @@ struct ModeratorSettingsView: View {
                     "Notification Badge",
                     value: tabInboxBadgeIncludedTypes.label(accountType: AccountsTracker.main.highestLevelAccountType),
                     fallbackValue: .init(localized: "Some"),
+                    systemImage: Icons.unreadBadge,
                     destination: .settings(.inboxBadge)
                 )
             }
         }
         .navigationTitle("Moderation")
+        .labelStyle(ConditionalIconLabelStyle())
     }
 }
 

--- a/Mlem/App/Views/Root/Tabs/Settings/ModeratorSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ModeratorSettingsView.swift
@@ -39,8 +39,8 @@ struct ModeratorSettingsView: View {
                 )
             }
         }
+        .labelStyle(.conditional)
         .navigationTitle("Moderation")
-        .labelStyle(ConditionalIconLabelStyle())
     }
 }
 

--- a/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
@@ -32,14 +32,17 @@ struct PostSettingsView: View {
                 }
             }
             
+            if postSize == .headline || postSize == .compact {
+                NavigationLink(
+                    "Thumbnail",
+                    value: .init(localized: thumbnailLocation.label),
+                    fallbackValue: "",
+                    systemImage: Icons.thumbnail,
+                    destination: .settings(.postThumbnail)
+                )
+            }
+            
             Section {
-                if postSize == .headline || postSize == .compact {
-                    DisclosureGroup {
-                        PostThumbnailSettingsView()
-                    } label: {
-                        Label("Thumbnail", systemImage: Icons.thumbnail)
-                    }
-                }
                 NavigationLink(
                     "Subscription Indicator",
                     value: showSubscribedStatus ? "On" : "Off",

--- a/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
@@ -32,17 +32,17 @@ struct PostSettingsView: View {
                 }
             }
             
-            if postSize == .headline || postSize == .compact {
-                NavigationLink(
-                    "Thumbnail",
-                    value: .init(localized: thumbnailLocation.label),
-                    fallbackValue: "",
-                    systemImage: Icons.thumbnail,
-                    destination: .settings(.postThumbnail)
-                )
-            }
-            
             Section {
+                if postSize == .headline || postSize == .compact {
+                    NavigationLink(
+                        "Thumbnail",
+                        value: .init(localized: thumbnailLocation.label),
+                        fallbackValue: "",
+                        systemImage: Icons.thumbnail,
+                        destination: .settings(.postThumbnail)
+                    )
+                }
+                
                 NavigationLink(
                     "Subscription Indicator",
                     value: showSubscribedStatus ? "On" : "Off",
@@ -50,6 +50,7 @@ struct PostSettingsView: View {
                     systemImage: Icons.subscribedFeed,
                     destination: .settings(.postSubscriptionIndicator)
                 )
+                
                 if differentiateWithoutColor {
                     NavigationLink(
                         "Read Indicator",

--- a/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
@@ -73,7 +73,7 @@ struct PostSettingsView: View {
                 }
             }
         }
+        .labelStyle(.conditional)
         .navigationTitle("Posts")
-        .labelStyle(ConditionalIconLabelStyle())
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
@@ -25,22 +25,28 @@ struct PostSettingsView: View {
     var body: some View {
         Form {
             PostSizePicker()
+            
+            Section {
+                NavigationLink(.settings(.postInteractionBar)) {
+                    SettingsInteractionBarSummaryView(configuration: InteractionBarTracker.main.postInteractionBar)
+                }
+            }
+            
             Section {
                 if postSize == .headline || postSize == .compact {
                     NavigationLink(
                         "Thumbnail",
                         value: .init(localized: thumbnailLocation.label),
                         fallbackValue: "",
+                        systemImage: Icons.thumbnail,
                         destination: .settings(.postThumbnail)
                     )
-                }
-                NavigationLink(.settings(.postInteractionBar)) {
-                    SettingsInteractionBarSummaryView(configuration: InteractionBarTracker.main.postInteractionBar)
                 }
                 NavigationLink(
                     "Subscription Indicator",
                     value: showSubscribedStatus ? "On" : "Off",
                     fallbackValue: "",
+                    systemImage: Icons.subscribedFeed,
                     destination: .settings(.postSubscriptionIndicator)
                 )
                 if differentiateWithoutColor {
@@ -48,6 +54,7 @@ struct PostSettingsView: View {
                         "Read Indicator",
                         value: .init(localized: readPostIndicator.label),
                         fallbackValue: "",
+                        systemImage: Icons.readIndicatorSetting,
                         destination: .settings(.postReadIndicator)
                     )
                 }
@@ -55,21 +62,16 @@ struct PostSettingsView: View {
             
             if postSize != .tile, postSize != .compact {
                 Section {
-                    Toggle(isOn: $showCreator) {
-                        Text("Always Show Usernames")
-                    }
+                    Toggle("Always show Usernames", systemImage: Icons.author, isOn: $showCreator)
                 }
             }
             
             Section {
-                Toggle(isOn: $showPersonAvatar) {
-                    Text("User Avatar")
-                }
-                Toggle(isOn: $showCommunityAvatar) {
-                    Text("Community Avatar")
-                }
+                Toggle("User Avatar", systemImage: Icons.personCircle, isOn: $showPersonAvatar)
+                Toggle("Community Avatar", systemImage: Icons.communityCircle, isOn: $showCommunityAvatar)
             }
         }
         .navigationTitle("Posts")
+        .labelStyle(ConditionalIconLabelStyle())
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
@@ -58,15 +58,15 @@ struct PostSettingsView: View {
                 }
             }
             
+            Section {
+                Toggle("User Avatar", systemImage: Icons.personCircle, isOn: $showPersonAvatar)
+                Toggle("Community Avatar", systemImage: Icons.communityCircle, isOn: $showCommunityAvatar)
+            }
+            
             if postSize != .tile, postSize != .compact {
                 Section {
                     Toggle("Always show Usernames", systemImage: Icons.author, isOn: $showCreator)
                 }
-            }
-            
-            Section {
-                Toggle("User Avatar", systemImage: Icons.personCircle, isOn: $showPersonAvatar)
-                Toggle("Community Avatar", systemImage: Icons.communityCircle, isOn: $showCommunityAvatar)
             }
         }
         .navigationTitle("Posts")

--- a/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
@@ -34,13 +34,11 @@ struct PostSettingsView: View {
             
             Section {
                 if postSize == .headline || postSize == .compact {
-                    NavigationLink(
-                        "Thumbnail",
-                        value: .init(localized: thumbnailLocation.label),
-                        fallbackValue: "",
-                        systemImage: Icons.thumbnail,
-                        destination: .settings(.postThumbnail)
-                    )
+                    DisclosureGroup {
+                        PostThumbnailSettingsView()
+                    } label: {
+                        Label("Thumbnail", systemImage: Icons.thumbnail)
+                    }
                 }
                 NavigationLink(
                     "Subscription Indicator",

--- a/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
@@ -69,7 +69,7 @@ struct PostSettingsView: View {
             
             if postSize != .tile, postSize != .compact {
                 Section {
-                    Toggle("Always show Usernames", systemImage: Icons.author, isOn: $showCreator)
+                    Toggle("Always Show Usernames", systemImage: Icons.author, isOn: $showCreator)
                 }
             }
         }

--- a/Mlem/App/Views/Root/Tabs/Settings/PostThumbnailSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostThumbnailSettingsView.swift
@@ -13,23 +13,20 @@ struct PostThumbnailSettingsView: View {
     @Setting(\.thumbnailLocation) var thumbnailLocation
     
     var body: some View {
-        Form {
-            VStack(spacing: Constants.main.doubleSpacing) {
-                ForEach(ThumbnailLocation.allCases, id: \.self) { location in
-                    alignmentPickerItem(location: location)
-                }
+        VStack {
+            ForEach(ThumbnailLocation.allCases, id: \.self) { location in
+                alignmentPickerItem(location: location)
             }
-            .padding(Constants.main.doubleSpacing)
-            .listRowInsets(EdgeInsets())
         }
-        .animation(.easeOut(duration: 0.1), value: thumbnailLocation)
-        .navigationTitle("Thumbnail")
+        .frame(maxWidth: 300)
     }
     
     @ViewBuilder
     func alignmentPickerItem(location: ThumbnailLocation) -> some View {
-        alignmentPreview(location: location)
-        
+        HStack(spacing: Constants.main.doubleSpacing) {
+            Checkbox(isOn: location == thumbnailLocation)
+            alignmentPreview(location: location)
+        }
         .frame(maxWidth: .infinity)
         .onTapGesture {
             HapticManager.main.play(haptic: .gentleInfo, priority: .low)

--- a/Mlem/App/Views/Root/Tabs/Settings/PostThumbnailSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostThumbnailSettingsView.swift
@@ -14,21 +14,13 @@ struct PostThumbnailSettingsView: View {
     
     var body: some View {
         Form {
-            Toggle(
-                "Show Thumbnails",
-                isOn: .init(
-                    get: { thumbnailLocation != .none },
-                    set: { thumbnailLocation = $0 ? .left : .none }
-                )
-            )
-            if thumbnailLocation != .none {
-                Section("Alignment") {
-                    HStack {
-                        alignmentPickerItem(location: .left)
-                        alignmentPickerItem(location: .right)
-                    }
+            VStack(spacing: Constants.main.doubleSpacing) {
+                ForEach(ThumbnailLocation.allCases, id: \.self) { location in
+                    alignmentPickerItem(location: location)
                 }
             }
+            .padding(Constants.main.doubleSpacing)
+            .listRowInsets(EdgeInsets())
         }
         .animation(.easeOut(duration: 0.1), value: thumbnailLocation)
         .navigationTitle("Thumbnail")
@@ -36,14 +28,8 @@ struct PostThumbnailSettingsView: View {
     
     @ViewBuilder
     func alignmentPickerItem(location: ThumbnailLocation) -> some View {
-        VStack(spacing: Constants.main.standardSpacing) {
-            alignmentPreview(location: location)
-                .padding(.horizontal, Constants.main.standardSpacing)
-            HStack {
-                Text(location.label)
-                Checkbox(isOn: thumbnailLocation == location)
-            }
-        }
+        alignmentPreview(location: location)
+        
         .frame(maxWidth: .infinity)
         .onTapGesture {
             HapticManager.main.play(haptic: .gentleInfo, priority: .low)
@@ -53,12 +39,13 @@ struct PostThumbnailSettingsView: View {
     
     @ViewBuilder
     func alignmentPreview(location: ThumbnailLocation) -> some View {
-        HStack(spacing: 5) {
+        let color: Color = location == thumbnailLocation ? palette.accent : palette.secondary
+        HStack(spacing: 6) {
             if location == .left {
-                thumbnailView
+                thumbnailView(color)
             }
             GeometryReader { geometry in
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: 5) {
                     Capsule()
                         .fill(.opacity(0.7))
                         .frame(width: geometry.size.width / 2, height: geometry.size.height / 6)
@@ -68,25 +55,28 @@ struct PostThumbnailSettingsView: View {
                         .fill(.opacity(0.7))
                         .frame(width: geometry.size.width / 3, height: geometry.size.height / 6)
                 }
-                .foregroundStyle(palette.secondary)
+                .foregroundStyle(color)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 2)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             if location == .right {
-                thumbnailView
+                thumbnailView(color)
             }
         }
         .aspectRatio(8 / 2, contentMode: .fit)
-        .frame(maxWidth: 300)
-        .padding(5)
-        .background(palette.tertiaryGroupedBackground, in: .rect(cornerRadius: 7))
+        .padding(6)
+        .background(palette.tertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.mediumItemCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: Constants.main.mediumItemCornerRadius)
+                .stroke(location == thumbnailLocation ? palette.accent : .clear, lineWidth: 3)
+        }
     }
     
     @ViewBuilder
-    var thumbnailView: some View {
-        RoundedRectangle(cornerRadius: 5)
-            .fill(palette.secondary.opacity(0.3))
+    func thumbnailView(_ color: Color) -> some View {
+        RoundedRectangle(cornerRadius: Constants.main.smallItemCornerRadius)
+            .fill(color.opacity(0.3))
             .frame(maxHeight: .infinity)
             .aspectRatio(1, contentMode: .fit)
     }

--- a/Mlem/App/Views/Root/Tabs/Settings/PostThumbnailSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostThumbnailSettingsView.swift
@@ -33,7 +33,7 @@ struct PostThumbnailSettingsView: View {
             Section {
                 Toggle("Website Icon", isOn: $websiteThumbnailIcon)
             } footer: {
-                Text("Indicate link thumbnails with an icon")
+                Text("Indicate link thumbnails with an icon.")
             }
         }
         .navigationTitle("Thumbnail")

--- a/Mlem/App/Views/Root/Tabs/Settings/PostThumbnailSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostThumbnailSettingsView.swift
@@ -11,36 +11,39 @@ struct PostThumbnailSettingsView: View {
     @Environment(Palette.self) var palette
     
     @Setting(\.thumbnailLocation) var thumbnailLocation
+    @Setting(\.websiteThumbnailIcon) var websiteThumbnailIcon
     
     var body: some View {
-        VStack {
-            ForEach(ThumbnailLocation.allCases, id: \.self) { location in
-                alignmentPickerItem(location: location)
+        Form {
+            Section {
+                alignmentPreview(location: thumbnailLocation)
+                    .animation(.easeInOut(duration: 0.2), value: thumbnailLocation)
+            }
+            
+            Section {
+                Picker("Thumbnail Location", selection: $thumbnailLocation) {
+                    ForEach(ThumbnailLocation.allCases, id: \.self) { location in
+                        Text(location.label).tag(location)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.inline)
+            }
+            
+            Section {
+                Toggle("Website Icon", isOn: $websiteThumbnailIcon)
+            } footer: {
+                Text("Indicate link thumbnails with an icon")
             }
         }
-        .frame(maxWidth: 300)
-    }
-    
-    @ViewBuilder
-    func alignmentPickerItem(location: ThumbnailLocation) -> some View {
-        HStack(spacing: Constants.main.doubleSpacing) {
-            Checkbox(isOn: location == thumbnailLocation)
-            alignmentPreview(location: location)
-        }
-        .frame(maxWidth: .infinity)
-        .onTapGesture {
-            HapticManager.main.play(haptic: .gentleInfo, priority: .low)
-            thumbnailLocation = location
-        }
+        .navigationTitle("Thumbnail")
     }
     
     @ViewBuilder
     func alignmentPreview(location: ThumbnailLocation) -> some View {
-        let color: Color = location == thumbnailLocation ? palette.accent : palette.secondary
-        HStack(spacing: 6) {
-            if location == .left {
-                thumbnailView(color)
-            }
+        HStack(spacing: 8) {
+            thumbnailView(active: location == .left)
+            
             GeometryReader { geometry in
                 VStack(alignment: .leading, spacing: 5) {
                     Capsule()
@@ -52,29 +55,37 @@ struct PostThumbnailSettingsView: View {
                         .fill(.opacity(0.7))
                         .frame(width: geometry.size.width / 3, height: geometry.size.height / 6)
                 }
-                .foregroundStyle(color)
+                .foregroundStyle(palette.secondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 2)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            if location == .right {
-                thumbnailView(color)
-            }
+            .padding(.leading, location == .left ? 0 : -8)
+            
+            thumbnailView(active: location == .right)
         }
         .aspectRatio(8 / 2, contentMode: .fit)
-        .padding(6)
+        .padding(8)
         .background(palette.tertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.mediumItemCornerRadius))
-        .overlay {
-            RoundedRectangle(cornerRadius: Constants.main.mediumItemCornerRadius)
-                .stroke(location == thumbnailLocation ? palette.accent : .clear, lineWidth: 3)
-        }
     }
     
     @ViewBuilder
-    func thumbnailView(_ color: Color) -> some View {
+    func thumbnailView(active: Bool) -> some View {
         RoundedRectangle(cornerRadius: Constants.main.smallItemCornerRadius)
-            .fill(color.opacity(0.3))
+            .fill(palette.accent.opacity(0.4))
             .frame(maxHeight: .infinity)
-            .aspectRatio(1, contentMode: .fit)
+            .aspectRatio(.init(width: active ? 1 : 0, height: 1), contentMode: .fit)
+            .overlay {
+                Image(systemName: Icons.browser)
+                    .resizable()
+                    .frame(width: 20, height: 20)
+                    .foregroundStyle(.white)
+                    .background(.ultraThinMaterial, in: .circle)
+                    .padding(6)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .opacity(websiteThumbnailIcon ? 1 : 0)
+                    .opacity(active ? 1 : 0)
+                    .animation(.easeIn(duration: 0.2), value: websiteThumbnailIcon)
+            }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
@@ -18,7 +18,7 @@ struct SubscriptionListSettingsView: View {
                 }
             }
         }
-        .labelStyle(ConditionalIconLabelStyle())
+        .labelStyle(.conditional)
         .navigationTitle("Subscription List")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
@@ -12,12 +12,13 @@ struct SubscriptionListSettingsView: View {
     
     var body: some View {
         Form {
-            Picker("Label Style", selection: $instanceLocation) {
+            Picker("Label Style", systemImage: Icons.qualifiedLabel, selection: $instanceLocation) {
                 ForEach(InstanceLocation.allCases, id: \.self) { item in
                     Text(item.label)
                 }
             }
         }
+        .labelStyle(ConditionalIconLabelStyle())
         .navigationTitle("Subscription List")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/TabBarSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/TabBarSettingsView.swift
@@ -64,7 +64,7 @@ struct TabBarSettingsView: View {
                 )
             }
         }
-        .labelStyle(ConditionalIconLabelStyle())
+        .labelStyle(.conditional)
         .navigationTitle("Tab Bar")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/TabBarSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/TabBarSettingsView.swift
@@ -52,17 +52,19 @@ struct TabBarSettingsView: View {
                         }
                     }
                 }
-                Toggle("Show Avatar", isOn: $showUserAvatar)
+                Toggle("Show Avatar", systemImage: Icons.personCircle, isOn: $showUserAvatar)
             }
             Section {
                 NavigationLink(
                     "Notification Badge",
                     value: tabInboxBadgeIncludedTypes.label(accountType: AccountsTracker.main.highestLevelAccountType),
                     fallbackValue: .init(localized: "Some"),
+                    systemImage: Icons.unreadBadge,
                     destination: .settings(.inboxBadge)
                 )
             }
         }
+        .labelStyle(ConditionalIconLabelStyle())
         .navigationTitle("Tab Bar")
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ThemeSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ThemeSettingsView.swift
@@ -23,12 +23,14 @@ struct ThemeSettingsView: View {
                 // so that it reverts the the actual settings value when a multi-mode theme is selected
                 Picker("Style", selection: supportedModes == .unspecified ? $interfaceStyle : .constant(supportedModes)) {
                     ForEach(UIUserInterfaceStyle.optionCases, id: \.self) { style in
-                        Text(style.label)
-                            .foregroundStyle(
-                                supportedModes == .unspecified || supportedModes == style
-                                    ? palette.primary
-                                    : palette.secondary
-                            )
+                        interfaceStyleLabel(for: style)
+                        // Text(style.label)
+//                        ThemeLabel(title: String(localized: style.label), color1: style.labelColor1, color2: style.labelColor2)
+//                            .foregroundStyle(
+//                                supportedModes == .unspecified || supportedModes == style
+//                                    ? palette.primary
+//                                    : palette.secondary
+//                            )
                     }
                 }
                 .labelsHidden()
@@ -49,5 +51,15 @@ struct ThemeSettingsView: View {
             .pickerStyle(.inline)
         }
         .navigationTitle("Theme")
+    }
+    
+    @ViewBuilder
+    func interfaceStyleLabel(for style: UIUserInterfaceStyle) -> some View {
+        Label(style.label, systemImage: style.systemImage)
+            .foregroundStyle(
+                supportedModes == .unspecified || supportedModes == style
+                    ? palette.primary
+                    : palette.secondary
+            )
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ThemeSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ThemeSettingsView.swift
@@ -39,6 +39,7 @@ struct ThemeSettingsView: View {
                     ThemeLabel(palette: item)
                         .tag(item)
                 }
+                .labelStyle(.titleAndIcon)
             }
             .labelsHidden()
             .pickerStyle(.inline)

--- a/Mlem/App/Views/Root/Tabs/Settings/ThemeSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ThemeSettingsView.swift
@@ -44,8 +44,8 @@ struct ThemeSettingsView: View {
             .labelsHidden()
             .pickerStyle(.inline)
         }
+        .labelStyle(.conditional)
         .navigationTitle("Theme")
-        .labelStyle(ConditionalIconLabelStyle())
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Settings/ThemeSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ThemeSettingsView.swift
@@ -24,13 +24,6 @@ struct ThemeSettingsView: View {
                 Picker("Style", selection: supportedModes == .unspecified ? $interfaceStyle : .constant(supportedModes)) {
                     ForEach(UIUserInterfaceStyle.optionCases, id: \.self) { style in
                         interfaceStyleLabel(for: style)
-                        // Text(style.label)
-//                        ThemeLabel(title: String(localized: style.label), color1: style.labelColor1, color2: style.labelColor2)
-//                            .foregroundStyle(
-//                                supportedModes == .unspecified || supportedModes == style
-//                                    ? palette.primary
-//                                    : palette.secondary
-//                            )
                     }
                 }
                 .labelsHidden()
@@ -51,6 +44,7 @@ struct ThemeSettingsView: View {
             .pickerStyle(.inline)
         }
         .navigationTitle("Theme")
+        .labelStyle(ConditionalIconLabelStyle())
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Shared/Accounts/AccountListView.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView.swift
@@ -100,6 +100,7 @@ struct AccountListView: View {
         Section {
             Button { isShowingAddAccountDialogue = true } label: {
                 Label("Add Account", systemImage: Icons.add)
+                    .labelStyle(.titleAndIcon)
             }
             .confirmationDialog("Choose Account Type", isPresented: $isShowingAddAccountDialogue) {
                 Button("Log In") {

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -54,7 +54,7 @@ enum SettingsPage: Hashable {
         case .accessibility:
             AccessibilitySettingsView()
         case .importExportSettings:
-            ImportExportSettingsPage()
+            ImportExportSettingsView()
         case .advanced:
             AdvancedSettingsView()
         case .developer:

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -325,7 +325,7 @@
     "Always Allow Direct Loading" : {
 
     },
-    "Always Show Usernames" : {
+    "Always show Usernames" : {
 
     },
     "An endorsement signifies that an instance approves of another instance. It is completely subjective, and a reason does not have to be given." : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1845,6 +1845,9 @@
     "Settings" : {
 
     },
+    "Settings Icons" : {
+
+    },
     "Share" : {
 
     },

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -998,9 +998,6 @@
     "Green" : {
 
     },
-    "Group actions using" : {
-
-    },
     "Grouped" : {
 
     },
@@ -1743,9 +1740,6 @@
     "Reset" : {
 
     },
-    "Reset Settings State" : {
-
-    },
     "Resolve" : {
 
     },
@@ -1776,10 +1770,16 @@
     "Save" : {
 
     },
+    "Save and Restore" : {
+
+    },
     "Save Image" : {
 
     },
     "Save Settings" : {
+
+    },
+    "Save the current settings and restore them later." : {
 
     },
     "Save V1 Settings" : {
@@ -1836,10 +1836,10 @@
     "Sent %@" : {
 
     },
-    "Separate Menu" : {
+    "Separate Actions Using" : {
 
     },
-    "Separate moderator actions using..." : {
+    "Separate Menu" : {
 
     },
     "Settings" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -307,9 +307,6 @@
     "Alien" : {
 
     },
-    "Alignment" : {
-
-    },
     "All" : {
 
     },
@@ -1891,9 +1888,6 @@
 
     },
     "Show Sidebar on App Launch" : {
-
-    },
-    "Show Thumbnails" : {
 
     },
     "Shown" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -322,7 +322,7 @@
     "Always Allow Direct Loading" : {
 
     },
-    "Always show Usernames" : {
+    "Always Show Usernames" : {
 
     },
     "An endorsement signifies that an instance approves of another instance. It is completely subjective, and a reason does not have to be given." : {
@@ -1088,7 +1088,7 @@
     "Incidents" : {
 
     },
-    "Indicate link thumbnails with an icon" : {
+    "Indicate link thumbnails with an icon." : {
 
     },
     "Infinite Scroll" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1088,6 +1088,9 @@
     "Incidents" : {
 
     },
+    "Indicate link thumbnails with an icon" : {
+
+    },
     "Infinite Scroll" : {
 
     },
@@ -2215,6 +2218,9 @@
     "Thumbnail" : {
 
     },
+    "Thumbnail Location" : {
+
+    },
     "Tiled" : {
 
     },
@@ -2444,6 +2450,9 @@
 
     },
     "Website" : {
+
+    },
+    "Website Icon" : {
 
     },
     "Website Thumbnail Indicator" : {


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1629 

## Description

This PR adds settings icons; these are off by default, and can be toggled under Accessibility -> Settings Icons:
<img width="408" alt="Screenshot 2025-01-20 at 1 00 33 PM" src="https://github.com/user-attachments/assets/cf5d4a35-af78-4b6c-a23c-53d6e8956a0a" />


Also makes a few minor changes to settings:
- Moderation -> Separate Actions Using is now a standard picker rather than an inline for consistency with the rest of the app. Per Slack, this should ultimately get its own page as we migrate to that settings design pattern.
- New thumbnail settings UI: 
<img width="417" alt="Screenshot 2025-01-20 at 4 08 22 PM" src="https://github.com/user-attachments/assets/5f0da9d0-daf0-4030-81af-8a7f530796dc" />

## Implementation Notes

I also alphabetized the settings views, which is why Project.pbxproj has a massive diff.