### PR TITLE
fix eof infinite load

### DIFF
--- a/Mlem/App/Views/Shared/EndOfFeedView.swift
+++ b/Mlem/App/Views/Shared/EndOfFeedView.swift
@@ -44,7 +44,7 @@ struct EndOfFeedView: View {
     @Environment(Palette.self) var palette
     @Setting(\.developerMode) var developerMode
     
-    @State var idleId: UUID?
+    @State var showLoadMore: Bool = false
     
     let loadingState_: LoadingState?
     let viewType: EndOfFeedViewType
@@ -72,14 +72,33 @@ struct EndOfFeedView: View {
             switch loadingState {
             case .idle:
                 Group {
-                    if developerMode {
-                        Text(verbatim: "IDLE")
+                    if showLoadMore, let feedLoader {
+                        Button("Load More") {
+                            Task {
+                                do {
+                                    try await feedLoader.loadMoreItems()
+                                } catch {
+                                    handleError(error)
+                                }
+                            }
+                        }
+                        .buttonStyle(.bordered)
                     } else {
-                        ProgressView()
+                        Group {
+                            if developerMode {
+                                Text(verbatim: "IDLE")
+                            } else {
+                                ProgressView()
+                            }
+                        }
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                if loadingState == .idle {
+                                    showLoadMore = true
+                                }
+                            }
+                        }
                     }
-                }
-                .task {
-                    await fallbackIdleLoad()
                 }
             case .loading:
                 ProgressView()
@@ -92,22 +111,9 @@ struct EndOfFeedView: View {
             }
         }
         .frame(minHeight: 100)
-    }
-    
-    private func fallbackIdleLoad() async {
-        if let feedLoader {
-            let newIdleId = UUID()
-            idleId = newIdleId
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                if loadingState == .idle, idleId == newIdleId {
-                    Task {
-                        do {
-                            try await feedLoader.loadMoreItems()
-                        } catch {
-                            handleError(error)
-                        }
-                    }
-                }
+        .onChange(of: loadingState, initial: true) {
+            if loadingState != .idle {
+                showLoadMore = false
             }
         }
     }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1360,6 +1360,9 @@
     "Load directly from %@" : {
 
     },
+    "Load More" : {
+
+    },
     "Load This Image Directly" : {
 
     },


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1795 

## Description

Fixes the previous end-of-feed logic causing an infinite load. The "Load More" button is back, and now appears after 0.5s in the idle state.