### PR TITLE
Update ci_lint.yml

### DIFF
--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -12,6 +12,7 @@ on:
         - '.github/workflows/swiftlint.yml'
         - '.swiftlint.yml'
         - '**/*.swift'
+        - 'Mlem.xcodeproj/project.pbxproj'
 
 jobs:
   SwiftLint:


### PR DESCRIPTION
Update `ci_lint` to pick up `project.pbxproj` changes, preventing pure package PRs (e.g., https://github.com/mlemgroup/mlem/pull/1734) from getting stuck expecting the lint job to run when it never will