### PR TITLE
More Moderator Widgets

### DIFF
--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -56,6 +56,10 @@ enum Icons {
     static let transferCommunity: String = "arrow.right"
     static let removeAdministrator: String = "arrowshape.down"
     static let removeAdministratorFill: String = "arrowshape.down.fill"
+    static let resolve: String = "checkmark.circle"
+    static let resolveFill: String = "checkmark.circle.fill"
+    static let unresolve: String = "xmark.circle"
+    static let unresolveFill: String = "xmark.circle.fill"
     
     // inbox
     static let mention: String = "quote.bubble"
@@ -141,7 +145,7 @@ enum Icons {
     static let developerFlair: String = "hammer.fill"
     static let botFlair: String = "terminal.fill"
     static let opFlair: String = "person.fill"
-    static let instanceBannedFlair: String = "xmark.circle.fill"
+    static let instanceBannedFlair: String = "xmark.square.fill"
     static let communityBannedFlair: String = "xmark.shield.fill"
     static let newAccountFlair: String = "leaf.fill"
     
@@ -283,8 +287,8 @@ enum Icons {
     static let developerMode: String = "wrench.adjustable.fill"
     static let limitImageHeightSetting: String = "rectangle.compress.vertical"
     static let appLockSettings: String = "lock.app.dashed"
-    static let banFromInstance: String = "xmark.circle"
-    static let unbanFromInstance: String = "checkmark.circle"
+    static let banFromInstance: String = "xmark.square"
+    static let unbanFromInstance: String = "checkmark.square"
     static let banFromCommunity: String = "xmark.shield"
     static let unbanFromCommunity: String = "checkmark.shield"
     static let logIn: String = "person.text.rectangle"

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -71,6 +71,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
         case upvote
         case downvote
         case comment
+        case saved
         
         var appearance: MockReadoutAppearance {
             switch self {
@@ -79,6 +80,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             case .upvote: .init(icon: Icons.upvoteSquare, label: "9")
             case .downvote: .init(icon: Icons.downvoteSquare, label: "2")
             case .comment: .init(icon: Icons.replies, label: "1")
+            case .saved: .init(icon: Icons.save, label: "")
             }
         }
         

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -19,6 +19,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
         case report
         case resolve
         case remove
+        case ban
         
         static var defaultWidgets: [ActionType] {[
             .upvote,
@@ -29,9 +30,10 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
         ]}
         
         static var defaultReportWidgets: [ActionType] {[
-            .save,
             .share,
-            .remove
+            .resolve,
+            .remove,
+            .ban
         ]}
         
         var appearance: ActionAppearance {
@@ -45,6 +47,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             case .report: .report()
             case .resolve: .resolve(isOn: false)
             case .remove: .remove(isOn: false)
+            case .ban: .banFromCommunity(isOn: false)
             }
         }
     }
@@ -129,9 +132,9 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
     
     static var reportDefault: Self {
         .init(
-            leading: [.action(.share)],
-            trailing: [.action(.remove)],
-            readouts: [.created, .comment],
+            leading: [.action(.resolve), .action(.share)],
+            trailing: [.action(.ban), .action(.remove)],
+            readouts: [.upvote, .downvote, .created, .comment],
             availableWidgets: .init(ActionType.defaultReportWidgets.map { .action($0) })
         )
     }

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -17,6 +17,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
         case share
         case selectText
         case report
+        case resolve
         case remove
         
         static var defaultWidgets: [ActionType] {[
@@ -42,6 +43,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             case .share: .share()
             case .selectText: .selectText()
             case .report: .report()
+            case .resolve: .resolve(isOn: false)
             case .remove: .remove(isOn: false)
             }
         }

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -24,7 +24,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
         case pin
         case resolve
         case remove
-        // case ban
+        case ban
         
         static var defaultWidgets: [ActionType] {[
                 .upvote,
@@ -58,6 +58,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             case .pin: .pin(isOn: false)
             case .resolve: .resolve(isOn: false)
             case .remove: .remove(isOn: false)
+            case .ban: .banFromCommunity(isOn: false)
             }
         }
     }

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -35,11 +35,12 @@ struct PostBarConfiguration: InteractionBarConfiguration {
         ]}
         
         static var defaultReportWidgets: [ActionType] {[
-            .save,
             .share,
             .lock,
             .pin,
-            .remove
+            .resolve,
+            .remove,
+            .ban
         ]}
         
         var appearance: ActionAppearance {
@@ -143,9 +144,9 @@ struct PostBarConfiguration: InteractionBarConfiguration {
     
     static var reportDefault: Self {
         .init(
-            leading: [.action(.share), .action(.pin)],
-            trailing: [.action(.lock), .action(.remove)],
-            readouts: [.created, .comment],
+            leading: [.action(.resolve), .action(.lock)],
+            trailing: [.action(.ban), .action(.remove)],
+            readouts: [.upvote, .downvote, .created, .comment],
             availableWidgets: .init(ActionType.defaultReportWidgets.map { .action($0) })
         )
     }

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -22,7 +22,9 @@ struct PostBarConfiguration: InteractionBarConfiguration {
         case crossPost
         case lock
         case pin
+        case resolve
         case remove
+        // case ban
         
         static var defaultWidgets: [ActionType] {[
                 .upvote,
@@ -54,6 +56,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             case .crossPost: .crossPost()
             case .lock: .lock(isOn: false)
             case .pin: .pin(isOn: false)
+            case .resolve: .resolve(isOn: false)
             case .remove: .remove(isOn: false)
             }
         }

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -63,6 +63,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
         case upvote
         case downvote
         case comment
+        case saved
         
         var appearance: MockReadoutAppearance {
             switch self {
@@ -71,6 +72,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             case .upvote: .init(icon: Icons.upvoteSquare, label: "9")
             case .downvote: .init(icon: Icons.downvoteSquare, label: "2")
             case .comment: .init(icon: Icons.replies, label: "1")
+            case .saved: .init(icon: Icons.save, label: "")
             }
         }
         

--- a/Mlem/App/Legacy/LegacyInteractionBarConfigurations.swift
+++ b/Mlem/App/Legacy/LegacyInteractionBarConfigurations.swift
@@ -47,7 +47,7 @@ enum LegacyInterationBarItem: String, Codable {
         case .resolve: return .action(.resolve)
         case .remove: return .action(.remove)
         case .purge: return nil
-        case .ban: return nil
+        case .ban: return .action(.ban)
         }
     }
     
@@ -66,7 +66,7 @@ enum LegacyInterationBarItem: String, Codable {
         case .resolve: return .action(.resolve)
         case .remove: return .action(.remove)
         case .purge: return nil
-        case .ban: return nil
+        case .ban: return .action(.ban)
         }
     }
     

--- a/Mlem/App/Legacy/LegacyInteractionBarConfigurations.swift
+++ b/Mlem/App/Legacy/LegacyInteractionBarConfigurations.swift
@@ -44,7 +44,7 @@ enum LegacyInterationBarItem: String, Codable {
         case .upvoteCounter: return .counter(.upvote)
         case .downvoteCounter: return .counter(.downvote)
         case .scoreCounter: return .counter(.score)
-        case .resolve: return nil
+        case .resolve: return .action(.resolve)
         case .remove: return .action(.remove)
         case .purge: return nil
         case .ban: return nil
@@ -63,7 +63,7 @@ enum LegacyInterationBarItem: String, Codable {
         case .upvoteCounter: return .counter(.upvote)
         case .downvoteCounter: return .counter(.downvote)
         case .scoreCounter: return .counter(.score)
-        case .resolve: return nil
+        case .resolve: return .action(.resolve)
         case .remove: return .action(.remove)
         case .purge: return nil
         case .ban: return nil

--- a/Mlem/App/Legacy/LegacyInteractionBarConfigurations.swift
+++ b/Mlem/App/Legacy/LegacyInteractionBarConfigurations.swift
@@ -187,8 +187,7 @@ extension CommentBarConfiguration {
             }
         }
         if shouldShowRepliesInCommentBar { newReadouts.append(.comment) }
-        // TODO: pending #1768
-        // if shouldShowSavedInCommentBar { newReadouts.append(.saved) }
+        if shouldShowSavedInCommentBar { newReadouts.append(.saved) }
         self.readouts = newReadouts
         
         var newAvailableWidgets: Set<Item>
@@ -236,8 +235,7 @@ extension ReplyBarConfiguration {
             }
         }
         if shouldShowRepliesInCommentBar { newReadouts.append(.comment) }
-        // TODO: pending #1768
-        // if shouldShowSavedInCommentBar { newReadouts.append(.saved) }
+        if shouldShowSavedInCommentBar { newReadouts.append(.saved) }
         self.readouts = newReadouts
         
         var newAvailableWidgets: Set<Item> = .init(

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -204,6 +204,15 @@ extension ActionAppearance {
         )
     }
     
+    static func resolve(isOn: Bool) -> Self {
+        .init(
+            label: isOn ? "Unresolve" : "Resolve",
+            color: isOn ? Palette.main.negative : Palette.main.positive,
+            icon: isOn ? Icons.failureCircle : Icons.successCircle,
+            swipeIcon2: isOn ? Icons.failureCircleFill : Icons.successCircleFill
+        )
+    }
+    
     /// Adds or removes a user as administrator
     /// - Parameter isOn: true when user is admin, false otherwise
     static func addAdmin(isOn: Bool) -> Self {

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -210,6 +210,7 @@ extension ActionAppearance {
             isOn: isOn,
             color: isOn ? Palette.main.negative : Palette.main.positive,
             icon: isOn ? Icons.unresolve : Icons.resolve,
+            barIcon: isOn ? Icons.resolveFill : Icons.resolve,
             swipeIcon2: isOn ? Icons.unresolveFill : Icons.resolveFill
         )
     }

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -207,6 +207,7 @@ extension ActionAppearance {
     static func resolve(isOn: Bool) -> Self {
         .init(
             label: isOn ? "Unresolve" : "Resolve",
+            isOn: isOn,
             color: isOn ? Palette.main.negative : Palette.main.positive,
             icon: isOn ? Icons.unresolve : Icons.resolve,
             swipeIcon2: isOn ? Icons.unresolveFill : Icons.resolveFill

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -208,8 +208,8 @@ extension ActionAppearance {
         .init(
             label: isOn ? "Unresolve" : "Resolve",
             color: isOn ? Palette.main.negative : Palette.main.positive,
-            icon: isOn ? Icons.failureCircle : Icons.successCircle,
-            swipeIcon2: isOn ? Icons.failureCircleFill : Icons.successCircleFill
+            icon: isOn ? Icons.unresolve : Icons.resolve,
+            swipeIcon2: isOn ? Icons.unresolveFill : Icons.resolveFill
         )
     }
     

--- a/Mlem/App/Models/Action/BasicAction.swift
+++ b/Mlem/App/Models/Action/BasicAction.swift
@@ -7,6 +7,7 @@
 
 import Dependencies
 import SwiftUI
+import MlemMiddleware
 
 struct BasicAction: Action {
     let id: String

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -131,7 +131,8 @@ extension Comment1Providing {
     func action(
         type: CommentBarConfiguration.ActionType,
         commentTreeTracker: CommentTreeTracker? = nil,
-        communityContext: (any CommunityStubProviding)? = nil
+        communityContext: (any CommunityStubProviding)? = nil,
+        reportContext: Report? = nil
     ) -> (any Action)? {
         switch type {
         case .upvote: upvoteAction(feedback: [.haptic])
@@ -141,6 +142,7 @@ extension Comment1Providing {
         case .share: shareAction()
         case .selectText: selectTextAction()
         case .report: reportAction(communityContext: communityContext)
+        case .resolve: reportContext?.resolveAction(feedback: [.haptic])
         case .remove: removeAction().disabled(!canModerate)
         }
     }

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -164,6 +164,7 @@ extension Comment1Providing {
         case .upvote: upvoteReadout
         case .downvote: api.downvotesEnabled ? downvoteReadout : nil
         case .comment: commentReadout
+        case .saved: savedReadout
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -136,7 +136,7 @@ extension Comment1Providing {
     ) -> (any Action)? {
         switch type {
         case .upvote: upvoteAction(feedback: [.haptic])
-        case .downvote:  api.downvotesEnabled ? downvoteAction(feedback: [.haptic]) : nil
+        case .downvote: api.downvotesEnabled ? downvoteAction(feedback: [.haptic]) : nil
         case .save: saveAction(feedback: [.haptic])
         case .reply: replyAction(commentTreeTracker: commentTreeTracker)
         case .share: shareAction()

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -136,7 +136,7 @@ extension Comment1Providing {
     ) -> (any Action)? {
         switch type {
         case .upvote: upvoteAction(feedback: [.haptic])
-        case .downvote: api.downvotesEnabled ? downvoteAction(feedback: [.haptic]) : nil
+        case .downvote:  api.downvotesEnabled ? downvoteAction(feedback: [.haptic]) : nil
         case .save: saveAction(feedback: [.haptic])
         case .reply: replyAction(commentTreeTracker: commentTreeTracker)
         case .share: shareAction()
@@ -144,6 +144,7 @@ extension Comment1Providing {
         case .report: reportAction(communityContext: communityContext)
         case .resolve: reportContext?.resolveAction(feedback: [.haptic])
         case .remove: removeAction().disabled(!canModerate)
+        case .ban: reportContext?.contextualBanAction()
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -220,7 +220,8 @@ extension Post1Providing {
         type: PostBarConfiguration.ActionType,
         feedback: Set<FeedbackType> = [.haptic, .toast],
         commentTreeTracker: CommentTreeTracker? = nil,
-        communityContext: (any CommunityStubProviding)? = nil
+        communityContext: (any CommunityStubProviding)? = nil,
+        reportContext: Report? = nil
     ) -> (any Action)? {
         switch type {
         case .upvote: upvoteAction(feedback: feedback)
@@ -238,6 +239,7 @@ extension Post1Providing {
         // in parenthesis, but the pre-commit hook removed the paranthesis
         // swiftlint:disable:next void_function_in_ternary
         case .pin: api.isAdmin ? pinAction(feedback: feedback) : pinToCommunityAction(feedback: feedback)
+        case .resolve: reportContext?.resolveAction(feedback: feedback)
         case .remove: removeAction(feedback: feedback).disabled(!canModerate)
         }
     }

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -241,7 +241,7 @@ extension Post1Providing {
         case .pin: api.isAdmin ? pinAction(feedback: feedback) : pinToCommunityAction(feedback: feedback)
         case .resolve: reportContext?.resolveAction(feedback: feedback)
         case .remove: removeAction(feedback: feedback).disabled(!canModerate)
-        case .ban: contextualBanAction(reportContext: reportContext)
+        case .ban: reportContext?.contextualBanAction()
         }
     }
     
@@ -478,16 +478,6 @@ extension Post1Providing {
             appearance: .viewVotes(),
             callback: enabled ? { @MainActor in navigation.push(.votesList(.post(self))) } : nil
         )
-    }
-    
-    func contextualBanAction(reportContext: Report?) -> BasicAction? {
-        guard let reportContext, let myPerson = reportContext.api.myPerson else { return nil }
-        
-        if let community = reportContext.target.community, myPerson.moderates(communityId: community.id) {
-            return reportContext.target.creator.banFromCommunityAction(community: community)
-        }
-        
-        return reportContext.target.creator.banFromInstanceAction()
     }
     // swiftlint:disable:next file_length
 }

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -17,7 +17,7 @@ extension Post1Providing {
     var shouldHideInFeed: Bool {
         (creator_?.shouldHideInFeed ?? false) || (community_?.shouldHideInFeed ?? false) || (hidden_ ?? false) || purged
     }
-
+    
     var canModerate: Bool {
         api.myPerson?.moderates(communityId: communityId) ?? false || api.isAdmin
     }
@@ -162,7 +162,7 @@ extension Post1Providing {
                 selectTextAction()
             }
             shareAction()
-
+            
             if isOwnPost {
                 editAction()
                 deleteAction(feedback: feedback)
@@ -241,6 +241,7 @@ extension Post1Providing {
         case .pin: api.isAdmin ? pinAction(feedback: feedback) : pinToCommunityAction(feedback: feedback)
         case .resolve: reportContext?.resolveAction(feedback: feedback)
         case .remove: removeAction(feedback: feedback).disabled(!canModerate)
+        case .ban: contextualBanAction(reportContext: reportContext)
         }
     }
     
@@ -269,17 +270,17 @@ extension Post1Providing {
     
     func taggedTitle(communityContext: (any Community1Providing)?) -> Text {
         let hasTags: Bool = removed
-            || deleted
-            || pinnedInstance
-            || (communityContext != nil && pinnedCommunity)
-            || locked
+        || deleted
+        || pinnedInstance
+        || (communityContext != nil && pinnedCommunity)
+        || locked
         
         return postTag(active: removed, icon: Icons.removeFill, color: Palette.main.negative) +
-            postTag(active: deleted, icon: Icons.delete, color: Palette.main.negative) +
-            postTag(active: pinnedInstance, icon: Icons.pinFill, color: Palette.main.administration) +
-            postTag(active: pinnedCommunity && communityContext != nil, icon: Icons.pinFill, color: Palette.main.moderation) +
-            postTag(active: locked, icon: Icons.lockFill, color: Palette.main.lockAccent) +
-            Text(verbatim: "\(hasTags ? "  " : "")\(title)")
+        postTag(active: deleted, icon: Icons.delete, color: Palette.main.negative) +
+        postTag(active: pinnedInstance, icon: Icons.pinFill, color: Palette.main.administration) +
+        postTag(active: pinnedCommunity && communityContext != nil, icon: Icons.pinFill, color: Palette.main.moderation) +
+        postTag(active: locked, icon: Icons.lockFill, color: Palette.main.lockAccent) +
+        Text(verbatim: "\(hasTags ? "  " : "")\(title)")
     }
     
     /// Host if this is a link post, otherwise nil.
@@ -477,6 +478,16 @@ extension Post1Providing {
             appearance: .viewVotes(),
             callback: enabled ? { @MainActor in navigation.push(.votesList(.post(self))) } : nil
         )
+    }
+    
+    func contextualBanAction(reportContext: Report?) -> BasicAction? {
+        guard let reportContext, let myPerson = reportContext.api.myPerson else { return nil }
+        
+        if let community = reportContext.target.community, myPerson.moderates(communityId: community.id) {
+            return reportContext.target.creator.banFromCommunityAction(community: community)
+        }
+        
+        return reportContext.target.creator.banFromInstanceAction()
     }
     // swiftlint:disable:next file_length
 }

--- a/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
@@ -79,6 +79,7 @@ extension Reply1Providing {
         case .upvote: upvoteReadout
         case .downvote: api.downvotesEnabled ? downvoteReadout : nil
         case .comment: commentReadout
+        case .saved: savedReadout
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Content Models/Report+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Report+Extensions.swift
@@ -25,12 +25,7 @@ extension Report {
     func resolveAction(feedback: Set<FeedbackType> = []) -> BasicAction {
         .init(
             id: "resolve\(cacheId)",
-            appearance: .init(
-                label: resolved ? "Unresolve" : "Resolve",
-                color: resolved ? Palette.main.negative : Palette.main.positive,
-                icon: resolved ? Icons.failureCircle : Icons.successCircle,
-                swipeIcon2: resolved ? Icons.failureCircleFill : Icons.successCircleFill
-            ),
+            appearance: .resolve(isOn: resolved),
             callback: api.canInteract ? { @MainActor in self.toggleResolved(feedback: feedback) } : nil
         )
     }

--- a/Mlem/App/Utility/Extensions/Content Models/Report+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Report+Extensions.swift
@@ -29,4 +29,14 @@ extension Report {
             callback: api.canInteract ? { @MainActor in self.toggleResolved(feedback: feedback) } : nil
         )
     }
+    
+    func contextualBanAction() -> BasicAction? {
+        guard let myPerson = api.myPerson else { return nil }
+        
+        if let community = target.community, myPerson.moderates(communityId: community.id) {
+            return target.creator.banFromCommunityAction(community: community)
+        }
+        
+        return target.creator.banFromInstanceAction()
+    }
 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
@@ -17,6 +17,7 @@ struct FeedPostView<EmbeddedContent: View>: View {
     @Environment(FiltersTracker.self) var filtersTracker
     @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor
     @Environment(\.communityContext) var communityContext
+    @Environment(\.reportContext) var reportContext
     
     @State var obscured: Bool
     

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/HeadlinePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/HeadlinePostView.swift
@@ -85,7 +85,8 @@ struct HeadlinePostView<EmbeddedContent: View>: View {
                 post: post,
                 configuration: interactionBarConfiguration,
                 commentTreeTracker: commentTreeTracker,
-                communityContext: communityContext
+                communityContext: communityContext,
+                reportContext: reportContext
             )
             .padding(.horizontal, 2)
             .padding(.vertical, 5)

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostView.swift
@@ -96,7 +96,8 @@ struct LargePostView: View {
                 post: post,
                 configuration: interactionBarConfiguration,
                 commentTreeTracker: commentTreeTracker,
-                communityContext: communityContext
+                communityContext: communityContext,
+                reportContext: reportContext
             )
             .padding(.horizontal, 12)
             .padding(.vertical, 5)

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -114,7 +114,8 @@ struct CommentView<EmbeddedContent: View>: View {
                             comment: comment,
                             configuration: interactionBarConfiguration,
                             commentTreeTracker: commentTreeTracker,
-                            communityContext: communityContext
+                            communityContext: communityContext,
+                            reportContext: reportContext
                         )
                         .padding(.horizontal, 2)
                         .padding(.bottom, 5)

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -67,6 +67,8 @@ struct CommentView<EmbeddedContent: View>: View {
         }
     }
     
+    var compact: Bool { compactComments && reportContext == nil }
+    
     @ViewBuilder
     var content: some View {
         let collapsed = treeNode?.collapsed ?? false
@@ -79,7 +81,7 @@ struct CommentView<EmbeddedContent: View>: View {
                 HStack(spacing: 0) {
                     FullyQualifiedLinkView(comment.creator_, labelStyle: .small)
                     Spacer()
-                    if compactComments {
+                    if compact {
                         InfoStackView(
                             comment: comment,
                             readouts: InteractionBarTracker.main.commentInteractionBar.readouts,
@@ -109,7 +111,7 @@ struct CommentView<EmbeddedContent: View>: View {
                         .id("\(comment.id)_commment_footer")
                     }
                     embeddedContent
-                    if !compactComments {
+                    if !compact {
                         InteractionBarView(
                             comment: comment,
                             configuration: interactionBarConfiguration,
@@ -124,7 +126,7 @@ struct CommentView<EmbeddedContent: View>: View {
                 }
             }
             .padding(.vertical, Constants.main.standardSpacing)
-            .padding(.top, compactComments || collapsed ? 0 : 3)
+            .padding(.top, compact || collapsed ? 0 : 3)
         }
         .padding(depth == 0 ? .horizontal : .trailing, Constants.main.standardSpacing)
         .background(highlight ? palette.accent.opacity(0.2) : .clear)

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
@@ -20,19 +20,22 @@ struct InteractionBarView: View {
         post: any Post1Providing,
         configuration: PostBarConfiguration,
         commentTreeTracker: CommentTreeTracker? = nil,
-        communityContext: (any CommunityStubProviding)? = nil
+        communityContext: (any CommunityStubProviding)? = nil,
+        reportContext: Report? = nil
     ) {
         self.leading = .init(
             post: post,
             items: configuration.leading,
             commentTreeTracker: commentTreeTracker,
-            communityContext: communityContext
+            communityContext: communityContext,
+            reportContext: reportContext
         )
         self.trailing = .init(
             post: post,
             items: configuration.trailing,
             commentTreeTracker: commentTreeTracker,
-            communityContext: communityContext
+            communityContext: communityContext,
+            reportContext: reportContext
         )
         self.readouts = configuration.readouts.compactMap { post.readout(type: $0) }
     }
@@ -41,19 +44,22 @@ struct InteractionBarView: View {
         comment: any Comment1Providing,
         configuration: CommentBarConfiguration,
         commentTreeTracker: CommentTreeTracker? = nil,
-        communityContext: (any CommunityStubProviding)? = nil
+        communityContext: (any CommunityStubProviding)? = nil,
+        reportContext: Report?
     ) {
         self.leading = .init(
             comment: comment,
             items: configuration.leading,
             commentTreeTracker: commentTreeTracker,
-            communityContext: communityContext
+            communityContext: communityContext,
+            reportContext: reportContext
         )
         self.trailing = .init(
             comment: comment,
             items: configuration.trailing,
             commentTreeTracker: commentTreeTracker,
-            communityContext: communityContext
+            communityContext: communityContext,
+            reportContext: reportContext
         )
         self.readouts = configuration.readouts.compactMap { comment.readout(type: $0) }
     }
@@ -213,7 +219,8 @@ extension [EnrichedWidget] {
         post: any Post1Providing,
         items: [PostBarConfiguration.Item],
         commentTreeTracker: CommentTreeTracker?,
-        communityContext: (any CommunityStubProviding)?
+        communityContext: (any CommunityStubProviding)?,
+        reportContext: Report?
     ) {
         self = items.compactMap { item in
             switch item {
@@ -221,7 +228,8 @@ extension [EnrichedWidget] {
                 if let action = post.action(
                     type: action,
                     commentTreeTracker: commentTreeTracker,
-                    communityContext: communityContext
+                    communityContext: communityContext,
+                    reportContext: reportContext
                 ) {
                     return .action(action)
                 }
@@ -238,7 +246,8 @@ extension [EnrichedWidget] {
         comment: any Comment1Providing,
         items: [CommentBarConfiguration.Item],
         commentTreeTracker: CommentTreeTracker?,
-        communityContext: (any CommunityStubProviding)?
+        communityContext: (any CommunityStubProviding)?,
+        reportContext: Report?
     ) {
         self = items.compactMap { item in
             switch item {
@@ -246,7 +255,8 @@ extension [EnrichedWidget] {
                 if let action = comment.action(
                     type: action,
                     commentTreeTracker: commentTreeTracker,
-                    communityContext: communityContext
+                    communityContext: communityContext,
+                    reportContext: reportContext
                 ) {
                     return .action(action)
                 }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1360,9 +1360,6 @@
     "Load directly from %@" : {
 
     },
-    "Load More" : {
-
-    },
     "Load This Image Directly" : {
 
     },


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1768 

## Description

Adds the resolve and ban widgets to the report interaction bar and the saved readout to the comment interaction bar.

Additional changes:
- Instance ban now uses square instead of circle to avoid confusion with resolve/unresolve
- Updated report defaults to use new widgets