### PR TITLE
Display error when `ContentLoader` fails

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3357,8 +3357,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
 			requirement = {
-				branch = "sjmarf/bug-fix";
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.76.0;
 			};
 		};
 		CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3357,8 +3357,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.75.0;
+				branch = "sjmarf/bug-fix";
+				kind = branch;
 			};
 		};
 		CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
-        "revision" : "dd5984331a107d7a21e86712f3c364d364a200b6",
-        "version" : "0.75.0"
+        "branch" : "sjmarf/bug-fix",
+        "revision" : "39fb468f2aac44eaecef4c28a8bb9dc986aa3f18"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/MlemMiddleware",
       "state" : {
-        "branch" : "sjmarf/bug-fix",
-        "revision" : "39fb468f2aac44eaecef4c28a8bb9dc986aa3f18"
+        "revision" : "2590a08ee6bb2354e5eddc99acbe933f6836fb8c",
+        "version" : "0.76.0"
       }
     },
     {

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -69,6 +69,8 @@ struct CommunityView: View {
                             logVisit(community2)
                         }
                     }
+            } else if let error = proxy.error {
+                ErrorView(.init(error: error))
             } else {
                 ProgressView()
                     .tint(palette.secondary)
@@ -80,6 +82,8 @@ struct CommunityView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(palette.groupedBackground)
     }
         
     @ViewBuilder
@@ -120,7 +124,6 @@ struct CommunityView: View {
             }
             .environment(\.communityContext, community)
         }
-        .background(palette.groupedBackground)
         // don't show the refresh popup if community api isn't the active api, since that indicates an unresolvable community
         .outdatedFeedPopup(
             feedLoader: postFeedLoader,

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -110,6 +110,8 @@ struct PersonView: View {
                         }
                     }
                     .popupAnchor()
+            } else if let error = proxy.error {
+                ErrorView(.init(error: error))
             } else {
                 ProgressView()
                     .tint(palette.secondary)
@@ -150,6 +152,8 @@ struct PersonView: View {
         }
         .navigationTitle(isAtTop ? "" : (person.wrappedValue.displayName_ ?? ""))
         .navigationBarTitleDisplayMode(.inline)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(palette.groupedBackground)
     }
     
     @ViewBuilder
@@ -179,7 +183,6 @@ struct PersonView: View {
             .animation(.easeOut(duration: 0.2), value: person is any Person3Providing)
         }
         .outdatedFeedPopup(feedLoader: feedLoader, showPopup: selectedTab != .communities)
-        .background(palette.groupedBackground)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Shared/ContentLoader.swift
+++ b/Mlem/App/Views/Shared/ContentLoader.swift
@@ -110,6 +110,7 @@ class ContentLoaderProxy<Model: Upgradable> {
             upgradeState = .idle
         } catch {
             upgradeState = .failed
+            handleError(error, silent: true)
             self.error = error
         }
     }

--- a/Mlem/App/Views/Shared/ErrorView.swift
+++ b/Mlem/App/Views/Shared/ErrorView.swift
@@ -70,7 +70,7 @@ struct ErrorView: View {
             }
             
             if errorDetails.error != nil, errorDetails.title == nil || developerMode {
-                Button("Show Details") {
+                Button(showingFullError ? "Hide Details" : "Show Details") {
                     showingFullError.toggle()
                 }
                 .buttonStyle(.plain)

--- a/Mlem/App/Views/Shared/ErrorView.swift
+++ b/Mlem/App/Views/Shared/ErrorView.swift
@@ -115,6 +115,6 @@ struct ErrorView: View {
         }
         .padding(Constants.main.standardSpacing)
         .background(Color(.secondarySystemGroupedBackground))
-        .clipShape(RoundedRectangle(cornerRadius: Constants.main.smallItemCornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: Constants.main.standardSpacing))
     }
 }

--- a/Mlem/App/Views/Shared/ExpandedPost/CommentPage.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/CommentPage.swift
@@ -36,6 +36,7 @@ struct CommentPage: View {
             let post: (any Post)? = post ?? proxy.entity?.post_
             ExpandedPostView(
                 post: post,
+                contentLoaderError: proxy.error,
                 isLoading: proxy.isLoading,
                 tracker: $tracker,
                 scrollTargetedComment: proxy.entity

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -29,6 +29,7 @@ struct ExpandedPostView<Content: View>: View {
     @Setting(\.compactComments) var compactComments
     
     var post: (any PostStubProviding)?
+    var contentLoaderError: Error?
     let isLoading: Bool
     let highlightedComment: (any CommentStubProviding)?
     let content: Content
@@ -43,6 +44,7 @@ struct ExpandedPostView<Content: View>: View {
     
     init(
         post: (any PostStubProviding)?,
+        contentLoaderError: Error?,
         isLoading: Bool,
         tracker: Binding<CommentTreeTracker?>,
         highlightedComment: (any CommentStubProviding)? = nil,
@@ -50,6 +52,7 @@ struct ExpandedPostView<Content: View>: View {
         @ViewBuilder content: () -> Content = { EmptyView() }
     ) {
         self.post = post
+        self.contentLoaderError = contentLoaderError
         self.isLoading = isLoading
         self.highlightedComment = highlightedComment
         self.content = content()
@@ -69,6 +72,8 @@ struct ExpandedPostView<Content: View>: View {
                             post.markRead()
                         }
                     }
+            } else if let contentLoaderError {
+                ErrorView(.init(error: contentLoaderError))
             } else {
                 ProgressView()
                     .tint(palette.secondary)

--- a/Mlem/App/Views/Shared/ExpandedPost/PostPage.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/PostPage.swift
@@ -29,6 +29,7 @@ struct PostPage: View {
         ContentLoader(model: post) { proxy in
             ExpandedPostView(
                 post: proxy.entity,
+                contentLoaderError: proxy.error,
                 isLoading: proxy.isLoading,
                 tracker: $tracker,
                 scrollTargetedComment: scrollTargetedComment

--- a/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
@@ -8,11 +8,9 @@
 import SwiftUI
 
 extension MediaView {
-    
     /// Struct to actually render the media.
     /// This is declared as its own struct to prevent state updates from the parent view causing unwanted behavior.
     private struct InternalMediaView: View {
-        
         @Environment(\.blurred) var blurred
         
         let media: MediaType
@@ -77,7 +75,8 @@ extension MediaView {
             media: loader.mediaType,
             playing: playing,
             aspectRatio: uiImage.verticallyBoundedAspectRatio(bounds: aspectRatio),
-            contentMode: contentMode)
+            contentMode: contentMode
+        )
     }
     
     @ViewBuilder
@@ -100,7 +99,7 @@ extension MediaView {
     @ViewBuilder
     var errorOverlay: some View {
         if let loaderError = loader.error {
-            palette.secondaryBackground.overlay {
+            palette.tertiaryGroupedBackground.overlay {
                 switch loaderError {
                 case let .proxyFailure(proxyBypass):
                     VStack(spacing: Constants.main.standardSpacing) {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1204,6 +1204,9 @@
     "Hide Community" : {
 
     },
+    "Hide Details" : {
+
+    },
     "Hide Older Incidents" : {
 
     },


### PR DESCRIPTION
Previously it would just show a `ProgressView` indefinitely when it fails. The test case here is #1735.

Also fixed #1746

See also [this MlemMiddleware PR](https://github.com/mlemgroup/MlemMiddleware/pull/118) - it's not directly linked, but if you aren't using that version of MlemMiddleware you'll get an `assertionFailure` rather than seeing the error details