### PR TITLE
Remove `loadMore` from `EndOfFeedView`

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 		CD03742A2D1DBFD2001E85FA /* ReadCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0374292D1DBFCF001E85FA /* ReadCheck.swift */; };
 		CD0507732C6AA0C8008B1505 /* FeedSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0507722C6AA0C8008B1505 /* FeedSelection.swift */; };
 		CD09BA7F2CB4698E00C93926 /* OledPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD09BA7E2CB4698600C93926 /* OledPalette.swift */; };
+		CD0C008D2D63DE2E0089FB36 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD0C008C2D63DE2E0089FB36 /* MlemMiddleware */; };
 		CD0E06F72C0E739F00445849 /* PostType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0E06F62C0E739F00445849 /* PostType+Extensions.swift */; };
 		CD0F280A2C6CEFBE00C1F65B /* View+IsAtTopSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0F28092C6CEFBE00C1F65B /* View+IsAtTopSubscriber.swift */; };
 		CD10FA772C7A8622008985AD /* ImageSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD10FA762C7A8622008985AD /* ImageSaver.swift */; };
@@ -462,7 +463,6 @@
 		CDB41E8C2C84CED500BD2DE9 /* FixedImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB41E8B2C84CED500BD2DE9 /* FixedImageLoader.swift */; };
 		CDB41E8E2C84CFA200BD2DE9 /* FixedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB41E8D2C84CFA200BD2DE9 /* FixedImageView.swift */; };
 		CDB738292CB8A6A5005B11BB /* View+PaletteBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB738282CB8A69D005B11BB /* View+PaletteBorder.swift */; };
-		CDBF21F82D62772D0011C298 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CDBF21F72D62772D0011C298 /* MlemMiddleware */; };
 		CDBFCB652C03920C008CD468 /* PostLinkHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBFCB642C03920C008CD468 /* PostLinkHostView.swift */; };
 		CDBFCB6A2C04EFFE008CD468 /* PostSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBFCB692C04EFFE008CD468 /* PostSettingsView.swift */; };
 		CDBFCB6C2C054AA7008CD468 /* TilePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBFCB6B2C054AA7008CD468 /* TilePostView.swift */; };
@@ -1037,7 +1037,7 @@
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CDE4AC452CA370E000981010 /* SDWebImageSwiftUI in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
-				CDBF21F82D62772D0011C298 /* MlemMiddleware in Frameworks */,
+				CD0C008D2D63DE2E0089FB36 /* MlemMiddleware in Frameworks */,
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
@@ -2280,7 +2280,7 @@
 				CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */,
 				CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */,
 				CD64A9192CA37E8D007CA7E6 /* Gifu */,
-				CDBF21F72D62772D0011C298 /* MlemMiddleware */,
+				CD0C008C2D63DE2E0089FB36 /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -2368,7 +2368,7 @@
 				CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
 				CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */,
-				CDBF21F62D6277240011C298 /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
+				CD0C008B2D63DE240089FB36 /* XCLocalSwiftPackageReference "../MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -3292,6 +3292,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		CD0C008B2D63DE240089FB36 /* XCLocalSwiftPackageReference "../MlemMiddleware" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../MlemMiddleware;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -3355,14 +3362,6 @@
 			requirement = {
 				branch = master;
 				kind = branch;
-			};
-		};
-		CDBF21F62D6277240011C298 /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.78.0;
 			};
 		};
 		CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
@@ -3429,6 +3428,11 @@
 			package = B104A6D62A59BF3C00B3E725 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeVideo;
 		};
+		CD0C008C2D63DE2E0089FB36 /* MlemMiddleware */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD0C008B2D63DE240089FB36 /* XCLocalSwiftPackageReference "../MlemMiddleware" */;
+			productName = MlemMiddleware;
+		};
 		CD4368C02AE23FD400BD8BD1 /* Semaphore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */;
@@ -3438,11 +3442,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */;
 			productName = Gifu;
