### PR TITLE
[#1124] Add french localization

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -346,6 +346,7 @@
 		03FE14082BF94FFB00A8377F /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE14072BF94FFB00A8377F /* ErrorView.swift */; };
 		03FE140C2BF953B000A8377F /* HandleError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE140B2BF953B000A8377F /* HandleError.swift */; };
 		50C99B562A61D792005D57DD /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = 50C99B552A61D792005D57DD /* Dependencies */; };
+		515B78D82D6F6F4E0027D6D4 /* String+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B78D72D6F6F480027D6D4 /* String+extension.swift */; };
 		6332FDBD27EFAF7C0009A98A /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6332FDBC27EFAF7B0009A98A /* Settings.bundle */; };
 		636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 636250DB2A18111400FC59B4 /* KeychainAccess */; };
 		6363D5C527EE196700E34822 /* MlemApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6363D5C427EE196700E34822 /* MlemApp.swift */; };
@@ -867,6 +868,7 @@
 		03FE14052BF9445F00A8377F /* CloseButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseButtonView.swift; sourceTree = "<group>"; };
 		03FE14072BF94FFB00A8377F /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		03FE140B2BF953B000A8377F /* HandleError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleError.swift; sourceTree = "<group>"; };
+		515B78D72D6F6F480027D6D4 /* String+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extension.swift"; sourceTree = "<group>"; };
 		630D753C27F65E44006E60C9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		6332FDBC27EFAF7B0009A98A /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		6363D5C127EE196700E34822 /* Mlem.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mlem.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1901,6 +1903,7 @@
 				0397D4712C68078F002C6CDC /* PrefetchingConfiguration+Extensions.swift */,
 				CD4D59152B87B38C00B82964 /* UIApplication+Extensions.swift */,
 				0343C0472D3AD6DB001CF709 /* Set+Extensions.swift */,
+				515B78D72D6F6F480027D6D4 /* String+extension.swift */,
 				03AF91E02C1B25DE00E56644 /* UIDevice+Extensions.swift */,
 				03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */,
 				03B431BF2C45ABFB001A1EB5 /* UITextView+Extensions.swift */,
@@ -2706,6 +2709,7 @@
 				CD2C86542D5556C00034CD8A /* MlemError.swift in Sources */,
 				CD4E386B2C836837009B24F2 /* DraculaPalette.swift in Sources */,
 				CD9857A42C5E7F9D0084C71F /* NsfwOverlayView.swift in Sources */,
