### PR TITLE
End-of-feed fallback load

### DIFF
--- a/Mlem/App/Views/Pages/Modlog/ModlogView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogView.swift
@@ -107,7 +107,7 @@ struct ModlogView: View {
                     Array(feedLoader.items(ofType: actionTypeFilter).enumerated()),
                     id: \.offset
                 ) { _, entry in entryView(entry) }
-                EndOfFeedView(loadingState: activeFeedLoader.loadingState, viewType: .hobbit)
+                EndOfFeedView(feedLoader: activeFeedLoader, viewType: .hobbit)
             }
             .padding([.horizontal, .bottom], Constants.main.standardSpacing)
         }

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
@@ -32,7 +32,7 @@ extension InboxView {
                     }
                 }
                 
-                EndOfFeedView(loadingState: feedLoader.loadingState, viewType: .cartoon)
+                EndOfFeedView(feedLoader: feedLoader, viewType: .cartoon)
             } header: { sectionHeader }
         }
         .animation(.easeOut(duration: 0.1), value: feedLoader.items.isEmpty)

--- a/Mlem/App/Views/Shared/EndOfFeedView.swift
+++ b/Mlem/App/Views/Shared/EndOfFeedView.swift
@@ -44,17 +44,42 @@ struct EndOfFeedView: View {
     @Environment(Palette.self) var palette
     @Setting(\.developerMode) var developerMode
     
-    let loadingState: LoadingState
+    @State var idleId: UUID?
+    
+    let loadingState_: LoadingState?
     let viewType: EndOfFeedViewType
+    let feedLoader: (any FeedLoading)?
+    
+    var loadingState: LoadingState {
+        assert(loadingState_ != nil || feedLoader != nil, "either loadingState_ or feedLoader must be defined")
+        return loadingState_ ?? feedLoader?.loadingState ?? .done
+    }
+    
+    init(loadingState: LoadingState, viewType: EndOfFeedViewType) {
+        self.loadingState_ = loadingState
+        self.feedLoader = nil
+        self.viewType = viewType
+    }
+    
+    init(feedLoader: any FeedLoading, viewType: EndOfFeedViewType) {
+        self.loadingState_ = nil
+        self.feedLoader = feedLoader
+        self.viewType = viewType
+    }
     
     var body: some View {
         Group {
             switch loadingState {
             case .idle:
-                if developerMode {
-                    Text(verbatim: "IDLE")
-                } else {
-                    ProgressView()
+                Group {
+                    if developerMode {
+                        Text(verbatim: "IDLE")
+                    } else {
+                        ProgressView()
+                    }
+                }
+                .task {
+                    await fallbackIdleLoad()
                 }
             case .loading:
                 ProgressView()
@@ -67,5 +92,23 @@ struct EndOfFeedView: View {
             }
         }
         .frame(minHeight: 100)
+    }
+    
+    private func fallbackIdleLoad() async {
+        if let feedLoader {
+            let newIdleId = UUID()
+            idleId = newIdleId
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                if loadingState == .idle, idleId == newIdleId {
+                    Task {
+                        do {
+                            try await feedLoader.loadMoreItems()
+                        } catch {
+                            handleError(error)
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/Mlem/App/Views/Shared/PostGridView.swift
+++ b/Mlem/App/Views/Shared/PostGridView.swift
@@ -108,7 +108,7 @@ struct PostGridView: View {
             }
             .padding(.horizontal, postSize.tiled || columns.count == 1 ? 0 : Constants.main.halfSpacing)
             .animation(.easeOut(duration: 0.1), value: postFeedLoader.items.isEmpty)
-            EndOfFeedView(loadingState: postFeedLoader.loadingState, viewType: .hobbit)
+            EndOfFeedView(feedLoader: postFeedLoader, viewType: .hobbit)
         }
     }
     

--- a/Mlem/App/Views/Shared/Search/SearchView+Views.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView+Views.swift
@@ -58,7 +58,7 @@ extension SearchView {
                         }
                     }
                 }
-                EndOfFeedView(loadingState: communityLoader.loadingState, viewType: .hobbit)
+                EndOfFeedView(feedLoader: communityLoader, viewType: .hobbit)
             }
             .animation(.easeOut(duration: 0.1), value: communityLoader.items.isEmpty)
         case .people:
@@ -78,7 +78,7 @@ extension SearchView {
                         }
                     }
                 }
-                EndOfFeedView(loadingState: personLoader.loadingState, viewType: .hobbit)
+                EndOfFeedView(feedLoader: personLoader, viewType: .hobbit)
             }
             .animation(.easeOut(duration: 0.1), value: personLoader.items.isEmpty)
         case .instances:
@@ -123,7 +123,7 @@ extension SearchView {
                     }
                     .animation(.easeOut(duration: 0.1), value: commentLoader.items.isEmpty)
                     .padding(.horizontal, Constants.main.standardSpacing)
-                    EndOfFeedView(loadingState: commentLoader.loadingState, viewType: .hobbit)
+                    EndOfFeedView(feedLoader: commentLoader, viewType: .hobbit)
                 }
             }
         }


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1544 
- 
## Description

Band-aid fix for #1544. `EndOfFeedView` now triggers a `loadMoreItems` if it sits in `.idle` for 1 second.