### PR TITLE
Eric/uikit scroll to section

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Feeds/SectionIndexTitles.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SectionIndexTitles.swift
@@ -16,13 +16,14 @@ struct SectionIndexTitles: View {
         var id: String { label }
     }
     
-    let proxy: ScrollViewProxy
     let sections: [Section]
     @GestureState private var dragLocation: CGPoint = .zero
 
     // Track which sidebar label we picked last so we
     // only send a haptic when selecting a new one
     @State var lastSelectedLabel: String = ""
+    
+    @Binding var sectionScroller: Int
 
     var body: some View {
         VStack {
@@ -57,8 +58,9 @@ struct SectionIndexTitles: View {
                                 if sectionLabel != lastSelectedLabel {
                                     Task { @MainActor in
                                         lastSelectedLabel = sectionLabel
-                                        proxy.scrollTo(sectionLabel, anchor: .top)
 
+                                        sectionScroller = sectionIndex
+                                        
                                         // Play nice tappy taps
                                         HapticManager.main.play(haptic: .rigidInfo, priority: .low)
                                     }

--- a/Mlem/App/Views/Root/Tabs/Feeds/SectionIndexTitles.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SectionIndexTitles.swift
@@ -17,13 +17,20 @@ struct SectionIndexTitles: View {
     }
     
     let sections: [Section]
+    @Binding var sectionScroller: Int
+    
+    init(sections: [SubscriptionListSection], sectionScroller: Binding<Int>) {
+        self.sections = sections.map {
+            .init(label: $0.label, systemImage: $0.systemImage)
+        }
+        self._sectionScroller = sectionScroller
+    }
+    
     @GestureState private var dragLocation: CGPoint = .zero
 
     // Track which sidebar label we picked last so we
     // only send a haptic when selecting a new one
     @State var lastSelectedLabel: String = ""
-    
-    @Binding var sectionScroller: Int
 
     var body: some View {
         VStack {
@@ -58,10 +65,7 @@ struct SectionIndexTitles: View {
                                 if sectionLabel != lastSelectedLabel {
                                     Task { @MainActor in
                                         lastSelectedLabel = sectionLabel
-
                                         sectionScroller = sectionIndex
-                                        
-                                        // Play nice tappy taps
                                         HapticManager.main.play(haptic: .rigidInfo, priority: .low)
                                     }
                                 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -7,6 +7,7 @@
 
 import MlemMiddleware
 import SwiftUI
+@_spi(Advanced) import SwiftUIIntrospect
 
 struct SubscriptionListView: View {
     @Environment(AppState.self) private var appState
@@ -22,6 +23,10 @@ struct SubscriptionListView: View {
         FeedSelection.cases(for: appState.firstAccount.accountType)
     }
     
+    @State var sectionScroller: Int = 0
+    
+    @Weak var form: UICollectionView?
+    
     var body: some View {
         content
             .listStyle(.sidebar)
@@ -35,87 +40,89 @@ struct SubscriptionListView: View {
             navigation.path.isEmpty
         }
     }
-
+    
     @ViewBuilder
     var content: some View {
         let sections = subscriptions?.visibleSections(sort: sort) ?? []
         
-        ScrollViewReader { proxy in
-            Form {
-                Section {
-                    ForEach(feedOptions, id: \.hashValue) { feedOption in
-                        SubscriptionListNavigationButton(.feeds(feedOption)) {
-                            HStack(spacing: 15) {
-                                FeedIconView(
-                                    feedDescription: feedOption.description,
-                                    size: appState.firstSession is GuestSession ? 36 : 28
-                                )
-                                VStack(alignment: .leading) {
-                                    Text(feedOption.description.label)
-                                    if appState.firstSession is GuestSession {
-                                        Text(feedOption.description.subtitle)
-                                            .font(.footnote)
-                                            .foregroundStyle(palette.secondary)
-                                    }
+        Form {
+            Section {
+                ForEach(feedOptions, id: \.hashValue) { feedOption in
+                    SubscriptionListNavigationButton(.feeds(feedOption)) {
+                        HStack(spacing: 15) {
+                            FeedIconView(
+                                feedDescription: feedOption.description,
+                                size: appState.firstSession is GuestSession ? 36 : 28
+                            )
+                            VStack(alignment: .leading) {
+                                Text(feedOption.description.label)
+                                if appState.firstSession is GuestSession {
+                                    Text(feedOption.description.subtitle)
+                                        .font(.footnote)
+                                        .foregroundStyle(palette.secondary)
                                 }
                             }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .contentShape(.rect)
                         }
-                    }
-                }
-                
-                if AccountsTracker.main.isEmpty {
-                    Section {
-                        signedOutInfoView
-                            .listRowBackground(Color.clear)
-                    }
-                }
-                
-                ForEach(sections) { section in
-                    SubscriptionListSectionView(section: section, sectionIndicesShown: sectionIndicesShown)
-                        .id(section.label)
-                }
-                .scrollTargetLayout()
-            }
-            .foregroundStyle(palette.primary)
-            .overlay(alignment: .trailing) {
-                if sectionIndicesShown {
-                    SectionIndexTitles(
-                        proxy: proxy,
-                        sections: [.init(label: String(localized: "Favorites"), systemImage: "star.fill")]
-                            + "ABCDEFGHIJKLMNOPQRSTUVWYZ#".map { .init(label: String($0)) }
-                    )
-                }
-            }
-            .toolbar {
-                if !(subscriptions?.communities.isEmpty ?? true) {
-                    Picker("Sort", selection: $sort) {
-                        ForEach(SubscriptionListSort.allCases, id: \.self) { item in
-                            Label(item.label, systemImage: item.systemImage)
-                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(.rect)
                     }
                 }
             }
-            .onChange(of: tabReselectTracker.flag) {
-                // normal reselect tracker does not work here thanks to NavigationSplitView, so we need to implement a custom one
-                if detailDisplayed, tabReselectTracker.flag {
-                    tabReselectTracker.reset()
-                    withAnimation {
-                        proxy.scrollTo(sections.first?.label)
-                    }
+            
+            if AccountsTracker.main.isEmpty {
+                Section {
+                    signedOutInfoView
+                        .listRowBackground(Color.clear)
                 }
             }
-            .scrollIndicators(sectionIndicesShown ? .hidden : .visible)
-            .refreshable {
-                do {
-                    try await subscriptions?.refresh()
-                } catch {
-                    handleError(error)
-                }
+            
+            ForEach(sections) { section in
+                SubscriptionListSectionView(section: section, sectionIndicesShown: sectionIndicesShown)
+                    .id(section.label)
             }
-            .background(palette.background)
+            .scrollTargetLayout()
         }
+        .introspect(.form, on: .iOS(.v17, .v18)) { introspectedForm in
+            self.form = introspectedForm
+        }
+        .onChange(of: sectionScroller) {
+            form?.scrollToItem(at: .init(row: 0, section: sectionScroller), at: .centeredVertically, animated: false)
+        }
+        .foregroundStyle(palette.primary)
+        .overlay(alignment: .trailing) {
+            if sectionIndicesShown {
+                SectionIndexTitles(
+                    sections: [.init(label: String(localized: "Favorites"), systemImage: "star.fill")]
+                    + "ABCDEFGHIJKLMNOPQRSTUVWXYZ#".map { .init(label: String($0)) },
+                    sectionScroller: $sectionScroller
+                )
+            }
+        }
+        .toolbar {
+            if !(subscriptions?.communities.isEmpty ?? true) {
+                Picker("Sort", selection: $sort) {
+                    ForEach(SubscriptionListSort.allCases, id: \.self) { item in
+                        Label(item.label, systemImage: item.systemImage)
+                    }
+                }
+            }
+        }
+        .onChange(of: tabReselectTracker.flag) {
+            // normal reselect tracker does not work here thanks to NavigationSplitView, so we need to implement a custom one
+            if detailDisplayed, tabReselectTracker.flag {
+                tabReselectTracker.reset()
+                form?.scrollToItem(at: .init(row: 0, section: 0), at: .bottom, animated: true)
+            }
+        }
+        .scrollIndicators(sectionIndicesShown ? .hidden : .visible)
+        .refreshable {
+            do {
+                try await subscriptions?.refresh()
+            } catch {
+                handleError(error)
+            }
+        }
+        .background(palette.background)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -92,8 +92,7 @@ struct SubscriptionListView: View {
         .overlay(alignment: .trailing) {
             if sectionIndicesShown {
                 SectionIndexTitles(
-                    sections: [.init(label: String(localized: "Favorites"), systemImage: "star.fill")]
-                    + "ABCDEFGHIJKLMNOPQRSTUVWXYZ#".map { .init(label: String($0)) },
+                    sections: sections,
                     sectionScroller: $sectionScroller
                 )
             }


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1349 

## Description

Replaces the SwiftUI-based index scrolling with a UIKit/introspection-based implementation that uses `UICollectionView.scrollTo` to perform scrolling.

Since we already have a custom scroll-to-top implementation on this view anyway, I also use the UIKit approach to handle that and have ripped out the `ScrollViewReader` altogether.

## Implementation Notes

Setting the scroll target to `.top` puts it a little _too_ at the top (and trying to fix it with edge insets on the `UICollectionView` makes the top insets bad), I've set the scroll target to `.verticallyCentered`.