### PR TITLE
Disable image context menu on error

### DIFF
--- a/Mlem/App/Views/Shared/Images/Core/MediaView.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaView.swift
@@ -87,7 +87,7 @@ struct MediaView: View {
             .overlay(developerOverlay)
             .overlay(errorOverlay)
             .clipShape(.rect(cornerRadius: cornerRadius))
-            .withContextMenu(menuContent: contextMenuContent, isEnabled: enableContextMenu)
+            .withContextMenu(menuContent: contextMenuContent, isEnabled: enableContextMenu && loader.error?.case != .proxyFailure)
             .gesture(TapGesture().onEnded(tapActions), isEnabled: (onTapActions != nil) || enableImageViewer)
             .frame(maxWidth: .infinity)
             .onChange(of: blurred) {

--- a/Mlem/App/Views/Shared/Images/Core/MediaView.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaView.swift
@@ -87,7 +87,7 @@ struct MediaView: View {
             .overlay(developerOverlay)
             .overlay(errorOverlay)
             .clipShape(.rect(cornerRadius: cornerRadius))
-            .withContextMenu(menuContent: contextMenuContent, isEnabled: enableContextMenu && loader.error?.case != .proxyFailure)
+            .withContextMenu(menuContent: contextMenuContent, isEnabled: enableContextMenu && loader.error == nil)
             .gesture(TapGesture().onEnded(tapActions), isEnabled: (onTapActions != nil) || enableImageViewer)
             .frame(maxWidth: .infinity)
             .onChange(of: blurred) {

--- a/Mlem/App/Views/Shared/Images/Helpers/MediaLoader.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/MediaLoader.swift
@@ -13,17 +13,6 @@ import SwiftUI
 enum ImageLoadingError {
     case proxyFailure(proxyBypass: URL)
     case error(error: Error)
-    
-    enum Case {
-        case proxyFailure, error
-    }
-    
-    var `case`: Case {
-        switch self {
-        case .proxyFailure: .proxyFailure
-        case .error: .error
-        }
-    }
 }
 
 enum MediaType {

--- a/Mlem/App/Views/Shared/Images/Helpers/MediaLoader.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/MediaLoader.swift
@@ -14,10 +14,14 @@ enum ImageLoadingError {
     case proxyFailure(proxyBypass: URL)
     case error(error: Error)
     
-    var canBypassProxy: Bool {
+    enum Case {
+        case proxyFailure, error
+    }
+    
+    var `case`: Case {
         switch self {
-        case .proxyFailure: true
-        default: false
+        case .proxyFailure: .proxyFailure
+        case .error: .error
         }
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1668 

## Description

Disables the context menu if the image didn't load. Also removes some unused code.