+				515B78D82D6F6F4E0027D6D4 /* String+extension.swift in Sources */,
 				CD64A91C2CA38DBA007CA7E6 /* NukeWebpBridgeDecoder.swift in Sources */,
 				CD1DF6402D387EB700F7851E /* MediaView+Functions.swift in Sources */,
 				030E95E72C80A20A0045BC2C /* View+NavigationTransition.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -2384,6 +2384,7 @@
 				en,
 				Base,
 				"en-GB",
+				fr,
 			);
 			mainGroup = 6363D5B827EE196700E34822;
 			packageReferences = (

--- a/Mlem/App/Models/Settings/Options/PostSize.swift
+++ b/Mlem/App/Models/Settings/Options/PostSize.swift
@@ -21,7 +21,7 @@ enum PostSize: String, CaseIterable, Codable {
         }
     }
 
-    var label: LocalizedStringResource {
+    var label: String {
         switch self {
         case .compact: "Compact"
         case .headline: "Headline"

--- a/Mlem/App/Utility/Extensions/ApiSortType+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/ApiSortType+Extensions.swift
@@ -134,10 +134,10 @@ extension ApiSortType: @retroactive CaseIterable {
         }
     }
     
-    var explanation: LocalizedStringResource? {
+    var explanation: String? {
         switch self {
         case .hot: "Ranks posts based on the post score and creation time."
-        case .scaled: "Similar to \"Hot\", but ranks posts from smaller communities higher."
+        case .scaled: "Similar to Hot, but ranks posts from smaller communities higher."
         case .active: "Ranks posts based on the post score and the time since the last comment was created."
         default: nil
         }

--- a/Mlem/App/Utility/Extensions/Bundle+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Bundle+Extensions.swift
@@ -15,4 +15,12 @@ extension Bundle {
     var buildVersionNumber: String? {
         infoDictionary?["CFBundleVersion"] as? String
     }
+    
+    /// Returns the fist preferred localization according to `Bundle.main`, or at least, "en"
+    static var preferredLocalization: String {
+        guard let firstPreferredLocalization = Bundle.main.preferredLocalizations.first else {
+            return "en"
+        }
+        return firstPreferredLocalization
+    }
 }

--- a/Mlem/App/Utility/Extensions/String+extension.swift
+++ b/Mlem/App/Utility/Extensions/String+extension.swift
@@ -1,0 +1,29 @@
+//
+// Software Name: Mlem
+// SPDX-FileCopyrightText: Copyright (c) Mlem Group
+// SPDX-License-Identifier: GPL-3.0
+//
+// This software is distributed under the GNU General Public License v3.0 license,
+// the text of which is available at https://www.gnu.org/licenses/gpl-3.0-standalone.html
+// or see the "LICENSE" file for more details.
+//
+
+import Foundation
+
+extension String {
+    /// Returns the localized result string using `self` as key.
+    /// - Returns String: The conversion of `self` as `NSLocalizedString`
+    func localized() -> String {
+        let prefferedLocalization = Bundle.preferredLocalization
+
+        guard let path = Bundle.main.path(forResource: prefferedLocalization, ofType: "lproj") else {
+            return NSLocalizedString(self, bundle: Bundle.main, comment: "")
+        }
+
+        guard let languageBundle = Bundle(path: path) else {
+            return NSLocalizedString(self, bundle: Bundle.main, comment: "")
+        }
+
+        return NSLocalizedString(self, tableName: nil, bundle: languageBundle, value: "", comment: "")
+    }
+}

--- a/Mlem/App/Views/Pages/Community/AdvancedSortView+SortButton.swift
+++ b/Mlem/App/Views/Pages/Community/AdvancedSortView+SortButton.swift
@@ -81,7 +81,7 @@ extension AdvancedSortView {
                     }
                     .popover(isPresented: $showingExplanation) {
                         PopoverContainer {
-                            Text(explanation)
+                            Text(LocalizedStringKey(explanation))
                                 .frame(maxWidth: 200)
                                 .fixedSize(horizontal: false, vertical: true)
                                 .font(.footnote)

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -83,7 +83,7 @@ struct SubscriptionListView: View {
             .scrollTargetLayout()
         }
         .introspect(.form, on: .iOS(.v17, .v18)) { introspectedForm in
-            self.form = introspectedForm
+            form = introspectedForm
         }
         .onChange(of: sectionScroller) {
             form?.scrollToItem(at: .init(row: 0, section: sectionScroller), at: .centeredVertically, animated: false)
@@ -101,7 +101,7 @@ struct SubscriptionListView: View {
             if !(subscriptions?.communities.isEmpty ?? true) {
                 Picker("Sort", selection: $sort) {
                     ForEach(SubscriptionListSort.allCases, id: \.self) { item in
-                        Label(item.label, systemImage: item.systemImage)
+                        Label(item.label.localized(), systemImage: item.systemImage)
                     }
                 }
             }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
@@ -85,11 +85,11 @@ struct AccountSettingsView: View {
                     Button {
                         appState.firstAccount.signOut()
                     } label: {
-                        Text(signOutLabel)
+                        Text(signOutLabel.localized())
                             .frame(maxWidth: .infinity)
                     }
                     .confirmationDialog(signOutPrompt, isPresented: $showingSignOutConfirmation) {
-                        Button(signOutLabel, role: .destructive) {
+                        Button(signOutLabel.localized(), role: .destructive) {
                             appState.firstAccount.signOut()
                         }
                     } message: {

--- a/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
@@ -57,7 +57,7 @@ struct CommentSettingsView: View {
     }
     
     @ViewBuilder
-    func sizePickerItem(_ titleKey: LocalizedStringResource, isOn: Bool) -> some View {
+    func sizePickerItem(_ titleKey: String, isOn: Bool) -> some View {
         DevicePickerItem(titleKey, item: isOn, selected: $compactComments, scale: 1.2) {
             VStack(spacing: 3) {
                 ForEach(Array(sizePickerCommentPreviewDepths.enumerated()), id: \.offset) { _, depth in

--- a/Mlem/App/Views/Root/Tabs/Settings/Components/DevicePickerItem.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/Components/DevicePickerItem.swift
@@ -17,13 +17,13 @@ struct DevicePickerItem<Item: Equatable, ScreenContent: View>: View {
     @ViewBuilder var screenContent: () -> ScreenContent
     
     init(
-        _ titleKey: LocalizedStringResource,
+        _ titleKey: String,
         item: Item,
         selected: Binding<Item>,
         scale: CGFloat = 1.0,
         @ViewBuilder screenContent: @escaping () -> ScreenContent
     ) {
-        self.title = .init(localized: titleKey)
+        self.title = titleKey
         self.item = item
         self.scale = scale
         self._selected = selected

--- a/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
@@ -25,7 +25,7 @@ struct SubscriptionListSettingsView: View {
             Section("Sort by...") {
                 Picker("Sort by...", selection: $sort) {
                     ForEach(SubscriptionListSort.allCases, id: \.self) { item in
-                        Label(item.label, systemImage: item.systemImage)
+                        Label(item.label.localized(), systemImage: item.systemImage)
                     }
                 }
                 .labelsHidden()

--- a/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
@@ -53,7 +53,7 @@ struct AccountListRow: View {
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if (account as? GuestAccount)?.isSaved ?? true {
-                Button(signOutLabel) {
+                Button(signOutLabel.localized()) {
                     showingSignOutConfirmation = true
                 }
                 .buttonStyle(.automatic)

--- a/Mlem/App/Views/Shared/PersonContentGridView.swift
+++ b/Mlem/App/Views/Shared/PersonContentGridView.swift
@@ -64,7 +64,11 @@ struct PersonContentGridView: View {
                         Menu {
                             Picker("Post Size", selection: $postSize) {
                                 ForEach(PostSize.allCases, id: \.self) { item in
-                                    Label(item.label.key, systemImage: item.icon(filled: postSize == item))
+                                    Label {
+                                        Text(LocalizedStringResource(stringLiteral: item.label))
+                                    } icon: {
+                                        Image(systemName: item.icon(filled: postSize == item))
+                                    }
                                 }
                             }
                         } label: {

--- a/Mlem/App/Views/Shared/PostGridView.swift
+++ b/Mlem/App/Views/Shared/PostGridView.swift
@@ -144,7 +144,11 @@ struct PostGridView: View {
         Menu {
             Picker("Post Size", selection: $postSize) {
                 ForEach(PostSize.allCases, id: \.self) { item in
-                    Label(item.label.key, systemImage: item.icon(filled: postSize == item))
+                    Label {
+                        Text(LocalizedStringResource(stringLiteral: item.label))
+                    } icon: {
+                        Image(systemName: item.icon(filled: postSize == item))
+                    }
                 }
             }
         } label: {

--- a/Mlem/App/Views/Shared/Search/SearchBar/SearchBar.swift
+++ b/Mlem/App/Views/Shared/Search/SearchBar/SearchBar.swift
@@ -43,7 +43,7 @@ import SwiftUI
             onEditingChanged: @escaping (Bool) -> Void = { _ in },
             onCommit: @escaping () -> Void = {}
         ) {
-            self.placeholder = String(title)
+            self.placeholder = String(title).localized()
             self._text = text
             self.onCommit = onCommit
             self.onEditingChanged = onEditingChanged

--- a/Mlem/App/Views/Shared/Search/SearchSheetView.swift
+++ b/Mlem/App/Views/Shared/Search/SearchSheetView.swift
@@ -15,7 +15,8 @@ struct SearchSheetView<Item: Searchable, Content: View>: View {
     @Environment(Palette.self) var palette
     
     enum CloseButtonLabel: String {
-        case cancel, done
+        case cancel = "Cancel"
+        case done = "Done"
     }
     
     @ViewBuilder let content: ([Item], NavigationLayer) -> Content
@@ -59,7 +60,7 @@ struct SearchSheetView<Item: Searchable, Content: View>: View {
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Button(closeButtonLabel.rawValue.capitalized) {
+                Button(closeButtonLabel.rawValue.localized()) {
                     navigation.dismissSheet()
                 }
             }

--- a/Mlem/App/Views/Shared/Search/SearchView.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView.swift
@@ -131,7 +131,7 @@ struct SearchView: View {
     
     func searchBar() -> SearchBar {
         SearchBar(
-            "Search...",
+            "Search...".localized(),
             text: $query,
             isEditing: $isSearching,
             onCommit: {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -125,6 +125,26 @@
         }
       }
     },
+    "%@ is {{online}}" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ est {{online}}"
+          }
+        }
+      }
+    },
+    "%@ is {{unhealthy}}" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ est {{unhealthy}}"
+          }
+        }
+      }
+    },
     "%@ is banned from %@ until %@." : {
       "localizations" : {
         "en" : {
@@ -1163,6 +1183,16 @@
         }
       }
     },
+    "Ban" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bannir"
+          }
+        }
+      }
+    },
     "Ban %@" : {
       "localizations" : {
         "fr" : {
@@ -1203,12 +1233,32 @@
         }
       }
     },
+    "Ban from..." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bannir de…"
+          }
+        }
+      }
+    },
     "Ban Target" : {
       "localizations" : {
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cible de bannisement"
+          }
+        }
+      }
+    },
+    "Ban User" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bannir l’utilisateur"
           }
         }
       }
@@ -1259,6 +1309,16 @@
         }
       }
     },
+    "Banning from..." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bannissement de..."
+          }
+        }
+      }
+    },
     "Biography" : {
       "localizations" : {
         "fr" : {
@@ -1285,6 +1345,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bloquer la communauté"
+          }
+        }
+      }
+    },
+    "Block community or user?" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloquer la communauté ou l’utilisateur ?"
           }
         }
       }
@@ -2219,6 +2289,16 @@
         }
       }
     },
+    "Custom Order" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnaliser l’ordre"
+          }
+        }
+      }
+    },
     "Customize how content is displayed in your feed. Choose which types of content are blurred, and apply filters to hide posts from the feed altogether." : {
       "localizations" : {
         "en-GB" : {
@@ -2799,6 +2879,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saisissez le nom de domaine de votre instance ci-dessous."
+          }
+        }
+      }
+    },
+    "Error" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur"
           }
         }
       }
@@ -4468,6 +4558,16 @@
         }
       }
     },
+    "Most Recent" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le plus récent"
+          }
+        }
+      }
+    },
     "Mozilla Observatory" : {
       "localizations" : {
         "fr" : {
@@ -5110,6 +5210,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Épingler la Communauté"
+          }
+        }
+      }
+    },
+    "Pin to Community or Instance?" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épingler dans la communauté ou l’instance ?"
           }
         }
       }
@@ -6120,6 +6230,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nécessite une inscription"
+          }
+        }
+      }
+    },
+    "Requires Lemmy %@ or later" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nécessite Lemmy %@ ou plus récent"
           }
         }
       }
@@ -7171,6 +7291,16 @@
         }
       }
     },
+    "Tap to Undo" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tapper pour annuler"
+          }
+        }
+      }
+    },
     "Tappable Links" : {
       "localizations" : {
         "fr" : {
@@ -7842,12 +7972,42 @@
         }
       }
     },
+    "Unban" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débannier"
+          }
+        }
+      }
+    },
     "Unban %@" : {
       "localizations" : {
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Débannir %@"
+          }
+        }
+      }
+    },
+    "Unban from..." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débannir de..."
+          }
+        }
+      }
+    },
+    "Unban User" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débannir l’utilisateur"
           }
         }
       }
@@ -7864,6 +8024,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Débanni : %1$@\nDe : %2$@"
+          }
+        }
+      }
+    },
+    "Unbanning from..." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débanissement de…"
           }
         }
       }
@@ -7924,6 +8094,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Annuler vote positif"
+          }
+        }
+      }
+    },
+    "Undone!" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulé !"
           }
         }
       }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -8,6 +8,12 @@
             "state" : "new",
             "value" : "**%1$@** and **%2$@** chose to defederate from one another."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%1$@** et **%2$@** ont choisi de se défédérer l'une de l'autre."
+          }
         }
       }
     },
@@ -17,6 +23,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "**%1$@** chose to defederate from your instance, **%2$@**."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%1$@** a choisi de se défédérer de votre instance, **%2$@**."
           }
         }
       }
@@ -28,20 +40,54 @@
             "state" : "new",
             "value" : "**%1$@** hasn't chosen to federate with your instance, **%2$@**."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%1$@** n'a pas choisi de se fédérer avec votre instance, **%2$@**."
+          }
         }
       }
     },
     "%@ Administrator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Administrateur"
+          }
+        }
+      }
     },
     "%@ appointed a moderator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a nommé un modérateur"
+          }
+        }
+      }
     },
     "%@ appointed an administrator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a nommé un administrateur"
+          }
+        }
+      }
     },
     "%@ banned a user" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a banni un utilisateur"
+          }
+        }
+      }
     },
     "%@ disallows %@" : {
       "localizations" : {
@@ -50,14 +96,34 @@
             "state" : "new",
             "value" : "%1$@ disallows %2$@"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ interdit %2$@"
+          }
         }
       }
     },
     "%@ has been unresponsive recently." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ n'a pas répondu récemment."
+          }
+        }
+      }
     },
     "%@ hid a community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a caché une communauté"
+          }
+        }
+      }
     },
     "%@ is banned from %@ until %@." : {
       "localizations" : {
@@ -65,6 +131,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ is banned from %2$@ until %3$@."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ est banni de %2$@ jusqu'à %3$@."
           }
         }
       }
@@ -76,6 +148,12 @@
             "state" : "new",
             "value" : "%1$@ is guaranteed by %2$@."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ est garanti par %2$@."
+          }
         }
       }
     },
@@ -86,11 +164,24 @@
             "state" : "new",
             "value" : "%1$@ is permanently banned from %2$@."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ est définitivement banni par %2$@."
+          }
         }
       }
     },
     "%@ locked a post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a verrouillé une publication"
+          }
+        }
+      }
     },
     "%@ pinned a post to %@" : {
       "localizations" : {
@@ -99,62 +190,194 @@
             "state" : "new",
             "value" : "%1$@ pinned a post to %2$@"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ a épinglé une publication sur %2$@"
+          }
         }
       }
     },
     "%@ purged a comment" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a purgé un commentaire"
+          }
+        }
+      }
     },
     "%@ purged a community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a purgé une communauté"
+          }
+        }
+      }
     },
     "%@ purged a post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a purgé une publication"
+          }
+        }
+      }
     },
     "%@ purged a user" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a purgé un utilisateur"
+          }
+        }
+      }
     },
     "%@ removed a comment" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a supprimé un commentaire"
+          }
+        }
+      }
     },
     "%@ removed a community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a supprimé une communauté"
+          }
+        }
+      }
     },
     "%@ removed a moderator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a supprimé un modérateur"
+          }
+        }
+      }
     },
     "%@ removed a post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a supprimé une publication"
+          }
+        }
+      }
     },
     "%@ removed an administrator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a supprimé un administrateur"
+          }
+        }
+      }
     },
     "%@ restored a comment" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a restauré un commentaire"
+          }
+        }
+      }
     },
     "%@ restored a community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a restauré une communauté"
+          }
+        }
+      }
     },
     "%@ restored a post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a restauré une publication"
+          }
+        }
+      }
     },
     "%@ rules:" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ règles:"
+          }
+        }
+      }
     },
     "%@ rules..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ règles…"
+          }
+        }
+      }
     },
     "%@ transferred ownership of a community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a transféré la propriété d'une communauté"
+          }
+        }
+      }
     },
     "%@ unbanned a user" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a débanni un utilisateur"
+          }
+        }
+      }
     },
     "%@ unhid a community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a rendu visible une communauté"
+          }
+        }
+      }
     },
     "%@ unlocked a post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a déverrouillé une publication"
+          }
+        }
+      }
     },
     "%@ unpinned a post from %@" : {
       "localizations" : {
@@ -162,6 +385,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ unpinned a post from %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ a désépinglé une publication de %2$@"
           }
         }
       }
@@ -199,6 +428,24 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld Crossposts..."
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld publication croisée…"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld publications croisées…"
                 }
               }
             }
@@ -243,155 +490,516 @@
               }
             }
           }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Il y a %lld an aujourd'hui !"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Il y a %lld ans aujourd'hui !"
+                }
+              }
+            }
+          }
         }
       }
     },
     "A censure signifies that an instance disapproves of another instance. Like an endorsement, it is completely subjective and a reason does not have to be given." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une censure signifie qu'une instance désapprouve une autre instance. Comme une approbation, elle est entièrement subjective et il n'est pas nécessaire de donner de raison."
+          }
+        }
+      }
     },
     "A hesitation signifies that an instance mistrusts another instance. It is a milder version of a censure." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une hésitation signifie qu'une instance se méfie d'une autre instance. C'est une version atténuée d'une censure."
+          }
+        }
+      }
     },
     "About" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À propos"
+          }
+        }
+      }
     },
     "About Mlem" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À propos de Mlem"
+          }
+        }
+      }
     },
     "Abuse" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abus"
+          }
+        }
+      }
     },
     "Accessibility" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accessibilité"
+          }
+        }
+      }
     },
     "Account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compte"
+          }
+        }
+      }
     },
     "Accounts" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comptes"
+          }
+        }
+      }
     },
     "Action Type" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type d’action"
+          }
+        }
+      }
     },
     "Actions" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actions"
+          }
+        }
+      }
     },
     "Active" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actif"
+          }
+        }
+      }
     },
     "Active Users" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisateurs actifs"
+          }
+        }
+      }
     },
     "Add" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter"
+          }
+        }
+      }
     },
     "Add a Link..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un lien…"
+          }
+        }
+      }
     },
     "Add Account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un compte"
+          }
+        }
+      }
     },
     "Add Administrator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un administrateur"
+          }
+        }
+      }
     },
     "Add Guest" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un invité"
+          }
+        }
+      }
     },
     "Add Moderator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un modérateur"
+          }
+        }
+      }
     },
     "Additional Read Indicator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicateur supplémentaire de lecture"
+          }
+        }
+      }
     },
     "Administration" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Administration"
+          }
+        }
+      }
     },
     "Administrator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Administrateur"
+          }
+        }
+      }
     },
     "Administrator was appointed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'administrateur a été nommé"
+          }
+        }
+      }
     },
     "Administrator was removed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'administrateur a été supprimé"
+          }
+        }
+      }
     },
     "Advanced" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avancé"
+          }
+        }
+      }
     },
     "Alien" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alien"
+          }
+        }
+      }
     },
     "Alignment" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alignement"
+          }
+        }
+      }
     },
     "All" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout"
+          }
+        }
+      }
     },
     "All Time" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout le temps"
+          }
+        }
+      }
     },
     "Alphabetical" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alphabétiquement"
+          }
+        }
+      }
     },
     "Always" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toujours"
+          }
+        }
+      }
     },
     "Always Allow Direct Loading" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toujours autoriser le chargement direct"
+          }
+        }
+      }
     },
     "Always Show Usernames" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toujours afficher les noms d'utilisateur"
+          }
+        }
+      }
     },
     "An endorsement signifies that an instance approves of another instance. It is completely subjective, and a reason does not have to be given." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une approbation signifie qu'une instance approuve une autre instance. Elle est entièrement subjective et il n'est pas nécessaire de donner de raison."
+          }
+        }
+      }
     },
     "Anonymous" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anonyme"
+          }
+        }
+      }
     },
     "Answer..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponse…"
+          }
+        }
+      }
     },
     "Any" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "N’importe"
+          }
+        }
+      }
     },
     "Any Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "N’importe quelle communauté"
+          }
+        }
+      }
     },
     "Any Instance" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "N’importe quelle instance"
+          }
+        }
+      }
     },
     "Anyone" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "N’importe qui"
+          }
+        }
+      }
     },
     "Anywhere" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "N’importe où"
+          }
+        }
+      }
     },
     "App Icon" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Icône de l’application"
+          }
+        }
+      }
     },
     "Application submitted!" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inscription envoyée !"
+          }
+        }
+      }
     },
     "Applications" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inscriptions"
+          }
+        }
+      }
     },
     "Applications Email Admins" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Administrateurs de messages d’inscription"
+          }
+        }
+      }
     },
     "Applications Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inscriptions uniquement"
+          }
+        }
+      }
     },
     "Apply to All" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appliquer à tout"
+          }
+        }
+      }
     },
     "Appoint Administrator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nommer administrateur"
+          }
+        }
+      }
     },
     "Appoint Moderator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nommer modérateur"
+          }
+        }
+      }
     },
     "Appointed: %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nommé : %@"
+          }
+        }
+      }
     },
     "Appointed: %@\nTo: %@" : {
       "localizations" : {
@@ -400,14 +1008,34 @@
             "state" : "new",
             "value" : "Appointed: %1$@\nTo: %2$@"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nommé : %1$@\nEn tant que : %2$@"
+          }
         }
       }
     },
     "Approve" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approuver"
+          }
+        }
+      }
     },
     "Approved by %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approuvé par %@"
+          }
+        }
+      }
     },
     "Are you sure you want to delete all community favorites for this account? This cannot be undone." : {
       "localizations" : {
@@ -416,62 +1044,194 @@
             "state" : "translated",
             "value" : "Are you sure you want to delete all community favourites for this account? This cannot be undone."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etes-vous sûr de vouloir supprimer tous les favoris de la communauté pour ce compte ? Cette opération est irréversible."
+          }
         }
       }
     },
     "Ask First" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demander d'abbord"
+          }
+        }
+      }
     },
     "Ask to confirm every time" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demander de confirmer à chaque fois"
+          }
+        }
+      }
     },
     "Authenticating..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentification"
+          }
+        }
+      }
     },
     "Authentication code is incorrect." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le code d’authentification est incorrect."
+          }
+        }
+      }
     },
     "Automatic" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatique"
+          }
+        }
+      }
     },
     "Automatically" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatiquement"
+          }
+        }
+      }
     },
     "Automatically enable Reader for supported webpages. You can only enable this when using the in-app browser." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer automatiquement le « mode lecture » pour les pages Web prises en charge. Vous ne pouvez activer cette option que lorsque vous utilisez le navigateur intégré à l'application."
+          }
+        }
+      }
     },
     "Automatically refreshes every %lld seconds." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S'actualise automatiquement toutes les %lld secondes."
+          }
+        }
+      }
     },
     "Autoplay" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture automatique"
+          }
+        }
+      }
     },
     "Avatar" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avatar"
+          }
+        }
+      }
     },
     "Average: %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moyenne : %@"
+          }
+        }
+      }
     },
     "Ban %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bannir %@"
+          }
+        }
+      }
     },
     "Ban Duration" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durée de bannissement"
+          }
+        }
+      }
     },
     "Ban from Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bannir de la communauté"
+          }
+        }
+      }
     },
     "Ban from Instance" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bannir de l’instance"
+          }
+        }
+      }
     },
     "Ban Target" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cible de bannisement"
+          }
+        }
+      }
     },
     "Banned from Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Banni de la communauté"
+          }
+        }
+      }
     },
     "Banned from Instance" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Banni de l’Instance"
+          }
+        }
+      }
     },
     "Banned: %@\nFrom: %@\nExpires: %@" : {
       "localizations" : {
@@ -480,77 +1240,244 @@
             "state" : "new",
             "value" : "Banned: %1$@\nFrom: %2$@\nExpires: %3$@"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Banni : %1$@\nDepuis : %2$@\nExpire : %3$@"
+          }
         }
       }
     },
     "Banner" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bannisseur"
+          }
+        }
+      }
     },
     "Biography" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biographie"
+          }
+        }
+      }
     },
     "Block" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloquer"
+          }
+        }
+      }
     },
     "Block Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloquer la communauté"
+          }
+        }
+      }
     },
     "Block List" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloquer la liste"
+          }
+        }
+      }
     },
     "Block User" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloquer l’utilisateur"
+          }
+        }
+      }
     },
     "Block..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloquer…"
+          }
+        }
+      }
     },
     "Blocked" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloqué"
+          }
+        }
+      }
     },
     "Blocking..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloquage…"
+          }
+        }
+      }
     },
     "Blur NSFW Content" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer le contenu NSFW"
+          }
+        }
+      }
     },
     "Bold" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gras"
+          }
+        }
+      }
     },
     "Bot Account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compte robot"
+          }
+        }
+      }
     },
     "Bot accounts are unable to vote." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les comptes robots ne peuvent pas voter."
+          }
+        }
+      }
     },
     "Bottom" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bas"
+          }
+        }
+      }
     },
     "by %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "par %@"
+          }
+        }
+      }
     },
     "Bypass Image Proxy" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contourner le proxy d’image"
+          }
+        }
+      }
     },
     "Bypass Image Proxy?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contourner le proxy d’image ?"
+          }
+        }
+      }
     },
     "Bypass Image Proxy..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contournement du proxy d’image…"
+          }
+        }
+      }
     },
     "Cache" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache"
+          }
+        }
+      }
     },
     "Cache Cleared" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache nettoyé"
+          }
+        }
+      }
     },
     "Cake Day" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jour du gâteau"
+          }
+        }
+      }
     },
     "Cancel" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler"
+          }
+        }
+      }
     },
     "Captcha" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Captcha"
+          }
+        }
+      }
     },
     "Captcha Difficulty Yes" : {
       "comment" : "Used to indicate Captcha difficulty. E.g. \"Yes (Hard)\".",
@@ -561,17 +1488,44 @@
             "state" : "new",
             "value" : "Yes (%@)"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oui (%@)"
+          }
         }
       }
     },
     "Censored" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Censuré"
+          }
+        }
+      }
     },
     "Censured" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Censurés"
+          }
+        }
+      }
     },
     "Censures" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Censure"
+          }
+        }
+      }
     },
     "Center" : {
       "localizations" : {
@@ -580,137 +1534,444 @@
             "state" : "translated",
             "value" : "Centre"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Centré"
+          }
         }
       }
     },
     "Change Password" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer le mot de passe"
+          }
+        }
+      }
     },
     "Checkmark" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coche"
+          }
+        }
+      }
     },
     "Choose a community..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir une communauté..."
+          }
+        }
+      }
     },
     "Choose Account Type" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir un type de compte"
+          }
+        }
+      }
     },
     "Choose Community..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélection de la communauté..."
+          }
+        }
+      }
     },
     "Choose File" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir un fichier"
+          }
+        }
+      }
     },
     "Choose Instance..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélection d’une Instance…"
+          }
+        }
+      }
     },
     "Choose the default sort mode for posts and comments." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir le mode de tri par défaut pour les publications et les commentaires."
+          }
+        }
+      }
     },
     "Choose when Not Safe For Work content should be blurred." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir quand le contenu NSFW doit être flouté."
+          }
+        }
+      }
     },
     "Choose whether to show a warning when opening a page that is likely to contain sensitive content." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir d'afficher ou non un avertissement lors de l'ouverture d'une page susceptible de contenir du contenu sensible."
+          }
+        }
+      }
     },
     "Choose whether to use an alternate interaction bar layout for post and comment reports in Mod Mail." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir d'utiliser ou non une disposition de barre d'interaction alternative pour les rapports de publication et de commentaire dans Mod Mail."
+          }
+        }
+      }
     },
     "Choose which feed is shown when the app opens." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir le flux à afficher à l'ouverture de l'application."
+          }
+        }
+      }
     },
     "Choose which languages appear in your feed. Posts and comments in other languages will be hidden." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir les langues qui s'affichent dans votre flux. Les publications et commentaires dans d'autres langues seront masqués."
+          }
+        }
+      }
     },
     "Choose which widgets to display in your palette." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir les widgets à afficher dans votre palette."
+          }
+        }
+      }
     },
     "Choose wisely - you cannot change this later." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez judicieusement : vous ne pourrez pas changer cela plus tard."
+          }
+        }
+      }
     },
     "Clear" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nettoyer"
+          }
+        }
+      }
     },
     "Clear Cache" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nettoyer le cache"
+          }
+        }
+      }
     },
     "Clear Search History" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nettoyer l’historique de recherche"
+          }
+        }
+      }
     },
     "Clear search history?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nettoyer l’historique de recherche ?"
+          }
+        }
+      }
     },
     "Click on the link in the email to continue." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cliquez sur le lien dans l'e-mail pour continuer."
+          }
+        }
+      }
     },
     "Close" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer"
+          }
+        }
+      }
     },
     "Closed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermé"
+          }
+        }
+      }
     },
     "Code" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code"
+          }
+        }
+      }
     },
     "Code Block" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloc de Code"
+          }
+        }
+      }
     },
     "Comment" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commentaire"
+          }
+        }
+      }
     },
     "Comment Reports" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapports de commentaires"
+          }
+        }
+      }
     },
     "Comment Reports Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapports de commentaires uniquement"
+          }
+        }
+      }
     },
     "Comment was deleted" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le commentaire a été supprimé"
+          }
+        }
+      }
     },
     "Comment was purged" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le commentaire a été purgé"
+          }
+        }
+      }
     },
     "Comment was removed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le commentaire a été retiré"
+          }
+        }
+      }
     },
     "Comment was restored" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le commentaire a été restauré"
+          }
+        }
+      }
     },
     "Comments" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commentaires"
+          }
+        }
+      }
     },
     "Communities" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Communautés"
+          }
+        }
+      }
     },
     "Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Communauté"
+          }
+        }
+      }
     },
     "Community Avatar" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avatar de le communauté"
+          }
+        }
+      }
     },
     "Community Creation" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Création de la communauté"
+          }
+        }
+      }
     },
     "Community Link" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lien de la communauté"
+          }
+        }
+      }
     },
     "Community ownership was transferred" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La propriété de la communauté a été transférée"
+          }
+        }
+      }
     },
     "Community was hidden" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La communauté a été cachée"
+          }
+        }
+      }
     },
     "Community was purged" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La communauté a été purgée"
+          }
+        }
+      }
     },
     "Community was removed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La communauté a été retirée"
+          }
+        }
+      }
     },
     "Community was restored" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La communauté a été restaurée"
+          }
+        }
+      }
     },
     "Community was unhidden" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La communauté a été rendue visible"
+          }
+        }
+      }
     },
     "Community: %@\nNew Owner: %@" : {
       "localizations" : {
@@ -719,77 +1980,244 @@
             "state" : "new",
             "value" : "Community: %1$@\nNew Owner: %2$@"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Communauté : %1$@\nNouveau propriétaire : %2$@"
+          }
         }
       }
     },
     "Compact" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compacte"
+          }
+        }
+      }
     },
     "Configure which types of notification should be included in the notification badge." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurez les types de notifications à inclure dans le badge de notification."
+          }
+        }
+      }
     },
     "Confirm" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmer"
+          }
+        }
+      }
     },
     "Confirm Image Uploads" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmer le téléversement d’image"
+          }
+        }
+      }
     },
     "Confirm New Password" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmer le nouveau mot de passe"
+          }
+        }
+      }
     },
     "Confirm Password" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conformer le mot de passe"
+          }
+        }
+      }
     },
     "Connecting..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connexion…"
+          }
+        }
+      }
     },
     "Content & Notifications" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contenu & notifications"
+          }
+        }
+      }
     },
     "Content Warnings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avertissements de contenu"
+          }
+        }
+      }
     },
     "Continue" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuer"
+          }
+        }
+      }
     },
     "Controversial" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controversé"
+          }
+        }
+      }
     },
     "Copied" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copié"
+          }
+        }
+      }
     },
     "Copy" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier"
+          }
+        }
+      }
     },
     "Copy All" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout copier"
+          }
+        }
+      }
     },
     "Copy Name" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier le nom"
+          }
+        }
+      }
     },
     "Could not find settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de trouver les réglages"
+          }
+        }
+      }
     },
     "Couldn't read URL" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de lire l’URL"
+          }
+        }
+      }
     },
     "Counters" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compteurs"
+          }
+        }
+      }
     },
     "Crosspost" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publication croisée"
+          }
+        }
+      }
     },
     "Crossposted from %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publication croisée depuis %@"
+          }
+        }
+      }
     },
     "Current Password" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mot de passe actuel"
+          }
+        }
+      }
     },
     "Current password is incorrect" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mot de passe actuel est incorrect"
+          }
+        }
+      }
     },
     "Custom" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisé"
+          }
+        }
+      }
     },
     "Customize how content is displayed in your feed. Choose which types of content are blurred, and apply filters to hide posts from the feed altogether." : {
       "localizations" : {
@@ -797,6 +2225,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Customise how content is displayed in your feed. Choose which types of content are blurred, and apply filters to hide posts from the feed altogether."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisez la manière dont le contenu est affiché dans votre flux. Choisissez les types de contenu floutés et appliquez des filtres pour masquer complètement les publications du flux."
           }
         }
       }
@@ -808,6 +2242,12 @@
             "state" : "translated",
             "value" : "Customise how moderator actions are separated from regular actions in context menus."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisez la manière dont les actions du modérateur sont séparées des actions normales dans les menus contextuels."
+          }
         }
       }
     },
@@ -817,6 +2257,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Customise how often Mlem plays haptic feedback."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisez la fréquence à laquelle Mlem diffuse un retour haptique."
           }
         }
       }
@@ -828,6 +2274,12 @@
             "state" : "translated",
             "value" : "Customise how your subscription list is sorted."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisez la manière dont votre liste d’abonnement est triée."
+          }
         }
       }
     },
@@ -837,6 +2289,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Customise Mlem to work best for you. Some features are tied to system-wide accessibility settings."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisez Mlem pour qu'il fonctionne au mieux pour vous. Certaines fonctionnalités sont liées aux paramètres d'accessibilité du système."
           }
         }
       }
@@ -848,6 +2306,12 @@
             "state" : "translated",
             "value" : "Customise the appearance of the tab bar."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnaliser l'apparence de la barre d'onglets."
+          }
         }
       }
     },
@@ -858,29 +2322,84 @@
             "state" : "translated",
             "value" : "Customise the interaction bar for inbox items, and choose which types of notification are included in the tab bar badge."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisez la barre d’interaction pour les éléments de la boîte de réception et choisissez les types de notifications inclus dans le badge de la barre d’onglets."
+          }
         }
       }
     },
     "Days:" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jours :"
+          }
+        }
+      }
     },
     "Debug" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débogage"
+          }
+        }
+      }
     },
     "Default" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Défaut"
+          }
+        }
+      }
     },
     "Default Feed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flux par défaut"
+          }
+        }
+      }
     },
     "Default Feed Type (Desktop)" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type de flux par défaut (bureau)"
+          }
+        }
+      }
     },
     "Delete" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer"
+          }
+        }
+      }
     },
     "Delete Account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer un compte"
+          }
+        }
+      }
     },
     "Delete Community Favorites" : {
       "localizations" : {
@@ -889,17 +2408,44 @@
             "state" : "translated",
             "value" : "Delete Community Favourites"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer les favoris de la communauté"
+          }
         }
       }
     },
     "Delete posts and comments" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer les publications et les commentaires"
+          }
+        }
+      }
     },
     "Deleted" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimé"
+          }
+        }
+      }
     },
     "Denied by %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refusé par %@"
+          }
+        }
+      }
     },
     "Denied by %@: \"%@\"" : {
       "localizations" : {
@@ -908,185 +2454,604 @@
             "state" : "new",
             "value" : "Denied by %1$@: \"%2$@\""
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refusé par %1$@ : « %2$@ »"
+          }
         }
       }
     },
     "Deny" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refuser"
+          }
+        }
+      }
     },
     "Deny Application" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refuser la Demande"
+          }
+        }
+      }
     },
     "Details" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Détails"
+          }
+        }
+      }
     },
     "Developer" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Développeur"
+          }
+        }
+      }
     },
     "Diagnosing..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analyse…"
+          }
+        }
+      }
     },
     "Differentiate Without Color" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Différencier sans couleur"
+          }
+        }
+      }
     },
     "Disabled" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactivé"
+          }
+        }
+      }
     },
     "Disclosure Group" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Groupe de divulgation"
+          }
+        }
+      }
     },
     "Discussion Languages" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Langues de discussion"
+          }
+        }
+      }
     },
     "Disk Usage" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisation du disque"
+          }
+        }
+      }
     },
     "Dismiss" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rejeter"
+          }
+        }
+      }
     },
     "Display linked media from supported hosts in-app rather than as a link." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affichez les médias liés provenant d'hôtes pris en charge dans l'application plutôt que sous forme de lien."
+          }
+        }
+      }
     },
     "Display Name" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom d'affichage"
+          }
+        }
+      }
     },
     "Divider" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Séparateur"
+          }
+        }
+      }
     },
     "Domain" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Domaine"
+          }
+        }
+      }
     },
     "Don't show this again" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ne plus montrer ceci à nouveau"
+          }
+        }
+      }
     },
     "Done" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminé"
+          }
+        }
+      }
     },
     "Downvote" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote négatif"
+          }
+        }
+      }
     },
     "Downvote Counter" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compteur de vote négatif"
+          }
+        }
+      }
     },
     "Downvotes" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votes négatifs"
+          }
+        }
+      }
     },
     "Dracula" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dracula"
+          }
+        }
+      }
     },
     "Easy" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Facile"
+          }
+        }
+      }
     },
     "Edit" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Éditer"
+          }
+        }
+      }
     },
     "Edited" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Édité"
+          }
+        }
+      }
     },
     "Either" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soit"
+          }
+        }
+      }
     },
     "Email" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email"
+          }
+        }
+      }
     },
     "Email Verification" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérification de l'e-mail"
+          }
+        }
+      }
     },
     "Embedded Content" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contenu emabrqué"
+          }
+        }
+      }
     },
     "Enable Keyword Filters" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer les filtres de mots-clés"
+          }
+        }
+      }
     },
     "end.of.feed.icon.1" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "end.of.feed.icon.1"
+          }
+        }
+      }
     },
     "end.of.feed.icon.2" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "end.of.feed.icon.2"
+          }
+        }
+      }
     },
     "end.of.feed.icon.3" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "end.of.feed.icon.3"
+          }
+        }
+      }
     },
     "Endorsements" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approbations"
+          }
+        }
+      }
     },
     "Enter your instance's domain name below." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saisissez le nom de domaine de votre instance ci-dessous."
+          }
+        }
+      }
     },
     "EULA" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EULA"
+          }
+        }
+      }
     },
     "example.com" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "example.com"
+          }
+        }
+      }
     },
     "Except Applications" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauf les inscriptions"
+          }
+        }
+      }
     },
     "Except Comment Reports" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauf les rapports de commentaires"
+          }
+        }
+      }
     },
     "Except Mentions" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauf les mentions"
+          }
+        }
+      }
     },
     "Except Message Reports" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauf les rapports de messages"
+          }
+        }
+      }
     },
     "Except Messages" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauf les messages"
+          }
+        }
+      }
     },
     "Except Post Reports" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauf les rapports de publications"
+          }
+        }
+      }
     },
     "Except Replies" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauf les réponses"
+          }
+        }
+      }
     },
     "Expires:" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expire :"
+          }
+        }
+      }
     },
     "Export Settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres d'exportation"
+          }
+        }
+      }
     },
     "External Links" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liens externes"
+          }
+        }
+      }
     },
     "Failed to connect to %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de se connecter à %@"
+          }
+        }
+      }
     },
     "Failed to delete post!" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de supprimer la publication !"
+          }
+        }
+      }
     },
     "Failed to import settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’importer les réglages"
+          }
+        }
+      }
     },
     "Failed to lock post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de verrouiller la publication"
+          }
+        }
+      }
     },
     "Failed to open sheet" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’ouvrir la page"
+          }
+        }
+      }
     },
     "Failed to pin post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’épingler la publication"
+          }
+        }
+      }
     },
     "Failed to remove content" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de supprimer le contenu"
+          }
+        }
+      }
     },
     "Failed to resolve post. Try another account." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de résoudre la publication. Essayez un autre compte."
+          }
+        }
+      }
     },
     "Failed to save media" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de sauvegarder le média"
+          }
+        }
+      }
     },
     "Failed to unlock post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de déverrouiller la publication"
+          }
+        }
+      }
     },
     "Failed to unpin post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de désépingler la publication"
+          }
+        }
+      }
     },
     "Fallback" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Replis"
+          }
+        }
+      }
     },
     "Fast" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapide"
+          }
+        }
+      }
     },
     "Favorite" : {
       "localizations" : {
@@ -1094,6 +3059,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Favourite"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoris"
           }
         }
       }
@@ -1105,6 +3076,12 @@
             "state" : "translated",
             "value" : "Favourited"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mis en favoris"
+          }
         }
       }
     },
@@ -1115,11 +3092,24 @@
             "state" : "translated",
             "value" : "Favourites"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoris"
+          }
         }
       }
     },
     "Federates" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fédères"
+          }
+        }
+      }
     },
     "federation.explanation" : {
       "extractionState" : "extracted_with_value",
@@ -1129,254 +3119,834 @@
             "state" : "new",
             "value" : "Lemmy instances talk to each other so that content can be shared across sites. This is called \"federation\". Instance administrators can choose which other instances they would like their instance to federate with. Some instances federate with all but a curated \"block-list\" of other instances; other instances might only federate with instances on an \"allow-list\"."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les instances Lemmy communiquent entre elles afin que le contenu puisse être partagé entre les sites. C'est ce qu'on appelle la « fédération ». Les administrateurs d'instances peuvent choisir avec quelles autres instances ils souhaitent que leur instance se fédère. Certaines instances se fédèrent avec toutes les autres instances, à l'exception d'une « liste de blocage » organisée ; d'autres instances peuvent se fédérer uniquement avec des instances figurant sur une « liste d'autorisation »."
+          }
         }
       }
     },
     "Fediseer GUI" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface Fediseer"
+          }
+        }
+      }
     },
     "Feed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flux"
+          }
+        }
+      }
     },
     "Feed is outdated" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le flux est périmé"
+          }
+        }
+      }
     },
     "Feeds" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flux"
+          }
+        }
+      }
     },
     "Files" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fichiers"
+          }
+        }
+      }
     },
     "Filter" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtre"
+          }
+        }
+      }
     },
     "Filter violation" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Violation de filtre"
+          }
+        }
+      }
     },
     "Filters" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtres"
+          }
+        }
+      }
     },
     "Follow on Mastodon" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suivre sur Mastodon"
+          }
+        }
+      }
     },
     "General" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Général"
+          }
+        }
+      }
     },
     "Gestures" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestes"
+          }
+        }
+      }
     },
     "GitHub Repository" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dépôt GitHub"
+          }
+        }
+      }
     },
     "Go Back" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retour"
+          }
+        }
+      }
     },
     "Green" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vert"
+          }
+        }
+      }
     },
     "Grouped" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Groupé"
+          }
+        }
+      }
     },
     "Guaranteed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Garantis"
+          }
+        }
+      }
     },
     "Guarantees" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Garanties"
+          }
+        }
+      }
     },
     "Guest" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invité"
+          }
+        }
+      }
     },
     "Haptic Level" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niveau d’Haptique"
+          }
+        }
+      }
     },
     "Haptics" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haptiques"
+          }
+        }
+      }
     },
     "Hard" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dur"
+          }
+        }
+      }
     },
     "Heading" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titre"
+          }
+        }
+      }
     },
     "Heading %lld" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titre %lld"
+          }
+        }
+      }
     },
     "Headline" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En-tête"
+          }
+        }
+      }
     },
     "Hesitations" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hésitations"
+          }
+        }
+      }
     },
     "Hidden" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masqué"
+          }
+        }
+      }
     },
     "Hidden by keyword filters" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masqué par des filtres de mots-clés"
+          }
+        }
+      }
     },
     "Hide" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer"
+          }
+        }
+      }
     },
     "Hide Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer la communauté"
+          }
+        }
+      }
     },
     "Hide Details" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer les détails"
+          }
+        }
+      }
     },
     "Hide Older Incidents" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer les incidents plus vieux"
+          }
+        }
+      }
     },
     "Hide Read" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer la lecture"
+          }
+        }
+      }
     },
     "Hide Website Icons" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer les icônes du site web"
+          }
+        }
+      }
     },
     "Hot" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chaud"
+          }
+        }
+      }
     },
     "I think I've found the bottom!" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Je crois que je suis arrivé en bas !"
+          }
+        }
+      }
     },
     "If an instance is \"guaranteed\", it is known as definitely not spam. Unguaranteed instances are not necessarily spam; rather, it is unknown whether a non-guaranteed instance is spam or not.\n\nAn instance can be guaranteed by any other guaranteed instance. This forms a chain of guaranteed instances known as the \"Chain of Trust\". The Chain of Trust starts at the Fediseer itself, which guarantees several of the largest instances.\n\nA guarantee can be revoked by the guarantor at any time. If an instance's guarantee is revoked, it returns to a \"not guaranteed\" state along with any instances it guarantees.\n\nOnce an instance has been guaranteed, it is able to express its approval or disapproval of other instances using endorsements, hesitations and censures." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si une instance est « garantie », elle n'est pas considérée comme du spam. Les instances non garanties ne sont pas nécessairement du spam. En revanche, on ne sait pas si une instance non garantie est du spam ou non.\n\nUne instance peut être garantie par n'importe quelle autre instance garantie. Cela forme une chaîne d'instances garanties appelée « chaîne de confiance ». La chaîne de confiance commence au niveau du Fediseer lui-même, qui garantit plusieurs des plus grandes instances.\n\nUne garantie peut être révoquée par le garant à tout moment. Si la garantie d'une instance est révoquée, elle revient à l'état « non garantie » avec toutes les instances qu'elle garantit.\n\nUne fois qu'une instance a été garantie, elle est en mesure d'exprimer son approbation ou sa désapprobation d'autres instances en utilisant des approbations, des hésitations et des censures."
+          }
+        }
+      }
     },
     "If set to \"Automatic\", the full URL will be hidden in compact comments." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si défini sur « Automatique », l'URL complète sera masquée dans les commentaires compacts."
+          }
+        }
+      }
     },
     "Image" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image"
+          }
+        }
+      }
     },
     "Image Saved" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image enregistrée"
+          }
+        }
+      }
     },
     "Images are cached on your device for fast reuse. The maximum cache size is around %@." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les images sont mises en cache sur votre appareil pour une réutilisation rapide. La taille maximale du cache est d'environ %@."
+          }
+        }
+      }
     },
     "Import Settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres d’importation"
+          }
+        }
+      }
     },
     "Import/Export Settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres d’importation / exportation"
+          }
+        }
+      }
     },
     "Imported Settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres importés"
+          }
+        }
+      }
     },
     "In Browser" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dans le navigateur"
+          }
+        }
+      }
     },
     "In Default Browser" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dans le navigateur par défaut"
+          }
+        }
+      }
     },
     "In Reader" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dans le « mode lecture »"
+          }
+        }
+      }
     },
     "In-App" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dans l'app"
+          }
+        }
+      }
     },
     "Inbox" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Boîte de réception"
+          }
+        }
+      }
     },
     "Inbox is outdated" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La boîte de réception est périmée"
+          }
+        }
+      }
     },
     "Incidents" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incidents"
+          }
+        }
+      }
     },
     "Indicate link thumbnails with an icon." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indiquer les miniatures des liens avec une icône."
+          }
+        }
+      }
     },
     "Infinite Scroll" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Défilement infini"
+          }
+        }
+      }
     },
     "Instance" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instance"
+          }
+        }
+      }
     },
     "Instance Link" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lien de l'instance"
+          }
+        }
+      }
     },
     "Instances" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instances"
+          }
+        }
+      }
     },
     "Interaction Bar" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barre d’intéraction"
+          }
+        }
+      }
     },
     "It's turtles all the way down" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce sont des tortues tout le long"
+          }
+        }
+      }
     },
     "Italic" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Italique"
+          }
+        }
+      }
     },
     "john_doe" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "john_doe"
+          }
+        }
+      }
     },
     "john_doe@example.com" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "john_doe@example.com"
+          }
+        }
+      }
     },
     "Join Discord Server" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rejoindre le serveur Discord"
+          }
+        }
+      }
     },
     "Join Matrix Room" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rejoindre l’espace Matrix"
+          }
+        }
+      }
     },
     "Jump Button" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bouton de saut"
+          }
+        }
+      }
     },
     "Just Now" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maintenant"
+          }
+        }
+      }
     },
     "Keep" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conserver"
+          }
+        }
+      }
     },
     "Keep Place" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conserver l’Emplacement"
+          }
+        }
+      }
     },
     "Keyword Filters" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtres de mots-clés"
+          }
+        }
+      }
     },
     "Large" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Large"
+          }
+        }
+      }
     },
     "Last %lld days" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ces %lld derniers jours"
+          }
+        }
+      }
     },
     "Learn more..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En savoir davantage…"
+          }
+        }
+      }
     },
     "Left" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gauche"
+          }
+        }
+      }
     },
     "Lemmy" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lemmy"
+          }
+        }
+      }
     },
     "Lemmy Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Communauté Lemmy"
+          }
+        }
+      }
     },
     "Licenses" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Licences"
+          }
+        }
+      }
     },
     "Link" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lien"
+          }
+        }
+      }
     },
     "Load directly from %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Charger directement depuis %@"
+          }
+        }
+      }
     },
     "Load More" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Charger davantage"
+          }
+        }
+      }
     },
     "Load This Image Directly" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Charger cette image directement"
+          }
+        }
+      }
     },
     "Loading instance details" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chargement des détails de l’instance"
+          }
+        }
+      }
     },
     "Loading..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chargement…"
+          }
+        }
+      }
     },
     "Local" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local"
+          }
+        }
+      }
     },
     "Local Options" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Options locales"
+          }
+        }
+      }
     },
     "local.subscriber.count.text" : {
       "comment" : "Used in the \"Details\" tab of a community page to indicate how many local subscribers use the instance. E.g. \"56 on lemmy.world\".",
@@ -1387,191 +3957,624 @@
             "state" : "new",
             "value" : "%1$lld on %2$@"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld dans %2$@"
+          }
         }
       }
     },
     "Location" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Localisation"
+          }
+        }
+      }
     },
     "Lock" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verrouillage"
+          }
+        }
+      }
     },
     "Lock Post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verrouiller la publication"
+          }
+        }
+      }
     },
     "Log In" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se connecter"
+          }
+        }
+      }
     },
     "Log in or sign up to view your inbox." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connectez-vous ou inscrivez-vous pour voir votre boîte de réception."
+          }
+        }
+      }
     },
     "Log in or sign up to view your subscriptions." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connectez-vous ou inscrivez-vous pour consulter vos abonnements."
+          }
+        }
+      }
     },
     "Manage how Mlem handles links and control how images and videos are displayed." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gérez la manière dont Mlem gère les liens et contrôle la manière dont les images et les vidéos sont affichées."
+          }
+        }
+      }
     },
     "Manage how Mlem interacts with Lemmy instances and other websites." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gérez la manière dont Mlem interagit avec les instances Lemmy et d'autres sites Web."
+          }
+        }
+      }
     },
     "Manage settings related to content moderation." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gérer les paramètres liés à la modération du contenu."
+          }
+        }
+      }
     },
     "Manage your overall setup for Mlem." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gérez votre configuration globale pour Mlem."
+          }
+        }
+      }
     },
     "Mark Read" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marquer comme lu"
+          }
+        }
+      }
     },
     "Mark Read on Scroll" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marquer comme lu au défilement"
+          }
+        }
+      }
     },
     "Mark Unread" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marquer comme non lu"
+          }
+        }
+      }
     },
     "Matrix Room" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espace Matrix"
+          }
+        }
+      }
     },
     "Maximum Comment Depth" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profondeur maximale des commentaires"
+          }
+        }
+      }
     },
     "Maximum Depth" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profondeur maximale"
+          }
+        }
+      }
     },
     "Media & Links" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Médias & liens"
+          }
+        }
+      }
     },
     "Medium" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moyen"
+          }
+        }
+      }
     },
     "Mentions" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mentions"
+          }
+        }
+      }
     },
     "Mentions Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uniquement les mentions"
+          }
+        }
+      }
     },
     "Message Reports" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapports de messages"
+          }
+        }
+      }
     },
     "Message Reports Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapports de messages uniquement"
+          }
+        }
+      }
     },
     "Message was deleted" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le message a été supprimé"
+          }
+        }
+      }
     },
     "Messages" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Messages"
+          }
+        }
+      }
     },
     "Messages Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Messages uniquement"
+          }
+        }
+      }
     },
     "Mlem %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mlem %@"
+          }
+        }
+      }
     },
     "Mlem Developer" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Développeur de Mlem"
+          }
+        }
+      }
     },
     "Mlem Privacy Policy" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Politique de confidentialité de Mlem"
+          }
+        }
+      }
     },
     "Mlem uses a Google API to fetch website icon URLs. If you'd prefer not to use this, you can choose to hide favicons." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mlem utilise une API Google pour récupérer les URL des icônes de sites Web. Si vous préférez ne pas l'utiliser, vous pouvez choisir de masquer les icônes de favoris."
+          }
+        }
+      }
     },
     "Mlem will always try to load from the proxy first." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mlem essaiera toujours de charger à partir du proxy en premier."
+          }
+        }
+      }
     },
     "Mod Mail" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Messages de modération"
+          }
+        }
+      }
     },
     "Mod Mail Interaction Bar" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barre d’intéraction des messages de modération"
+          }
+        }
+      }
     },
     "Mod Mail Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uniquement les messages de modération"
+          }
+        }
+      }
     },
     "Moderated" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modéré"
+          }
+        }
+      }
     },
     "Moderation" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modération"
+          }
+        }
+      }
     },
     "Moderation..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modération..."
+          }
+        }
+      }
     },
     "Moderator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modérateur"
+          }
+        }
+      }
     },
     "Moderator Actions" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actions du modérateur"
+          }
+        }
+      }
     },
     "Moderator was appointed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le modérateur a été nommé"
+          }
+        }
+      }
     },
     "Moderator was removed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le Modérateur a été retiré"
+          }
+        }
+      }
     },
     "Modlog" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Log de modération"
+          }
+        }
+      }
     },
     "Modlogs" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logs de modération"
+          }
+        }
+      }
     },
     "Monochrome" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monochrome"
+          }
+        }
+      }
     },
     "More" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus"
+          }
+        }
+      }
     },
     "More Info" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus d'info"
+          }
+        }
+      }
     },
     "More Replies" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus de réponses"
+          }
+        }
+      }
     },
     "More Widgets..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus de widgets..."
+          }
+        }
+      }
     },
     "More..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus..."
+          }
+        }
+      }
     },
     "Most Comments" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus de commentaires"
+          }
+        }
+      }
     },
     "Mozilla Observatory" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mozilla Observatory"
+          }
+        }
+      }
     },
     "Multiple Columns" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colonnes multiples"
+          }
+        }
+      }
     },
     "Mute Videos" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vidéos en sourdine"
+          }
+        }
+      }
     },
     "My Profile" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mon profil"
+          }
+        }
+      }
     },
     "Name" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom"
+          }
+        }
+      }
     },
     "Never" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jamais"
+          }
+        }
+      }
     },
     "New" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau"
+          }
+        }
+      }
     },
     "New Account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau compte"
+          }
+        }
+      }
     },
     "New Comments" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau commentaire"
+          }
+        }
+      }
     },
     "New Keyword..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau mot clé..."
+          }
+        }
+      }
     },
     "New Password" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau mot de passe"
+          }
+        }
+      }
     },
     "New password is invalid" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nouveau mot de passe n’est pas valide"
+          }
+        }
+      }
     },
     "New password must be between %lld and %lld characters long." : {
       "localizations" : {
@@ -1580,284 +4583,934 @@
             "state" : "new",
             "value" : "New password must be between %1$lld and %2$lld characters long."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nouveau mot de passe doit comporter entre %1$lld et %2$lld caractères."
+          }
         }
       }
     },
     "New Post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvelle publication"
+          }
+        }
+      }
     },
     "news@example.com" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "news@example.com"
+          }
+        }
+      }
     },
     "Next" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suivant"
+          }
+        }
+      }
     },
     "Nickname" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Surnom"
+          }
+        }
+      }
     },
     "No" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non"
+          }
+        }
+      }
     },
     "No comments found" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun commentaire trouvé"
+          }
+        }
+      }
     },
     "No reason given" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas de motif donné"
+          }
+        }
+      }
     },
     "Non-Text Indicators" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicateur non textuel"
+          }
+        }
+      }
     },
     "None" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun"
+          }
+        }
+      }
     },
     "Not Guaranteed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non garanti"
+          }
+        }
+      }
     },
     "Notification Badge" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Badge de notification"
+          }
+        }
+      }
     },
     "Notifications will be sent to %@." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les notifications seront envoyées vers %@."
+          }
+        }
+      }
     },
     "Now" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maintenant"
+          }
+        }
+      }
     },
     "NSFW" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NSFW"
+          }
+        }
+      }
     },
     "NSFW Communities" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Communautés NSFW"
+          }
+        }
+      }
     },
     "NSFW Content" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contenu NSFW"
+          }
+        }
+      }
     },
     "NSFW Tag" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Étiquette NSFW"
+          }
+        }
+      }
     },
     "Ocean" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Océan"
+          }
+        }
+      }
     },
     "Off" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Off"
+          }
+        }
+      }
     },
     "Old" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vieux"
+          }
+        }
+      }
     },
     "Older" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus vieux"
+          }
+        }
+      }
     },
     "OLED" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OLED"
+          }
+        }
+      }
     },
     "On" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On"
+          }
+        }
+      }
     },
     "Once approved, you'll be able to log in to your account from the Settings tab." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une fois approuvé, vous pourrez vous connecter à votre compte depuis l'onglet des paramètres."
+          }
+        }
+      }
     },
     "One of more of your posts failed to send." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un ou plusieurs de vos messages n'ont pas pu être envoyés."
+          }
+        }
+      }
     },
     "Open" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir"
+          }
+        }
+      }
     },
     "Open Authenticator App..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir l’app d’authentification..."
+          }
+        }
+      }
     },
     "Open External Links" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir les liens externes"
+          }
+        }
+      }
     },
     "Open in Browser" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir dans le navigateur"
+          }
+        }
+      }
     },
     "Open in Reader" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir en « mode lecture »"
+          }
+        }
+      }
     },
     "Open URL from Clipboard" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier l’URL dans le Presse-papiers"
+          }
+        }
+      }
     },
     "Optional Description" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Description optionnelle"
+          }
+        }
+      }
     },
     "Orange" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orange"
+          }
+        }
+      }
     },
     "Original Poster" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publieur originel"
+          }
+        }
+      }
     },
     "Other" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autre"
+          }
+        }
+      }
     },
     "Outline" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contour"
+          }
+        }
+      }
     },
     "Outline Thickness" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épaisseur de contour"
+          }
+        }
+      }
     },
     "Outside NSFW Communities" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En dehors de Communautés NSFW"
+          }
+        }
+      }
     },
     "Overview" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aperçu"
+          }
+        }
+      }
     },
     "Password" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mot de passe"
+          }
+        }
+      }
     },
     "Password must be %lld characters or more." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mot de passe doit contenir %lld caractères ou plus."
+          }
+        }
+      }
     },
     "Passwords don't match." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les mots de passe en correspondent pas."
+          }
+        }
+      }
     },
     "Paste" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coller"
+          }
+        }
+      }
     },
     "Permanent" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définitivement"
+          }
+        }
+      }
     },
     "Permanently delete %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer définitivement %@"
+          }
+        }
+      }
     },
     "Personal Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Perspnnel Seulement"
+          }
+        }
+      }
     },
     "Photo Library" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gallerie de photos"
+          }
+        }
+      }
     },
     "Photos" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Photos"
+          }
+        }
+      }
     },
     "Pin" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épingler"
+          }
+        }
+      }
     },
     "Pin Post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épingler la Publication"
+          }
+        }
+      }
     },
     "Pin to Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épingler la Communauté"
+          }
+        }
+      }
     },
     "Pin to Instance" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épingler l’Instance"
+          }
+        }
+      }
     },
     "Pink" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rose"
+          }
+        }
+      }
     },
     "Post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publication"
+          }
+        }
+      }
     },
     "Post failed to send." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La publication n’a pas pu être envoyée."
+          }
+        }
+      }
     },
     "Post Read Indicator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicateur de lecture de publication"
+          }
+        }
+      }
     },
     "Post Reports" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapports de publication"
+          }
+        }
+      }
     },
     "Post Reports Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapports de publication seulement"
+          }
+        }
+      }
     },
     "Post Size" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taille de la publication"
+          }
+        }
+      }
     },
     "Post was locked" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La publication a été verrouillée"
+          }
+        }
+      }
     },
     "Post was pinned to %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La publication a été épinglée sur %@"
+          }
+        }
+      }
     },
     "Post was purged" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La publication a été purgée"
+          }
+        }
+      }
     },
     "Post was removed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La publication a été retirée"
+          }
+        }
+      }
     },
     "Post was restored" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La publication a été restaurée"
+          }
+        }
+      }
     },
     "Post was unlocked" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La publication a été déverrouillée"
+          }
+        }
+      }
     },
     "Post was unpinned from %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La publication a été désépinglée depuis %@"
+          }
+        }
+      }
     },
     "Posts" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publications"
+          }
+        }
+      }
     },
     "Posts from %@ communities" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publications des communautés %@"
+          }
+        }
+      }
     },
     "Posts from all federated instances" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publications de toutes les instances fédérées"
+          }
+        }
+      }
     },
     "Posts from communities you moderate" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publications depuis les communautés que vous modérez"
+          }
+        }
+      }
     },
     "Posts from communities you subscribe to" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publications depuis les communautés suivies"
+          }
+        }
+      }
     },
     "Posts with these keywords in their titles will be hidden. If you are a moderator or administrator of a matching post, it will appear in your feed but require you to tap to view its content." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les publications contenant ces mots-clés dans leur titre seront masquées. Si vous êtes modérateur ou administrateur d'une publication correspondante, elle apparaîtra dans votre flux, mais vous devrez appuyer dessus pour afficher son contenu."
+          }
+        }
+      }
     },
     "Pride" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fierté"
+          }
+        }
+      }
     },
     "Privacy" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vie privée"
+          }
+        }
+      }
     },
     "Privacy Policy" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Politique de Confidentialité"
+          }
+        }
+      }
     },
     "Private" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privé"
+          }
+        }
+      }
     },
     "Profile" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profil"
+          }
+        }
+      }
     },
     "Profile Tab Label" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Étiquette de l'onglet de profil"
+          }
+        }
+      }
     },
     "Proxy Failure" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec du proxy"
+          }
+        }
+      }
     },
     "Purge" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purger"
+          }
+        }
+      }
     },
     "Purge Comment" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purger un commentaire"
+          }
+        }
+      }
     },
     "Purge Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purger une communauté"
+          }
+        }
+      }
     },
     "Purge Person" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purger une personne"
+          }
+        }
+      }
     },
     "Purge Post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purger une publication"
+          }
+        }
+      }
     },
     "Purge User" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purger un utilisateur"
+          }
+        }
+      }
     },
     "Purged content is erased from the database and cannot be restored." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le contenu purgé est effacé de la base de données et ne peut pas être restauré."
+          }
+        }
+      }
     },
     "Quick Look" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aperçu rapide"
+          }
+        }
+      }
     },
     "Quote" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Citation"
+          }
+        }
+      }
     },
     "Ranks posts based on the post score and creation time." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classe les publications en fonction du score de publication et du temps de création."
+          }
+        }
+      }
     },
     "Read Indicator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicateur de lecture"
+          }
+        }
+      }
     },
     "Read posts are shown with dimmed title text. If you like, you can choose an additional way of indicating read status." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les articles lus sont affichés avec un titre grisé. Si vous le souhaitez, vous pouvez choisir une autre façon d'indiquer le statut de lecture."
+          }
+        }
+      }
     },
     "Really apply this configuration to all interaction bars?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faut-il vraiment appliquer cette configuration à toutes les barres d’interaction ?"
+          }
+        }
+      }
     },
     "Really appoint %@ as a moderator of %@?" : {
       "localizations" : {
@@ -1865,6 +5518,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Really appoint %1$@ as a moderator of %2$@?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment nommer %1$@ comme modérateur de %2$@ ?"
           }
         }
       }
@@ -1876,35 +5535,104 @@
             "state" : "new",
             "value" : "Really appoint %1$@ as an administrator of %2$@?"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment nommer %1$@ comme administrateur de %2$@ ?"
+          }
         }
       }
     },
     "Really appoint this user as a moderator of %@?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment nommer cet utilisateur comme modérateur de %@ ?"
+          }
+        }
+      }
     },
     "Really appoint this user as an administrator of %@?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment nommer cet utilisateur comme administrateur de %@ ?"
+          }
+        }
+      }
     },
     "Really block this community?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment bloquer cette communauté ?"
+          }
+        }
+      }
     },
     "Really block this instance?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment bloquer cette instance ?"
+          }
+        }
+      }
     },
     "Really block this user?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment bloquer cet utilisateur ?"
+          }
+        }
+      }
     },
     "Really delete %@?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment supprimer %@ ?"
+          }
+        }
+      }
     },
     "Really delete?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vraiment supprimer ?"
+          }
+        }
+      }
     },
     "Really pin this post to %@?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment épingler ce message sur %@ ?"
+          }
+        }
+      }
     },
     "Really pin this post to the community?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment épingler ce message dans la communauté ?"
+          }
+        }
+      }
     },
     "Really remove administrator %@ from %@?" : {
       "localizations" : {
@@ -1912,6 +5640,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Really remove administrator %1$@ from %2$@?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment supprimer l’administrateur %1$@ de %2$@ ?"
           }
         }
       }
@@ -1923,89 +5657,284 @@
             "state" : "new",
             "value" : "Really remove moderator %1$@ from %2$@?"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment supprimer le modérateur %1$@ de %2$@ ?"
+          }
         }
       }
     },
     "Really unlock this post?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment débloquer ce post ?"
+          }
+        }
+      }
     },
     "Really unpin this post from %@?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment retirer ce message de %@ ?"
+          }
+        }
+      }
     },
     "Really unpin this post from the community?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment retirer ce message de la communauté ?"
+          }
+        }
+      }
     },
     "Reason" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Motif"
+          }
+        }
+      }
     },
     "Reason (Optional)" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Motif (optionnel)"
+          }
+        }
+      }
     },
     "Reason: " : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Motif :"
+          }
+        }
+      }
     },
     "Received %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reçu %@"
+          }
+        }
+      }
     },
     "Recent Checks" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifications Récentes"
+          }
+        }
+      }
     },
     "Recently Searched" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherches Récentes"
+          }
+        }
+      }
     },
     "Redo" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refaire"
+          }
+        }
+      }
     },
     "Refresh" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rafraîchir"
+          }
+        }
+      }
     },
     "Refresh Token" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token de rafraîchissement"
+          }
+        }
+      }
     },
     "Registration" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inscription"
+          }
+        }
+      }
     },
     "Registration Applications" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demandes d’inscription"
+          }
+        }
+      }
     },
     "Registrations are closed on this instance." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les inscriptions sont closes sur cette instance."
+          }
+        }
+      }
     },
     "Reload" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechargement"
+          }
+        }
+      }
     },
     "Reload on Switch" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recharger au changement"
+          }
+        }
+      }
     },
     "Remember Search History" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se souvenir de l’historique de recherche"
+          }
+        }
+      }
     },
     "Remove" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer"
+          }
+        }
+      }
     },
     "Remove Administrator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer un administrateur"
+          }
+        }
+      }
     },
     "Remove Comment" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer un commentaire"
+          }
+        }
+      }
     },
     "Remove Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer une communauté"
+          }
+        }
+      }
     },
     "Remove Content" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer un contenu"
+          }
+        }
+      }
     },
     "Remove Moderator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer un modérateur"
+          }
+        }
+      }
     },
     "Remove Post" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer une publication"
+          }
+        }
+      }
     },
     "Remove Recent Search" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer une recherche récente"
+          }
+        }
+      }
     },
     "Removed: %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimé : %@"
+          }
+        }
+      }
     },
     "Removed: %@\nFrom: %@" : {
       "localizations" : {
@@ -2014,26 +5943,74 @@
             "state" : "new",
             "value" : "Removed: %1$@\nFrom: %2$@"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimé : %1$@\nDe : %2$@"
+          }
         }
       }
     },
     "Replies" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponses"
+          }
+        }
+      }
     },
     "Replies Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponses uniquement"
+          }
+        }
+      }
     },
     "Replies, mentions and messages" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponses, mentions et messages"
+          }
+        }
+      }
     },
     "Reply" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponse"
+          }
+        }
+      }
     },
     "Reply Counter" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compteur de réponse"
+          }
+        }
+      }
     },
     "Report" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signaler"
+          }
+        }
+      }
     },
     "Reported %@ by %@" : {
       "localizations" : {
@@ -2042,224 +6019,734 @@
             "state" : "new",
             "value" : "Reported %1$@ by %2$@"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signalé %1$@ par %2$@"
+          }
         }
       }
     },
     "Reports" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signalements"
+          }
+        }
+      }
     },
     "Reports and Registration Applications" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signalements et demandes d’inscriptions"
+          }
+        }
+      }
     },
     "Reports Email Admins" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signalements d’emails d’admins"
+          }
+        }
+      }
     },
     "Reports from communities you moderate" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signalements depuis des communautés que vous modérez"
+          }
+        }
+      }
     },
     "Reports Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signalements uniquement"
+          }
+        }
+      }
     },
     "Requires Application" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nécessite une inscription"
+          }
+        }
+      }
     },
     "Reset" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réinitialsier"
+          }
+        }
+      }
     },
     "Resolve" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Résoudre"
+          }
+        }
+      }
     },
     "Resolved" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Résolu"
+          }
+        }
+      }
     },
     "Resolved by %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Résolu par %@"
+          }
+        }
+      }
     },
     "Response Time" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temps de réponse"
+          }
+        }
+      }
     },
     "Restore" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurer"
+          }
+        }
+      }
     },
     "Restore Settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres de restauration"
+          }
+        }
+      }
     },
     "Restored Settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres restaurés"
+          }
+        }
+      }
     },
     "Right" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Droite"
+          }
+        }
+      }
     },
     "Row Size" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taille de ligne"
+          }
+        }
+      }
     },
     "Safety & Filtering" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sécurité & filtrage"
+          }
+        }
+      }
     },
     "Save" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer"
+          }
+        }
+      }
     },
     "Save and Restore" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer et restaurer"
+          }
+        }
+      }
     },
     "Save Settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer les réglages"
+          }
+        }
+      }
     },
     "Save the current settings and restore them later." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrez les réglages actuels et restaurez-les ultérieurement."
+          }
+        }
+      }
     },
     "Saved" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistré"
+          }
+        }
+      }
     },
     "Saved Settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres enregistrés"
+          }
+        }
+      }
     },
     "Scaled" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mis à l’échelle"
+          }
+        }
+      }
     },
     "Score" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Score"
+          }
+        }
+      }
     },
     "Score Counter" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compteur de score"
+          }
+        }
+      }
     },
     "Search" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche"
+          }
+        }
+      }
     },
     "Search for comments" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des commentaires"
+          }
+        }
+      }
     },
     "Search for communities" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des communautés"
+          }
+        }
+      }
     },
     "Search for Lemmy instances" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des instances Lemmy"
+          }
+        }
+      }
     },
     "Search for posts" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des publications"
+          }
+        }
+      }
     },
     "Search for users" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des utilisateurs"
+          }
+        }
+      }
     },
     "See All" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voir tout"
+          }
+        }
+      }
     },
     "Select Text" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionner le texte"
+          }
+        }
+      }
     },
     "Send" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer"
+          }
+        }
+      }
     },
     "Send a Message..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer un message..."
+          }
+        }
+      }
     },
     "Send Message" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer un message"
+          }
+        }
+      }
     },
     "Send Notifications to Email" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer des notifications par e-mail"
+          }
+        }
+      }
     },
     "Send to Lemmy User" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer à un utilisateur Lemmy"
+          }
+        }
+      }
     },
     "Sent %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyé %@"
+          }
+        }
+      }
     },
     "Separate Actions Using" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Séparer les actions à l'aide de"
+          }
+        }
+      }
     },
     "Separate Menu" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menu séparé"
+          }
+        }
+      }
     },
     "Settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres"
+          }
+        }
+      }
     },
     "Settings Icons" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres des Icônes"
+          }
+        }
+      }
     },
     "Share" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partager"
+          }
+        }
+      }
     },
     "Share..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partager..."
+          }
+        }
+      }
     },
     "Show" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher"
+          }
+        }
+      }
     },
     "Show All Actions in Feed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher toutes les actions dans le flux"
+          }
+        }
+      }
     },
     "Show Avatar" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l’avatar"
+          }
+        }
+      }
     },
     "Show Bot Accounts" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les comptes robots"
+          }
+        }
+      }
     },
     "Show content flagged as Not Safe For Work." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les contenus étiquetés comme NSFW"
+          }
+        }
+      }
     },
     "Show Details" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les détails"
+          }
+        }
+      }
     },
     "Show Downvotes Separately" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher séparément les votes négatifs"
+          }
+        }
+      }
     },
     "Show Full URL" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher toute l’URL"
+          }
+        }
+      }
     },
     "Show Mod Names in Modlog" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les noms de modérateurs dans le journal de modération"
+          }
+        }
+      }
     },
     "Show NSFW Content" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le contenu NSFW"
+          }
+        }
+      }
     },
     "Show Older Incidents" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les incidents plus vieux"
+          }
+        }
+      }
     },
     "Show Parent" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le parent"
+          }
+        }
+      }
     },
     "Show Read" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher lu"
+          }
+        }
+      }
     },
     "Show Sidebar on App Launch" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher la barre latérale au lancement de l'application"
+          }
+        }
+      }
     },
     "Show warnings when opening..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les avertissements lors de l'ouverture..."
+          }
+        }
+      }
     },
     "Shown" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affiché"
+          }
+        }
+      }
     },
     "Sign In" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se connecter"
+          }
+        }
+      }
     },
     "Sign In to Lemmy" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se connecter à Lemmy"
+          }
+        }
+      }
     },
     "Sign Up" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S’inscrire"
+          }
+        }
+      }
     },
     "Sign-In & Security" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connexion & sécurité"
+          }
+        }
+      }
     },
     "Silver" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Argent"
+          }
+        }
+      }
     },
     "Size" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taille"
+          }
+        }
+      }
     },
     "Slide to Zoom" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Glisser pour zoomer"
+          }
+        }
+      }
     },
     "Slide to Zoom Images" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Glisser pour zoomer sur les images"
+          }
+        }
+      }
     },
     "Slow" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lent"
+          }
+        }
+      }
     },
     "Slur Filter" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtre de liaison"
+          }
+        }
+      }
     },
     "Solarized" : {
       "localizations" : {
@@ -2268,113 +6755,364 @@
             "state" : "translated",
             "value" : "Solarised"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solarisé"
+          }
         }
       }
     },
     "Some" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quelques"
+          }
+        }
+      }
     },
     "Some instances proxy images to protect your privacy. In certain cases, this causes image loading to fail. You can bypass the image proxy and load directly, but this will expose your IP address to the image host." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Certaines instances utilisent des images proxy pour protéger votre vie privée. Dans certains cas, cela entraîne l'échec du chargement de l'image. Vous pouvez contourner le proxy d'image et charger directement, mais cela exposera votre adresse IP à l'hôte de l'image."
+          }
+        }
+      }
     },
     "Sort" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trier"
+          }
+        }
+      }
     },
     "Sort by: %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trier par : %@"
+          }
+        }
+      }
     },
     "Sort by..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trier par..."
+          }
+        }
+      }
     },
     "Sorting" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Triage"
+          }
+        }
+      }
     },
     "Spam" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spam"
+          }
+        }
+      }
     },
     "Spoiler" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Divulgâcheur"
+          }
+        }
+      }
     },
     "Start writing..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commencer à écrire…"
+          }
+        }
+      }
     },
     "Strikethrough" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barré"
+          }
+        }
+      }
     },
     "Style" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Style"
+          }
+        }
+      }
     },
     "Submit Application" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soumettre l’inscription"
+          }
+        }
+      }
     },
     "Submitting..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoi..."
+          }
+        }
+      }
     },
     "Subscribe" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S'abonner"
+          }
+        }
+      }
     },
     "Subscribed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abonné"
+          }
+        }
+      }
     },
     "Subscribers" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abonnés"
+          }
+        }
+      }
     },
     "Subscript" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subscript"
+          }
+        }
+      }
     },
     "Subscription Indicator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicateur d’Abonnement"
+          }
+        }
+      }
     },
     "Subscription List" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liste d’Abonnement"
+          }
+        }
+      }
     },
     "Subscription statuses can't be displayed when using these filters." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les statuts d'abonnement ne peuvent pas être affichés lors de l'utilisation de ces filtres."
+          }
+        }
+      }
     },
     "Superscript" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Superscript"
+          }
+        }
+      }
     },
     "Swipe Actions" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actions de glissement"
+          }
+        }
+      }
     },
     "Swipe Anywhere to Navigate" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Glisser n’importe où pour naviguer"
+          }
+        }
+      }
     },
     "Switch Account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer de Compte"
+          }
+        }
+      }
     },
     "Switch account to view your inbox." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer de compte pour voir votre boîte de réception."
+          }
+        }
+      }
     },
     "Switch to this account and..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer de compte et…"
+          }
+        }
+      }
     },
     "Tab Bar" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barre d'onglets"
+          }
+        }
+      }
     },
     "Table" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tableau"
+          }
+        }
+      }
     },
     "Tap and hold items to add, remove, or rearrange them." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez longuement sur les éléments pour les ajouter, les supprimer ou les réorganiser."
+          }
+        }
+      }
     },
     "Tap on the Jump Button whilst viewing a comment thread to scroll to the next comment." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez sur le bouton de saut lorsque vous consultez un fil de commentaires pour faire défiler jusqu'au commentaire suivant."
+          }
+        }
+      }
     },
     "Tap to Collapse" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez pour réduire"
+          }
+        }
+      }
     },
     "Tap to show slur filter regex." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez pour afficher l'expression régulière du filtre de liaison."
+          }
+        }
+      }
     },
     "Tappable Links" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liens clickables"
+          }
+        }
+      }
     },
     "Temporary" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temporaire"
+          }
+        }
+      }
     },
     "That's all, folks!" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "C'est tout, les amis !"
+          }
+        }
+      }
     },
     "The \"%@\" sort mode is only available on instances running version %@ or later. On instances running earlier versions, the \"Fallback\" sort mode will be used instead." : {
       "localizations" : {
@@ -2382,6 +7120,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "The \"%1$@\" sort mode is only available on instances running version %2$@ or later. On instances running earlier versions, the \"Fallback\" sort mode will be used instead."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mode de tri « %1$@ » n'est disponible que sur les instances exécutant la version %2$@ ou ultérieure. Sur les instances exécutant des versions antérieures, le mode de tri « Fallback » sera utilisé à la place."
           }
         }
       }
@@ -2393,17 +7137,44 @@
             "state" : "new",
             "value" : "The %1$@ theme only supports %2$@ mode."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le thème %1$@ ne prend en charge que le mode %2$@."
+          }
         }
       }
     },
     "The Fediseer" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le Fediseer"
+          }
+        }
+      }
     },
     "The Fediseer is a service that instance administrators use to identify spam instances and express their approval or disapproval of other instances." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fediseer est un service que les administrateurs d'instance utilisent pour identifier les instances de spam et exprimer leur approbation ou leur désapprobation d'autres instances."
+          }
+        }
+      }
     },
     "The modlog may contain disturbing or adult material." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le modlog peut contenir du contenu dérangeant ou réservé aux adultes."
+          }
+        }
+      }
     },
     "The most recent outage was %@, and lasted for %@." : {
       "localizations" : {
@@ -2412,23 +7183,64 @@
             "state" : "new",
             "value" : "The most recent outage was %1$@, and lasted for %2$@."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La panne la plus récente était %1$@ et a duré %2$@."
+          }
         }
       }
     },
     "The name shown in the account switcher and tab bar." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nom affiché dans le sélecteur de compte et la barre d'onglets."
+          }
+        }
+      }
     },
     "The name shown in the account switcher." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nom affiché dans le sélecteur de compte."
+          }
+        }
+      }
     },
     "The name that is displayed on your profile. This is not the same as your username, which cannot be changed." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nom qui apparaît sur votre profil. Il ne correspond pas à votre nom d'utilisateur, qui ne peut pas être modifié."
+          }
+        }
+      }
     },
     "The number of child comments that can appear in a chain before the \"More Replies\" button is shown." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nombre de commentaires enfants qui peuvent apparaître dans une chaîne avant que le bouton « Plus de réponses » ne soit affiché."
+          }
+        }
+      }
     },
     "Theme" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thèmes"
+          }
+        }
+      }
     },
     "There were %lld recorded incidents today." : {
       "localizations" : {
@@ -2467,14 +7279,46 @@
               }
             }
           }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Il y a eu %lld incident enregistré aujourd'hui."
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Il y a eu %lld incidents enregistrés aujourd'hui."
+                }
+              }
+            }
+          }
         }
       }
     },
     "There were no recorded incidents today." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun incident n'a été enregistré aujourd'hui."
+          }
+        }
+      }
     },
     "These options are stored locally in Mlem and not on your Lemmy account." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ces options sont stockées localement dans Mlem et non sur votre compte Lemmy."
+          }
+        }
+      }
     },
     "This account has %lld favorite communities." : {
       "localizations" : {
@@ -2513,6 +7357,24 @@
               }
             }
           }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Ce compte a %lld communauté favorite."
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Ce compte a %lld communautés favorites."
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2523,119 +7385,384 @@
             "state" : "translated",
             "value" : "This account has no favourite communities."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce compte n'a pas de communautés favorites."
+          }
         }
       }
     },
     "This action cannot be undone." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette action ne peut pas être annulée."
+          }
+        }
+      }
     },
     "This community has been removed." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette communauté a été supprimée."
+          }
+        }
+      }
     },
     "This community likely contains graphic or explicit content." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette communauté contient probablement du contenu graphique ou explicite."
+          }
+        }
+      }
     },
     "This content will be loaded from **%@** instead." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu sera chargé depuis **%@** à la place."
+          }
+        }
+      }
     },
     "This field is optional." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce champ est facultatif."
+          }
+        }
+      }
     },
     "This instance is not part of the Fediseer Chain of Trust." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette instance ne fait pas partie de la chaîne de confiance Fediseer."
+          }
+        }
+      }
     },
     "This instance is viewed very negatively by one or more trusted instances." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette instance est perçue très négativement par une ou plusieurs instances de confiance."
+          }
+        }
+      }
     },
     "This is turned on by default because Differentiate Without Color is enabled in System Settings." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette option est activée par défaut car l'option « Différencier sans couleur » est activée dans les paramètres système."
+          }
+        }
+      }
     },
     "This probably contains foul language." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cela contient probablement un langage grossier."
+          }
+        }
+      }
     },
     "This username is taken." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce nom d'utilisateur est pris."
+          }
+        }
+      }
     },
     "This will clear your recent searches, which cannot be undone." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cela effacera vos recherches récentes, ce qui ne peut pas être annulé."
+          }
+        }
+      }
     },
     "This will permanently remove it from %@, not just Mlem!" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cela le supprimera définitivement de %@, pas seulement de Mlem !"
+          }
+        }
+      }
     },
     "Thumbnail" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vignette"
+          }
+        }
+      }
     },
     "Thumbnail Location" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emplacement de la vignette"
+          }
+        }
+      }
     },
     "Tiled" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tuile"
+          }
+        }
+      }
     },
     "Time" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temps"
+          }
+        }
+      }
     },
     "Title" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titre"
+          }
+        }
+      }
     },
     "To confirm, please enter your password:" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pour confirmer, entrez svp votre mot de passe :"
+          }
+        }
+      }
     },
     "To join this instance, you need to create an application and wait to be accepted." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pour rejoindre cette instance, vous devez faire une demande et attendre d'être accepté."
+          }
+        }
+      }
     },
     "Today" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aujourd’hui"
+          }
+        }
+      }
     },
     "Too many items" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trop d’éléments"
+          }
+        }
+      }
     },
     "Top" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top"
+          }
+        }
+      }
     },
     "Top of..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top…"
+          }
+        }
+      }
     },
     "Top: %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top : %@"
+          }
+        }
+      }
     },
     "Top..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top…"
+          }
+        }
+      }
     },
     "Trailing" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À la fin"
+          }
+        }
+      }
     },
     "Transfer Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transférer la communauté"
+          }
+        }
+      }
     },
     "Transfer Ownership" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transférer la propriété"
+          }
+        }
+      }
     },
     "Troll" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Troll"
+          }
+        }
+      }
     },
     "Trust & Safety" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confiance & sécurité"
+          }
+        }
+      }
     },
     "Try a different Captcha..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Essayer un autre captcha…"
+          }
+        }
+      }
     },
     "Turn Off" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver"
+          }
+        }
+      }
     },
     "Turn Off Search History" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver l’historique de recherche"
+          }
+        }
+      }
     },
     "Turn off search history?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver l’historique de recherche ?"
+          }
+        }
+      }
     },
     "Two-Factor Authentication" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentification à Double-Facteur (2FA)"
+          }
+        }
+      }
     },
     "Unavailable" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indisponible"
+          }
+        }
+      }
     },
     "Unban %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débannir %@"
+          }
+        }
+      }
     },
     "Unbanned: %@\nFrom: %@" : {
       "localizations" : {
@@ -2644,26 +7771,74 @@
             "state" : "new",
             "value" : "Unbanned: %1$@\nFrom: %2$@"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débanni : %1$@\nDe : %2$@"
+          }
         }
       }
     },
     "Unblock" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débloquer"
+          }
+        }
+      }
     },
     "Unblocked" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débloqué"
+          }
+        }
+      }
     },
     "Unblocking..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déblocage…"
+          }
+        }
+      }
     },
     "Undo" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler"
+          }
+        }
+      }
     },
     "Undo Downvote" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler vote négatif"
+          }
+        }
+      }
     },
     "Undo Upvote" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler vote positif"
+          }
+        }
+      }
     },
     "Unfavorite" : {
       "localizations" : {
@@ -2671,6 +7846,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unfavourite"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enlever des favoris"
           }
         }
       }
@@ -2682,197 +7863,646 @@
             "state" : "translated",
             "value" : "Unfavourited"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enlevé des favoris"
+          }
         }
       }
     },
     "Unhealthy for %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mauvais pour %@"
+          }
+        }
+      }
     },
     "Unknown" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inconnu"
+          }
+        }
+      }
     },
     "Unlock" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débloquer"
+          }
+        }
+      }
     },
     "Unpin" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désépingler"
+          }
+        }
+      }
     },
     "Unpin From Community" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désépingler de la communauté"
+          }
+        }
+      }
     },
     "Unpin From Instance" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désépingler de l’instance"
+          }
+        }
+      }
     },
     "Unresolve" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ne plus résoudre"
+          }
+        }
+      }
     },
     "Unsave" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ne plus enregistrer"
+          }
+        }
+      }
     },
     "Unsubscribe" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désinscrire"
+          }
+        }
+      }
     },
     "Unsubscribed" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désinscrit"
+          }
+        }
+      }
     },
     "Unsupported Badge" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Badge non supporté"
+          }
+        }
+      }
     },
     "Upload" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléverser"
+          }
+        }
+      }
     },
     "Upload an image..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléverser une image"
+          }
+        }
+      }
     },
     "Upload this image to %@?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléverser cette image sur %@ ?"
+          }
+        }
+      }
     },
     "Uploading..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléversement…"
+          }
+        }
+      }
     },
     "Uptime" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temps de disponibilité"
+          }
+        }
+      }
     },
     "Uptime data fetched from %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Données de disponibilité récupérées à partir de %@"
+          }
+        }
+      }
     },
     "Upvote" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote positif"
+          }
+        }
+      }
     },
     "Upvote Counter" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compteur de votes positifs"
+          }
+        }
+      }
     },
     "Upvote on Save" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote positif si enregistrement"
+          }
+        }
+      }
     },
     "Use Alternate Layout" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utiliser un layout alternatif"
+          }
+        }
+      }
     },
     "User" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisateur"
+          }
+        }
+      }
     },
     "User Avatar" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avatar de l'utilisateur"
+          }
+        }
+      }
     },
     "User Link" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lien de l’utilisateur"
+          }
+        }
+      }
     },
     "User was banned" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’utilisateur a été banni"
+          }
+        }
+      }
     },
     "User was purged" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’utilisateur a été purgé"
+          }
+        }
+      }
     },
     "User was unbanned" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’utilisateur a été débanni"
+          }
+        }
+      }
     },
     "Username" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom d’utilisateur"
+          }
+        }
+      }
     },
     "Username can only contain lowercase letters, numbers and underscores." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nom d'utilisateur ne peut contenir que des lettres minuscules, des chiffres et des traits de soulignement."
+          }
+        }
+      }
     },
     "Username must be 3 or more characters." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nom d'utilisateur doit comporter 3 caractères ou plus."
+          }
+        }
+      }
     },
     "Users" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisateurs"
+          }
+        }
+      }
     },
     "Version" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
+          }
+        }
+      }
     },
     "Video Saved" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vidéo enregistrée"
+          }
+        }
+      }
     },
     "View All" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout voir"
+          }
+        }
+      }
     },
     "View on %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voir sur %@"
+          }
+        }
+      }
     },
     "View on original host" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voir sur la publication originale"
+          }
+        }
+      }
     },
     "View Votes" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voir les votes"
+          }
+        }
+      }
     },
     "Viewing %@ as guest" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture %@ en tant qu’invité"
+          }
+        }
+      }
     },
     "Visit" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visiter"
+          }
+        }
+      }
     },
     "Votes" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votes"
+          }
+        }
+      }
     },
     "We sent an email to %@ to verify your email address and activate your account." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nous avons envoyé un e-mail à %@ pour vérifier votre adresse e-mail et activer votre compte."
+          }
+        }
+      }
     },
     "Website" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Site web"
+          }
+        }
+      }
     },
     "Website Icon" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Icône du site web"
+          }
+        }
+      }
     },
     "Website Thumbnail Indicator" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicateur de miniature de site Web"
+          }
+        }
+      }
     },
     "Welcome %@" : {
-      "comment" : "Example: \"Welcome John\""
+      "comment" : "Example: \"Welcome John\"",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bievenue %@"
+          }
+        }
+      }
     },
     "Welcome to %@" : {
-      "comment" : "Example: \"Welcome to lemmy.world\""
+      "comment" : "Example: \"Welcome to lemmy.world\"",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bienvenue sur %@"
+          }
+        }
+      }
     },
     "Welcome to Lemmy!" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bienvenue sur Lemmy !"
+          }
+        }
+      }
     },
     "What is Federation?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "C’est quoi la fédération ?"
+          }
+        }
+      }
     },
     "When disabled, some moderator actions will only be accessible from the post page." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lorsque cette option est désactivée, certaines actions du modérateur ne seront accessibles qu'à partir de la page de publication."
+          }
+        }
+      }
     },
     "When enabled, Mlem will ask you to confirm your choice before uploading an image to your instance." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lorsqu'il est activé, Mlem vous demandera de confirmer votre choix avant de télécharger une image sur votre instance."
+          }
+        }
+      }
     },
     "Wrap Code Block Lines" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envelopper les lignes du bloc de code"
+          }
+        }
+      }
     },
     "Write a bit about yourself..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écrivez un peu sur vous-même..."
+          }
+        }
+      }
     },
     "Yes" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yes"
+          }
+        }
+      }
     },
     "You are browsing %@ as a guest. If you'd like to vote or reply, you'll need to log in or sign up." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous parcourez %@ en tant qu'invité. Si vous souhaitez voter ou répondre, vous devez vous connecter ou vous inscrire."
+          }
+        }
+      }
     },
     "You are required to provide an email on this instance." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous devez fournir une adresse e-mail sur cette instance."
+          }
+        }
+      }
     },
     "You can also turn off search history completely for this account." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous pouvez également désactiver complètement l’historique de recherche pour ce compte."
+          }
+        }
+      }
     },
     "You don't have an email attached to this account." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous n'avez pas d'e-mail associé à ce compte."
+          }
+        }
+      }
     },
     "You don't have any accounts." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous n'avez aucun compte."
+          }
+        }
+      }
     },
     "You may need to allow Mlem to access your Photo Library in System Settings." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous devrez peut-être autoriser Mlem à accéder à votre galerie de photos dans les paramètres système."
+          }
+        }
+      }
     },
     "You will not see most content if Undetermined is not selected." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous ne verrez pas la plupart du contenu si « Indéterminé » n'est pas sélectionné."
+          }
+        }
+      }
     },
     "You'll receive an email once your application has been approved. Once approved, you can log in to your account from the Settings tab." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous recevrez un e-mail une fois votre demande approuvée. Une fois approuvée, vous pourrez vous connecter à votre compte depuis l'onglet des paramètres."
+          }
+        }
+      }
     },
     "Your Answer..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre réponse..."
+          }
+        }
+      }
     },
     "Your instance and **%@** federate, but the content could not be loaded. It may not have federated yet, or your instance may have purged it." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre instance et **%@** se fédèrent, mais le contenu n'a pas pu être chargé. Il se peut qu'il n'ait pas encore été fédéré ou que votre instance l'ait purgé."
+          }
+        }
+      }
     },
     "Your instance, **%@**, chose to defederate from **%@**." : {
       "localizations" : {
@@ -2880,6 +8510,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Your instance, **%1$@**, chose to defederate from **%2$@**."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre instance, **%1$@**, a choisi de se défédérer de **%2$@**."
           }
         }
       }
@@ -2891,20 +8527,54 @@
             "state" : "new",
             "value" : "Your instance, **%1$@**, hasn't chosen to federate with **%2$@**."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre instance, **%1$@**, n'a pas choisi de se fédérer avec **%2$@**."
+          }
         }
       }
     },
     "Your saved posts and comments" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vos publications et commentaires enregistrés"
+          }
+        }
+      }
     },
     "Your session has expired. Enter your password to authenticate a new session." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre session a expiré. Saisissez votre mot de passe pour authentifier une nouvelle session."
+          }
+        }
+      }
     },
     "Your subscriptions live here." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vos abonnements sont ici."
+          }
+        }
+      }
     },
     "Zoom the image viewer with a slide gesture on the selected side." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoomez la visionneuse d'images avec un geste de glissement sur le côté sélectionné."
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -786,7 +786,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tout le temps"
+            "value" : "Tout les temps"
           }
         }
       }
@@ -1058,7 +1058,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Demander d'abbord"
+            "value" : "Demander d'abord"
           }
         }
       }
@@ -1254,7 +1254,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bannisseur"
+            "value" : "Bannière"
           }
         }
       }
@@ -1294,7 +1294,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bloquer la liste"
+            "value" : "Liste de blocage"
           }
         }
       }
@@ -1334,7 +1334,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bloquage…"
+            "value" : "Blocage…"
           }
         }
       }
@@ -2064,7 +2064,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Contenu & notifications"
+            "value" : "Contenu et notifications"
           }
         }
       }
@@ -2738,7 +2738,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Contenu emabrqué"
+            "value" : "Contenu embarqué"
           }
         }
       }
@@ -4143,7 +4143,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Médias & liens"
+            "value" : "Médias et liens"
           }
         }
       }
@@ -6229,7 +6229,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sécurité & filtrage"
+            "value" : "Sécurité et filtrage"
           }
         }
       }
@@ -6516,7 +6516,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Paramètres des Icônes"
+            "value" : "Paramètres des icônes"
           }
         }
       }
@@ -6586,7 +6586,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afficher les contenus étiquetés comme NSFW"
+            "value" : "Afficher les contenus étiquetés comme « Not Safe For Work »."
           }
         }
       }
@@ -6721,6 +6721,23 @@
         }
       }
     },
+    "Sign Out" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign Out"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se déconnecter"
+          }
+        }
+      }
+    },
     "Sign Up" : {
       "localizations" : {
         "fr" : {
@@ -6736,7 +6753,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Connexion & sécurité"
+            "value" : "Connexion et sécurité"
           }
         }
       }
@@ -6849,7 +6866,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Certaines instances utilisent des images proxy pour protéger votre vie privée. Dans certains cas, cela entraîne l'échec du chargement de l'image. Vous pouvez contourner le proxy d'image et charger directement, mais cela exposera votre adresse IP à l'hôte de l'image."
+            "value" : "Certaines instances utilisent des proxy d’images pour protéger votre vie privée. Dans certains cas, cela entraîne l'échec du chargement de l'image. Vous pouvez contourner le proxy d'image et charger directement, mais cela exposera votre adresse IP à l'hôte de l'image."
           }
         }
       }
@@ -7009,7 +7026,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indicateur d’Abonnement"
+            "value" : "Indicateur d’abonnement"
           }
         }
       }
@@ -7019,7 +7036,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Liste d’Abonnement"
+            "value" : "Liste d’abonnement"
           }
         }
       }
@@ -7760,7 +7777,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Confiance & sécurité"
+            "value" : "Confiance et sécurité"
           }
         }
       }
@@ -8540,7 +8557,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vous ne verrez pas la plupart du contenu si « Indéterminé » n'est pas sélectionné."
+            "value" : "Vous ne verrez pas la plupart du contenu si « Undetermined » n'est pas sélectionné."
           }
         }
       }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -3604,7 +3604,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Boîte de réception"
+            "value" : "Notifications"
           }
         }
       }
@@ -8487,7 +8487,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yes"
+            "value" : "Oui"
           }
         }
       }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -6349,6 +6349,23 @@
         }
       }
     },
+    "Search..." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche…"
+          }
+        }
+      }
+    },
     "See All" : {
       "localizations" : {
         "fr" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -3359,6 +3359,7 @@
       }
     },
     "Headline" : {
+      "extractionState" : "manual",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -7535,6 +7536,7 @@
       }
     },
     "Tiled" : {
+      "extractionState" : "manual",
       "localizations" : {
         "fr" : {
           "stringUnit" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -3789,6 +3789,17 @@
         }
       }
     },
+    "Key" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé"
+          }
+        }
+      }
+    },
     "Keyword Filters" : {
       "localizations" : {
         "fr" : {
@@ -5474,11 +5485,35 @@
       }
     },
     "Ranks posts based on the post score and creation time." : {
+      "extractionState" : "stale",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ranks posts based on the post score and creation time."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Classe les publications en fonction du score de publication et du temps de création."
+          }
+        }
+      }
+    },
+    "Ranks posts based on the post score and the time since the last comment was created." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ranks posts based on the post score and the time since the last comment was created."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classe les publications en se basant sur son score et la durée écoulée depuis la création du dernier commentaire."
           }
         }
       }
@@ -6712,6 +6747,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Argent"
+          }
+        }
+      }
+    },
+    "Similar to Hot, but ranks posts from smaller communities higher." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Similar to \\\"Hot\\\", but ranks posts from smaller communities higher."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Similaire à « Chaud », mais met davantage en avant les publications des plus petites communautés."
           }
         }
       }


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- Closes #1124 

## Description

<!-- Describe what this PR does at a high level (e.g., "adds a toggle to do <thing>") -->
Add french support for application.
Translate wordings in french.
Modify a bit Swift code so as to load localized wordings.

## Implementation Notes

<!-- Any information about the code that would be helpful for reviewing -->
You may notice some parts of Swift source code have been modified a bit so as to use localized versions of wordings.
In fact, SwftUI computes the wording to translate at runtime mostly but depending to how you add strings in your views, these strings can be considered as pure string to keep asis, or no localized string key to translated then. The more indirectly you add the string, the string won't get translated. Thus a `localized` method has been defined to force to use the localized version considering the string as wording key. Otherwise it will imply to refactor a lot of views to use the string keys the closest to the views. I use that tricky since eons :-D