### PR TITLE
Stop Printing Errors

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		CD1DF6382D38357500F7851E /* MediaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1DF6372D38357100F7851E /* MediaView.swift */; };
 		CD1DF63E2D387E8500F7851E /* MediaView+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1DF63D2D387E8300F7851E /* MediaView+Views.swift */; };
 		CD1DF6402D387EB700F7851E /* MediaView+Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1DF63F2D387EB300F7851E /* MediaView+Functions.swift */; };
+		CD2C86542D5556C00034CD8A /* MlemError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2C86532D5556BE0034CD8A /* MlemError.swift */; };
 		CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */; };
 		CD317D4C2BE97FED008F63E2 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4B2BE97FED008F63E2 /* Palette.swift */; };
 		CD317D4F2BE983ED008F63E2 /* MonochromePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD317D4E2BE983ED008F63E2 /* MonochromePalette.swift */; };
@@ -884,6 +885,7 @@
 		CD1DF6372D38357100F7851E /* MediaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaView.swift; sourceTree = "<group>"; };
 		CD1DF63D2D387E8300F7851E /* MediaView+Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaView+Views.swift"; sourceTree = "<group>"; };
 		CD1DF63F2D387EB300F7851E /* MediaView+Functions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaView+Functions.swift"; sourceTree = "<group>"; };
+		CD2C86532D5556BE0034CD8A /* MlemError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlemError.swift; sourceTree = "<group>"; };
 		CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+LoadFeed.swift"; sourceTree = "<group>"; };
 		CD317D4B2BE97FED008F63E2 /* Palette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Palette.swift; sourceTree = "<group>"; };
 		CD317D4E2BE983ED008F63E2 /* MonochromePalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonochromePalette.swift; sourceTree = "<group>"; };
@@ -1880,6 +1882,7 @@
 		CD4D58C62B86DCE500B82964 /* Enums */ = {
 			isa = PBXGroup;
 			children = (
+				CD2C86532D5556BE0034CD8A /* MlemError.swift */,
 				CD3485BA2D501463006748B8 /* ZoomSliderLocation.swift */,
 				CDC44A352D1CBC200030F01C /* ReadPostIndicator.swift */,
 				CD4D58C72B86DCED00B82964 /* AvatarType.swift */,
@@ -2657,6 +2660,7 @@
 				CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */,
 				CD317D4C2BE97FED008F63E2 /* Palette.swift in Sources */,
 				039F588F2C7B599800C61658 /* ThemeLabel.swift in Sources */,
+				CD2C86542D5556C00034CD8A /* MlemError.swift in Sources */,
 				CD4E386B2C836837009B24F2 /* DraculaPalette.swift in Sources */,
 				CD9857A42C5E7F9D0084C71F /* NsfwOverlayView.swift in Sources */,
 				CD64A91C2CA38DBA007CA7E6 /* NukeWebpBridgeDecoder.swift in Sources */,

--- a/Mlem/App/Enums/MlemError.swift
+++ b/Mlem/App/Enums/MlemError.swift
@@ -7,6 +7,8 @@
 
 enum MlemError: Error {
     case modelError(String)
+    case navigationError(String)
+    case unexpectedValue
 }
 
 extension MlemError: CustomStringConvertible {
@@ -14,6 +16,10 @@ extension MlemError: CustomStringConvertible {
         switch self {
         case let .modelError(string):
             return "Model Error: \(string)"
+        case let .navigationError(string):
+            return "Navigation Error: \(string)"
+        case .unexpectedValue:
+            return "Encountered unexpected value"
         }
     }
 }

--- a/Mlem/App/Enums/MlemError.swift
+++ b/Mlem/App/Enums/MlemError.swift
@@ -1,0 +1,19 @@
+//
+//  MlemError.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2025-02-06.
+//
+
+enum MlemError: Error {
+    case modelError(String)
+}
+
+extension MlemError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case let .modelError(string):
+            return "Model Error: \(string)"
+        }
+    }
+}

