### PR TITLE
Recent search editor tweaks & other bug fixes

### DIFF
--- a/Mlem/App/Views/Pages/CommentEditor/CommentEditorView.swift
+++ b/Mlem/App/Views/Pages/CommentEditor/CommentEditorView.swift
@@ -133,7 +133,7 @@ struct CommentEditorView: View {
             VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
                 if resolutionState == .notFound {
                     resolutionWarning
-                        .padding([.horizontal, .bottom], 10)
+                        .padding(.horizontal, 10)
                 }
                 MarkdownTextEditor(
                     onChange: {

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -75,7 +75,12 @@ struct InstanceView: View {
             upgradeState = .loading
             do {
                 if !(instance is any Instance3Providing) {
-                    let instance3 = try await instance.upgradeLocal()
+                    let instance3: Instance3
+                    if let myInstance = appState.firstSession.instance, instance.host == myInstance.host {
+                        instance3 = myInstance
+                    } else {
+                        instance3 = try await instance.upgradeLocal()
+                    }
                     instance = instance3
                     logVisit(instance3)
                 }
@@ -83,24 +88,6 @@ struct InstanceView: View {
             } catch {
                 upgradeState = .idle
                 handleError(error)
-            }
-        }
-        .task {
-            if instance.local {
-                do {
-                    let myInstance: Instance3
-                    if let apiInstance = appState.firstApi.myInstance {
-                        myInstance = apiInstance
-                    } else {
-                        myInstance = try await appState.firstApi.getMyInstance()
-                    }
-                    
-                    Task { @MainActor in
-                        instance = myInstance
-                    }
-                } catch {
-                    handleError(error)
-                }
             }
         }
         .isAtTopSubscriber(isAtTop: $isAtTop)

--- a/Mlem/App/Views/Pages/PostEditor/PostEditorTargetView.swift
+++ b/Mlem/App/Views/Pages/PostEditor/PostEditorTargetView.swift
@@ -27,17 +27,19 @@ struct PostEditorTargetView: View {
                     communityPicker
                 }
             }
-            switch target.sendState {
-            case .unsent:
-                EmptyView()
-            case .sent:
-                Image(systemName: Icons.successCircleFill)
-                    .symbolRenderingMode(.hierarchical)
-                    .foregroundStyle(palette.positive)
-            case .failed:
-                Image(systemName: Icons.errorCircleFill)
-                    .symbolRenderingMode(.hierarchical)
-                    .foregroundStyle(palette.negative)
+            if isMoreThanOneTarget {
+                switch target.sendState {
+                case .unsent:
+                    EmptyView()
+                case .sent:
+                    Image(systemName: Icons.successCircleFill)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(palette.positive)
+                case .failed:
+                    Image(systemName: Icons.errorCircleFill)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(palette.negative)
+                }
             }
         }
     }

--- a/Mlem/App/Views/Shared/Search/SearchView+Views.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView+Views.swift
@@ -133,6 +133,7 @@ extension SearchView {
                     SearchResultsView(results: items) { community in
                         HStack {
                             CommunityListRow(community, readout: .subscribers)
+                                .disabled(editingRecentSearches)
                             deleteRecentSearchButton(session: session) {
                                 visitHistory.removeCommunity(community, context: .search)
                             }
@@ -148,6 +149,7 @@ extension SearchView {
                     SearchResultsView(results: items) { person in
                         HStack {
                             PersonListRow(person, readout: .postsAndComments)
+                                .disabled(editingRecentSearches)
                             deleteRecentSearchButton(session: session) {
                                 visitHistory.removePerson(person, context: .search)
                             }
@@ -163,6 +165,7 @@ extension SearchView {
                     SearchResultsView(results: items) { instance in
                         HStack {
                             InstanceListRow(instance, readout: .users)
+                                .disabled(editingRecentSearches)
                             deleteRecentSearchButton(session: session) {
                                 visitHistory.removeInstance(instance, context: .search)
                             }
@@ -183,11 +186,7 @@ extension SearchView {
     var recentSearchesHeader: some View {
         HStack {
             if editingRecentSearches {
-                Button("Done") {
-                    withAnimation {
-                        editingRecentSearches = false
-                    }
-                }
+                ClearRecentSearchesButton()
             } else {
                 Text("Recently Searched")
                     .foregroundStyle(palette.primary)
@@ -196,7 +195,11 @@ extension SearchView {
             Spacer()
             
             if editingRecentSearches {
-                ClearRecentSearchesButton()
+                Button("Done") {
+                    withAnimation {
+                        editingRecentSearches = false
+                    }
+                }
             } else {
                 Button("Edit") {
                     withAnimation {


### PR DESCRIPTION
- Swapped the "Done" and "Clear" buttons in the recent search editor (Closes #1639)
- Search results items are now disabled when editing recent searches (prevents accidental taps)
- Fixes #1673
- Fixes #1669