-		};
-		CDBF21F72D62772D0011C298 /* MlemMiddleware */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CDBF21F62D6277240011C298 /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
-			productName = MlemMiddleware;
 		};
 		CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -356,7 +356,6 @@
 		CD03742A2D1DBFD2001E85FA /* ReadCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0374292D1DBFCF001E85FA /* ReadCheck.swift */; };
 		CD0507732C6AA0C8008B1505 /* FeedSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0507722C6AA0C8008B1505 /* FeedSelection.swift */; };
 		CD09BA7F2CB4698E00C93926 /* OledPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD09BA7E2CB4698600C93926 /* OledPalette.swift */; };
-		CD0C008D2D63DE2E0089FB36 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD0C008C2D63DE2E0089FB36 /* MlemMiddleware */; };
 		CD0E06F72C0E739F00445849 /* PostType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0E06F62C0E739F00445849 /* PostType+Extensions.swift */; };
 		CD0F280A2C6CEFBE00C1F65B /* View+IsAtTopSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0F28092C6CEFBE00C1F65B /* View+IsAtTopSubscriber.swift */; };
 		CD10FA772C7A8622008985AD /* ImageSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD10FA762C7A8622008985AD /* ImageSaver.swift */; };
@@ -436,6 +435,7 @@
 		CD7DB9732C4AEDDE00DCC542 /* TileCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7DB9722C4AEDDE00DCC542 /* TileCommentView.swift */; };
 		CD7DB9762C4D6C0A00DCC542 /* FeedCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7DB9752C4D6C0A00DCC542 /* FeedCommentView.swift */; };
 		CD8457142D07576A00CEA2B8 /* AVPlayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8457132D07576700CEA2B8 /* AVPlayer+Extensions.swift */; };
+		CD848FC42D63E1CB009A7AE7 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD848FC32D63E1CB009A7AE7 /* MlemMiddleware */; };
 		CD869FCC2C15F8AC00FC8B5B /* BubblePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD869FCB2C15F8AC00FC8B5B /* BubblePickerView.swift */; };
 		CD869FCE2C15F90C00FC8B5B /* ChildSizeReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD869FCD2C15F90C00FC8B5B /* ChildSizeReader.swift */; };
 		CD87BEBC2D51257A0099F190 /* Instance2Providing+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD87BEBB2D5125750099F190 /* Instance2Providing+Extensions.swift */; };
@@ -1037,7 +1037,7 @@
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CDE4AC452CA370E000981010 /* SDWebImageSwiftUI in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
-				CD0C008D2D63DE2E0089FB36 /* MlemMiddleware in Frameworks */,
+				CD848FC42D63E1CB009A7AE7 /* MlemMiddleware in Frameworks */,
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
@@ -2280,7 +2280,7 @@
 				CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */,
 				CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */,
 				CD64A9192CA37E8D007CA7E6 /* Gifu */,
-				CD0C008C2D63DE2E0089FB36 /* MlemMiddleware */,
+				CD848FC32D63E1CB009A7AE7 /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -2368,7 +2368,7 @@
 				CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
 				CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */,
-				CD0C008B2D63DE240089FB36 /* XCLocalSwiftPackageReference "../MlemMiddleware" */,
+				CD848FC22D63E1BF009A7AE7 /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -3292,13 +3292,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		CD0C008B2D63DE240089FB36 /* XCLocalSwiftPackageReference "../MlemMiddleware" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../MlemMiddleware;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -3362,6 +3355,14 @@
 			requirement = {
 				branch = master;
 				kind = branch;
+			};
+		};
+		CD848FC22D63E1BF009A7AE7 /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.78.0;
 			};
 		};
 		CDE4AC402CA3706400981010 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
@@ -3428,11 +3429,6 @@
 			package = B104A6D62A59BF3C00B3E725 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeVideo;
 		};
-		CD0C008C2D63DE2E0089FB36 /* MlemMiddleware */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CD0C008B2D63DE240089FB36 /* XCLocalSwiftPackageReference "../MlemMiddleware" */;
-			productName = MlemMiddleware;
-		};
 		CD4368C02AE23FD400BD8BD1 /* Semaphore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */;