--- a/Mlem/App/Globals/Definitions/ErrorsTracker.swift
+++ b/Mlem/App/Globals/Definitions/ErrorsTracker.swift
@@ -12,8 +12,8 @@ class ErrorsTracker {
     private(set) var errors: [ErrorDetails] = .init()
     
     @MainActor
-    func addError(_ error: Error) {
-        errors.prepend(.init(error: error))
+    func addError(_ error: Error, location: String) {
+        errors.prepend(.init(error: error, location: location))
     }
     
     static var main: ErrorsTracker = .init()
@@ -22,8 +22,7 @@ class ErrorsTracker {
         var ret = ""
         
         for details in errors {
-            let description = String(describing: details.error)
-            ret += "\(details.when.formatted(.iso8601))\t\(details.title ?? "Error")\t\(description)\n"
+            ret += "\(details.when.formatted(.iso8601))\t\(details.title ?? "Error")\t\(details.errorText)\n"
         }
         
         return ret

--- a/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
+++ b/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
@@ -57,8 +57,7 @@ class HapticManager {
                 try ret.start()
                 return ret
             } catch {
-                // TODO: feed to error handler once we have swift-repositories
-                print("There was an error creating the engine: \(error.localizedDescription)")
+                handleError(error, silent: true)
             }
         }
         return nil
@@ -74,7 +73,7 @@ class HapticManager {
                 do {
                     try hapticEngine.playPattern(from: file)
                 } catch {
-                    print("Failed to play pattern: \(error.localizedDescription). Will not restart engine.")
+                    handleError(error, silent: true)
                 }
             }
         } else {
@@ -86,7 +85,7 @@ class HapticManager {
         do {
             try engine.start()
         } catch {
-            print("Failed to start the engine: \(error)")
+            handleError(error)
         }
     }
     
@@ -106,7 +105,7 @@ class HapticManager {
                     try hapticEngine.playPattern(from: file)
                 } catch {
                     // worst-case scenario--tried to play and no engine!
-                    print("Failed to play pattern: \(error.localizedDescription). Attempting to restart engine.")
+                    handleError(error, silent: true)
                     handleEngineFailure(with: file)
                 }
             } else {

--- a/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
+++ b/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
@@ -45,7 +45,7 @@ class HapticManager {
         do {
             try hapticEngine?.start()
         } catch {
-            handleError(error)
+            handleError(error, silent: true)
         }
     }
     

--- a/Mlem/App/Logic/HandleError.swift
+++ b/Mlem/App/Logic/HandleError.swift
@@ -10,19 +10,20 @@ import SwiftUI
 
 func handleError(
     _ error: Error,
-    file: StaticString = #fileID,
-    function: StaticString = #function,
+    silent: Bool = false,
+    file: String = #fileID,
+    function: String = #function,
     line: Int = #line
 ) {
-    if !_handleError(error, file: file, function: function, line: line) {
+    if !_handleError(error, file: file, function: function, line: line), !silent {
         ToastModel.main.add(.error(.init(error: error)))
     }
 }
 
 func handleErrorWithDetails(
     _ error: Error,
-    file: StaticString = #fileID,
-    function: StaticString = #function,
+    file: String = #fileID,
+    function: String = #function,
     line: Int = #line
 ) -> ErrorDetails? {
     if !_handleError(error, file: file, function: function, line: line) {
@@ -31,10 +32,11 @@ func handleErrorWithDetails(
     return nil
 }
 
+/// - Returns: true if no further handling is required, false otherwise
 private func _handleError(
     _ error: Error,
-    file: StaticString = #fileID,
-    function: StaticString = #function,
+    file: String = #fileID,
+    function: String = #function,
     line: Int = #line
 ) -> Bool {
     #if DEBUG
@@ -46,8 +48,10 @@ private func _handleError(
         print("📂 -> \(file) | \(function) | line: \(line)")
     #endif
     
+    let location: String = "\(file), \(function):\(line)"
+    
     Task {
-        await ErrorsTracker.main.addError(error)
+        await ErrorsTracker.main.addError(error, location: location)
     }
     
     switch error {

--- a/Mlem/App/Models/ErrorDetails.swift
+++ b/Mlem/App/Models/ErrorDetails.swift
@@ -14,6 +14,7 @@ struct ErrorDetails: Hashable {
     var title: String?
     var body: String?
     var error: Error?
+    var location: String?
     var systemImage: String?
     var buttonText: String?
     var refresh: (() async -> Bool)?
@@ -24,6 +25,7 @@ struct ErrorDetails: Hashable {
         title: String? = nil,
         body: String? = nil,
         error: Error? = nil,
+        location: String? = nil,
         systemImage: String? = nil,
         buttonText: String? = nil,
         refresh: (() -> Bool)? = nil,
@@ -32,6 +34,7 @@ struct ErrorDetails: Hashable {
         self.title = title
         self.body = body
         self.error = error
+        self.location = location
         self.systemImage = systemImage
         self.buttonText = buttonText
         self.refresh = refresh
@@ -52,6 +55,7 @@ struct ErrorDetails: Hashable {
         hasher.combine(title)
         hasher.combine(body)
         hasher.combine(error?.localizedDescription)
+        hasher.combine(location)
         hasher.combine(systemImage)
         hasher.combine(buttonText)
         hasher.combine(refresh == nil)
@@ -62,12 +66,18 @@ struct ErrorDetails: Hashable {
         lhs.hashValue == rhs.hashValue
     }
     
-    var errorText: String {
-        var output: String
-        if let error = error as? ApiClientError {
-            output = error.description
+    var errorDescription: String {
+        if let error = error as? CustomStringConvertible {
+            return error.description
         } else {
-            output = String(describing: error)
+            return String(describing: error)
+        }
+    }
+    
+    var errorText: String {
+        var output = errorDescription
+        if let location {
+            output += " (\(location))"
         }
         for account in AccountsTracker.main.userAccounts {
             if let token = account.api.token {

--- a/Mlem/App/Models/ErrorDetails.swift
+++ b/Mlem/App/Models/ErrorDetails.swift
@@ -66,16 +66,8 @@ struct ErrorDetails: Hashable {
         lhs.hashValue == rhs.hashValue
     }
     
-    var errorDescription: String {
-        if let error = error as? CustomStringConvertible {
-            return error.description
-        } else {
-            return String(describing: error)
-        }
-    }
-    
     var errorText: String {
-        var output = errorDescription
+        var output = String(describing: error)
         if let location {
             output += " (\(location))"
         }

--- a/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
@@ -50,11 +50,12 @@ extension Community1Providing {
             }
             self2.toggleSubscribe()
         } else {
-            print("DEBUG no self2 found in toggleSubscribe!")
+            handleError(MlemError.modelError("No self2 found"), silent: true)
         }
     }
     
     func toggleFavorite(feedback: Set<FeedbackType>) {
+        handleError(MlemError.modelError("No self2 found"), silent: true)
         if let self2 {
             if feedback.contains(.haptic) {
                 HapticManager.main.play(haptic: .lightSuccess, priority: .low)
@@ -79,7 +80,7 @@ extension Community1Providing {
             }
             self2.toggleFavorite()
         } else {
-            print("DEBUG no self2 found in toggleFavorite!")
+            handleError(MlemError.modelError("No self2 found"), silent: true)
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
@@ -55,7 +55,6 @@ extension Community1Providing {
     }
     
     func toggleFavorite(feedback: Set<FeedbackType>) {
-        handleError(MlemError.modelError("No self2 found"), silent: true)
         if let self2 {
             if feedback.contains(.haptic) {
                 HapticManager.main.play(haptic: .lightSuccess, priority: .low)

--- a/Mlem/App/Utility/Extensions/Content Models/DeletableProviding+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/DeletableProviding+Extensions.swift
@@ -26,7 +26,7 @@ extension DeletableProviding {
                 case .failed:
                     ToastModel.main.add(.failure("Failed to delete post!"))
                 default:
-                    print("Unexpected `toggleDeleted` result type")
+                    handleError(MlemError.unexpectedValue, silent: true)
                 }
             }
         } else {

--- a/Mlem/App/Utility/Extensions/Content Models/Instance2Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Instance2Providing+Extensions.swift
@@ -14,7 +14,7 @@ extension Instance2Providing {
                 return try .init(regex)
             }
         } catch {
-            print("Invalid slur filter regex")
+            handleError(error, silent: true)
         }
         return nil
     }

--- a/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
@@ -36,7 +36,7 @@ extension Interactable1Providing {
             self2.toggleUpvoted()
             inboxItem?.updateRead(true)
         } else {
-            print("DEBUG no self2 found in toggleUpvote!")
+            handleError(MlemError.modelError("No self2 found"), silent: true)
         }
     }
     
@@ -48,7 +48,7 @@ extension Interactable1Providing {
             self2.toggleDownvoted()
             inboxItem?.updateRead(true)
         } else {
-            print("DEBUG no self2 found in toggleDownvote!")
+            handleError(MlemError.modelError("No self2 found"), silent: true)
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
@@ -17,7 +17,7 @@ extension Interactable1Providing {
         if let responseContext {
             NavigationModel.main.openSheet(.createComment(responseContext, commentTreeTracker: commentTreeTracker))
         } else {
-            print("DEBUG showReplySheet: cannot open sheet!")
+            handleError(MlemError.navigationError("Cannot open sheet"), silent: true)
         }
     }
     
@@ -65,13 +65,13 @@ extension Interactable1Providing {
             self2.toggleSaved()
             inboxItem?.updateRead(true)
         } else {
-            print("DEBUG no self2 found in toggleSave!")
+            handleError(MlemError.modelError("No self2 found"), silent: true)
         }
     }
     
     func toggleRemoved(reason: String?, feedback: Set<FeedbackType>) {
         guard let self2 else {
-            print("DEBUG no self2 found in toggleRemoved!")
+            handleError(MlemError.modelError("No self2 found"), silent: true)
             return
         }
         Task {

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -51,7 +51,7 @@ extension Post1Providing {
             }
             self2.toggleHidden()
         } else {
-            print("DEBUG no self2 found in toggleHidden!")
+            handleError(MlemError.modelError("No self2 found"), silent: true)
         }
     }
     

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/CommentEditorView+Logic.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/CommentEditorView+Logic.swift
@@ -36,7 +36,7 @@ extension CommentEditorView {
             }
             
         } catch ApiClientError.noEntityFound {
-            print("No entity found!")
+            handleError(ApiClientError.noEntityFound, silent: true)
             Task { @MainActor in
                 resolutionState = .notFound
             }

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/CommentEditorView+Logic.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/CommentEditorView+Logic.swift
@@ -106,7 +106,7 @@ extension CommentEditorView {
                 slurMatch = nil
             }
         } catch {
-            print("Failed to parse regex")
+            handleError(error, silent: true)
         }
     }
 }

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Logic.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Logic.swift
@@ -179,7 +179,7 @@ extension PostEditorView {
                     newSlurMatches[host] = String(text[output.range])
                 }
             } catch {
-                print("Failed to parse regex")
+                handleError(error, silent: true)
             }
         }
         

--- a/Mlem/App/Views/Root/ContentView+Logic.swift
+++ b/Mlem/App/Views/Root/ContentView+Logic.swift
@@ -42,7 +42,7 @@ extension ContentView {
                 }
             }
         } catch {
-            print(error)
+            handleError(error, silent: true)
         }
     }
     

--- a/Mlem/App/Views/Root/Onboarding/LoginCredentialsView.swift
+++ b/Mlem/App/Views/Root/Onboarding/LoginCredentialsView.swift
@@ -194,7 +194,7 @@ struct LoginCredentialsView: View {
                     case ApiClientError.invalidSession:
                         failureReason = .incorrectPassword
                     default:
-                        print("LOGIN ERROR", error)
+                        handleError(error, silent: true)
                         failureReason = .other
                     }
                     Task { @MainActor in

--- a/Mlem/App/Views/Root/Onboarding/SignUpView+Logic.swift
+++ b/Mlem/App/Views/Root/Onboarding/SignUpView+Logic.swift
@@ -38,7 +38,7 @@ extension SignUpView {
             } catch ApiClientError.noEntityFound {
                 usernameValidity = .valid
             } catch {
-                print("Error checking username validity", error)
+                handleError(error, silent: true)
             }
         }
     }

--- a/Mlem/App/Views/Root/Tabs/Settings/DeveloperSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/DeveloperSettingsView.swift
@@ -36,6 +36,10 @@ struct DeveloperSettingsView: View {
                     Button(String("Create Error")) {
                         handleError(ApiClientError.insufficientPermissions)
                     }
+                    
+                    Button(String("Create Silent Error")) {
+                        handleError(ApiClientError.noEntityFound, silent: true)
+                    }
                 } header: {
                     Text(verbatim: "Debug Tools")
                 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ErrorLogView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ErrorLogView.swift
@@ -68,7 +68,7 @@ struct ErrorLogView: View {
                 }
             }
             
-            Text(details.errorDescription)
+            Text(String(describing: details.error))
             
             if let location = details.location {
                 HStack(alignment: .top, spacing: 2) {

--- a/Mlem/App/Views/Root/Tabs/Settings/ErrorLogView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ErrorLogView.swift
@@ -68,7 +68,17 @@ struct ErrorLogView: View {
                 }
             }
             
-            Text(details.errorText)
+            Text(details.errorDescription)
+            
+            if let location = details.location {
+                HStack(alignment: .top, spacing: 2) {
+                    Image(systemName: "arrow.turn.down.right")
+                        .offset(y: 2)
+                    
+                    Text(location)
+                }
+                .font(.subheadline)
+            }
             
             Text(details.when.formatted(date: .abbreviated, time: .standard))
                 .font(.caption)

--- a/Mlem/App/Views/Shared/Images/Helpers/MediaLoader.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/MediaLoader.swift
@@ -144,7 +144,7 @@ private func generateAVThumbnail(asset: AVAsset) -> UIImage {
     do {
         return try .init(cgImage: assetImgGenerate.copyCGImage(at: time, actualTime: nil))
     } catch {
-        print(error)
+        handleError(error, silent: true)
         return .blank
     }
 }

--- a/Mlem/App/Views/Shared/Images/SimpleAvatarView.swift
+++ b/Mlem/App/Views/Shared/Images/SimpleAvatarView.swift
@@ -58,7 +58,7 @@ struct SimpleAvatarView: View {
             uiImage = image.circleMasked
             loading = false
         } catch {
-            print(error)
+            handleError(error, silent: true)
         }
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- progress towards #124 

## Description

Adds a `silent` toggle to `handleError` that suppresses the toast and replaces all error prints with calls to `handleError` with `silent: true`. This gives us consistent, detailed error prints through `handleError`, plus better insight into errors that may happen outside of the debugger mode through the error log.

## Implementation Notes

<!-- Any information about the code that would be helpful for reviewing -->