### PR TITLE
Possible fix for inline image crash

### DIFF
--- a/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
@@ -98,13 +98,11 @@ private func loadInlineImage(inlineImage: MarkdownImage) async {
     guard let image: UIImage = try? await imageTask.image else { return }
     let height = inlineImage.fontSize
     let width = image.size.width * (height / image.size.height)
-    UIGraphicsBeginImageContextWithOptions(CGSize(width: width, height: height), false, 2.0)
-    defer { UIGraphicsEndImageContext() }
-    image.draw(in: CGRect(x: 0, y: 0, width: width, height: height))
-    let newImage = UIGraphicsGetImageFromCurrentImageContext()
-    if let newImage {
-        DispatchQueue.main.async {
-            inlineImage.image = Image(uiImage: newImage)
+    Task { @MainActor in
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height))
+        let newImage = renderer.image { _ in
+            image.draw(in: CGRect(x: 0, y: 0, width: width, height: height))
         }
+        inlineImage.image = Image(uiImage: newImage)
     }
 }


### PR DESCRIPTION
We've had a few TF crashes related to `UIGraphicsBeginImageContextWithOptions`. I can't repro the crash, but I'm guessing it might be because it needs to run on `@MainActor`