### PR TITLE
Inline image load failure fix

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3147,7 +3147,7 @@
 			repositoryURL = "https://github.com/mlemgroup/LemmyMarkdownUI";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.5.2;
+				minimumVersion = 0.6.0;
 			};
 		};
 		0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/LemmyMarkdownUI",
       "state" : {
-        "revision" : "b42b1e301194fd56a144cf199ab2b807a0413a97",
-        "version" : "0.5.2"
+        "revision" : "ab579f496b1acaa3230dcc5ae16fa804f53ed504",
+        "version" : "0.6.0"
       }
     },
     {

--- a/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
@@ -74,22 +74,12 @@ private func imageView(_ inlineImage: InlineImage, shouldBlur: Bool) -> AnyView 
             cornerRadius: Constants.main.mediumItemCornerRadius,
             enableContextMenu: true,
             enableImageViewer: true,
-            enableNsfwBlur: shouldBlur)
+            enableNsfwBlur: shouldBlur
+        )
     )
 }
 
 private func loadInlineImage(inlineImage: InlineImage) async {
-    // Only custom emojis should be displayed inline. Custom emojis have tooltips.
-    // People are unlikely to use tooltips in any other circumstances, so images
-    // with tooltips are displayed inline. I haven't found a better way to test for
-    // a custom emoji.
-    if inlineImage.tooltip == nil {
-        _ = await Task { @MainActor in
-            inlineImage.renderFullWidth = true
-        }.result
-        return
-    }
-    
     guard inlineImage.image == nil else { return }
     let imageTask = ImagePipeline.shared.imageTask(with: inlineImage.url)
     guard let image: UIImage = try? await imageTask.image else { return }


### PR DESCRIPTION
Closes #1470. Just [moved the logic to LemmyMarkdownUI](https://github.com/mlemgroup/LemmyMarkdownUI/pull/48) so it's decided before the markdown renders rather than after