### PR TITLE
More Image Control Bugfix

### DIFF
--- a/Mlem/App/Views/Pages/ImageViewer.swift
+++ b/Mlem/App/Views/Pages/ImageViewer.swift
@@ -44,7 +44,7 @@ struct ImageViewer: View {
     @State var quickLookUrl: URL?
     
     // Whether the controls are currently visible
-    var controlsShown: Bool { controlOpacity == 1 }
+    var controlsShown: Bool { controlOpacity > 0 }
     
     init(url: URL) {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
@@ -183,8 +183,10 @@ struct ImageViewer: View {
     private func handleOffsetUpdate(_ newOffset: CGFloat) {
         let absOffset = abs(newOffset)
         offset = newOffset
-        controlOffset = absOffset / 3
-        controlOpacity = 1.0 - (controlOffset / maxControlOffset)
+        if controlsShown {
+            controlOffset = absOffset / 3
+            controlOpacity = 1.0 - (controlOffset / maxControlOffset)
+        }
         opacity = 1.0 - (absOffset / screenHeight)
     }
     

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1743,9 +1743,6 @@
     "Reset" : {
 
     },
-    "Reset Settings State" : {
-
-    },
     "Resolve" : {
 
     },


### PR DESCRIPTION
Fixes an issue where image controls would reappear when interactively dismissing the image viewer after tapping to dismiss the controls