### PR TITLE
Remember last active account when opening app

### DIFF
--- a/Mlem/App/Globals/Definitions/AccountsTracker.swift
+++ b/Mlem/App/Globals/Definitions/AccountsTracker.swift
@@ -36,7 +36,7 @@ class AccountsTracker {
         if let lastUsedAccount = sorted.last {
             return lastUsedAccount
         }
-        return defaultGuestAccount
+        return userAccounts.first() ?? defaultGuestAccount
     }
     
     var defaultGuestAccount: GuestAccount {

--- a/Mlem/App/Globals/Definitions/AccountsTracker.swift
+++ b/Mlem/App/Globals/Definitions/AccountsTracker.swift
@@ -25,11 +25,24 @@ class AccountsTracker {
     
     var userAccounts: [UserAccount] = .init()
     var guestAccounts: [GuestAccount] = .init()
-    var defaultAccount: any Account { userAccounts.first ?? defaultGuestAccount }
+    
+    // Used on startup to determine which account should be made active
+    func mostRecentAccount() -> any Account {
+        var allAccounts: [any Account] = userAccounts + guestAccounts
+        if let activeAccount = allAccounts.first(where: { $0.activityState == .active }) {
+            return activeAccount
+        }
+        let sorted = allAccounts.sorted(by: { $0.activityState.lastUsed ?? .distantPast < $1.activityState.lastUsed ?? .distantPast })
+        if let lastUsedAccount = sorted.last {
+            return lastUsedAccount
+        }
+        return defaultGuestAccount
+    }
+    
     var defaultGuestAccount: GuestAccount {
         // This will never fail because we're passing a literal URL that is known to always succeed
         // swiftlint:disable:next force_try
-        try! (guestAccounts.first ?? .getGuestAccount(url: URL(string: "https://lemmy.world/")!))
+        try! GuestAccount.getGuestAccount(url: URL(string: "https://lemmy.world/")!)
     }
     
     var isEmpty: Bool { userAccounts.isEmpty && guestAccounts.isEmpty }

--- a/Mlem/App/Globals/Definitions/AccountsTracker.swift
+++ b/Mlem/App/Globals/Definitions/AccountsTracker.swift
@@ -36,7 +36,7 @@ class AccountsTracker {
         if let lastUsedAccount = sorted.last {
             return lastUsedAccount
         }
-        return userAccounts.first() ?? defaultGuestAccount
+        return userAccounts.first ?? defaultGuestAccount
     }
     
     var defaultGuestAccount: GuestAccount {

--- a/Mlem/App/Globals/Definitions/AppState.swift
+++ b/Mlem/App/Globals/Definitions/AppState.swift
@@ -39,7 +39,7 @@ class AppState {
     
     private init() {
         self.guestSession = .init(account: AccountsTracker.main.defaultGuestAccount)
-        setAccount(to: AccountsTracker.main.defaultAccount)
+        setAccount(to: AccountsTracker.main.mostRecentAccount())
     }
     
     /// If `keepPlace` is `nil`, use the value from `UserDefaults`.
@@ -108,7 +108,7 @@ class AppState {
             guard account == guestSession.account else { return }
             guestSession = .init(account: AccountsTracker.main.defaultGuestAccount)
         }
-        changeAccount(to: AccountsTracker.main.defaultAccount)
+        changeAccount(to: AccountsTracker.main.mostRecentAccount())
     }
     
     var firstSession: any Session { activeSessions.first ?? guestSession }

--- a/Mlem/App/Models/Account/Account.swift
+++ b/Mlem/App/Models/Account/Account.swift
@@ -17,7 +17,7 @@ protocol Account: AnyObject, Codable, ActorIdentifiable, Profile1Providing, Hash
     var storedNickname: String? { get }
     var cachedSiteVersion: SiteVersion? { get }
     var avatar: URL? { get }
-    var lastUsed: Date? { get set }
+    var activityState: AccountActivityState { get set }
     var accountType: AccountType { get }
     
     // Computed
@@ -28,6 +28,18 @@ protocol Account: AnyObject, Codable, ActorIdentifiable, Profile1Providing, Hash
     var uniqueStringId: String { get }
     
     func setNickname(_ newValue: String)
+}
+
+enum AccountActivityState: Codable, Hashable {
+    case inactive(lastUsed: Date?)
+    case active
+    
+    var lastUsed: Date? {
+        switch self {
+        case let .inactive(lastUsed: lastUsed): lastUsed
+        case .active: nil
+        }
+    }
 }
 
 // Profile1Providing conformance
@@ -50,8 +62,12 @@ extension Account {
         AccountsTracker.main.removeAccount(account: self)
     }
     
-    func logActivity() {
-        lastUsed = .now
+    func activate() {
+        activityState = .active
+    }
+    
+    func deactivate() {
+        activityState = .inactive(lastUsed: .now)
     }
     
     var nickname: String { storedNickname ?? name }

--- a/Mlem/App/Models/Account/GuestAccount.swift
+++ b/Mlem/App/Models/Account/GuestAccount.swift
@@ -17,12 +17,13 @@ class GuestAccount: Account {
     var storedNickname: String?
     var cachedSiteVersion: SiteVersion?
     var avatar: URL?
-    var lastUsed: Date?
+    var activityState: AccountActivityState
     let accountType: AccountType = .guest
     
     fileprivate init(url: URL) throws {
         guard let host = url.host() else { throw DecodingError.invalidHost }
         self.actorId = .instance(host: host)
+        self.activityState = .inactive(lastUsed: nil)
         self.api = .getApiClient(url: url, username: nil)
     }
     
@@ -32,7 +33,7 @@ class GuestAccount: Account {
     
     enum CodingKeys: String, CodingKey {
         // Keys are named this way to be consistent with the `UserAccount.CodingKey` cases
-        case storedNickname, instanceLink, siteVersion, avatarUrl, lastUsed
+        case storedNickname, instanceLink, siteVersion, avatarUrl, lastUsed, activityState
     }
     
     enum DecodingError: Error {
@@ -45,7 +46,13 @@ class GuestAccount: Account {
         self.storedNickname = try values.decode(String?.self, forKey: .storedNickname)
         self.cachedSiteVersion = try values.decode(SiteVersion?.self, forKey: .siteVersion)
         self.avatar = try values.decode(URL?.self, forKey: .avatarUrl)
-        self.lastUsed = try values.decode(Date?.self, forKey: .lastUsed)
+        
+        if let activityState = try values.decodeIfPresent(AccountActivityState.self, forKey: .activityState) {
+            self.activityState = activityState
+        } else {
+            let lastUsed = try values.decodeIfPresent(Date?.self, forKey: .lastUsed) ?? nil
+            self.activityState = .inactive(lastUsed: lastUsed)
+        }
 
         let actorId = try values.decode(ActorIdentifier.self, forKey: .instanceLink)
         self.actorId = actorId
@@ -58,7 +65,7 @@ class GuestAccount: Account {
         try container.encode(storedNickname, forKey: .storedNickname)
         try container.encode(cachedSiteVersion, forKey: .siteVersion)
         try container.encode(avatar, forKey: .avatarUrl)
-        try container.encode(lastUsed, forKey: .lastUsed)
+        try container.encode(activityState, forKey: .activityState)
         try container.encode(api.baseUrl, forKey: .instanceLink)
     }
     

--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -21,7 +21,7 @@ class UserAccount: Account, CommunityOrPerson {
     var storedNickname: String?
     var cachedSiteVersion: SiteVersion?
     var avatar: URL?
-    var lastUsed: Date?
+    var activityState: AccountActivityState
     var favorites: Set<Int>
     var visitHistoryEnabled: Bool
     var accountType: AccountType
@@ -34,7 +34,7 @@ class UserAccount: Account, CommunityOrPerson {
         self.storedNickname = nil
         self.cachedSiteVersion = instance.version
         self.avatar = person.avatar
-        self.lastUsed = .now
+        self.activityState = .inactive(lastUsed: nil)
         self.favorites = []
         self.visitHistoryEnabled = true
         self.accountType = person.moderatedCommunities.isEmpty ? .user : .moderator
@@ -42,7 +42,8 @@ class UserAccount: Account, CommunityOrPerson {
     
     enum CodingKeys: String, CodingKey {
         // These key names don't match the identifiers of their corresponding properties - this is because these key names must match the property names used in SavedAccount pre-1.3 in order to maintain compatibility
-        case id, username, storedNickname, instanceLink, siteVersion, avatarUrl, lastUsed, favorites, accountType, visitHistoryEnabled
+        case id, username, storedNickname, instanceLink, siteVersion, avatarUrl
+        case lastUsed, favorites, accountType, visitHistoryEnabled, activityState
     }
     
     enum DecodingError: Error { case cannotModifyPathComponents, invalidHost }
@@ -57,7 +58,14 @@ class UserAccount: Account, CommunityOrPerson {
         self.storedNickname = try values.decode(String?.self, forKey: .storedNickname)
         self.cachedSiteVersion = try values.decode(SiteVersion?.self, forKey: .siteVersion)
         self.avatar = try values.decode(URL?.self, forKey: .avatarUrl)
-        self.lastUsed = try values.decode(Date?.self, forKey: .lastUsed)
+        
+        if let activityState = try values.decodeIfPresent(AccountActivityState.self, forKey: .activityState) {
+            self.activityState = activityState
+        } else {
+            let lastUsed = try values.decodeIfPresent(Date?.self, forKey: .lastUsed) ?? nil
+            self.activityState = .inactive(lastUsed: lastUsed)
+        }
+        
         self.favorites = try values.decodeIfPresent(Set<Int>.self, forKey: .favorites) ?? []
         self.visitHistoryEnabled = try values.decodeIfPresent(Bool.self, forKey: .visitHistoryEnabled) ?? true
         self.accountType = try values.decodeIfPresent(AccountType.self, forKey: .accountType) ?? .user
@@ -94,7 +102,7 @@ class UserAccount: Account, CommunityOrPerson {
         try container.encode(storedNickname, forKey: .storedNickname)
         try container.encode(cachedSiteVersion, forKey: .siteVersion)
         try container.encode(avatar, forKey: .avatarUrl)
-        try container.encode(lastUsed, forKey: .lastUsed)
+        try container.encode(activityState, forKey: .activityState)
         try container.encode(api.baseUrl, forKey: .instanceLink)
         try container.encode(visitHistoryEnabled, forKey: .visitHistoryEnabled)
         try container.encode(accountType, forKey: .accountType)

--- a/Mlem/App/Models/Session/GuestSession.swift
+++ b/Mlem/App/Models/Session/GuestSession.swift
@@ -18,6 +18,7 @@ class GuestSession: Session {
 
     init(account: GuestAccount) {
         self.account = account
+        account.activate()
         
         Task {
             try await self.api.contextDataManager.getValue(task: Task {
@@ -36,7 +37,7 @@ class GuestSession: Session {
     }
     
     func deactivate() {
-        account.logActivity()
+        account.deactivate()
         api.cleanCaches()
     }
     

--- a/Mlem/App/Models/Session/UserSession.swift
+++ b/Mlem/App/Models/Session/UserSession.swift
@@ -26,6 +26,7 @@ class UserSession: Session {
 
     init(account: UserAccount) {
         self.account = account
+        account.activate()
         self.subscriptions = api.setupSubscriptionList(
             getFavorites: { account.favorites },
             setFavorites: {
@@ -65,7 +66,7 @@ class UserSession: Session {
     }
     
     func deactivate() {
-        account.logActivity()
+        account.deactivate()
         api.cleanCaches()
     }
     

--- a/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
@@ -25,7 +25,7 @@ extension AccountListView {
                 } else if appState.firstSession.actorId == right.actorId {
                     return false
                 }
-                return left.lastUsed ?? .distantPast > right.lastUsed ?? .distantPast
+                return left.activityState.lastUsed ?? .distantPast > right.activityState.lastUsed ?? .distantPast
             }
         }
     }
@@ -80,7 +80,7 @@ extension AccountListView {
                 dateComponents.second = 0
                 let todayDate = Calendar.current.date(from: dateComponents) ?? .distantFuture
                 
-                if let date = account.lastUsed {
+                if let date = account.activityState.lastUsed {
                     if date > todayDate {
                         today.append(account)
                     } else if date.timeIntervalSinceNow <= 60 * 60 * 24 * 7 {
@@ -94,7 +94,7 @@ extension AccountListView {
             }
             var groups = [AccountGroup]()
             
-            today.sort { $0.lastUsed ?? .distantPast > $1.lastUsed ?? .distantPast }
+            today.sort { $0.activityState.lastUsed ?? .distantPast > $1.activityState.lastUsed ?? .distantPast }
             today.prepend(appState.firstSession.account)
             
             if !today.isEmpty {
@@ -108,8 +108,10 @@ extension AccountListView {
             if !last30Days.isEmpty {
                 groups.append(
                     AccountGroup(
-                        header: "Last 30 days",
-                        accounts: last30Days.sorted { $0.lastUsed ?? .distantPast > $1.lastUsed ?? .distantPast }
+                        header: "Last \(30) days",
+                        accounts: last30Days.sorted {
+                            $0.activityState.lastUsed ?? .distantPast > $1.activityState.lastUsed ?? .distantPast
+                        }
                     )
                 )
             }
@@ -117,7 +119,9 @@ extension AccountListView {
                 groups.append(
                     AccountGroup(
                         header: "Older",
-                        accounts: older.sorted { $0.lastUsed ?? .distantPast > $1.lastUsed ?? .distantPast }
+                        accounts: older.sorted {
+                            $0.activityState.lastUsed ?? .distantPast > $1.activityState.lastUsed ?? .distantPast
+                        }
                     )
                 )
             }

--- a/Mlem/App/Views/Shared/Accounts/AccountListView.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView.swift
@@ -27,6 +27,17 @@ struct AccountListView: View {
     struct AccountGroup {
         let header: String
         let accounts: [any Account]
+        
+        init(header: LocalizedStringResource, accounts: [any Account]) {
+            self.header = .init(localized: header)
+            self.accounts = accounts
+        }
+        
+        @_disfavoredOverload
+        init(header: String, accounts: [any Account]) {
+            self.header = header
+            self.accounts = accounts
+        }
     }
     
     let isQuickSwitcher: Bool
@@ -173,5 +184,6 @@ struct AccountListView: View {
             .foregroundStyle(palette.accent)
         }
         .textCase(nil)
+        .labelStyle(.titleAndIcon) // Override `.conditional` label style from parent view
     }
 }

--- a/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
@@ -81,6 +81,7 @@ struct AccountListRow: View {
                 }
             }
         }
+        .labelStyle(.titleAndIcon) // Override `.conditional` label style from parent view
         .confirmationDialog(signOutPrompt, isPresented: $showingSignOutConfirmation) {
             Button(signOutLabel, role: .destructive) {
                 if navigation.isInsideSheet, appState.activeSessions.contains(where: { $0.account === account }) {

--- a/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
@@ -43,18 +43,18 @@ struct AccountListRowBody: View {
     }
     
     var timeText: String? {
-        if account.actorId == appState.firstSession.actorId {
-            return .init(localized: "Now")
-        }
-        if let time = account.lastUsed {
-            if abs(time.timeIntervalSinceNow) < 5 {
+        switch account.activityState {
+        case let .inactive(lastUsed):
+            guard let lastUsed else { return nil }
+            if abs(lastUsed.timeIntervalSinceNow) < 5 {
                 return .init(localized: "Just Now")
             }
             let formatter = RelativeDateTimeFormatter()
             formatter.unitsStyle = .short
-            return formatter.localizedString(for: time, relativeTo: Date.now)
+            return formatter.localizedString(for: lastUsed, relativeTo: Date.now)
+        case .active:
+            return .init(localized: "Now")
         }
-        return nil
     }
     
     var captionText: String? {
@@ -63,7 +63,7 @@ struct AccountListRowBody: View {
             if account is GuestAccount {
                 output.append(.init(localized: "Guest"))
             } else {
-                output.append("@\(account.api.baseUrl.host ?? "unknown")")
+                output.append("@\(account.api.host)")
             }
         }
         if complications.contains(.lastUsed), let timeText {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -776,6 +776,9 @@
     "Current password is incorrect" : {
 
     },
+    "Custom" : {
+
+    },
     "Customize how content is displayed in your feed. Choose which types of content are blurred, and apply filters to hide posts from the feed altogether." : {
       "localizations" : {
         "en-GB" : {
@@ -1318,6 +1321,9 @@
     "Large" : {
 
     },
+    "Last %lld days" : {
+
+    },
     "Learn more..." : {
 
     },
@@ -1617,6 +1623,9 @@
 
     },
     "Old" : {
+
+    },
+    "Older" : {
 
     },
     "OLED" : {
@@ -2557,6 +2566,9 @@
 
     },
     "To join this instance, you need to create an application and wait to be accepted." : {
+
+    },
+    "Today" : {
 
     },
     "Too many items" : {


### PR DESCRIPTION
When you open the app, the account you were using when you last closed the app is now made active. I think this is better UX than making the user explicitly set a default account.

Closes #39