### PR TITLE
Hide status bar in image viewer

### DIFF
--- a/Mlem/App/Globals/Definitions/AppState+transition.swift
+++ b/Mlem/App/Globals/Definitions/AppState+transition.swift
@@ -19,6 +19,7 @@ extension AppState {
                 return
             }
             
+            transitionView.overrideUserInterfaceStyle = Settings.main.interfaceStyle
             transitionView.alpha = 0
             window.addSubview(transitionView)
             UIView.animate(withDuration: 0.15) {

--- a/Mlem/App/Utility/Extensions/UIUserInterfaceStyle+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/UIUserInterfaceStyle+Extensions.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import UIKit
 import SwiftUICore
+import UIKit
 
 extension UIUserInterfaceStyle: Codable {
     var label: String {
@@ -29,6 +29,14 @@ extension UIUserInterfaceStyle: Codable {
         case .light: Icons.lightMode
         case .dark: Icons.darkMode
         default: Icons.systemMode
+        }
+    }
+    
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .light: .light
+        case .dark: .dark
+        default: nil
         }
     }
     

--- a/Mlem/App/Views/Pages/ImageViewer.swift
+++ b/Mlem/App/Views/Pages/ImageViewer.swift
@@ -109,6 +109,7 @@ struct ImageViewer: View {
         }
         .quickLookPreview($quickLookUrl)
         .background(ClearBackgroundView())
+        .statusBarHidden()
     }
     
     func fadeDismiss() {

--- a/Mlem/App/Views/Pages/ImageViewer.swift
+++ b/Mlem/App/Views/Pages/ImageViewer.swift
@@ -11,7 +11,8 @@ struct ImageViewer: View {
     @Environment(NavigationLayer.self) var navigation
     @Environment(Palette.self) var palette
     @Environment(\.dismiss) var dismiss
-    
+    @Environment(\.colorScheme) var colorScheme
+
     let url: URL
 
     let duration: CGFloat = 0.25
@@ -109,7 +110,7 @@ struct ImageViewer: View {
         }
         .quickLookPreview($quickLookUrl)
         .background(ClearBackgroundView())
-        .statusBarHidden()
+        .statusBarHidden(!isDismissing)
     }
     
     func fadeDismiss() {

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -22,7 +22,6 @@ struct ContentView: View {
     
     @Dependency(\.persistenceRepository) var persistenceRepository
     
-    @Setting(\.interfaceStyle) var interfaceStyle
     @Setting(\.colorPalette) var colorPalette
     @Setting(\.tabProfileLabelType) var tabProfileLabelType
     @Setting(\.tabProfileShowAvatar) var tabProfileShowAvatar
@@ -91,19 +90,10 @@ struct ContentView: View {
                     // TODO: when Observation adds continous observation monitoring, move this into FiltersTracker
                     filtersTracker.moderatedCommunityActorIds = appState.firstPerson?.moderatedCommunityActorIds ?? .init()
                 }
-                .onChange(of: interfaceStyle, initial: true) {
-                    let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-                    windowScene?.windows.first?.overrideUserInterfaceStyle = interfaceStyle
-                }
                 .onChange(of: colorPalette) {
                     withAnimation {
                         palette.changePalette(to: colorPalette)
                     }
-                }
-                .onChange(of: palette.supportedModes, initial: true) {
-                    let newStyle: UIUserInterfaceStyle = palette.supportedModes != .unspecified ? palette.supportedModes : interfaceStyle
-                    let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-                    windowScene?.windows.first?.overrideUserInterfaceStyle = newStyle
                 }
                 .onChange(of: scenePhase, initial: false) {
                     if AppState.main.firstAccount is UserAccount, scenePhase != .active {

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -191,4 +191,11 @@ class NavigationLayer: Identifiable {
     
     // Can be used inside of an `.onDisappear` to determine whether the disappearance was caused by the sheet closing
     var isAlive: Bool { model != nil }
+    
+    var isImageViewer: Bool {
+        switch root {
+        case .imageViewer: true
+        default: false
+        }
+    }
 }

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
@@ -10,6 +10,9 @@ import SwiftUIIntrospect
 import UIKit
 
 struct NavigationLayerView: View {
+    @Environment(Palette.self) var palette
+    @Setting(\.interfaceStyle) var interfaceStyle
+
     @Bindable var layer: NavigationLayer
     let hasSheetModifiers: Bool
     
@@ -83,6 +86,7 @@ struct NavigationLayerView: View {
         })
         .modifier(HandleLemmyLinksModifier())
         .environment(layer)
+        .preferredColorScheme(preferredColorScheme)
     }
     
     @ViewBuilder
@@ -91,6 +95,22 @@ struct NavigationLayerView: View {
             layer.root.view().navigationSheetModifiers(for: layer)
         } else {
             layer.root.view()
+        }
+    }
+    
+    private var preferredColorScheme: ColorScheme? {
+        let newStyle: UIUserInterfaceStyle = palette.supportedModes != .unspecified ? palette.supportedModes : interfaceStyle
+        
+        // The image viewer relies on having a concrete color scheme for the status bar color.
+        // Otherwise the status bar will "flash" when the sheet is dismissed
+        if layer.isImageViewer, newStyle == .unspecified {
+            return UIScreen.main.traitCollection.userInterfaceStyle == .dark ? .dark : .light
+        }
+        
+        switch newStyle {
+        case .light: return .light
+        case .dark: return .dark
+        default: return nil
         }
     }
 }

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
@@ -107,11 +107,7 @@ struct NavigationLayerView: View {
             return UIScreen.main.traitCollection.userInterfaceStyle == .dark ? .dark : .light
         }
         
-        switch newStyle {
-        case .light: return .light
-        case .dark: return .dark
-        default: return nil
-        }
+        return newStyle.colorScheme
     }
 }
 


### PR DESCRIPTION
What do you think? I think this is cleaner, and Apple hides the status bar when you tap on an image in Photos.

I had to rearrange some of the color scheme code to get this to work properly