### PR TITLE
Better haptic preheating

### DIFF
--- a/Mlem/App/Globals/Definitions/HapticManager/Haptic.swift
+++ b/Mlem/App/Globals/Definitions/HapticManager/Haptic.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Enumerates all custom defined haptics used in the app. The raw value of a case corresponds to the name of the file it is stored in.
-enum Haptic: String {
+enum Haptic: String, CaseIterable {
     /// Very gentle tap. Used for subtle feedback--things like crossing a swipe boundary
     case gentleInfo = "Gentle Info"
     

--- a/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
+++ b/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
@@ -28,6 +28,17 @@ class HapticManager {
         print("Initialized haptic engine")
         self.hapticEngine = initEngine()
         
+        // load all the haptic files into players to avoid lag on first play caused by slow disk read
+        Haptic.allCases.forEach { haptic in
+            do {
+                guard let file = getFile(for: haptic) else { return }
+                players[haptic] = try hapticEngine?.makePlayer(with: .init(contentsOf: file))
+            } catch {
+                assertionFailure("Failed to initialize haptic player")
+                handleError(error, silent: true)
+            }
+        }
+        
         // if the engine stops, tell us why
         hapticEngine?.stoppedHandler = { reason in
             print("The engine stopped: \(reason)")
@@ -47,25 +58,6 @@ class HapticManager {
             } catch {
                 handleError(error)
             }
-        }
-    }
-
-    /// Starts the haptic engine, if present, and preloads the haptics; call at app initialization to avoid lag on first haptic
-    func preheat() {
-        do {
-            try hapticEngine?.start()
-            // loads all the haptic files into players to avoid lag on first play caused by reading from disk
-            Haptic.allCases.forEach { haptic in
-                do {
-                    guard let file = getFile(for: haptic) else { return }
-                    players[haptic] = try hapticEngine?.makePlayer(with: .init(contentsOf: file))
-                } catch {
-                    assertionFailure("Failed to initialize haptic player")
-                    handleError(error, silent: true)
-                }
-            }
-        } catch {
-            handleError(error, silent: true)
         }
     }
     

--- a/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
+++ b/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
@@ -50,10 +50,11 @@ class HapticManager {
         }
     }
 
-    /// Starts the haptic engine, if present; call at app initialization to avoid lag on first haptic
+    /// Starts the haptic engine, if present, and preloads the haptics; call at app initialization to avoid lag on first haptic
     func preheat() {
         do {
             try hapticEngine?.start()
+            // loads all the haptic files into players to avoid lag on first play caused by reading from disk
             Haptic.allCases.forEach { haptic in
                 do {
                     guard let file = getFile(for: haptic) else { return }
@@ -63,7 +64,6 @@ class HapticManager {
                     handleError(error, silent: true)
                 }
             }
-            try AVAudioSession.sharedInstance().setActive(true)
         } catch {
             handleError(error, silent: true)
         }

--- a/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
+++ b/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
@@ -11,8 +11,6 @@ import Foundation
 import SwiftUI
 
 class HapticManager {
-    // MARK: Members and init
-    
     @Setting(\.hapticLevel) var hapticLevel
     
     // generators/engines
@@ -23,8 +21,9 @@ class HapticManager {
     // singleton to use in app
     static let main: HapticManager = .init()
     
+    var players: [Haptic: CHHapticPatternPlayer] = .init()
+    
     init() {
-        
         // create and start the engine if this device supports haptics
         print("Initialized haptic engine")
         self.hapticEngine = initEngine()
@@ -40,19 +39,69 @@ class HapticManager {
             self?.handleEngineFailure()
         }
     }
+    
+    func startEngine() {
+        if let hapticEngine {
+            do {
+                try hapticEngine.start()
+            } catch {
+                handleError(error)
+            }
+        }
+    }
 
     /// Starts the haptic engine, if present; call at app initialization to avoid lag on first haptic
     func preheat() {
         do {
             try hapticEngine?.start()
+            Haptic.allCases.forEach { haptic in
+                do {
+                    guard let file = getFile(for: haptic) else { return }
+                    players[haptic] = try hapticEngine?.makePlayer(with: .init(contentsOf: file))
+                } catch {
+                    assertionFailure("Failed to initialize haptic player")
+                    handleError(error, silent: true)
+                }
+            }
             try AVAudioSession.sharedInstance().setActive(true)
         } catch {
             handleError(error, silent: true)
         }
     }
     
+    /// Plays a haptic if the given priority is equal to or lower than the current haptic level
+    func play(haptic: Haptic, priority: HapticPriority) {
+        assert(priority != .sentinel, "Cannot use .sentinel as a haptic priority")
+        
+        Task(priority: .userInitiated) {
+            if priority <= hapticLevel, let hapticEngine {
+                do {
+                    // if player available, use it
+                    if let player = players[haptic] {
+                        try player.start(atTime: .zero)
+                        return
+                    }
+                    
+                    // otherwise try to read haptic from file and play it cold
+                    guard let file = getFile(for: haptic) else { return }
+                    try hapticEngine.playPattern(from: file)
+                } catch {
+                    // on failure, restart the engine and play the haptic cold
+                    handleError(error, silent: true)
+                    handleEngineFailure(with: haptic)
+                }
+            } else {
+                if priority > hapticLevel {
+                    print("\(haptic.rawValue) not played (priority \(priority.intValue) > \(hapticLevel.intValue))")
+                } else {
+                    print("\(haptic.rawValue) not played (no engine)")
+                }
+            }
+        }
+    }
+    
     /// If this device supports haptics, creates and returns a CHHaptic engine; otherwise returns nil
-    func initEngine() -> CHHapticEngine? {
+    private func initEngine() -> CHHapticEngine? {
         if CHHapticEngine.capabilitiesForHardware().supportsHaptics {
             do {
                 let ret = try CHHapticEngine(audioSession: AVAudioSession.sharedInstance())
@@ -66,12 +115,12 @@ class HapticManager {
     }
     
     /// Restarts the engine if it is present, creates it if not. Can be passed a pattern to play on start.
-    func handleEngineFailure(with file: URL? = nil) {
+    private func handleEngineFailure(with haptic: Haptic? = nil) {
         if let hapticEngine {
-            start(engine: hapticEngine)
+            startEngine()
             
             // attempt to play the pattern that failed, but don't do anything on failure here
-            if let file {
+            if let haptic, let file = getFile(for: haptic) {
                 do {
                     try hapticEngine.playPattern(from: file)
                 } catch {
@@ -83,40 +132,12 @@ class HapticManager {
         }
     }
     
-    func start(engine: CHHapticEngine) {
-        do {
-            try engine.start()
-        } catch {
-            handleError(error)
+    private func getFile(for haptic: Haptic) -> URL? {
+        guard let path = Bundle.main.path(forResource: haptic.rawValue, ofType: "ahap") else {
+            assertionFailure("No haptic file found for \(haptic.rawValue)")
+            return nil
         }
-    }
     
-    /// Plays a haptic if the given priority is equal to or lower than the current haptic level
-    func play(haptic: Haptic, priority: HapticPriority) {
-        assert(priority != .sentinel, "Cannot use .sentinel as a haptic priority")
-        
-        Task(priority: .userInitiated) {
-            if priority <= hapticLevel, let hapticEngine {
-                guard let path = Bundle.main.path(forResource: haptic.rawValue, ofType: "ahap") else {
-                    assertionFailure("Invalid haptic file: \(haptic.rawValue)")
-                    return
-                }
-                
-                let file = URL(filePath: path)
-                do {
-                    try hapticEngine.playPattern(from: file)
-                } catch {
-                    // worst-case scenario--tried to play and no engine!
-                    handleError(error, silent: true)
-                    handleEngineFailure(with: file)
-                }
-            } else {
-                if priority > hapticLevel {
-                    print("\(haptic.rawValue) not played (priority \(priority.intValue) > \(hapticLevel.intValue))")
-                } else {
-                    print("\(haptic.rawValue) not played (no engine)")
-                }
-            }
-        }
+        return URL(filePath: path)
     }
 }

--- a/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
+++ b/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
@@ -68,17 +68,10 @@ class HapticManager {
         Task(priority: .userInitiated) {
             if priority <= hapticLevel, let hapticEngine {
                 do {
-                    // if player available, use it
-                    if let player = players[haptic] {
-                        try player.start(atTime: .zero)
-                        return
-                    }
-                    
-                    // otherwise try to read haptic from file and play it cold
-                    guard let file = getFile(for: haptic) else { return }
-                    try hapticEngine.playPattern(from: file)
+                    guard let player = players[haptic] else { throw HapticError.noPlayer(haptic) }
+                    try player.start(atTime: .zero)
                 } catch {
-                    // on failure, restart the engine and play the haptic cold
+                    // on failure, restart the engine and play the haptic from file
                     handleError(error, silent: true)
                     handleEngineFailure(with: haptic)
                 }
@@ -106,8 +99,12 @@ class HapticManager {
         return nil
     }
     
-    /// Restarts the engine if it is present, creates it if not. Can be passed a pattern to play on start.
+    /// Restarts the engine if it is present, creates it if not, starts the engine, and plays the given haptic from file
     private func handleEngineFailure(with haptic: Haptic? = nil) {
+        if hapticEngine == nil {
+            hapticEngine = initEngine()
+        }
+        
         if let hapticEngine {
             startEngine()
             
@@ -119,8 +116,6 @@ class HapticManager {
                     handleError(error, silent: true)
                 }
             }
-        } else {
-            hapticEngine = initEngine()
         }
     }
     
@@ -131,5 +126,16 @@ class HapticManager {
         }
     
         return URL(filePath: path)
+    }
+}
+
+enum HapticError: Error, CustomStringConvertible {
+    case noPlayer(Haptic)
+    
+    public var description: String {
+        switch self {
+        case let .noPlayer(haptic):
+            "No player available for \(haptic.rawValue)"
+        }
     }
 }

--- a/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
+++ b/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
@@ -29,15 +29,7 @@ class HapticManager {
         self.hapticEngine = initEngine()
         
         // load all the haptic files into players to avoid lag on first play caused by slow disk read
-        Haptic.allCases.forEach { haptic in
-            do {
-                guard let file = getFile(for: haptic) else { return }
-                players[haptic] = try hapticEngine?.makePlayer(with: .init(contentsOf: file))
-            } catch {
-                assertionFailure("Failed to initialize haptic player")
-                handleError(error, silent: true)
-            }
-        }
+        loadPlayers()
         
         // if the engine stops, tell us why
         hapticEngine?.stoppedHandler = { reason in
@@ -47,7 +39,7 @@ class HapticManager {
         // if the engine fails, attempt to restart
         hapticEngine?.resetHandler = { [weak self] in
             print("The engine reset")
-            self?.handleEngineFailure()
+            self?.handleFailure()
         }
     }
     
@@ -66,14 +58,13 @@ class HapticManager {
         assert(priority != .sentinel, "Cannot use .sentinel as a haptic priority")
         
         Task(priority: .userInitiated) {
-            if priority <= hapticLevel, let hapticEngine {
+            if priority <= hapticLevel, hapticEngine != nil {
                 do {
                     guard let player = players[haptic] else { throw HapticError.noPlayer(haptic) }
                     try player.start(atTime: .zero)
                 } catch {
-                    // on failure, restart the engine and play the haptic from file
                     handleError(error, silent: true)
-                    handleEngineFailure(with: haptic)
+                    handleFailure(with: haptic, error: error as? HapticError)
                 }
             } else {
                 if priority > hapticLevel {
@@ -99,19 +90,28 @@ class HapticManager {
         return nil
     }
     
-    /// Restarts the engine if it is present, creates it if not, starts the engine, and plays the given haptic from file
-    private func handleEngineFailure(with haptic: Haptic? = nil) {
+    /// Restarts the engine if it is present, creates it if not, starts the engine, and plays the given haptic
+    private func handleFailure(with haptic: Haptic? = nil, error: HapticError? = nil) {
         if hapticEngine == nil {
             hapticEngine = initEngine()
         }
         
-        if let hapticEngine {
+        if let error, case let .noPlayer(failedHaptic) = error {
+            assertionFailure("No player for \(failedHaptic)")
+            loadPlayers()
+        }
+        
+        if hapticEngine != nil {
             startEngine()
             
             // attempt to play the pattern that failed, but don't do anything on failure here
-            if let haptic, let file = getFile(for: haptic) {
+            if let haptic {
                 do {
-                    try hapticEngine.playPattern(from: file)
+                    guard let player = players[haptic] else {
+                        assertionFailure("No player for \(haptic) in failure handler")
+                        throw HapticError.noPlayer(haptic)
+                    }
+                    try player.start(atTime: .zero)
                 } catch {
                     handleError(error, silent: true)
                 }
@@ -119,13 +119,21 @@ class HapticManager {
         }
     }
     
-    private func getFile(for haptic: Haptic) -> URL? {
-        guard let path = Bundle.main.path(forResource: haptic.rawValue, ofType: "ahap") else {
-            assertionFailure("No haptic file found for \(haptic.rawValue)")
-            return nil
+    private func loadPlayers() {
+        // load all the haptic files into players to avoid lag on first play caused by slow disk read
+        Haptic.allCases.forEach { haptic in
+            do {
+                guard let path = Bundle.main.path(forResource: haptic.rawValue, ofType: "ahap") else {
+                    assertionFailure("No haptic file found for \(haptic.rawValue)")
+                    return
+                }
+                let file = URL(filePath: path)
+                players[haptic] = try hapticEngine?.makePlayer(with: .init(contentsOf: file))
+            } catch {
+                assertionFailure("Failed to initialize haptic player")
+                handleError(error, silent: true)
+            }
         }
-    
-        return URL(filePath: path)
     }
 }
 

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -105,6 +105,9 @@ struct ContentView: View {
                             }
                         }
                     }
+                    if scenePhase == .active {
+                        HapticManager.main.startEngine()
+                    }
                 }
                 .environment(AppState.main)
         }

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -106,6 +106,8 @@ struct ContentView: View {
                         }
                     }
                     if scenePhase == .active {
+                        // When the app moves into the background, the haptic engine stops.
+                        // This ensures the engine is started before a haptic is played to avoid a short lag while the engine starts
                         HapticManager.main.startEngine()
                     }
                 }

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -39,10 +39,6 @@ struct ContentView: View {
 
     @State var avatarImage: UIImage?
     @State var selectedAvatarImage: UIImage?
-  
-    init() {
-        HapticManager.main.preheat()
-    }
     
     var body: some View {
         if appState.appRefreshToggle {


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1763 

## Description

Removes some hitches that would happen when playing haptics (especially noticeable when using a swipe action):
1. Engine startup. If the engine is not started when a haptic is played, the main thread hitches while the engine starts. `preheatEngine` handles this on the first launch, but the engine stops when the app moves into the background. I've added a `scenePhase` listener to `ContentView` to start the engine when the app moves into the foreground.
2. File read. Previously, playing a haptic required reading the pattern from the `.ahap` file. This was sometimes slow on the first read for a given pattern, again hitching the main thread. The `HapticManager` now loads each file into a `CHHapticPatternPlayer` at `init` so they're ready to go.

The best repro for the hitches is:
- Start the app
- Swipe a post
- Close the app (just move to background, no need to full quit), wait for the "haptic engine shut down" log message
- Start the app again and swipe a post

## Implementation Notes

I've also refactored the `HapticManager`:
- Rearranged functions into a slightly more sensical order (init/api/core/helpers)
- Removed `preheat()`. The preheating work is now done automatically in `init`
- Streamlined error handling