### PR TITLE
Eric/thumbnail load state

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -436,6 +436,7 @@
 		CD7DB9712C49C17200DCC542 /* PersonContentGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7DB9702C49C17200DCC542 /* PersonContentGridView.swift */; };
 		CD7DB9732C4AEDDE00DCC542 /* TileCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7DB9722C4AEDDE00DCC542 /* TileCommentView.swift */; };
 		CD7DB9762C4D6C0A00DCC542 /* FeedCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7DB9752C4D6C0A00DCC542 /* FeedCommentView.swift */; };
+		CD7F82762D6BE7BF001748BA /* MediaLoadingTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7F82752D6BE7BC001748BA /* MediaLoadingTracker.swift */; };
 		CD8457142D07576A00CEA2B8 /* AVPlayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8457132D07576700CEA2B8 /* AVPlayer+Extensions.swift */; };
 		CD848FC42D63E1CB009A7AE7 /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD848FC32D63E1CB009A7AE7 /* MlemMiddleware */; };
 		CD869FCC2C15F8AC00FC8B5B /* BubblePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD869FCB2C15F8AC00FC8B5B /* BubblePickerView.swift */; };
@@ -951,6 +952,7 @@
 		CD7DB9702C49C17200DCC542 /* PersonContentGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonContentGridView.swift; sourceTree = "<group>"; };
 		CD7DB9722C4AEDDE00DCC542 /* TileCommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileCommentView.swift; sourceTree = "<group>"; };
 		CD7DB9752C4D6C0A00DCC542 /* FeedCommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCommentView.swift; sourceTree = "<group>"; };
+		CD7F82752D6BE7BC001748BA /* MediaLoadingTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLoadingTracker.swift; sourceTree = "<group>"; };
 		CD8457132D07576700CEA2B8 /* AVPlayer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVPlayer+Extensions.swift"; sourceTree = "<group>"; };
 		CD869FCB2C15F8AC00FC8B5B /* BubblePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubblePickerView.swift; sourceTree = "<group>"; };
 		CD869FCD2C15F90C00FC8B5B /* ChildSizeReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildSizeReader.swift; sourceTree = "<group>"; };
@@ -1642,6 +1644,7 @@
 		CD13CC672C5D3CBE001AF428 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				CD7F82752D6BE7BC001748BA /* MediaLoadingTracker.swift */,
 				CD605B022D53D6AA00F682AE /* MediaControlState.swift */,
 				CD1DF6372D38357100F7851E /* MediaView.swift */,
 				CD1DF63D2D387E8300F7851E /* MediaView+Views.swift */,
@@ -2732,6 +2735,7 @@
 				CD1C64152D3428710006B3C1 /* CommunityView+Logic.swift in Sources */,
 				031E2D512BEF961D0003BC45 /* SubscriptionListView.swift in Sources */,
 				CDD4A09E2C8B69FC0001AD1A /* Button.swift in Sources */,
+				CD7F82762D6BE7BF001748BA /* MediaLoadingTracker.swift in Sources */,
 				038028DA2CACACD30091A8A2 /* PostEllipsisMenus.swift in Sources */,
 				030FF67B2BC8521600F6BFAC /* CustomTabView.swift in Sources */,
 				03531EF52C2DA610004A3464 /* NavigationSearchType.swift in Sources */,

--- a/Mlem/App/Utility/Extensions/EnvironmentValues+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/EnvironmentValues+Extensions.swift
@@ -18,5 +18,5 @@ extension EnvironmentValues {
     @Entry var parentFrameWidth: CGFloat = .zero
     @Entry var isRootView: Bool = false
     
-    @Entry var loadingTracker: MediaLoadingStateTracker?
+    @Entry var loadingTracker: MediaLoadingTracker?
 }

--- a/Mlem/App/Utility/Extensions/EnvironmentValues+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/EnvironmentValues+Extensions.swift
@@ -17,4 +17,6 @@ extension EnvironmentValues {
     
     @Entry var parentFrameWidth: CGFloat = .zero
     @Entry var isRootView: Bool = false
+    
+    @Entry var loadingTracker: MediaLoadingStateTracker?
 }

