### PR TITLE
Multiple post columns on iPad

### DIFF
--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -63,6 +63,7 @@ struct CodableSettings: Codable { // swiftlint:disable:this type_body_length
     var post_showSubscribedStatus: Bool
     var post_showWebsitePreview: Bool
     var post_size: PostSize
+    var post_allowMultipleColumns: Bool
     var post_thumbnailLocation: ThumbnailLocation
     var post_webPreview_showHost: Bool
     var post_webPreview_showIcon: Bool
@@ -175,6 +176,7 @@ struct CodableSettings: Codable { // swiftlint:disable:this type_body_length
         self.post_showWebsitePreview = try container.decodeIfPresent(Bool.self, forKey: .post_showWebsitePreview) ?? true
         self.post_showDownvotesCompact = try container.decodeIfPresent(Bool.self, forKey: .post_showDownvotesCompact) ?? false
         self.post_size = try container.decodeIfPresent(PostSize.self, forKey: .post_size) ?? .large
+        self.post_allowMultipleColumns = try container.decodeIfPresent(Bool.self, forKey: .post_allowMultipleColumns) ?? true
         self.post_thumbnailLocation = try container.decodeIfPresent(ThumbnailLocation.self, forKey: .post_thumbnailLocation) ?? .left
         self.post_webPreview_showHost = try container.decodeIfPresent(Bool.self, forKey: .post_webPreview_showHost) ?? true
         self.post_webPreview_showIcon = try container.decodeIfPresent(Bool.self, forKey: .post_webPreview_showIcon) ?? true
@@ -253,6 +255,7 @@ struct CodableSettings: Codable { // swiftlint:disable:this type_body_length
         self.post_showSubscribedStatus = settings.showSubscribedStatus
         self.post_showWebsitePreview = true
         self.post_size = settings.postSize
+        self.post_allowMultipleColumns = settings.allowMultiplePostColumns
         self.post_thumbnailLocation = settings.thumbnailLocation
         self.post_webPreview_showHost = true
         self.post_webPreview_showIcon = true

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -131,6 +131,7 @@ class Settings: ObservableObject {
     // swiftlint:disable:next function_body_length
     func reinit(from settings: CodableSettings) {
         postSize = settings.post_size
+        allowMultiplePostColumns = settings.post_allowMultipleColumns
         defaultPostSort = settings.post_defaultSort
         fallbackPostSort = settings.post_fallbackSort
         thumbnailLocation = settings.post_thumbnailLocation

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -24,6 +24,7 @@ class Settings: ObservableObject {
     @AppStorage("a11y.websiteThumbnailIcon") var websiteThumbnailIcon: Bool = false
 
     @AppStorage("post.size") var postSize: PostSize = .compact
+    @AppStorage("post.allowMultipleColumns") var allowMultiplePostColumns: Bool = true
     @AppStorage("post.defaultSort") var defaultPostSort: ApiSortType = .hot
     @AppStorage("post.fallbackSort") var fallbackPostSort: ApiSortType = .hot
     @AppStorage("post.thumbnailLocation") var thumbnailLocation: ThumbnailLocation = .left

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
@@ -19,8 +19,11 @@ struct CompactPostView: View {
     @Environment(Palette.self) var palette: Palette
     @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor
     
-    let post: any Post1Providing
+    @ScaledMetric(relativeTo: .caption) var titleHostHeightLimit: CGFloat = 40
     
+    let post: any Post1Providing
+    var requireConsistentHeight: Bool = false
+
     var readouts: [PostBarConfiguration.ReadoutType?] {
         let saved: PostBarConfiguration.ReadoutType? = post.saved_ ?? false ? .saved : nil
         if showDownvotesCompact {
@@ -78,18 +81,12 @@ struct CompactPostView: View {
                     PostEllipsisMenus(post: post, size: 18)
                 }
                 .padding(.bottom, -2)
-  
-                post.taggedTitle(communityContext: communityContext)
-                    .multilineTextAlignment(.leading)
-                    .imageScale(.small)
-                    .foregroundStyle(post.read_ ?? false ? palette.secondary : palette.primary)
-                    .font(.subheadline)
-                
-                if let host = post.linkHost {
-                    PostLinkHostView(host: host)
-                        .font(.caption)
+                if requireConsistentHeight {
+                    titleAndHostView
+                        .frame(height: titleHostHeightLimit, alignment: .top)
+                } else {
+                    titleAndHostView
                 }
-                
                 InfoStackView(post: post, readouts: readouts, showColor: true)
             }
             .frame(maxWidth: .infinity)
@@ -104,5 +101,25 @@ struct CompactPostView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    
+    @ViewBuilder
+    var titleAndHostView: some View {
+        VStack(alignment: .leading, spacing: Constants.main.compactSpacing) {
+            titleView
+            if let host = post.linkHost {
+                PostLinkHostView(host: host)
+                    .font(.caption)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var titleView: some View {
+        post.taggedTitle(communityContext: communityContext)
+            .multilineTextAlignment(.leading)
+            .imageScale(.small)
+            .foregroundStyle(post.read_ ?? false ? palette.secondary : palette.primary)
+            .font(.subheadline)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
@@ -25,6 +25,7 @@ struct FeedPostView<EmbeddedContent: View>: View {
     
     let post: any Post1Providing
     let favoredLink: PostViewNavigationLink?
+    let requireConsistentHeight: Bool
     let overridePostSize: PostSize?
     
     var postSize: PostSize {
@@ -37,11 +38,13 @@ struct FeedPostView<EmbeddedContent: View>: View {
         post: any Post1Providing,
         overridePostSize: PostSize? = nil,
         favoredLink: PostViewNavigationLink? = nil,
+        requireConsistentHeight: Bool = false,
         @ViewBuilder embeddedContent: @escaping () -> EmbeddedContent = { EmptyView() }
     ) {
         self.post = post
         self.overridePostSize = overridePostSize
         self.favoredLink = favoredLink
+        self.requireConsistentHeight = requireConsistentHeight
         self.embeddedContent = embeddedContent
         self._obscured = .init(wrappedValue: FiltersTracker.main.postWouldBeFiltered(post))
     }
@@ -95,11 +98,16 @@ struct FeedPostView<EmbeddedContent: View>: View {
     var content: some View {
         switch postSize {
         case .compact:
-            CompactPostView(post: post)
+            CompactPostView(post: post, requireConsistentHeight: requireConsistentHeight)
         case .tile:
             TilePostView(post: post)
         case .headline:
-            HeadlinePostView(post: post, favoredLink: favoredLink, embeddedContent: embeddedContent)
+            HeadlinePostView(
+                post: post,
+                favoredLink: favoredLink,
+                requireConsistentHeight: requireConsistentHeight,
+                embeddedContent: embeddedContent
+            )
         case .large:
             LargePostView(post: post, favoredLink: favoredLink)
         }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/HeadlinePostBodyView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/HeadlinePostBodyView.swift
@@ -14,8 +14,11 @@ struct HeadlinePostBodyView: View {
     
     @Setting(\.thumbnailLocation) var thumbnailLocation
     @Setting(\.blurNsfw) var blurNsfw
+    
+    @ScaledMetric(relativeTo: .headline) var titleHostHeightLimit: CGFloat = 75
 
     let post: any Post
+    var requireConsistentHeight: Bool = false
     
     var blurred: Bool {
         switch blurNsfw {
@@ -32,21 +35,15 @@ struct HeadlinePostBodyView: View {
                     post: post,
                     blurred: blurred,
                     size: .standard,
-                    frame: .init(width: Constants.main.thumbnailSize, height: Constants.main.thumbnailSize)
+                    frame: .init(width: thumbnailSize, height: thumbnailSize)
                 )
             }
 
-            VStack(alignment: .leading, spacing: Constants.main.halfSpacing) {
-                post.taggedTitle(communityContext: communityContext)
-                    .multilineTextAlignment(.leading)
-                    .foregroundStyle((post.read_ ?? false) ? palette.secondary : palette.primary)
-                    .font(.headline)
-                    .imageScale(.small)
-                
-                if let host = post.linkHost {
-                    PostLinkHostView(host: host)
-                        .font(.subheadline)
-                }
+            if requireConsistentHeight {
+                titleAndHostView
+                    .frame(height: titleHostHeightLimit, alignment: .top)
+            } else {
+                titleAndHostView
             }
             
             if thumbnailLocation == .right {
@@ -55,9 +52,37 @@ struct HeadlinePostBodyView: View {
                     post: post,
                     blurred: blurred,
                     size: .standard,
-                    frame: .init(width: Constants.main.thumbnailSize, height: Constants.main.thumbnailSize)
+                    frame: .init(width: thumbnailSize, height: thumbnailSize)
                 )
             }
         }
+    }
+    
+    var thumbnailSize: CGFloat {
+        if requireConsistentHeight, titleHostHeightLimit < Constants.main.thumbnailSize * 1.5 {
+            titleHostHeightLimit
+        } else {
+            Constants.main.thumbnailSize
+        }
+    }
+    
+    @ViewBuilder
+    var titleAndHostView: some View {
+        VStack(alignment: .leading, spacing: Constants.main.halfSpacing) {
+            titleView
+            if let host = post.linkHost {
+                PostLinkHostView(host: host)
+                    .font(.subheadline)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var titleView: some View {
+        post.taggedTitle(communityContext: communityContext)
+            .multilineTextAlignment(.leading)
+            .foregroundStyle((post.read_ ?? false) ? palette.secondary : palette.primary)
+            .font(.headline)
+            .imageScale(.small)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/HeadlinePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/HeadlinePostView.swift
@@ -23,14 +23,17 @@ struct HeadlinePostView<EmbeddedContent: View>: View {
     let post: any Post1Providing
     let embeddedContent: EmbeddedContent
     let favoredLink: PostViewNavigationLink?
-    
+    let requireConsistentHeight: Bool
+
     init(
         post: any Post1Providing,
         favoredLink: PostViewNavigationLink? = nil,
+        requireConsistentHeight: Bool = false,
         @ViewBuilder embeddedContent: () -> EmbeddedContent = { EmptyView() }
     ) {
         self.post = post
         self.favoredLink = favoredLink
+        self.requireConsistentHeight = requireConsistentHeight
         self.embeddedContent = embeddedContent()
     }
     
@@ -68,7 +71,7 @@ struct HeadlinePostView<EmbeddedContent: View>: View {
                 PostEllipsisMenus(post: post)
             }
             
-            HeadlinePostBodyView(post: post)
+            HeadlinePostBodyView(post: post, requireConsistentHeight: requireConsistentHeight)
             
             if alwaysShowCreator, communityContext == nil {
                 personLink

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -48,6 +48,7 @@ struct FeedsView: View {
 
     @State var isAtTop: Bool = true
     @State var scrollToTopTrigger: Bool = false
+    @State var presentingInspector: Bool = true
     
     var feedOptions: [FeedSelection] {
         FeedSelection.cases(for: appState.firstAccount.accountType)
@@ -105,6 +106,9 @@ struct FeedsView: View {
                 if let postFeedLoader, feedSelection != .saved {
                     FeedSortPicker(feedLoader: postFeedLoader)
                 }
+                Button("Toggle", systemImage: "triangle") {
+                    presentingInspector.toggle()
+                }
             }
             .navigationTitle(isAtTop ? "" : String(localized: feedSelection.description.label))
             .navigationBarTitleDisplayMode(.inline)
@@ -133,6 +137,9 @@ struct FeedsView: View {
                 return postFeedLoader
             }())
             .environment(\.feedContext, feedSelection.feedContext)
+            .inspector(isPresented: $presentingInspector) {
+                Text("Hello")
+            }
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -48,7 +48,6 @@ struct FeedsView: View {
 
     @State var isAtTop: Bool = true
     @State var scrollToTopTrigger: Bool = false
-    @State var presentingInspector: Bool = true
     
     var feedOptions: [FeedSelection] {
         FeedSelection.cases(for: appState.firstAccount.accountType)
@@ -106,9 +105,6 @@ struct FeedsView: View {
                 if let postFeedLoader, feedSelection != .saved {
                     FeedSortPicker(feedLoader: postFeedLoader)
                 }
-                Button("Toggle", systemImage: "triangle") {
-                    presentingInspector.toggle()
-                }
             }
             .navigationTitle(isAtTop ? "" : String(localized: feedSelection.description.label))
             .navigationBarTitleDisplayMode(.inline)
@@ -137,9 +133,6 @@ struct FeedsView: View {
                 return postFeedLoader
             }())
             .environment(\.feedContext, feedSelection.feedContext)
-            .inspector(isPresented: $presentingInspector) {
-                Text("Hello")
-            }
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
@@ -14,6 +14,7 @@ struct PostSettingsView: View {
     @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor: Bool
     
     @Setting(\.postSize) var postSize
+    @Setting(\.allowMultiplePostColumns) var allowMultipleColumns
     @Setting(\.thumbnailLocation) var thumbnailLocation
     @Setting(\.showPostCreator) var showCreator
     @Setting(\.showPersonAvatar) var showPersonAvatar
@@ -26,6 +27,9 @@ struct PostSettingsView: View {
     var body: some View {
         Form {
             PostSizePicker()
+            if UIDevice.isPad {
+                Toggle("Multiple Columns", systemImage: "square.grid.2x2", isOn: $allowMultipleColumns)
+            }
             
             Section {
                 NavigationLink(.settings(.postInteractionBar)) {

--- a/Mlem/App/Views/Shared/PostGridView.swift
+++ b/Mlem/App/Views/Shared/PostGridView.swift
@@ -20,6 +20,7 @@ struct PostGridView: View {
     @Setting(\.postSize) var postSize
     @Setting(\.showReadInFeed) var showRead
     @Setting(\.infiniteScroll) var infiniteScroll
+    @Setting(\.allowMultiplePostColumns) var allowMultipleColumns
     
     @Environment(AppState.self) var appState
     @Environment(Palette.self) var palette
@@ -119,7 +120,7 @@ struct PostGridView: View {
     }
     
     var columns: [GridItem] {
-        if postSize.tiled || (postSize != .large && isWideEnoughForTwoColumns) {
+        if postSize.tiled || (postSize != .large && isWideEnoughForTwoColumns), allowMultipleColumns {
             // leading/trailing alignment makes them want to stick to each other, allowing the Constants.main.halfSpacing padding applied below
             // to push them apart by a sum of Constants.main.standardSpacing
             

--- a/Mlem/App/Views/Shared/PostGridView.swift
+++ b/Mlem/App/Views/Shared/PostGridView.swift
@@ -107,6 +107,7 @@ struct PostGridView: View {
                     }
                 }
             }
+            .padding(.horizontal, postSize.tiled || columns.count == 1 ? 0 : Constants.main.halfSpacing)
             EndOfFeedView(loadingState: postFeedLoader.loadingState, loadMore: loadMore, viewType: .hobbit)
         }
     }

--- a/Mlem/App/Views/Shared/PostGridView.swift
+++ b/Mlem/App/Views/Shared/PostGridView.swift
@@ -27,9 +27,10 @@ struct PostGridView: View {
     
     @Environment(\.communityContext) var communityContext
     
-    @State var columns: [GridItem] = [GridItem(.flexible())]
     @State var frameWidth: CGFloat = .zero
     @State var bottomAppearedPostIndex: Int = -1
+    
+    @State var isWideEnoughForTwoColumns: Bool = false
     
     @Namespace var navigationNamespace
     
@@ -55,23 +56,6 @@ struct PostGridView: View {
                     handleError(error)
                 }
             }
-            .onChange(of: postSize, initial: true) { _, newValue in
-                if newValue.tiled {
-                    // leading/trailing alignment makes them want to stick to each other, allowing the Constants.main.halfSpacing padding applied below
-                    // to push them apart by a sum of Constants.main.standardSpacing
-                    
-                    // Avoid causing unnecessary view update
-                    if columns.count == 1 {
-                        columns = [
-                            GridItem(.flexible(), spacing: 0, alignment: .trailing),
-                            GridItem(.flexible(), spacing: 0, alignment: .leading)
-                        ]
-                    }
-                } else if columns.count > 1 {
-                    // Only trigger if not already 1 column to avoid causing unnecessary view update
-                    columns = [GridItem(.flexible())]
-                }
-            }
             .toolbar {
                 ToolbarItemGroup(placement: .secondaryAction) {
                     SwiftUI.Section {
@@ -83,15 +67,27 @@ struct PostGridView: View {
     
     var content: some View {
         VStack(spacing: 0) {
+            GeometryReader { geometry in
+                Spacer()
+                    .onChange(of: geometry.size.width, initial: true) {
+                        print(geometry.size.width)
+                        let newVal = geometry.size.width > 700
+                        if isWideEnoughForTwoColumns != newVal { // Avoid unnecessary view update
+                            isWideEnoughForTwoColumns = newVal
+                        }
+                    }
+            }
+            .frame(height: 0)
+            let columns = columns
             LazyVGrid(columns: columns, spacing: postSize.sectionSpacing) {
                 ForEach(Array(postFeedLoader.items.enumerated()), id: \.element.hashValue) { index, post in
                     if !post.shouldHideInFeed {
                         NavigationLink(.post(post, communityContext: communityContext, navigationNamespace: navigationNamespace)) {
-                            FeedPostView(post: post)
+                            FeedPostView(post: post, requireConsistentHeight: columns.count != 1)
                                 .matchedTransitionSource_(id: "post\(post.actorId)", in: navigationNamespace)
                         }
                         .buttonStyle(.empty)
-                        .padding(.horizontal, postSize.tiled ? Constants.main.halfSpacing : 10)
+                        .padding(.horizontal, postInnerPadding)
                         .markReadOnScroll(
                             index: index,
                             post: post,
@@ -110,8 +106,31 @@ struct PostGridView: View {
                     }
                 }
             }
-        
             EndOfFeedView(loadingState: postFeedLoader.loadingState, loadMore: loadMore, viewType: .hobbit)
+        }
+    }
+    
+    var postInnerPadding: CGFloat {
+        if columns.count == 1 {
+            Constants.main.standardSpacing
+        } else {
+            Constants.main.standardSpacing / (postSize == .compact ? 4 : 2)
+        }
+    }
+    
+    var columns: [GridItem] {
+        if postSize.tiled || (postSize != .large && isWideEnoughForTwoColumns) {
+            // leading/trailing alignment makes them want to stick to each other, allowing the Constants.main.halfSpacing padding applied below
+            // to push them apart by a sum of Constants.main.standardSpacing
+            
+            // Avoid causing unnecessary view update
+            return [
+                GridItem(.flexible(), spacing: 0, alignment: .trailing),
+                GridItem(.flexible(), spacing: 0, alignment: .leading)
+            ]
+        } else {
+            // Only trigger if not already 1 column to avoid causing unnecessary view update
+            return [GridItem(.flexible())]
         }
     }
     

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1077,6 +1077,9 @@
     "Headline" : {
 
     },
+    "Hello" : {
+
+    },
     "Hesitations" : {
 
     },
@@ -2385,6 +2388,9 @@
 
     },
     "To join this instance, you need to create an application and wait to be accepted." : {
+
+    },
+    "Toggle" : {
 
     },
     "Too many items!" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1077,9 +1077,6 @@
     "Headline" : {
 
     },
-    "Hello" : {
-
-    },
     "Hesitations" : {
 
     },
@@ -1363,6 +1360,9 @@
 
     },
     "Most Comments" : {
+
+    },
+    "Multiple Columns" : {
 
     },
     "Mute Videos" : {
@@ -2388,9 +2388,6 @@
 
     },
     "To join this instance, you need to create an application and wait to be accepted." : {
-
-    },
-    "Toggle" : {
 
     },
     "Too many items!" : {


### PR DESCRIPTION
This applies to Compact and Headline mode. It doesn't apply to Tiled or Large (yet).

This behavior can be disabled in post settings

Closes #1150