### PR TITLE
Customizable Interaction Bar Widget Palette

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 		CDEE15522D22190600EB9D7B /* ErrorsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEE15512D22190000EB9D7B /* ErrorsTracker.swift */; };
 		CDEE15542D22364B00EB9D7B /* ErrorLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEE15532D22364500EB9D7B /* ErrorLogView.swift */; };
 		CDF5B7092D4ED47000412DBD /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CDF5B7082D4ED47000412DBD /* MlemMiddleware */; };
+		CDF8C1912D5D502400295CBA /* InteractionBarWidgetPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8C1902D5D501E00295CBA /* InteractionBarWidgetPickerView.swift */; };
 		CDF9EF332AB2845C003F885B /* Icons.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF9EF322AB2845C003F885B /* Icons.swift */; };
 		CDFB8C692C7796020070845F /* View+DynamicBlur.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFB8C682C7796020070845F /* View+DynamicBlur.swift */; };
 		CDFF11712D3D93DC00386B71 /* ConditionalIconLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFF11702D3D93D900386B71 /* ConditionalIconLabelStyle.swift */; };
@@ -1012,6 +1013,7 @@
 		CDE4AC3E2CA2082F00981010 /* VideoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoView.swift; sourceTree = "<group>"; };
 		CDEE15512D22190000EB9D7B /* ErrorsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorsTracker.swift; sourceTree = "<group>"; };
 		CDEE15532D22364500EB9D7B /* ErrorLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorLogView.swift; sourceTree = "<group>"; };
+		CDF8C1902D5D501E00295CBA /* InteractionBarWidgetPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionBarWidgetPickerView.swift; sourceTree = "<group>"; };
 		CDF9EF322AB2845C003F885B /* Icons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icons.swift; sourceTree = "<group>"; };
 		CDFB8C682C7796020070845F /* View+DynamicBlur.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+DynamicBlur.swift"; sourceTree = "<group>"; };
 		CDFF11702D3D93D900386B71 /* ConditionalIconLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalIconLabelStyle.swift; sourceTree = "<group>"; };
@@ -1388,6 +1390,7 @@
 		0397D4982C6EA68A002C6CDC /* InteractionBarEditor */ = {
 			isa = PBXGroup;
 			children = (
+				CDF8C1902D5D501E00295CBA /* InteractionBarWidgetPickerView.swift */,
 				CD64364F2D483C8F002668FB /* InteractionBarEditorView+Views.swift */,
 				0397D4992C6EA6EE002C6CDC /* InteractionBarEditorView.swift */,
 				03036C822C727D0500C6DA1D /* InteractionBarEditorView+Logic.swift */,
@@ -2798,6 +2801,7 @@
 				0320B6542C8B65EB00D38548 /* Captcha+Extensions.swift in Sources */,
 				0397D4A42C6FBC04002C6CDC /* ActionAppearance+StaticValues.swift in Sources */,
 				03B431C02C45ABFB001A1EB5 /* UITextView+Extensions.swift in Sources */,
+				CDF8C1912D5D502400295CBA /* InteractionBarWidgetPickerView.swift in Sources */,
 				034B947F2C091EDD00039AF4 /* ProfileHeaderView.swift in Sources */,
 				03E0EF432CA73D7A002CB66C /* PostPage.swift in Sources */,
 				030030A12C416B0B009A65FF /* RefreshPopupView.swift in Sources */,

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -80,6 +80,10 @@ enum Icons {
     static let restore: String = "arrow.up.bin"
     static let restoreFill: String = "arrow.up.bin.fill"
     static let purge: String = "burn"
+    static let scoreCounter: String = "arrow.up.arrow.down.circle"
+    static let upvoteCounter: String = "arrow.up.circle"
+    static let downvoteCounter: String = "arrow.down.circle"
+    static let replyCounter: String = "arrowshape.turn.up.left.circle"
     
     // post sizes
     static let postSizeSetting: String = "rectangle.expand.vertical"

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUICore
 
 struct CommentBarConfiguration: InteractionBarConfiguration {
     enum ActionType: String, ActionTypeProviding {
@@ -89,7 +90,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
     var readouts: [ReadoutType]
     
     var availableWidgets: Set<Item>
-    var widgetPickerPage: SettingsPage { .commentBarWidgetPicker }
+    func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage { .commentBarWidgetPicker(configuration) }
     
     static var `default`: Self {
         .init(

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -125,8 +125,8 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
     
     static var reportDefault: Self {
         .init(
-            leading: [.counter(.score)],
-            trailing: [.action(.save), .action(.reply)],
+            leading: [.action(.share)],
+            trailing: [.action(.remove)],
             readouts: [.created, .comment],
             availableWidgets: .init(ActionType.defaultReportWidgets.map { .action($0) })
         )

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -19,12 +19,18 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
         case report
         case remove
         
-        static var standardWidgets: [ActionType] {[
+        static var defaultWidgets: [ActionType] {[
             .upvote,
             .downvote,
             .save,
             .reply,
             .share
+        ]}
+        
+        static var defaultReportWidgets: [ActionType] {[
+            .save,
+            .share,
+            .remove
         ]}
         
         var appearance: ActionAppearance {
@@ -47,7 +53,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
         case downvote
         case reply
         
-        static var standardWidgets: [CounterType] { Self.allCases }
+        static var defaultWidgets: [CounterType] { Self.allCases }
         
         var appearance: CounterAppearance {
             switch self {
@@ -97,7 +103,16 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             leading: [.counter(.score)],
             trailing: [.action(.save), .action(.reply)],
             readouts: [.created, .comment],
-            availableWidgets: .init(CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) })
+            availableWidgets: .init(CounterType.defaultWidgets.map { .counter($0) } + ActionType.defaultWidgets.map { .action($0) })
+        )
+    }
+    
+    static var reportDefault: Self {
+        .init(
+            leading: [.counter(.score)],
+            trailing: [.action(.save), .action(.reply)],
+            readouts: [.created, .comment],
+            availableWidgets: .init(ActionType.defaultReportWidgets.map { .action($0) })
         )
     }
 }

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -98,6 +98,22 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
     var availableWidgets: Set<Item>
     func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage { .commentBarWidgetPicker(configuration) }
     
+    init(leading: [Item], trailing: [Item], readouts: [ReadoutType], availableWidgets: Set<Item>) {
+        self.leading = leading
+        self.trailing = trailing
+        self.readouts = readouts
+        self.availableWidgets = availableWidgets
+    }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.leading = try container.decodeIfPresent([Item].self, forKey: .leading) ?? [.counter(.score)]
+        self.trailing = try container.decodeIfPresent([Item].self, forKey: .trailing) ?? [.action(.save), .action(.reply)]
+        self.readouts = try container.decodeIfPresent([ReadoutType].self, forKey: .readouts) ?? [.created, .comment]
+        self.availableWidgets = try container.decodeIfPresent(Set<Item>.self, forKey: .availableWidgets) ??
+            .init(CounterType.defaultWidgets.map { .counter($0) } + ActionType.defaultWidgets.map { .action($0) })
+    }
+    
     static var `default`: Self {
         .init(
             leading: [.counter(.score)],

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -88,7 +88,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
     var trailing: [Item]
     var readouts: [ReadoutType]
     
-    var availableWidgets: [Item]
+    var availableWidgets: Set<Item>
     var widgetPickerPage: SettingsPage { .commentBarWidgetPicker }
     
     static var `default`: Self {
@@ -96,7 +96,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             leading: [.counter(.score)],
             trailing: [.action(.save), .action(.reply)],
             readouts: [.created, .comment],
-            availableWidgets: CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) }
+            availableWidgets: .init(CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) })
         )
     }
 }

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -18,6 +18,14 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
         case report
         case remove
         
+        static var standardWidgets: [ActionType] {[
+            .upvote,
+            .downvote,
+            .save,
+            .reply,
+            .share
+        ]}
+        
         var appearance: ActionAppearance {
             switch self {
             case .upvote: .upvote(isOn: false)
@@ -37,6 +45,8 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
         case upvote
         case downvote
         case reply
+        
+        static var standardWidgets: [CounterType] { Self.allCases }
         
         var appearance: CounterAppearance {
             switch self {
@@ -78,11 +88,15 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
     var trailing: [Item]
     var readouts: [ReadoutType]
     
+    var availableWidgets: [Item]
+    var widgetPickerPage: SettingsPage { .commentBarWidgetPicker }
+    
     static var `default`: Self {
         .init(
             leading: [.counter(.score)],
             trailing: [.action(.save), .action(.reply)],
-            readouts: [.created, .comment]
+            readouts: [.created, .comment],
+            availableWidgets: CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) }
         )
     }
 }

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -18,9 +18,12 @@ protocol InteractionBarConfiguration: Codable {
     var trailing: [Item] { get set }
     var readouts: [ReadoutType] { get set }
     
+    var availableWidgets: [Item] { get set }
+    var widgetPickerPage: SettingsPage { get }
+    
     static var `default`: Self { get }
     
-    init(leading: [Item], trailing: [Item], readouts: [ReadoutType])
+    init(leading: [Item], trailing: [Item], readouts: [ReadoutType], availableWidgets: [Item])
 }
 
 extension InteractionBarConfiguration {
@@ -30,7 +33,8 @@ extension InteractionBarConfiguration {
         .init(
             leading: leading.compactMap { $0.convert() },
             trailing: trailing.compactMap { $0.convert() },
-            readouts: readouts.compactMap { .init(rawValue: $0.rawValue) }
+            readouts: readouts.compactMap { .init(rawValue: $0.rawValue) },
+            availableWidgets: availableWidgets.compactMap { $0.convert() }
         )
     }
     
@@ -74,10 +78,14 @@ enum InteractionConfigurationItem<ActionType: ActionTypeProviding, CounterType: 
 
 protocol ActionTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
     var appearance: ActionAppearance { get }
+    
+    static var standardWidgets: [Self] { get }
 }
 
 protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
     var appearance: CounterAppearance { get }
+    
+    static var standardWidgets: [Self] { get }
 }
 
 protocol ReadoutTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -18,12 +18,12 @@ protocol InteractionBarConfiguration: Codable {
     var trailing: [Item] { get set }
     var readouts: [ReadoutType] { get set }
     
-    var availableWidgets: [Item] { get set }
+    var availableWidgets: Set<Item> { get set }
     var widgetPickerPage: SettingsPage { get }
     
     static var `default`: Self { get }
     
-    init(leading: [Item], trailing: [Item], readouts: [ReadoutType], availableWidgets: [Item])
+    init(leading: [Item], trailing: [Item], readouts: [ReadoutType], availableWidgets: Set<Item>)
 }
 
 extension InteractionBarConfiguration {
@@ -34,7 +34,7 @@ extension InteractionBarConfiguration {
             leading: leading.compactMap { $0.convert() },
             trailing: trailing.compactMap { $0.convert() },
             readouts: readouts.compactMap { .init(rawValue: $0.rawValue) },
-            availableWidgets: availableWidgets.compactMap { $0.convert() }
+            availableWidgets: .init(availableWidgets.compactMap { $0.convert() })
         )
     }
     

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUICore
 
 protocol InteractionBarConfiguration: Codable {
     associatedtype ActionType: ActionTypeProviding
@@ -19,7 +20,7 @@ protocol InteractionBarConfiguration: Codable {
     var readouts: [ReadoutType] { get set }
     
     var availableWidgets: Set<Item> { get set }
-    var widgetPickerPage: SettingsPage { get }
+    func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage
     
     static var `default`: Self { get }
     

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -80,13 +80,13 @@ enum InteractionConfigurationItem<ActionType: ActionTypeProviding, CounterType: 
 protocol ActionTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
     var appearance: ActionAppearance { get }
     
-    static var standardWidgets: [Self] { get }
+    static var defaultWidgets: [Self] { get }
 }
 
 protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
     var appearance: CounterAppearance { get }
     
-    static var standardWidgets: [Self] { get }
+    static var defaultWidgets: [Self] { get }
 }
 
 protocol ReadoutTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
@@ -107,8 +107,8 @@ struct InteractionBarConfigurations: Codable {
             post: .default,
             comment: .default,
             reply: .default,
-            postReport: .default,
-            commentReport: .default
+            postReport: .reportDefault,
+            commentReport: .reportDefault
         )
     }
     
@@ -131,8 +131,8 @@ struct InteractionBarConfigurations: Codable {
         self.post = try container.decodeIfPresent(PostBarConfiguration.self, forKey: .post) ?? .default
         self.comment = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: .comment) ?? .default
         self.reply = try container.decodeIfPresent(ReplyBarConfiguration.self, forKey: .reply) ?? .default
-        self.postReport = try container.decodeIfPresent(PostBarConfiguration.self, forKey: .postReport) ?? .default
-        self.commentReport = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: .commentReport) ?? .default
+        self.postReport = try container.decodeIfPresent(PostBarConfiguration.self, forKey: .postReport) ?? .reportDefault
+        self.commentReport = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: .commentReport) ?? .reportDefault
     }
 }
 

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -112,6 +112,22 @@ struct PostBarConfiguration: InteractionBarConfiguration {
     var availableWidgets: Set<Item>
     func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage { .postBarWidgetPicker(configuration) }
     
+    init(leading: [Item], trailing: [Item], readouts: [ReadoutType], availableWidgets: Set<Item>) {
+        self.leading = leading
+        self.trailing = trailing
+        self.readouts = readouts
+        self.availableWidgets = availableWidgets
+    }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.leading = try container.decodeIfPresent([Item].self, forKey: .leading) ?? [.counter(.score)]
+        self.trailing = try container.decodeIfPresent([Item].self, forKey: .trailing) ?? [.action(.save), .action(.reply)]
+        self.readouts = try container.decodeIfPresent([ReadoutType].self, forKey: .readouts) ?? [.created, .comment]
+        self.availableWidgets = try container.decodeIfPresent(Set<Item>.self, forKey: .availableWidgets) ??
+            .init(CounterType.defaultWidgets.map { .counter($0) } + ActionType.defaultWidgets.map { .action($0) })
+    }
+    
     static var `default`: Self {
         .init(
             leading: [.counter(.score)],

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -104,8 +104,6 @@ struct PostBarConfiguration: InteractionBarConfiguration {
     var availableWidgets: Set<Item>
     func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage { .postBarWidgetPicker(configuration) }
     
-    // TODO: NOW decoder initializers
-    
     static var `default`: Self {
         .init(
             leading: [.counter(.score)],

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -23,6 +23,14 @@ struct PostBarConfiguration: InteractionBarConfiguration {
         case pin
         case remove
         
+        static var standardWidgets: [ActionType] {[
+                .upvote,
+                .downvote,
+                .save,
+                .reply,
+                .share
+        ]}
+        
         var appearance: ActionAppearance {
             switch self {
             case .upvote: .upvote(isOn: false)
@@ -47,6 +55,8 @@ struct PostBarConfiguration: InteractionBarConfiguration {
         case upvote
         case downvote
         case reply
+        
+        static var standardWidgets: [CounterType] { Self.allCases }
         
         var appearance: CounterAppearance {
             switch self {
@@ -90,11 +100,17 @@ struct PostBarConfiguration: InteractionBarConfiguration {
     var trailing: [Item]
     var readouts: [ReadoutType]
     
+    var availableWidgets: [Item]
+    var widgetPickerPage: SettingsPage { .postBarWidgetPicker }
+    
+    // TODO: NOW decoder initializers
+    
     static var `default`: Self {
         .init(
             leading: [.counter(.score)],
             trailing: [.action(.save), .action(.reply)],
-            readouts: [.created, .comment]
+            readouts: [.created, .comment],
+            availableWidgets: CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) }
         )
     }
 }

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -100,7 +100,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
     var trailing: [Item]
     var readouts: [ReadoutType]
     
-    var availableWidgets: [Item]
+    var availableWidgets: Set<Item>
     var widgetPickerPage: SettingsPage { .postBarWidgetPicker }
     
     // TODO: NOW decoder initializers
@@ -110,7 +110,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             leading: [.counter(.score)],
             trailing: [.action(.save), .action(.reply)],
             readouts: [.created, .comment],
-            availableWidgets: CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) }
+            availableWidgets: .init(CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) })
         )
     }
 }

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -24,12 +24,20 @@ struct PostBarConfiguration: InteractionBarConfiguration {
         case pin
         case remove
         
-        static var standardWidgets: [ActionType] {[
+        static var defaultWidgets: [ActionType] {[
                 .upvote,
                 .downvote,
                 .save,
                 .reply,
                 .share
+        ]}
+        
+        static var defaultReportWidgets: [ActionType] {[
+            .save,
+            .share,
+            .lock,
+            .pin,
+            .remove
         ]}
         
         var appearance: ActionAppearance {
@@ -57,7 +65,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
         case downvote
         case reply
         
-        static var standardWidgets: [CounterType] { Self.allCases }
+        static var defaultWidgets: [CounterType] { Self.allCases }
         
         var appearance: CounterAppearance {
             switch self {
@@ -109,7 +117,16 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             leading: [.counter(.score)],
             trailing: [.action(.save), .action(.reply)],
             readouts: [.created, .comment],
-            availableWidgets: .init(CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) })
+            availableWidgets: .init(CounterType.defaultWidgets.map { .counter($0) } + ActionType.defaultWidgets.map { .action($0) })
+        )
+    }
+    
+    static var reportDefault: Self {
+        .init(
+            leading: [.counter(.score)],
+            trailing: [.action(.save), .action(.reply)],
+            readouts: [.created, .comment],
+            availableWidgets: .init(ActionType.defaultReportWidgets.map { .action($0) })
         )
     }
 }

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 struct PostBarConfiguration: InteractionBarConfiguration {
     enum ActionType: String, ActionTypeProviding {
@@ -101,7 +102,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
     var readouts: [ReadoutType]
     
     var availableWidgets: Set<Item>
-    var widgetPickerPage: SettingsPage { .postBarWidgetPicker }
+    func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage { .postBarWidgetPicker(configuration) }
     
     // TODO: NOW decoder initializers
     

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -139,8 +139,8 @@ struct PostBarConfiguration: InteractionBarConfiguration {
     
     static var reportDefault: Self {
         .init(
-            leading: [.counter(.score)],
-            trailing: [.action(.save), .action(.reply)],
+            leading: [.action(.share), .action(.pin)],
+            trailing: [.action(.lock), .action(.remove)],
             readouts: [.created, .comment],
             availableWidgets: .init(ActionType.defaultReportWidgets.map { .action($0) })
         )

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -90,6 +90,22 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
     var availableWidgets: Set<Item>
     func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage { .replyBarWidgetPicker(configuration) }
     
+    init(leading: [Item], trailing: [Item], readouts: [ReadoutType], availableWidgets: Set<Item>) {
+        self.leading = leading
+        self.trailing = trailing
+        self.readouts = readouts
+        self.availableWidgets = availableWidgets
+    }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.leading = try container.decodeIfPresent([Item].self, forKey: .leading) ?? [.counter(.score)]
+        self.trailing = try container.decodeIfPresent([Item].self, forKey: .trailing) ?? [.action(.save), .action(.reply)]
+        self.readouts = try container.decodeIfPresent([ReadoutType].self, forKey: .readouts) ?? [.created, .comment]
+        self.availableWidgets = try container.decodeIfPresent(Set<Item>.self, forKey: .availableWidgets) ??
+            .init(CounterType.defaultWidgets.map { .counter($0) } + ActionType.defaultWidgets.map { .action($0) })
+    }
+    
     static var `default`: Self {
         .init(
             leading: [.counter(.score)],

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUICore
 
 struct ReplyBarConfiguration: InteractionBarConfiguration {
     enum ActionType: String, ActionTypeProviding {
@@ -87,7 +88,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
     var readouts: [ReadoutType]
     
     var availableWidgets: Set<Item>
-    var widgetPickerPage: SettingsPage { .replyBarWidgetPicker }
+    func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage { .replyBarWidgetPicker(configuration) }
     
     static var `default`: Self {
         .init(

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -17,6 +17,14 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
         case selectText
         case report
         
+        static var standardWidgets: [ActionType] {[
+            .upvote,
+            .downvote,
+            .save,
+            .reply,
+            .markRead
+        ]}
+        
         var appearance: ActionAppearance {
             switch self {
             case .upvote: .upvote(isOn: false)
@@ -35,6 +43,8 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
         case upvote
         case downvote
         case reply
+        
+        static var standardWidgets: [CounterType] { Self.allCases }
         
         var appearance: CounterAppearance {
             switch self {
@@ -76,11 +86,15 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
     var trailing: [Item]
     var readouts: [ReadoutType]
     
+    var availableWidgets: [Item]
+    var widgetPickerPage: SettingsPage { .replyBarWidgetPicker }
+    
     static var `default`: Self {
         .init(
             leading: [.counter(.score)],
             trailing: [.action(.save), .action(.reply)],
-            readouts: [.created, .comment]
+            readouts: [.created, .comment],
+            availableWidgets: CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) }
         )
     }
 }

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -86,7 +86,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
     var trailing: [Item]
     var readouts: [ReadoutType]
     
-    var availableWidgets: [Item]
+    var availableWidgets: Set<Item>
     var widgetPickerPage: SettingsPage { .replyBarWidgetPicker }
     
     static var `default`: Self {
@@ -94,7 +94,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             leading: [.counter(.score)],
             trailing: [.action(.save), .action(.reply)],
             readouts: [.created, .comment],
-            availableWidgets: CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) }
+            availableWidgets: .init(CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) })
         )
     }
 }

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -18,7 +18,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
         case selectText
         case report
         
-        static var standardWidgets: [ActionType] {[
+        static var defaultWidgets: [ActionType] {[
             .upvote,
             .downvote,
             .save,
@@ -45,7 +45,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
         case downvote
         case reply
         
-        static var standardWidgets: [CounterType] { Self.allCases }
+        static var defaultWidgets: [CounterType] { Self.allCases }
         
         var appearance: CounterAppearance {
             switch self {
@@ -95,7 +95,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             leading: [.counter(.score)],
             trailing: [.action(.save), .action(.reply)],
             readouts: [.created, .comment],
-            availableWidgets: .init(CounterType.standardWidgets.map { .counter($0) } + ActionType.standardWidgets.map { .action($0) })
+            availableWidgets: .init(CounterType.defaultWidgets.map { .counter($0) } + ActionType.defaultWidgets.map { .action($0) })
         )
     }
 }

--- a/Mlem/App/Models/Action/Counter.swift
+++ b/Mlem/App/Models/Action/Counter.swift
@@ -19,7 +19,8 @@ struct Counter: Identifiable {
             value: value,
             leading: leadingAction?.appearance,
             trailing: trailingAction?.appearance,
-            label: "Unknown"
+            label: "Unknown",
+            singleIcon: ""
         )
     }
 }

--- a/Mlem/App/Models/Action/CounterAppearance.swift
+++ b/Mlem/App/Models/Action/CounterAppearance.swift
@@ -12,4 +12,5 @@ struct CounterAppearance {
     let leading: ActionAppearance?
     let trailing: ActionAppearance?
     let label: LocalizedStringResource
+    let singleIcon: String
 }

--- a/Mlem/App/Models/Action/CounterApperance+StaticValues.swift
+++ b/Mlem/App/Models/Action/CounterApperance+StaticValues.swift
@@ -11,19 +11,20 @@ extension CounterAppearance {
             value: value,
             leading: .upvote(isOn: upvoteOn),
             trailing: .downvote(isOn: downvoteOn),
-            label: "Score Counter"
+            label: "Score Counter",
+            singleIcon: Icons.scoreCounter
         )
     }
     
     static func upvote(value: Int = 9, isOn: Bool = false) -> CounterAppearance {
-        .init(value: value, leading: .upvote(isOn: isOn), trailing: nil, label: "Upvote Counter")
+        .init(value: value, leading: .upvote(isOn: isOn), trailing: nil, label: "Upvote Counter", singleIcon: Icons.upvoteCounter)
     }
     
     static func downvote(value: Int = 2, isOn: Bool = false) -> CounterAppearance {
-        .init(value: value, leading: .downvote(isOn: isOn), trailing: nil, label: "Downvote Counter")
+        .init(value: value, leading: .downvote(isOn: isOn), trailing: nil, label: "Downvote Counter", singleIcon: Icons.downvoteCounter)
     }
     
     static func reply(value: Int = 3) -> CounterAppearance {
-        .init(value: value, leading: .reply(), trailing: nil, label: "Reply Counter")
+        .init(value: value, leading: .reply(), trailing: nil, label: "Reply Counter", singleIcon: Icons.replyCounter)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Logic.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Logic.swift
@@ -199,17 +199,14 @@ extension InteractionBarEditorView {
     func removeFromBar(barItem: BarItem) {
         // no removing the info stack
         guard let item = barItem.item else { return }
-        guard let trayItem = trayItems.first(where: { $0.item == item }) else {
-            assertionFailure("Could not find \(item) in tray!")
-            return
-        }
+        let trayItem = trayItems.first(where: { $0.item == item })
         
         HapticManager.main.play(haptic: .firmInfo, priority: .high)
         
         // smoothly animate away
         barItem.hide()
         withAnimation(.easeInOut(duration: barAnimationDuration)) {
-            trayItem.show()
+            trayItem?.show()
             barItem.collapse()
         }
         

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Logic.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Logic.swift
@@ -228,7 +228,8 @@ extension InteractionBarEditorView {
         configuration = .init(
             leading: barItems[..<infoStackIndex].compactMap(\.item),
             trailing: barItems[infoStackIndex...].compactMap(\.item),
-            readouts: configuration.readouts
+            readouts: configuration.readouts,
+            availableWidgets: configuration.availableWidgets
         )
     }
     

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
@@ -71,6 +71,7 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
             }
         }
         .onChange(of: configuration.availableWidgets, initial: true) {
+            onSet(configuration)
             let configurationItems: [Configuration.Item?] = configuration.leading + [nil] + configuration.trailing
             trayItems = Configuration.Item.allCases
                 .filter { configuration.availableWidgets.contains($0) }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
@@ -66,7 +66,7 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
             Divider()
             tray.zIndex(trayPickedUpItem == nil ? 0 : 1)
             
-            Button("More Widgets") {
+            Button("More Widgets...") {
                 navigation.openSheet(.settings(configuration.widgetPickerPage($configuration)))
             }
         }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: View {
     @Environment(Palette.self) var palette
+    @Environment(NavigationLayer.self) var navigation
     
     @State var configuration: Configuration {
         didSet {
@@ -67,6 +68,10 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
             readoutSelectors
             Divider()
             tray.zIndex(trayPickedUpItem == nil ? 0 : 1)
+            
+            Button("More") {
+                navigation.openSheet(.settings(.postBarWidgetPicker))
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(Constants.main.standardSpacing)

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
@@ -45,9 +45,12 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
         self._barItems = .init(wrappedValue: configurationItems.map { item in
             .init(item: item, expanded: true, visible: true)
         })
-        self._trayItems = .init(wrappedValue: Configuration.Item.allCases.map { item in
+        self._trayItems = .init(wrappedValue: configuration.availableWidgets.map { item in
             TrayItem(item: item, visible: !configurationItems.contains(item))
         })
+//        self._trayItems = .init(wrappedValue: Configuration.Item.allCases.map { item in
+//            TrayItem(item: item, visible: !configurationItems.contains(item))
+//        })
     }
     
     init(setting: WritableKeyPath<InteractionBarTracker, Configuration>) {
@@ -70,7 +73,7 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
             tray.zIndex(trayPickedUpItem == nil ? 0 : 1)
             
             Button("More") {
-                navigation.openSheet(.settings(.postBarWidgetPicker))
+                navigation.openSheet(.settings(configuration.widgetPickerPage))
             }
         }
         .frame(maxWidth: .infinity)

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
@@ -18,7 +18,7 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
         }
     }
     
-    @State var trayItems: [TrayItem]
+    @State var trayItems: [TrayItem] = .init()
     @State var barItems: [BarItem] = .init()
     
     @State var barPickedUpItem: (barItem: BarItem, index: Int)?
@@ -45,9 +45,6 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
         self._barItems = .init(wrappedValue: configurationItems.map { item in
             .init(item: item, expanded: true, visible: true)
         })
-        self._trayItems = .init(wrappedValue: Configuration.Item.allCases
-            .filter { configuration.availableWidgets.contains($0) }
-            .map { TrayItem(item: $0, visible: !configurationItems.contains($0)) })
     }
     
     init(setting: WritableKeyPath<InteractionBarTracker, Configuration>) {
@@ -70,11 +67,14 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
             tray.zIndex(trayPickedUpItem == nil ? 0 : 1)
             
             Button("More") {
-                navigation.openSheet(.settings(configuration.widgetPickerPage))
+                navigation.openSheet(.settings(configuration.widgetPickerPage($configuration)))
             }
         }
-        .onChange(of: configuration.availableWidgets) {
-            print("new widgets available")
+        .onChange(of: configuration.availableWidgets, initial: true) {
+            let configurationItems: [Configuration.Item?] = configuration.leading + [nil] + configuration.trailing
+            trayItems = Configuration.Item.allCases
+                .filter { configuration.availableWidgets.contains($0) }
+                .map { TrayItem(item: $0, visible: !configurationItems.contains($0)) }
         }
         .frame(maxWidth: .infinity)
         .padding(Constants.main.standardSpacing)

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
@@ -66,7 +66,7 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
             Divider()
             tray.zIndex(trayPickedUpItem == nil ? 0 : 1)
             
-            Button("More") {
+            Button("More Widgets") {
                 navigation.openSheet(.settings(configuration.widgetPickerPage($configuration)))
             }
         }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
@@ -45,12 +45,9 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
         self._barItems = .init(wrappedValue: configurationItems.map { item in
             .init(item: item, expanded: true, visible: true)
         })
-        self._trayItems = .init(wrappedValue: configuration.availableWidgets.map { item in
-            TrayItem(item: item, visible: !configurationItems.contains(item))
-        })
-//        self._trayItems = .init(wrappedValue: Configuration.Item.allCases.map { item in
-//            TrayItem(item: item, visible: !configurationItems.contains(item))
-//        })
+        self._trayItems = .init(wrappedValue: Configuration.Item.allCases
+            .filter { configuration.availableWidgets.contains($0) }
+            .map { TrayItem(item: $0, visible: !configurationItems.contains($0)) })
     }
     
     init(setting: WritableKeyPath<InteractionBarTracker, Configuration>) {
@@ -75,6 +72,9 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
             Button("More") {
                 navigation.openSheet(.settings(configuration.widgetPickerPage))
             }
+        }
+        .onChange(of: configuration.availableWidgets) {
+            print("new widgets available")
         }
         .frame(maxWidth: .infinity)
         .padding(Constants.main.standardSpacing)

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -37,15 +37,12 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
     @ViewBuilder
     func widgetButton(_ item: Configuration.Item) -> some View {
         // swiftlint:disable:next large_tuple
-        let (selected, label, icon): (Bool, String, String) = switch item {
+        let selected = configuration.availableWidgets.contains(item)
+        let (label, icon): (String, String) = switch item {
         case let .action(action):
-            (configuration.availableWidgets.contains(.action(action)),
-             action.appearance.label,
-             action.appearance.barIcon)
+             (action.appearance.label, action.appearance.barIcon)
         case let .counter(counter):
-            (configuration.availableWidgets.contains(.counter(counter)),
-             .init(localized: counter.appearance.label),
-             counter.appearance.singleIcon)
+             (.init(localized: counter.appearance.label), counter.appearance.singleIcon)
         }
         
         Button {

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration>: View {
     @Environment(Palette.self) var palette
+    @Environment(\.dismiss) var dismiss
     
     @Binding var configuration: Configuration
     
@@ -29,6 +30,13 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
             Section("Counters") {
                 ForEach(Array(Configuration.CounterType.allCases), id: \.self) { item in
                     widgetButton(.counter(item))
+                }
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                CloseButtonView {
+                    dismiss()
                 }
             }
         }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -11,18 +11,7 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
     @Environment(Palette.self) var palette
     @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor: Bool
     
-    @State var configuration: Configuration {
-        didSet {
-            onSet(configuration)
-        }
-    }
-    
-    let onSet: (Configuration) -> Void
-    
-    init(configuration: Configuration, onSet: @escaping (Configuration) -> Void) {
-        self.configuration = configuration
-        self.onSet = onSet
-    }
+    @Binding var configuration: Configuration
     
     var body: some View {
         Form {
@@ -65,13 +54,6 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
                     Label(String(localized: item.appearance.label), systemImage: item.appearance.leading?.barIcon ?? "globe")
                 }
             }
-        }
-    }
-    
-    init(setting: WritableKeyPath<InteractionBarTracker, Configuration>) {
-        self.init(configuration: InteractionBarTracker.main[keyPath: setting]) {
-            var main = InteractionBarTracker.main
-            main[keyPath: setting] = $0
         }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -22,69 +22,58 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
             
             Section("Actions") {
                 ForEach(Array(Configuration.ActionType.allCases), id: \.self) { item in
-                    let selected: Bool = configuration.availableWidgets.contains(.action(item))
-                    Button {
-                        if selected {
-                            configuration.availableWidgets.remove(.action(item))
-                        } else {
-                            configuration.availableWidgets.insert(.action(item))
-                        }
-                    } label: {
-                        HStack {
-                            Label {
-                                Text(item.appearance.label)
-                            } icon: {
-                                Image(systemName: item.appearance.barIcon)
-                                    .foregroundStyle(selected ? palette.accent : palette.secondary)
-                            }
-                            
-                            Spacer()
-                            
-                            if selected {
-                                Image(systemName: Icons.success)
-                                    .foregroundStyle(palette.accent)
-                                    .contentTransition(.symbolEffect(.replace, options: .speed(2)))
-                            }
-                        }
-                        .frame(maxWidth: .infinity)
-                        .contentShape(.rect)
-                    }
-                    .buttonStyle(.plain)
+                    widgetButton(.action(item))
                 }
             }
             
             Section("Counters") {
                 ForEach(Array(Configuration.CounterType.allCases), id: \.self) { item in
-                    let selected: Bool = configuration.availableWidgets.contains(.counter(item))
-                    Button {
-                        if selected {
-                            configuration.availableWidgets.remove(.counter(item))
-                        } else {
-                            configuration.availableWidgets.insert(.counter(item))
-                        }
-                    } label: {
-                        HStack {
-                            Label {
-                                Text(item.appearance.label)
-                            } icon: {
-                                Image(systemName: item.appearance.singleIcon)
-                                    .foregroundStyle(selected ? palette.accent : palette.secondary)
-                            }
-                            
-                            Spacer()
-                            
-                            if selected {
-                                Image(systemName: Icons.success)
-                                    .foregroundStyle(palette.accent)
-                                    .contentTransition(.symbolEffect(.replace, options: .speed(2)))
-                            }
-                        }
-                        .frame(maxWidth: .infinity)
-                        .contentShape(.rect)
-                    }
-                    .buttonStyle(.plain)
+                    widgetButton(.counter(item))
                 }
             }
         }
+    }
+    
+    @ViewBuilder
+    func widgetButton(_ item: Configuration.Item) -> some View {
+        // swiftlint:disable:next large_tuple
+        let (selected, label, icon): (Bool, String, String) = switch item {
+        case let .action(action):
+            (configuration.availableWidgets.contains(.action(action)),
+             action.appearance.label,
+             action.appearance.barIcon)
+        case let .counter(counter):
+            (configuration.availableWidgets.contains(.counter(counter)),
+             .init(localized: counter.appearance.label),
+             counter.appearance.singleIcon)
+        }
+        
+        Button {
+            if selected {
+                configuration.availableWidgets.remove(item)
+            } else {
+                configuration.availableWidgets.insert(item)
+            }
+        } label: {
+            HStack {
+                Label {
+                    Text(label)
+                } icon: {
+                    Image(systemName: icon)
+                        .foregroundStyle(selected ? palette.accent : palette.secondary)
+                }
+                
+                Spacer()
+                
+                if selected {
+                    Image(systemName: Icons.success)
+                        .foregroundStyle(palette.accent)
+                        .contentTransition(.symbolEffect(.replace, options: .speed(2)))
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -8,18 +8,55 @@
 import SwiftUI
 
 struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration>: View {
+    @Environment(Palette.self) var palette
+    @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor: Bool
     
-    @State var configuration: Configuration
+    @State var configuration: Configuration {
+        didSet {
+            onSet(configuration)
+        }
+    }
     
-    init(configuration: Configuration) {
+    let onSet: (Configuration) -> Void
+    
+    init(configuration: Configuration, onSet: @escaping (Configuration) -> Void) {
         self.configuration = configuration
+        self.onSet = onSet
     }
     
     var body: some View {
         Form {
+            Section {
+                Text("Select which widgets to display in your palette")
+            }
+            
             Section("Actions") {
                 ForEach(Array(Configuration.ActionType.allCases), id: \.self) { item in
-                    Label(item.appearance.label, systemImage: item.appearance.barIcon)
+                    let selected: Bool = configuration.availableWidgets.contains(.action(item))
+                    Button {
+                        if selected {
+                            configuration.availableWidgets.remove(.action(item))
+                        } else {
+                            configuration.availableWidgets.insert(.action(item))
+                        }
+                    } label: {
+                        HStack {
+                            Label {
+                                Text(item.appearance.label)
+                            } icon: {
+                                Image(systemName: item.appearance.barIcon)
+                                    .foregroundStyle(selected ? palette.accent : palette.secondary)
+                            }
+                            
+                            Spacer()
+                            
+                            if differentiateWithoutColor, selected {
+                                Image(systemName: Icons.success)
+                                    .foregroundStyle(palette.accent)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
                 }
             }
             
@@ -28,33 +65,13 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
                     Label(String(localized: item.appearance.label), systemImage: item.appearance.leading?.barIcon ?? "globe")
                 }
             }
-            
-//            ForEach(Configuration.Item.allCases, id: \.self) { item in
-//                Button {
-//                    switch item {
-//                    case let .action(action):
-//                        print(action.appearance.label)
-//                    case let .counter(counter):
-//                        print(counter.appearance.label)
-//                    }
-//                    // print(item.description)
-//                } label: {
-//                    HStack(spacing: Constants.main.standardSpacing) {
-//                        switch item {
-//                        case let .action(action):
-//                            HStack {
-//                                Image(systemName: action.appearance.barIcon)
-//                            }
-//                        case .counter:
-//                            Text("counter")
-//                        }
-//                    }
-//                }
-//            }
         }
     }
     
     init(setting: WritableKeyPath<InteractionBarTracker, Configuration>) {
-        self.init(configuration: InteractionBarTracker.main[keyPath: setting])
+        self.init(configuration: InteractionBarTracker.main[keyPath: setting]) {
+            var main = InteractionBarTracker.main
+            main[keyPath: setting] = $0
+        }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -35,9 +35,7 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
         }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                CloseButtonView {
-                    dismiss()
-                }
+                CloseButtonView()
             }
         }
     }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -8,6 +8,13 @@
 import SwiftUI
 
 struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration>: View {
+    
+    @State var configuration: Configuration
+    
+    init(configuration: Configuration) {
+        self.configuration = configuration
+    }
+    
     var body: some View {
         Form {
             Section("Actions") {
@@ -47,5 +54,7 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
         }
     }
     
-    // TODO: custom inits
+    init(setting: WritableKeyPath<InteractionBarTracker, Configuration>) {
+        self.init(configuration: InteractionBarTracker.main[keyPath: setting])
+    }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration>: View {
     @Environment(Palette.self) var palette
-    @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor: Bool
     
     @Binding var configuration: Configuration
     
@@ -17,6 +16,8 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
         Form {
             Section {
                 Text("Select which widgets to display in your palette")
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
             
             Section("Actions") {
@@ -39,11 +40,14 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
                             
                             Spacer()
                             
-                            if differentiateWithoutColor, selected {
+                            if selected {
                                 Image(systemName: Icons.success)
                                     .foregroundStyle(palette.accent)
+                                    .contentTransition(.symbolEffect(.replace, options: .speed(2)))
                             }
                         }
+                        .frame(maxWidth: .infinity)
+                        .contentShape(.rect)
                     }
                     .buttonStyle(.plain)
                 }
@@ -51,7 +55,34 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
             
             Section("Counters") {
                 ForEach(Array(Configuration.CounterType.allCases), id: \.self) { item in
-                    Label(String(localized: item.appearance.label), systemImage: item.appearance.leading?.barIcon ?? "globe")
+                    let selected: Bool = configuration.availableWidgets.contains(.counter(item))
+                    Button {
+                        if selected {
+                            configuration.availableWidgets.remove(.counter(item))
+                        } else {
+                            configuration.availableWidgets.insert(.counter(item))
+                        }
+                    } label: {
+                        HStack {
+                            Label {
+                                Text(item.appearance.label)
+                            } icon: {
+                                Image(systemName: item.appearance.singleIcon)
+                                    .foregroundStyle(selected ? palette.accent : palette.secondary)
+                            }
+                            
+                            Spacer()
+                            
+                            if selected {
+                                Image(systemName: Icons.success)
+                                    .foregroundStyle(palette.accent)
+                                    .contentTransition(.symbolEffect(.replace, options: .speed(2)))
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .contentShape(.rect)
+                    }
+                    .buttonStyle(.plain)
                 }
             }
         }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -38,6 +38,7 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
                 CloseButtonView()
             }
         }
+        .contentMargins(.top, 0)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -36,7 +36,6 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
     
     @ViewBuilder
     func widgetButton(_ item: Configuration.Item) -> some View {
-        // swiftlint:disable:next large_tuple
         let selected = configuration.availableWidgets.contains(item)
         let (label, icon): (String, String) = switch item {
         case let .action(action):

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -1,0 +1,51 @@
+//
+//  InteractionBarWidgetPickerView.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2025-02-12.
+//
+
+import SwiftUI
+
+struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration>: View {
+    var body: some View {
+        Form {
+            Section("Actions") {
+                ForEach(Array(Configuration.ActionType.allCases), id: \.self) { item in
+                    Label(item.appearance.label, systemImage: item.appearance.barIcon)
+                }
+            }
+            
+            Section("Counters") {
+                ForEach(Array(Configuration.CounterType.allCases), id: \.self) { item in
+                    Label(String(localized: item.appearance.label), systemImage: item.appearance.leading?.barIcon ?? "globe")
+                }
+            }
+            
+//            ForEach(Configuration.Item.allCases, id: \.self) { item in
+//                Button {
+//                    switch item {
+//                    case let .action(action):
+//                        print(action.appearance.label)
+//                    case let .counter(counter):
+//                        print(counter.appearance.label)
+//                    }
+//                    // print(item.description)
+//                } label: {
+//                    HStack(spacing: Constants.main.standardSpacing) {
+//                        switch item {
+//                        case let .action(action):
+//                            HStack {
+//                                Image(systemName: action.appearance.barIcon)
+//                            }
+//                        case .counter:
+//                            Text("counter")
+//                        }
+//                    }
+//                }
+//            }
+        }
+    }
+    
+    // TODO: custom inits
+}

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -15,7 +15,7 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
     var body: some View {
         Form {
             Section {
-                Text("Select which widgets to display in your palette")
+                Text("Choose which widgets to display in your palette.")
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity, alignment: .center)
             }

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -27,7 +27,11 @@ enum SettingsPage: Hashable {
     case inboxBadge
     case about, advanced, developer, errorLog
     case postInteractionBar, commentInteractionBar, replyInteractionBar, postReportInteractionBar, commentReportInteractionBar
-    case postBarWidgetPicker, commentBarWidgetPicker, replyBarWidgetPicker, postReportBarWidgetPicker, commentReportBarWidgetPicker
+    case postBarWidgetPicker(HashWrapper<Binding<PostBarConfiguration>>)
+    case commentBarWidgetPicker(HashWrapper<Binding<CommentBarConfiguration>>)
+    case replyBarWidgetPicker(HashWrapper<Binding<ReplyBarConfiguration>>)
+    case postReportBarWidgetPicker(HashWrapper<Binding<PostBarConfiguration>>)
+    case commentReportBarWidgetPicker(HashWrapper<Binding<CommentBarConfiguration>>)
     case moderation
     case modMailInteractionBar
     case separateModeratorActions
@@ -139,24 +143,24 @@ enum SettingsPage: Hashable {
             InboxBadgeSettingsView()
         case .postInteractionBar:
             InteractionBarEditorView(setting: \.postInteractionBar)
-        case .postBarWidgetPicker:
-            InteractionBarWidgetPickerView(setting: \.postInteractionBar)
+        case let .postBarWidgetPicker(configuration):
+            InteractionBarWidgetPickerView<PostBarConfiguration>(configuration: configuration.wrappedValue)
         case .commentInteractionBar:
             InteractionBarEditorView(setting: \.commentInteractionBar)
-        case.commentBarWidgetPicker:
-            InteractionBarWidgetPickerView(setting: \.commentInteractionBar)
+        case let .commentBarWidgetPicker(configuration):
+            InteractionBarWidgetPickerView<CommentBarConfiguration>(configuration: configuration.wrappedValue)
         case .replyInteractionBar:
             InteractionBarEditorView(setting: \.replyInteractionBar)
-        case .replyBarWidgetPicker:
-            InteractionBarWidgetPickerView(setting: \.replyInteractionBar)
+        case let .replyBarWidgetPicker(configuration):
+            InteractionBarWidgetPickerView<ReplyBarConfiguration>(configuration: configuration.wrappedValue)
         case .postReportInteractionBar:
             InteractionBarEditorView(setting: \.postReportInteractionBar)
-        case .postReportBarWidgetPicker:
-            InteractionBarWidgetPickerView(setting: \.postReportInteractionBar)
+        case let .postReportBarWidgetPicker(configuration):
+            InteractionBarWidgetPickerView<PostBarConfiguration>(configuration: configuration.wrappedValue)
         case .commentReportInteractionBar:
             InteractionBarEditorView(setting: \.commentReportInteractionBar)
-        case .commentReportBarWidgetPicker:
-            InteractionBarWidgetPickerView(setting: \.commentReportInteractionBar)
+        case let .commentReportBarWidgetPicker(configuration):
+            InteractionBarWidgetPickerView<CommentBarConfiguration>(configuration: configuration.wrappedValue)
         case let .document(doc):
             SimpleMarkdownPage(doc: doc)
         case .licences:
@@ -166,6 +170,26 @@ enum SettingsPage: Hashable {
                 }
             }
         }
+    }
+    
+    static func postBarWidgetPicker(_ configuration: Binding<PostBarConfiguration>) -> SettingsPage {
+        .postBarWidgetPicker(.init(wrappedValue: configuration))
+    }
+    
+    static func commentBarWidgetPicker(_ configuration: Binding<CommentBarConfiguration>) -> SettingsPage {
+        .commentBarWidgetPicker(.init(wrappedValue: configuration))
+    }
+    
+    static func replyBarWidgetPicker(_ configuration: Binding<ReplyBarConfiguration>) -> SettingsPage {
+        .replyBarWidgetPicker(.init(wrappedValue: configuration))
+    }
+    
+    static func postReportBarWidgetPicker(_ configuration: Binding<PostBarConfiguration>) -> SettingsPage {
+        .postReportBarWidgetPicker(.init(wrappedValue: configuration))
+    }
+    
+    static func commentReportBarWidgetPicker(_ configuration: Binding<CommentBarConfiguration>) -> SettingsPage {
+        .commentReportBarWidgetPicker(.init(wrappedValue: configuration))
     }
 }
 

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -27,6 +27,7 @@ enum SettingsPage: Hashable {
     case inboxBadge
     case about, advanced, developer, errorLog
     case postInteractionBar, commentInteractionBar, replyInteractionBar, postReportInteractionBar, commentReportInteractionBar
+    case postBarWidgetPicker
     case moderation
     case modMailInteractionBar
     case separateModeratorActions
@@ -138,6 +139,8 @@ enum SettingsPage: Hashable {
             InboxBadgeSettingsView()
         case .postInteractionBar:
             InteractionBarEditorView(setting: \.postInteractionBar)
+        case .postBarWidgetPicker:
+            InteractionBarWidgetPickerView<PostBarConfiguration>()
         case .commentInteractionBar:
             InteractionBarEditorView(setting: \.commentInteractionBar)
         case .replyInteractionBar:

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -27,7 +27,7 @@ enum SettingsPage: Hashable {
     case inboxBadge
     case about, advanced, developer, errorLog
     case postInteractionBar, commentInteractionBar, replyInteractionBar, postReportInteractionBar, commentReportInteractionBar
-    case postBarWidgetPicker
+    case postBarWidgetPicker, commentBarWidgetPicker, replyBarWidgetPicker, postReportBarWidgetPicker, commentReportBarWidgetPicker
     case moderation
     case modMailInteractionBar
     case separateModeratorActions
@@ -140,15 +140,23 @@ enum SettingsPage: Hashable {
         case .postInteractionBar:
             InteractionBarEditorView(setting: \.postInteractionBar)
         case .postBarWidgetPicker:
-            InteractionBarWidgetPickerView<PostBarConfiguration>()
+            InteractionBarWidgetPickerView(setting: \.postInteractionBar)
         case .commentInteractionBar:
             InteractionBarEditorView(setting: \.commentInteractionBar)
+        case.commentBarWidgetPicker:
+            InteractionBarWidgetPickerView(setting: \.commentInteractionBar)
         case .replyInteractionBar:
             InteractionBarEditorView(setting: \.replyInteractionBar)
+        case .replyBarWidgetPicker:
+            InteractionBarWidgetPickerView(setting: \.replyInteractionBar)
         case .postReportInteractionBar:
             InteractionBarEditorView(setting: \.postReportInteractionBar)
+        case .postReportBarWidgetPicker:
+            InteractionBarWidgetPickerView(setting: \.postReportInteractionBar)
         case .commentReportInteractionBar:
             InteractionBarEditorView(setting: \.commentReportInteractionBar)
+        case .commentReportBarWidgetPicker:
+            InteractionBarWidgetPickerView(setting: \.commentReportInteractionBar)
         case let .document(doc):
             SimpleMarkdownPage(doc: doc)
         case .licences:

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -2126,6 +2126,9 @@
     "Select Text" : {
 
     },
+    "Select which widgets to display in your palette" : {
+
+    },
     "Send" : {
 
     },

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -273,6 +273,9 @@
     "Action Type" : {
 
     },
+    "Actions" : {
+
+    },
     "Active" : {
 
     },
@@ -762,6 +765,9 @@
 
     },
     "Couldn't read URL" : {
+
+    },
+    "Counters" : {
 
     },
     "Crosspost" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1513,6 +1513,9 @@
     "More Replies" : {
 
     },
+    "More Widgets" : {
+
+    },
     "More..." : {
 
     },

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -619,6 +619,9 @@
     "Choose which languages appear in your feed. Posts and comments in other languages will be hidden." : {
 
     },
+    "Choose which widgets to display in your palette." : {
+
+    },
     "Choose wisely - you cannot change this later." : {
 
     },
@@ -1513,7 +1516,7 @@
     "More Replies" : {
 
     },
-    "More Widgets" : {
+    "More Widgets..." : {
 
     },
     "More..." : {
@@ -2130,9 +2133,6 @@
 
     },
     "Select Text" : {
-
-    },
-    "Select which widgets to display in your palette" : {
 
     },
     "Send" : {


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1724 

## Description

Hides uncommon widgets behind a "more widgets" button which pops a picker sheet to customize the widget palette.

## Implementation Notes

The widget palette is tracked and persisted as part of the relevant `InteractionBarConfiguration` under `availableWidgets`