--- a/Mlem/App/Views/Shared/Images/Core/FixedImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Core/FixedImageView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 /// Image view that always has a fixed size. The image will be scaled to the given size, but resized to fill its parent frame.
 struct FixedImageView: View {
     @Environment(Palette.self) var palette
+    @Environment(\.loadingTracker) var loadingTracker
     
     @Setting(\.postSize) var postSize
     
@@ -60,10 +61,15 @@ struct FixedImageView: View {
     
     var body: some View {
         Color.clear
-            .task(id: url) {
-                await loader.load(url)
-            }
             .contentShape(.rect)
+            .onChange(of: url, initial: true) {
+                Task {
+                    await loader.load(url)
+                }
+            }
+            .onChange(of: loader.loading, initial: true) {
+                loadingTracker?.loading = loader.loading
+            }
             .overlay {
                 content
                     .overlay {
@@ -72,8 +78,6 @@ struct FixedImageView: View {
                         }
                     }
                     .aspectRatio(1, contentMode: .fill)
-                    .onChange(of: loader.loading, initial: true) { loadingPref = loader.loading }
-                    .preference(key: MediaLoadingPreferenceKey.self, value: loadingPref)
                     .allowsHitTesting(false)
             }
     }

--- a/Mlem/App/Views/Shared/Images/Core/FixedImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Core/FixedImageView.swift
@@ -17,8 +17,6 @@ struct FixedImageView: View {
     
     @Setting(\.postSize) var postSize
     
-    @State var loadingPref: MediaLoadingState? // tracked separately to allow correct propagation of initial value
-    
     @State var loader: FixedImageLoader
     
     let url: URL?

--- a/Mlem/App/Views/Shared/Images/Core/MediaLoadingTracker.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaLoadingTracker.swift
@@ -1,0 +1,13 @@
+//
+//  MediaLoadingTracker.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2025-02-23.
+//
+
+import Observation
+
+@Observable
+class MediaLoadingTracker {
+    var loading: MediaLoadingState?
+}

--- a/Mlem/App/Views/Shared/Images/Helpers/FixedImageLoader.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/FixedImageLoader.swift
@@ -27,6 +27,7 @@ class FixedImageLoader {
     }
     
     func load(_ url: URL?) async {
+        print("DEBUG loading \(url)")
         // reset everything
         loading = .loading
         proxyBypass = nil
@@ -48,6 +49,7 @@ class FixedImageLoader {
         
         // if movie type, can't get a valid uiImage so abort early
         if url.proxyAwarePathExtension?.isMovieExtension ?? false {
+            print("DEBUG \(url) is movie")
             isAnimated = true
             loading = .done
             return

--- a/Mlem/App/Views/Shared/Images/Helpers/FixedImageLoader.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/FixedImageLoader.swift
@@ -27,7 +27,6 @@ class FixedImageLoader {
     }
     
     func load(_ url: URL?) async {
-        print("DEBUG loading \(url)")
         // reset everything
         loading = .loading
         proxyBypass = nil
@@ -49,7 +48,6 @@ class FixedImageLoader {
         
         // if movie type, can't get a valid uiImage so abort early
         if url.proxyAwarePathExtension?.isMovieExtension ?? false {
-            print("DEBUG \(url) is movie")
             isAnimated = true
             loading = .done
             return

--- a/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
@@ -10,11 +10,6 @@ import MlemMiddleware
 import QuickLook
 import SwiftUI
 
-@Observable
-class MediaLoadingStateTracker {
-    var loading: MediaLoadingState?
-}
-
 struct ThumbnailImageView: View {
     @Environment(Palette.self) var palette
     @Environment(NavigationLayer.self) var navigation
@@ -23,7 +18,7 @@ struct ThumbnailImageView: View {
     @Setting(\.websiteThumbnailIcon) var websiteThumbnailIcon
     
     // @State var loading: MediaLoadingState?
-    @State var loadingTracker: MediaLoadingStateTracker = .init()
+    @State var loadingTracker: MediaLoadingTracker = .init()
     @State var quickLookUrl: URL?
     
     let post: any Post1Providing

--- a/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
@@ -10,6 +10,11 @@ import MlemMiddleware
 import QuickLook
 import SwiftUI
 
+@Observable
+class MediaLoadingStateTracker {
+    var loading: MediaLoadingState?
+}
+
 struct ThumbnailImageView: View {
     @Environment(Palette.self) var palette
     @Environment(NavigationLayer.self) var navigation
@@ -17,7 +22,8 @@ struct ThumbnailImageView: View {
     
     @Setting(\.websiteThumbnailIcon) var websiteThumbnailIcon
     
-    @State var loading: MediaLoadingState?
+    // @State var loading: MediaLoadingState?
+    @State var loadingTracker: MediaLoadingStateTracker = .init()
     @State var quickLookUrl: URL?
     
     let post: any Post1Providing
@@ -55,7 +61,7 @@ struct ThumbnailImageView: View {
             case let .media(url), let .embedded(url, _):
                 content
                     .onTapGesture {
-                        if let loading, loading == .done || loading == .proxyFailed {
+                        if let loading = loadingTracker.loading, loading == .done || loading == .proxyFailed {
                             post.markRead()
                             navigation.showImageViewer(url: url)
                         }
@@ -110,10 +116,10 @@ struct ThumbnailImageView: View {
                 size: frame,
                 fallback: url.proxyAwarePathExtension?.isMovieExtension ?? false ? .movie : .image,
                 showProgress: true,
-                blurred: blurred && loading == .done
+                blurred: blurred && loadingTracker.loading == .done
             )
             .clipShape(RoundedRectangle(cornerRadius: Constants.main.smallItemCornerRadius))
-            .onPreferenceChange(MediaLoadingPreferenceKey.self, perform: { loading = $0 })
+            .environment(\.loadingTracker, loadingTracker)
         } else {
             Image(systemName: post.placeholderImageName)
                 .font(.title)
@@ -134,9 +140,9 @@ struct ThumbnailImageView: View {
                 size: frame,
                 fallback: .image,
                 showProgress: true,
-                blurred: blurred && loading == .done
+                blurred: blurred && loadingTracker.loading == .done
             )
-            .onPreferenceChange(MediaLoadingPreferenceKey.self, perform: { loading = $0 })
+            .environment(\.loadingTracker, loadingTracker)
         } else {
             Image(systemName: post.placeholderImageName)
                 .resizable()

--- a/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Wrappers/ThumbnailImageView.swift
@@ -17,7 +17,6 @@ struct ThumbnailImageView: View {
     
     @Setting(\.websiteThumbnailIcon) var websiteThumbnailIcon
     
-    // @State var loading: MediaLoadingState?
     @State var loadingTracker: MediaLoadingTracker = .init()
     @State var quickLookUrl: URL?
     


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1797

## Description

Fixes an issue where `loadingState` would not always propagate up through the loading preference key. This caused thumbnails to not open the media view on tap because the `ThumnailImageView` thought the loading state was done. I have implemented two changes to solve this:
- `loader.load()` is now called in a `Task` in an `onChange` instead of in a `task`, which should prevent it from getting cancelled
- Loading state is now handled using an environment object, `MediaLoadingStateTracker`. In #1737 I will unify this into `MediaControlState`