@@ -3442,6 +3438,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CD64A9182CA37D63007CA7E6 /* XCRemoteSwiftPackageReference "Gifu" */;
 			productName = Gifu;
+		};
+		CD848FC32D63E1CB009A7AE7 /* MlemMiddleware */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD848FC22D63E1BF009A7AE7 /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
+			productName = MlemMiddleware;
 		};
 		CDE4AC442CA370E000981010 /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e91c2cec61691543665fad5843f30eafc5288bb40fc3a60d50c7d7e9194f3135",
+  "originHash" : "7fe183dcbb4acc6bb34fdc0842377273418aa1caa6335cd2926051ef29f2a665",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -53,15 +53,6 @@
       "state" : {
         "revision" : "b2b1d20a90b14d11f6ef4241da6b81c1d3f171e4",
         "version" : "1.3.2"
-      }
-    },
-    {
-      "identity" : "mlemmiddleware",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlemgroup/MlemMiddleware",
-      "state" : {
-        "revision" : "823002b4d3367b2645f59fa7f20e1121cd7865f5",
-        "version" : "0.78.0"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7fe183dcbb4acc6bb34fdc0842377273418aa1caa6335cd2926051ef29f2a665",
+  "originHash" : "741161cefb0674ba95c43c14afc8238177d21974f95f4e66fe76b72259069ef1",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "b2b1d20a90b14d11f6ef4241da6b81c1d3f171e4",
         "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "mlemmiddleware",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mlemgroup/MlemMiddleware",
+      "state" : {
+        "revision" : "823002b4d3367b2645f59fa7f20e1121cd7865f5",
+        "version" : "0.78.0"
       }
     },
     {

--- a/Mlem/App/Views/Pages/Modlog/ModlogView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogView.swift
@@ -107,7 +107,7 @@ struct ModlogView: View {
                     Array(feedLoader.items(ofType: actionTypeFilter).enumerated()),
                     id: \.offset
                 ) { _, entry in entryView(entry) }
-                EndOfFeedView(loadingState: activeFeedLoader.loadingState, loadMore: nil, viewType: .hobbit)
+                EndOfFeedView(loadingState: activeFeedLoader.loadingState, viewType: .hobbit)
             }
             .padding([.horizontal, .bottom], Constants.main.standardSpacing)
         }

--- a/Mlem/App/Views/Pages/VotesListView.swift
+++ b/Mlem/App/Views/Pages/VotesListView.swift
@@ -73,7 +73,7 @@ struct VotesListView: View {
                     }
                     .padding(.horizontal, Constants.main.standardSpacing)
                 }
-                EndOfFeedView(loadingState: loadingState, loadMore: nil, viewType: .turtle)
+                EndOfFeedView(loadingState: loadingState, viewType: .turtle)
                     .onAppear {
                         loadNextPage()
                     }

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
@@ -32,7 +32,7 @@ extension InboxView {
                     }
                 }
                 
-                EndOfFeedView(loadingState: feedLoader.loadingState, loadMore: nil, viewType: .cartoon)
+                EndOfFeedView(loadingState: feedLoader.loadingState, viewType: .cartoon)
             } header: { sectionHeader }
         }
     }

