### PR TITLE
Improve keychain access error handling

### DIFF
--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -150,7 +150,13 @@ class UserAccount: Account, CommunityOrPerson {
     }
     
     func saveTokenToKeychain() {
-        Constants.main.keychain[getKeychainId(actorId: actorId)] = api.token
+        if let token = api.token {
+            do {
+                try Constants.main.keychain.set(token, key: getKeychainId(actorId: actorId))
+            } catch {
+                handleError(error)
+            }
+        }
     }
     
     func deleteTokenFromKeychain() {

--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -84,10 +84,17 @@ class UserAccount: Account, CommunityOrPerson {
         }
         self.actorId = actorId
         
-        // initialize ApiClient with token, if present
         self.api = ApiClient.getApiClient(url: instanceLink, username: name)
-        if let token = Constants.main.keychain[getKeychainId(actorId: actorId)] ?? Constants.main.keychain[getKeychainId(id: id)] {
-            api.updateToken(token)
+        do {
+            let keychain = Constants.main.keychain
+            let token = try keychain.get(getKeychainId(actorId: actorId)) ?? keychain.get(getKeychainId(id: id))
+            if let token {
+                api.updateToken(token)
+            } else {
+                handleError(MlemError.modelError("No token in keychain"))
+            }
+        } catch {
+            handleError(error)
         }
     }
     


### PR DESCRIPTION
Replaced the `keychain[key]` syntax we used for Keychain access with `get`/`set` methods. These methods throw errors when something goes wrong rather than returning `nil`. This should make it easier to debug issues like #1416