### PR TITLE
Drag-To-Zoom

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -371,6 +371,8 @@
 		CD332D7C2CA71E6F00A53988 /* GifView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D7B2CA71E6E00A53988 /* GifView.swift */; };
 		CD332D7E2CA7486000A53988 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D7D2CA7485D00A53988 /* String+Extensions.swift */; };
 		CD33CA522D3C18BF00106C8C /* ImageViewer+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD33CA512D3C18AE00106C8C /* ImageViewer+Views.swift */; };
+		CD3485BB2D501470006748B8 /* ZoomDraggerLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3485BA2D501463006748B8 /* ZoomDraggerLocation.swift */; };
+		CD3485BD2D501573006748B8 /* ZoomDraggerSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3485BC2D50156E006748B8 /* ZoomDraggerSettingsView.swift */; };
 		CD3FC6802D4A75090088E63B /* CounterApperance+StaticValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3FC67F2D4A75050088E63B /* CounterApperance+StaticValues.swift */; };
 		CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */ = {isa = PBXBuildFile; productRef = CD4368C02AE23FD400BD8BD1 /* Semaphore */; };
 		CD43E8B32BF2C24E007C3D71 /* ContentLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD43E8B22BF2C24E007C3D71 /* ContentLoader.swift */; };
@@ -869,6 +871,8 @@
 		CD332D7B2CA71E6E00A53988 /* GifView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GifView.swift; sourceTree = "<group>"; };
 		CD332D7D2CA7485D00A53988 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		CD33CA512D3C18AE00106C8C /* ImageViewer+Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageViewer+Views.swift"; sourceTree = "<group>"; };
+		CD3485BA2D501463006748B8 /* ZoomDraggerLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomDraggerLocation.swift; sourceTree = "<group>"; };
+		CD3485BC2D50156E006748B8 /* ZoomDraggerSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomDraggerSettingsView.swift; sourceTree = "<group>"; };
 		CD3FC67F2D4A75050088E63B /* CounterApperance+StaticValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CounterApperance+StaticValues.swift"; sourceTree = "<group>"; };
 		CD43E8B22BF2C24E007C3D71 /* ContentLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLoader.swift; sourceTree = "<group>"; };
 		CD45CB0C2D1880E3008BC729 /* FiltersSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersSettingsView.swift; sourceTree = "<group>"; };
@@ -1056,6 +1060,7 @@
 		03134A492BEACF46002662CC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				CD3485BC2D50156E006748B8 /* ZoomDraggerSettingsView.swift */,
 				039F58962C7B68F100C61658 /* AboutMlemView.swift */,
 				03BF11C62D3D634A00CC1F66 /* AccessibilitySettingsView.swift */,
 				03AB48542CBC0B8000567FF9 /* AccountAdvancedSettingsView.swift */,
