### PR TITLE
Fix dual load bug

### DIFF
--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+OutdatedFeedPopup.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+OutdatedFeedPopup.swift
@@ -8,15 +8,15 @@
 import MlemMiddleware
 import SwiftUI
 
-private struct OutdatedFeedPopupModifier: ViewModifier {
+private struct RefreshingFeedLoaderModifier: ViewModifier {
     @Environment(AppState.self) var appState
     @Environment(FiltersTracker.self) var filtersTracker
     
-    let feedLoader: (any FeedLoading)?
+    let feedLoader: any FeedLoading
     
     let canShowPopup: Bool
     
-    init(feedLoader: (any FeedLoading)?, showPopup canShowPopup: Bool) {
+    init(feedLoader: any FeedLoading, showPopup canShowPopup: Bool) {
         self.feedLoader = feedLoader
         self.canShowPopup = canShowPopup
     }
@@ -24,64 +24,89 @@ private struct OutdatedFeedPopupModifier: ViewModifier {
     @State var showRefreshPopup: Bool = false
     
     func body(content: Content) -> some View {
-        if let feedLoader {
-            content
-                .refreshable {
-                    await refresh(feedLoader)
+        content
+            .refreshable {
+                await refresh(feedLoader: feedLoader, appState: appState, filtersTracker: filtersTracker)
+            }
+            .preference(key: FeedPopupPreferenceKey.self, value: showRefreshPopup)
+            .onChange(of: apiChangeHash) {
+                if let newApi = feedLoader.items.first?.api {
+                    showRefreshPopup = canShowPopup && (newApi !== appState.firstApi && feedLoader.loadingState != .loading)
+                } else {
+                    showRefreshPopup = false
                 }
-                .onChange(of: apiChangeHash) {
-                    if let newApi = feedLoader.items.first?.api {
-                        showRefreshPopup = canShowPopup && (newApi !== appState.firstApi && feedLoader.loadingState != .loading)
-                    } else {
-                        showRefreshPopup = false
-                    }
+            }
+            .onChange(of: filtersTracker.changeHash) {
+                if feedLoader.items.count > 0 {
+                    showRefreshPopup = true
                 }
-                .onChange(of: filtersTracker.changeHash) {
-                    if feedLoader.items.count > 0 {
-                        showRefreshPopup = true
-                    }
-                }
-                .overlay(alignment: .bottom) {
-                    RefreshPopupView("Feed is outdated", isPresented: $showRefreshPopup) {
-                        Task {
-                            await refresh(feedLoader)
-                        }
-                    }
-                }
-        } else {
-            content
-        }
+            }
     }
     
     var apiChangeHash: Int {
         var hasher = Hasher()
         hasher.combine(canShowPopup)
         hasher.combine(appState.firstApi)
-        hasher.combine(feedLoader?.loadingState)
-        hasher.combine(feedLoader?.items.first?.api)
+        hasher.combine(feedLoader.loadingState)
+        hasher.combine(feedLoader.items.first?.api)
         return hasher.finalize()
     }
+}
+
+private struct OutdatedFeedPopupModifier: ViewModifier {
+    @Environment(AppState.self) var appState
+    @Environment(FiltersTracker.self) var filtersTracker
+
+    let feedLoader: (any FeedLoading)?
+    @State var showRefreshPopup: Bool = false
     
-    func refresh(_ feedLoader: any FeedLoading) async {
-        do {
-            showRefreshPopup = false
-            await feedLoader.changeApi(to: appState.firstApi, context: filtersTracker.filterContext)
-            
-            if let feedLoader = feedLoader as? CorePostFeedLoader {
-                if try await appState.firstApi.version < feedLoader.sortType.minimumVersion {
-                    try await feedLoader.changeSortType(to: appState.initialFeedSortType, forceRefresh: true)
-                    return
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .bottom) {
+                RefreshPopupView("Feed is outdated", isPresented: $showRefreshPopup) {
+                    Task {
+                        if let feedLoader {
+                            await refresh(feedLoader: feedLoader, appState: appState, filtersTracker: filtersTracker)
+                        }
+                    }
                 }
             }
-            try await feedLoader.refresh(clearBeforeRefresh: true)
-        } catch {
-            handleError(error)
+            .onPreferenceChange(FeedPopupPreferenceKey.self) { value in
+                showRefreshPopup = value
+            }
+    }
+}
+
+private func refresh(feedLoader: any FeedLoading, appState: AppState, filtersTracker: FiltersTracker) async {
+    do {
+        await feedLoader.changeApi(to: appState.firstApi, context: filtersTracker.filterContext)
+        
+        if let feedLoader = feedLoader as? CorePostFeedLoader {
+            if try await appState.firstApi.version < feedLoader.sortType.minimumVersion {
+                try await feedLoader.changeSortType(to: appState.initialFeedSortType, forceRefresh: true)
+                return
+            }
         }
+        try await feedLoader.refresh(clearBeforeRefresh: true)
+    } catch {
+        handleError(error)
+    }
+}
+
+private struct FeedPopupPreferenceKey: PreferenceKey {
+    static var defaultValue: Bool = false
+
+    static func reduce(value: inout Bool, nextValue: () -> Bool) {
+        value = value || nextValue()
     }
 }
 
 extension View {
-    func outdatedFeedPopup(feedLoader: (any FeedLoading)?, showPopup: Bool = true) -> some View {
-        modifier(OutdatedFeedPopupModifier(feedLoader: feedLoader, showPopup: showPopup))
+    func refreshing(feedLoader: any FeedLoading, showPopup: Bool = true) -> some View {
+        modifier(RefreshingFeedLoaderModifier(feedLoader: feedLoader, showPopup: showPopup))
+    }
+    
+    func outdatedFeedPopup(feedLoader: (any FeedLoading)?) -> some View {
+        modifier(OutdatedFeedPopupModifier(feedLoader: feedLoader))
     }
 }

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -111,6 +111,10 @@ struct CommunityView: View {
                     if let postFeedLoader {
                         postsTab(community: community, postFeedLoader: postFeedLoader)
                             .padding(.bottom, -4)
+                            .refreshing(
+                                feedLoader: postFeedLoader,
+                                showPopup: selectedTab == .posts && community.api === AppState.main.firstApi
+                            )
                     }
                 case .about:
                     aboutTab(community: community)
@@ -125,10 +129,6 @@ struct CommunityView: View {
             .environment(\.communityContext, community)
         }
         // don't show the refresh popup if community api isn't the active api, since that indicates an unresolvable community
-        .outdatedFeedPopup(
-            feedLoader: postFeedLoader,
-            showPopup: selectedTab == .posts && community.api === AppState.main.firstApi
-        )
         .navigationTitle(isAtTop ? "" : community.name)
         .isAtTopSubscriber(isAtTop: $isAtTop)
         .toolbar {
@@ -137,6 +137,7 @@ struct CommunityView: View {
             }
         }
         .popupAnchor()
+        .outdatedFeedPopup(feedLoader: postFeedLoader)
         .fullScreenCover(isPresented: $warningPresented) {
             WarningOverlayView(
                 text: "This community likely contains graphic or explicit content.",

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -182,7 +182,7 @@ struct PersonView: View {
             }
             .animation(.easeOut(duration: 0.2), value: person is any Person3Providing)
         }
-        .outdatedFeedPopup(feedLoader: feedLoader, showPopup: selectedTab != .communities)
+        .outdatedFeedPopup(feedLoader: feedLoader)
     }
     
     @ViewBuilder
@@ -276,6 +276,7 @@ struct PersonView: View {
                         .padding([.horizontal, .bottom], Constants.main.standardSpacing)
                     }
                     PersonContentGridView(feedLoader: feedLoader, contentType: $selectedContentType)
+                        .refreshing(feedLoader: feedLoader, showPopup: selectedTab != .communities)
                 } else {
                     ProgressView()
                 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -145,8 +145,10 @@ struct FeedsView: View {
                 }
                 if let savedFeedLoader, feedSelection == .saved {
                     PersonContentGridView(feedLoader: savedFeedLoader, contentType: .constant(.all))
+                        .refreshing(feedLoader: savedFeedLoader)
                 } else if let postFeedLoader {
                     PostGridView(postFeedLoader: postFeedLoader)
+                        .refreshing(feedLoader: postFeedLoader)
                 }
             } header: {
                 Menu {


### PR DESCRIPTION
Closes #1405

This was caused by this `if`/`else` block:

```swift
if let feedLoader {
    content
        .refreshable {  await refresh(feedLoader)  }
        // ...
} else {
    content
}
```

When `feedLoader` changed from `nil` to not `nil`, the view was entirely replaced because it switches from one `content` declaration to the other. I've refactored it to avoid doing this