### PR TITLE
Markdown fixes

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3294,7 +3294,7 @@
 			repositoryURL = "https://github.com/mlemgroup/LemmyMarkdownUI";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.8.0;
+				minimumVersion = 0.9.0;
 			};
 		};
 		0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/LemmyMarkdownUI",
       "state" : {
-        "revision" : "0c52aef58c09b3929db96741fb7705c6ccf2f701",
-        "version" : "0.8.0"
+        "revision" : "57ea1d725415b0c0d4ddd303007cbda2271f65ac",
+        "version" : "0.9.0"
       }
     },
     {


### PR DESCRIPTION
Closes #1447. The app seemed to freeze forever, but this wasn't actually the case - it would unfreeze eventually. 

It turns out that the `VStack` used in the `Markdown` view was spending all that time doing layout calculations for the large number of complex child views. To fix this, I simplified the logic by replacing the `VStack` with a custom `Layout` that only properly does calculations for the x axis and just always gives maximum space on the y axis. We're able to do this because the height of `Markdown` is always guaranteed to be infinite.

 There is still a small hitch when opening the post mentioned in the issue but it's no-where near as bad as before.

Also fixed shields.io badges being spaced super far apart.