@@ -1844,6 +1849,7 @@
 		CD4D58C62B86DCE500B82964 /* Enums */ = {
 			isa = PBXGroup;
 			children = (
+				CD3485BA2D501463006748B8 /* ZoomDraggerLocation.swift */,
 				CDC44A352D1CBC200030F01C /* ReadPostIndicator.swift */,
 				CD4D58C72B86DCED00B82964 /* AvatarType.swift */,
 				03CBD18C2C6120F600E870BC /* PersonFlair.swift */,
@@ -2519,6 +2525,7 @@
 				033819282D4424D9000AFC55 /* SafetyWarningsSettingsView.swift in Sources */,
 				033F844F2D196AC700D87A9E /* OptimalHeightLayout.swift in Sources */,
 				03ECD7212C8654BA00D48BF6 /* PostEditorView+Toolbar.swift in Sources */,
+				CD3485BD2D501573006748B8 /* ZoomDraggerSettingsView.swift in Sources */,
 				033EF4102CB9AEF7004D8A3F /* ExpandedPostView+Views.swift in Sources */,
 				03FE140C2BF953B000A8377F /* HandleError.swift in Sources */,
 				0320B65A2C8CBB0D00D38548 /* SignUpView+EmailConfirmationView.swift in Sources */,
@@ -2715,6 +2722,7 @@
 				032C32042C3439C600595286 /* ActorIdentifiable+Extensions.swift in Sources */,
 				CD57AFA52D0377EB00AB3956 /* AnimationControlLayer.swift in Sources */,
 				CD6436522D483F2D002668FB /* MockTextView.swift in Sources */,
+				CD3485BB2D501470006748B8 /* ZoomDraggerLocation.swift in Sources */,
 				CD4D59182B87B3B000B82964 /* UIViewController+Extensions.swift in Sources */,
 				034B94812C09306D00039AF4 /* CommunityOrPersonStub+Extensions.swift in Sources */,
 				0320B6692C93506300D38548 /* SearchView+Logic.swift in Sources */,

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -275,6 +275,7 @@ enum Icons {
     static let author: String = "signature"
     static let websiteAddress: String = "link"
     static let leftRight: String = "arrow.left.arrow.right"
+    static let leftAndRightCircle: String = "arrow.left.and.right.circle"
     static let developerMode: String = "wrench.adjustable.fill"
     static let limitImageHeightSetting: String = "rectangle.compress.vertical"
     static let appLockSettings: String = "lock.app.dashed"
@@ -306,6 +307,7 @@ enum Icons {
     static let right: String = "arrow.right.circle"
     static let left: String = "arrow.left.circle"
     static let center: String = "dot.circle"
+    static let zoomDragger: String = "arrow.up.and.down.and.sparkles"
     
     // fediseer
     static let fediseer: String = "shield.checkered"

--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -17,6 +17,7 @@ struct CodableSettings: Codable { // swiftlint:disable:this type_body_length
     var a11y_readOutlineThickness: Int
     var a11y_showSettingsIcons: Bool
     var a11y_websiteThumbnailIcon: Bool
+    var a11y_zoomDraggerLocation: ZoomDraggerLocation
     var accounts_defaultId: Int?
     var accounts_grouped: Bool
     var accounts_sort: AccountSortMode
@@ -106,6 +107,7 @@ struct CodableSettings: Codable { // swiftlint:disable:this type_body_length
         self.a11y_readOutlineThickness = try container.decodeIfPresent(Int.self, forKey: .a11y_readOutlineThickness) ?? 3
         self.a11y_showSettingsIcons = try container.decodeIfPresent(Bool.self, forKey: .a11y_showSettingsIcons) ?? true
         self.a11y_websiteThumbnailIcon = try container.decodeIfPresent(Bool.self, forKey: .a11y_websiteThumbnailIcon) ?? false
+        self.a11y_zoomDraggerLocation = try container.decodeIfPresent(ZoomDraggerLocation.self, forKey: .a11y_zoomDraggerLocation) ?? .none
         self.accounts_defaultId = try container.decodeIfPresent(Int?.self, forKey: .accounts_defaultId) ?? nil
         self.accounts_grouped = try container.decodeIfPresent(Bool.self, forKey: .accounts_grouped) ?? false
         self.accounts_sort = try container.decodeIfPresent(AccountSortMode.self, forKey: .accounts_sort) ?? .name
@@ -209,6 +211,7 @@ struct CodableSettings: Codable { // swiftlint:disable:this type_body_length
         self.a11y_readOutlineThickness = settings.readOutlineThickness
         self.a11y_showSettingsIcons = true
         self.a11y_websiteThumbnailIcon = settings.websiteThumbnailIcon
+        self.a11y_zoomDraggerLocation = settings.zoomDraggerLocation
         self.accounts_defaultId = nil
         self.accounts_grouped = settings.groupAccountSort
         self.accounts_sort = settings.accountSort

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -22,6 +22,7 @@ class Settings: ObservableObject {
     @AppStorage("a11y.readOutlineThickness") var readOutlineThickness: Int = 3
     @AppStorage("a11y.showSettingsIcons") var showSettingsIcons: Bool = false
     @AppStorage("a11y.websiteThumbnailIcon") var websiteThumbnailIcon: Bool = false
+    @AppStorage("a11y.zoomDraggerLocation") var zoomDraggerLocation: ZoomDraggerLocation = .none
 
     @AppStorage("post.size") var postSize: PostSize = .compact
     @AppStorage("post.allowMultipleColumns") var allowMultiplePostColumns: Bool = true
@@ -186,6 +187,7 @@ class Settings: ObservableObject {
         websiteThumbnailIcon = settings.a11y_websiteThumbnailIcon
         showSettingsIcons = settings.a11y_showSettingsIcons
         embedLoops = settings.links_embedLoops
+        zoomDraggerLocation = settings.a11y_zoomDraggerLocation
         
         Task {
             await FiltersTracker.main.resetFilteredKeywords(to: settings.filteredKeywords)

--- a/Mlem/App/Enums/ZoomDraggerLocation.swift
+++ b/Mlem/App/Enums/ZoomDraggerLocation.swift
@@ -1,0 +1,21 @@
+//
+//  ZoomDraggerLocation.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2025-02-02.
+//
+
+import Foundation
+
+enum ZoomDraggerLocation: String, CaseIterable, Codable {
+    case left, right, either, none
+    
+    var label: LocalizedStringResource {
+        switch self {
+        case .left: "Left"
+        case .right: "Right"
+        case .either: "Either"
+        case .none: "Disabled"
+        }
+    }
+}

--- a/Mlem/App/Enums/ZoomDraggerLocation.swift
+++ b/Mlem/App/Enums/ZoomDraggerLocation.swift
@@ -18,4 +18,13 @@ enum ZoomDraggerLocation: String, CaseIterable, Codable {
         case .none: "Disabled"
         }
     }
+    
+    var systemImage: String {
+        switch self {
+        case .left: Icons.left
+        case .right: Icons.right
+        case .either: Icons.leftAndRightCircle
+        case .none: Icons.absent
+        }
+    }
 }

--- a/Mlem/App/Views/Pages/ImageViewer+Views.swift
+++ b/Mlem/App/Views/Pages/ImageViewer+Views.swift
@@ -162,6 +162,9 @@ extension ImageViewer {
                 }
                 .onEnded { _ in
                     dragStartedScale = nil
+                }
+                .updating($scaleDragState) {  _, state, _ in
+                    state = true
                 })
     }
 }

--- a/Mlem/App/Views/Pages/ImageViewer+Views.swift
+++ b/Mlem/App/Views/Pages/ImageViewer+Views.swift
@@ -143,6 +143,8 @@ extension ImageViewer {
             .frame(maxHeight: .infinity)
             .highPriorityGesture(DragGesture()
                 .onChanged { value in
+                    guard offset == 0 else { return }
+                    
                     let baseScale: CGFloat
                     if let dragStartedScale {
                         baseScale = dragStartedScale

--- a/Mlem/App/Views/Pages/ImageViewer+Views.swift
+++ b/Mlem/App/Views/Pages/ImageViewer+Views.swift
@@ -14,7 +14,7 @@ extension ImageViewer {
         VStack {
             topControlBar
                 .offset(y: -controlOffset)
-
+            
             Spacer()
             
             bottomControlBar
@@ -102,5 +102,66 @@ extension ImageViewer {
         }
         .padding(Constants.main.standardSpacing)
         .contentShape(.rect)
+    }
+    
+    // MARK: Zoom and Scale
+    
+    @ViewBuilder
+    var scaleDisplay: some View {
+        Text(String(format: "%.1fx", currentScale))
+            .foregroundStyle(.white)
+            .padding(Constants.main.standardSpacing)
+            .padding(.horizontal, Constants.main.halfSpacing)
+            .background {
+                Capsule().fill(.ultraThinMaterial)
+                    .environment(\.colorScheme, .dark)
+            }
+            .padding(.leading, Constants.main.standardSpacing)
+            .opacity(scaleDisplayShown ? 1 : 0)
+    }
+    
+    @ViewBuilder
+    var zoomDraggerOverlay: some View {
+        HStack {
+            if zoomDraggerLocation == .left || zoomDraggerLocation == .either {
+                zoomDragger
+            }
+            
+            Spacer()
+            
+            if zoomDraggerLocation == .right || zoomDraggerLocation == .either {
+                zoomDragger
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var zoomDragger: some View {
+        Color.clear
+            .contentShape(.rect)
+            .frame(width: 40)
+            .frame(maxHeight: .infinity)
+            .highPriorityGesture(DragGesture()
+                .onChanged { value in
+                    let baseScale: CGFloat
+                    if let dragStartedScale {
+                        baseScale = dragStartedScale
+                    } else {
+                        baseScale = currentScale
+                        dragStartedScale = currentScale
+                    }
+                    
+                    let newScale = baseScale + (value.translation.height / -60)
+                    if newScale <= 1.0 {
+                        currentScale = 1.0
+                    } else if newScale >= 4.0 {
+                        currentScale = 4.0
+                    } else {
+                        currentScale = newScale
+                    }
+                }
+                .onEnded { _ in
+                    dragStartedScale = nil
+                })
     }
 }

--- a/Mlem/App/Views/Pages/ImageViewer.swift
+++ b/Mlem/App/Views/Pages/ImageViewer.swift
@@ -12,12 +12,17 @@ struct ImageViewer: View {
     @Environment(Palette.self) var palette
     @Environment(\.dismiss) var dismiss
     @Environment(\.colorScheme) var colorScheme
+    @Setting(\.zoomDraggerLocation) var zoomDraggerLocation
 
     let url: URL
 
     let duration: CGFloat = 0.25
     let maxControlOffset: CGFloat = 50
     let screenHeight: CGFloat = UIScreen.main.bounds.height
+    
+    @State var currentScale: CGFloat = 1.0
+    @State var dragStartedScale: CGFloat?
+    @State var scaleDisplayShown: Bool = false
     
     @GestureState var dragState: Bool = false
     
@@ -54,7 +59,7 @@ struct ImageViewer: View {
     }
     
     var body: some View {
-        ZoomableContainer(isZoomed: $isZoomed) {
+        ZoomableContainer(isZoomed: $isZoomed, currentScale: $currentScale) {
             MediaView(url: url, playImmediately: true)
         }
         .offset(y: offset)
@@ -88,6 +93,8 @@ struct ImageViewer: View {
                 state = true
             }
         )
+        .overlay(alignment: .topLeading) { scaleDisplay }
+        .overlay { zoomDraggerOverlay }
         .onAppear {
             animateOpacityUpdate(1.0)
         }
@@ -105,6 +112,21 @@ struct ImageViewer: View {
                         enableControlTap = true
                     }
                     animateOffsetUpdate(0)
+                }
+            }
+        }
+        .onChange(of: currentScale) {
+            if !scaleDisplayShown {
+                withAnimation(.easeIn(duration: 0.1)) {
+                    scaleDisplayShown = true
+                }
+            }
+            let oldScale: CGFloat = currentScale
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                if self.currentScale == oldScale {
+                    withAnimation {
+                        scaleDisplayShown = false
+                    }
                 }
             }
         }

--- a/Mlem/App/Views/Pages/ImageViewer.swift
+++ b/Mlem/App/Views/Pages/ImageViewer.swift
@@ -20,10 +20,15 @@ struct ImageViewer: View {
     let maxControlOffset: CGFloat = 50
     let screenHeight: CGFloat = UIScreen.main.bounds.height
     
+    /// Current scale of the ZoomableContainer
     @State var currentScale: CGFloat = 1.0
-    @State var dragStartedScale: CGFloat?
+    
+    /// True when the scale indicator should be visible, false otherwise
     @State var scaleDisplayShown: Bool = false
     
+    @State var dragStartedScale: CGFloat?
+    
+    @GestureState var scaleDragState: Bool = false
     @GestureState var dragState: Bool = false
     
     /// True when the image is zoomed in, false otherwise
@@ -115,6 +120,11 @@ struct ImageViewer: View {
                 }
             }
         }
+        .onChange(of: scaleDragState) {
+            if !scaleDragState {
+                dragStartedScale = nil
+            }
+        }
         .onChange(of: currentScale) {
             if !scaleDisplayShown {
                 withAnimation(.easeIn(duration: 0.1)) {
@@ -122,7 +132,7 @@ struct ImageViewer: View {
                 }
             }
             let oldScale: CGFloat = currentScale
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 if self.currentScale == oldScale {
                     withAnimation {
                         scaleDisplayShown = false

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -50,7 +50,7 @@ struct AccessibilitySettingsView: View {
                     "Drag-To-Zoom Images",
                     value: .init(localized: zoomDraggerLocation.label),
                     fallbackValue: "",
-                    systemImage: "arrow.up.and.down.and.sparkles",
+                    systemImage: Icons.zoomDragger,
                     destination: .settings(.zoomDragger)
                 )
             } header: {

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -47,7 +47,7 @@ struct AccessibilitySettingsView: View {
             
             Section {
                 NavigationLink(
-                    "Drag-To-Zoom Images",
+                    "Slide to Zoom Images",
                     value: .init(localized: zoomDraggerLocation.label),
                     fallbackValue: "",
                     systemImage: Icons.zoomDragger,

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -14,6 +14,7 @@ struct AccessibilitySettingsView: View {
     @Setting(\.readPostIndicator) var readPostIndicator
     @Setting(\.websiteThumbnailIcon) var websiteThumbnailIcon
     @Setting(\.showSettingsIcons) var showSettingsIcons
+    @Setting(\.zoomDraggerLocation) var zoomDraggerLocation
     
     var body: some View {
         Form {
@@ -32,12 +33,28 @@ struct AccessibilitySettingsView: View {
                         systemImage: Icons.read,
                         destination: .settings(.postReadIndicator)
                     )
+                } header: {
+                    Text("Differentiate Without Color")
                 }
             }
             
             Section {
                 Toggle("Website Thumbnail Indicator", systemImage: Icons.browser, isOn: $websiteThumbnailIcon)
                 Toggle("Settings Icons", systemImage: Icons.icon, isOn: $showSettingsIcons)
+            } header: {
+                Text("Non-Text Indicators")
+            }
+            
+            Section {
+                NavigationLink(
+                    "Drag-To-Zoom Images",
+                    value: .init(localized: zoomDraggerLocation.label),
+                    fallbackValue: "",
+                    systemImage: "arrow.up.and.down.and.sparkles",
+                    destination: .settings(.zoomDragger)
+                )
+            } header: {
+                Text("Gestures")
             }
         }
         .labelStyle(.conditional)

--- a/Mlem/App/Views/Root/Tabs/Settings/ZoomDraggerSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ZoomDraggerSettingsView.swift
@@ -1,0 +1,117 @@
+//
+//  ZoomDraggerSettingsView.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2025-02-02.
+//
+
+import SwiftUI
+
+enum AnimationPhase: CaseIterable {
+    case slideUp, slideDown, hide, show
+    
+    var circleOffset: CGFloat {
+        switch self {
+        case .slideUp: -50
+        case .slideDown: 50
+        case .hide: 50
+        case .show: 50
+        }
+    }
+    
+    var circleOpacity: CGFloat {
+        switch self {
+        case .slideUp: 1
+        case .slideDown: 1
+        case .hide: 0
+        case .show: 1
+        }
+    }
+    
+    var imageScale: CGFloat {
+        switch self {
+        case .slideUp: 2.0
+        case .slideDown: 0.8
+        case .hide: 0.8
+        case .show: 0.8
+        }
+    }
+    
+    var imageSize: CGFloat {
+        switch self {
+        case .slideUp: 400
+        case .slideDown: 150
+        case .hide: 150
+        case .show: 150
+        }
+    }
+}
+
+struct ZoomDraggerSettingsView: View {
+    @Setting(\.zoomDraggerLocation) var zoomDraggerLocation
+    
+    var body: some View {
+        Form {
+            SettingsHeaderView(
+                title: "Drag-To-Zoom",
+                description: "Zoom the image viewer by dragging on the selected side.") {
+                    ZoomDraggerAnimation()
+                }
+            
+            Picker("Location", selection: $zoomDraggerLocation) {
+                ForEach(ZoomDraggerLocation.allCases, id: \.self) { location in
+                    Text(String(localized: location.label))
+                        .tag(location)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.inline)
+        }
+        .labelStyle(.conditional)
+    }
+}
+
+struct ZoomDraggerAnimation: View {
+    @Environment(Palette.self) var palette
+    
+    var body: some View {
+        RoundedRectangle(cornerRadius: 10)
+            .fill(.black)
+            .frame(width: 72, height: 152)
+            .phaseAnimator(AnimationPhase.allCases) { content, phase in
+                content
+                    .overlay {
+                        Image(systemName: "bird.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .scaleEffect(phase.imageScale)
+                            .foregroundStyle(.white.opacity(0.8))
+                    }
+                    .clipped()
+                    .overlay(alignment: .leading) {
+                        Circle()
+                            .frame(width: 10, height: 10)
+                            .foregroundStyle(palette.accent)
+                            .opacity(phase.circleOpacity)
+                            .offset(y: phase.circleOffset)
+                            .padding(.leading, 4)
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+            } animation: { phase in
+                switch phase {
+                case .hide: .easeOut(duration: 1.0)
+                case .show: .easeOut(duration: 0.1)
+                default: .easeInOut(duration: 0.75)
+                }
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(palette.neutralAccent, lineWidth: 2)
+            }
+    }
+}
+
+#Preview {
+    ZoomDraggerSettingsView()
+        .environment(Palette.main)
+}

--- a/Mlem/App/Views/Root/Tabs/Settings/ZoomDraggerSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ZoomDraggerSettingsView.swift
@@ -60,7 +60,7 @@ struct ZoomDraggerSettingsView: View {
             
             Picker("Location", selection: $zoomDraggerLocation) {
                 ForEach(ZoomDraggerLocation.allCases, id: \.self) { location in
-                    Text(String(localized: location.label))
+                    Label(String(localized: location.label), systemImage: location.systemImage)
                         .tag(location)
                 }
             }
@@ -109,9 +109,4 @@ struct ZoomDraggerAnimation: View {
                     .strokeBorder(palette.neutralAccent, lineWidth: 2)
             }
     }
-}
-
-#Preview {
-    ZoomDraggerSettingsView()
-        .environment(Palette.main)
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ZoomDraggerSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ZoomDraggerSettingsView.swift
@@ -68,6 +68,7 @@ struct ZoomDraggerSettingsView: View {
             .pickerStyle(.inline)
         }
         .labelStyle(.conditional)
+        .contentMargins(.top, 16)
     }
 }
 

--- a/Mlem/App/Views/Root/Tabs/Settings/ZoomDraggerSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ZoomDraggerSettingsView.swift
@@ -53,8 +53,8 @@ struct ZoomDraggerSettingsView: View {
     var body: some View {
         Form {
             SettingsHeaderView(
-                title: "Drag-To-Zoom",
-                description: "Zoom the image viewer by dragging on the selected side.") {
+                title: "Slide to Zoom",
+                description: "Zoom the image viewer with a slide gesture on the selected side.") {
                     ZoomDraggerAnimation()
                 }
             

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -13,6 +13,7 @@ enum SettingsPage: Hashable {
     case accounts, account
     case profile, accountGeneral, accountAdvanced, accountSignIn, accountChangeEmail, accountLocal, accountChangePassword
     case general, privacy, safety, accessibility, sorting, filters
+    case zoomDragger
     case defaultFeed, haptics
     case privacyBypassImageProxy
     case safetyBlurNsfw, safetyWarnings
@@ -76,6 +77,8 @@ enum SettingsPage: Hashable {
             SafetyWarningsSettingsView()
         case .accessibility:
             AccessibilitySettingsView()
+        case .zoomDragger:
+            ZoomDraggerSettingsView()
         case .importExportSettings:
             ImportExportSettingsView()
         case .advanced:

--- a/Mlem/App/Views/Shared/ZoomableContainer.swift
+++ b/Mlem/App/Views/Shared/ZoomableContainer.swift
@@ -15,7 +15,7 @@ private let maxAllowedScale = 4.0
 @MainActor
 struct ZoomableContainer<Content: View>: View {
     let content: Content
-    @State private var currentScale: CGFloat = 1.0
+    @Binding var currentScale: CGFloat
     @State private var tapLocation: CGPoint = .zero
     
     /// True when currently zooming, false otherwise
@@ -28,8 +28,9 @@ struct ZoomableContainer<Content: View>: View {
     /// value is set immediately instead of waiting for the zoom to complete.
     @Binding var isZoomed: Bool
 
-    init(isZoomed: Binding<Bool> = .constant(false), @ViewBuilder content: () -> Content) {
+    init(isZoomed: Binding<Bool> = .constant(false), currentScale: Binding<CGFloat>, @ViewBuilder content: () -> Content) {
         self.content = content()
+        self._currentScale = currentScale
         self._isZoomed = isZoomed
     }
 
@@ -64,7 +65,7 @@ struct ZoomableContainer<Content: View>: View {
 
     fileprivate struct ZoomableScrollView<ScollContent: View>: UIViewRepresentable {
         private var content: ScollContent
-        @Binding private var currentScale: CGFloat
+        @ObservationIgnored @Binding private var currentScale: CGFloat
         @Binding private var tapLocation: CGPoint
         @Binding private var zooming: Bool
         
@@ -108,10 +109,13 @@ struct ZoomableContainer<Content: View>: View {
         func updateUIView(_ uiView: UIScrollView, context: Context) {
             context.coordinator.hostingController.rootView = content
 
-            if uiView.zoomScale > uiView.minimumZoomScale { // Scale out
-                uiView.setZoomScale(currentScale, animated: true)
-            } else if tapLocation != .zero { // Scale in to a specific point
-                uiView.zoom(to: zoomRect(for: uiView, scale: uiView.maximumZoomScale, center: tapLocation), animated: true)
+            if tapLocation == .zero {
+                if uiView.zoomScale != currentScale {
+                    uiView.setZoomScale(currentScale, animated: false)
+                    DispatchQueue.main.async { zooming = currentScale != 1.0 }
+                }
+            } else {
+                uiView.zoom(to: zoomRect(for: uiView, scale: currentScale, center: tapLocation), animated: true)
                 DispatchQueue.main.async { tapLocation = .zero }
             }
         }
@@ -141,6 +145,10 @@ struct ZoomableContainer<Content: View>: View {
 
             func viewForZooming(in _: UIScrollView) -> UIView? {
                 hostingController.view
+            }
+            
+            func scrollViewDidZoom(_ scrollView: UIScrollView) {
+                DispatchQueue.main.async { self.currentScale = scrollView.zoomScale }
             }
 
             func scrollViewDidEndZooming(_: UIScrollView, with _: UIView?, atScale scale: CGFloat) {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -914,12 +914,6 @@
     "Dracula" : {
 
     },
-    "Drag-To-Zoom" : {
-
-    },
-    "Drag-To-Zoom Images" : {
-
-    },
     "Easy" : {
 
     },
@@ -2162,6 +2156,12 @@
     "Size" : {
 
     },
+    "Slide to Zoom" : {
+
+    },
+    "Slide to Zoom Images" : {
+
+    },
     "Slow" : {
 
     },
@@ -2798,7 +2798,7 @@
     "Your subscriptions live here." : {
 
     },
-    "Zoom the image viewer by dragging on the selected side." : {
+    "Zoom the image viewer with a slide gesture on the selected side." : {
 
     }
   },

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -522,6 +522,9 @@
     "Bot accounts are unable to vote." : {
 
     },
+    "Both" : {
+
+    },
     "Bottom" : {
 
     },
@@ -869,6 +872,9 @@
     "Diagnosing..." : {
 
     },
+    "Differentiate Without Color" : {
+
+    },
     "Disabled" : {
 
     },
@@ -909,6 +915,12 @@
 
     },
     "Dracula" : {
+
+    },
+    "Drag-To-Zoom" : {
+
+    },
+    "Drag-To-Zoom Images" : {
 
     },
     "Easy" : {
@@ -1088,6 +1100,9 @@
 
     },
     "General" : {
+
+    },
+    "Gestures" : {
 
     },
     "GitHub Repository" : {
@@ -1300,6 +1315,9 @@
     "Local Options" : {
 
     },
+    "Location" : {
+
+    },
     "Lock" : {
 
     },
@@ -1500,6 +1518,9 @@
 
     },
     "No reason given" : {
+
+    },
+    "Non-Text Indicators" : {
 
     },
     "None" : {
@@ -2775,6 +2796,9 @@
 
     },
     "Your subscriptions live here." : {
+
+    },
+    "Zoom the image viewer by dragging on the selected side." : {
 
     }
   },

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -522,9 +522,6 @@
     "Bot accounts are unable to vote." : {
 
     },
-    "Both" : {
-
-    },
     "Bottom" : {
 
     },
@@ -930,6 +927,9 @@
 
     },
     "Edited" : {
+
+    },
+    "Either" : {
 
     },
     "Email" : {


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Description

Adds an accessibility feature to drag the side of the image viewer to zoom. This can be toggled in Settings -> Accessibility -> Drag-To-Zoom Images.

Also makes some minor enhancements to the image viewer:
- Double tap to zoom out no longer zooms in first
- While actively changing scale, a zoom indicator appears in the top left.