--- a/Mlem/App/Views/Shared/EndOfFeedView.swift
+++ b/Mlem/App/Views/Shared/EndOfFeedView.swift
@@ -45,24 +45,16 @@ struct EndOfFeedView: View {
     @Setting(\.developerMode) var developerMode
     
     let loadingState: LoadingState
-    let loadMore: (() -> Void)?
     let viewType: EndOfFeedViewType
     
     var body: some View {
         Group {
             switch loadingState {
             case .idle:
-                if let loadMore {
-                    Button("Load More") {
-                        loadMore()
-                    }
-                    .buttonStyle(.bordered)
+                if developerMode {
+                    Text(verbatim: "IDLE")
                 } else {
-                    if developerMode {
-                        Text(verbatim: "IDLE")
-                    } else {
-                        ProgressView()
-                    }
+                    ProgressView()
                 }
             case .loading:
                 ProgressView()

--- a/Mlem/App/Views/Shared/PersonContentGridView.swift
+++ b/Mlem/App/Views/Shared/PersonContentGridView.swift
@@ -96,7 +96,7 @@ struct PersonContentGridView: View {
                     }
                 }
             }
-            EndOfFeedView(loadingState: loadingState, loadMore: loadMore, viewType: .hobbit)
+            EndOfFeedView(loadingState: loadingState, viewType: .hobbit)
         }
     }
     
@@ -110,16 +110,6 @@ struct PersonContentGridView: View {
         case let .comment(comment):
             NavigationLink(.comment(comment)) {
                 FeedCommentView(comment: comment)
-            }
-        }
-    }
-    
-    func loadMore() {
-        Task {
-            do {
-                try await feedLoader.loadMoreItems()
-            } catch {
-                handleError(error)
             }
         }
     }

--- a/Mlem/App/Views/Shared/PostGridView.swift
+++ b/Mlem/App/Views/Shared/PostGridView.swift
@@ -107,7 +107,7 @@ struct PostGridView: View {
                 }
             }
             .padding(.horizontal, postSize.tiled || columns.count == 1 ? 0 : Constants.main.halfSpacing)
-            EndOfFeedView(loadingState: postFeedLoader.loadingState, loadMore: loadMore, viewType: .hobbit)
+            EndOfFeedView(loadingState: postFeedLoader.loadingState, viewType: .hobbit)
         }
     }
     
@@ -149,16 +149,6 @@ struct PostGridView: View {
             }
         } label: {
             Label("Post Size", systemImage: Icons.postSizeSetting)
-        }
-    }
-    
-    func loadMore() {
-        Task {
-            do {
-                try await postFeedLoader.loadMoreItems()
-            } catch {
-                handleError(error)
-            }
         }
     }
 }

--- a/Mlem/App/Views/Shared/Search/SearchView+Views.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView+Views.swift
@@ -58,7 +58,7 @@ extension SearchView {
                         }
                     }
                 }
-                EndOfFeedView(loadingState: communityLoader.loadingState, loadMore: nil, viewType: .hobbit)
+                EndOfFeedView(loadingState: communityLoader.loadingState, viewType: .hobbit)
             }
         case .people:
             LazyVStack(spacing: 0) {
@@ -77,7 +77,7 @@ extension SearchView {
                         }
                     }
                 }
-                EndOfFeedView(loadingState: personLoader.loadingState, loadMore: nil, viewType: .hobbit)
+                EndOfFeedView(loadingState: personLoader.loadingState, viewType: .hobbit)
             }
         case .instances:
             LazyVStack(spacing: 0) {
@@ -88,7 +88,7 @@ extension SearchView {
                         visitContext: page == .home ? .other : .search
                     )
                 }
-                EndOfFeedView(loadingState: .done, loadMore: nil, viewType: .hobbit)
+                EndOfFeedView(loadingState: .done, viewType: .hobbit)
             }
         case .posts:
             if postLoader.loadingState == .idle, postLoader.items.isEmpty {
@@ -114,7 +114,7 @@ extension SearchView {
                             }
                         }
                     }
-                    EndOfFeedView(loadingState: commentLoader.loadingState, loadMore: nil, viewType: .hobbit)
+                    EndOfFeedView(loadingState: commentLoader.loadingState, viewType: .hobbit)
                 }
                 .padding(.horizontal, Constants.main.standardSpacing)
             }


### PR DESCRIPTION
The `loadMore` functionality should be irrelevant as of [this MlemMiddleware PR](https://github.com/mlemgroup/MlemMiddleware/pull/121). This PR is not strictly dependent on that one.