### PR TITLE
Interaction Bar Report Defaults

### DIFF
--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -130,7 +130,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
         )
     }
     
-    static var reportDefault: Self {
+    static var reportDefault_: Self {
         .init(
             leading: [.action(.resolve), .action(.share)],
             trailing: [.action(.ban), .action(.remove)],
@@ -138,4 +138,6 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             availableWidgets: .init(ActionType.defaultReportWidgets.map { .action($0) })
         )
     }
+    
+    static var reportDefault: Self? { reportDefault_ }
 }

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -23,6 +23,7 @@ protocol InteractionBarConfiguration: Codable {
     func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage
     
     static var `default`: Self { get }
+    static var reportDefault: Self { get }
     
     init(leading: [Item], trailing: [Item], readouts: [ReadoutType], availableWidgets: Set<Item>)
 }

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -22,8 +22,10 @@ protocol InteractionBarConfiguration: Codable {
     var availableWidgets: Set<Item> { get set }
     func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage
     
+    /// Default configuration for this type
     static var `default`: Self { get }
-    static var reportDefault: Self { get }
+    /// Default report configuration for this type. `nil` if inapplicable.
+    static var reportDefault: Self? { get }
     
     init(leading: [Item], trailing: [Item], readouts: [ReadoutType], availableWidgets: Set<Item>)
 }
@@ -108,8 +110,8 @@ struct InteractionBarConfigurations: Codable {
             post: .default,
             comment: .default,
             reply: .default,
-            postReport: .reportDefault,
-            commentReport: .reportDefault
+            postReport: .reportDefault_,
+            commentReport: .reportDefault_
         )
     }
     
@@ -132,8 +134,8 @@ struct InteractionBarConfigurations: Codable {
         self.post = try container.decodeIfPresent(PostBarConfiguration.self, forKey: .post) ?? .default
         self.comment = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: .comment) ?? .default
         self.reply = try container.decodeIfPresent(ReplyBarConfiguration.self, forKey: .reply) ?? .default
-        self.postReport = try container.decodeIfPresent(PostBarConfiguration.self, forKey: .postReport) ?? .reportDefault
-        self.commentReport = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: .commentReport) ?? .reportDefault
+        self.postReport = try container.decodeIfPresent(PostBarConfiguration.self, forKey: .postReport) ?? .reportDefault_
+        self.commentReport = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: .commentReport) ?? .reportDefault_
     }
 }
 

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -142,7 +142,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
         )
     }
     
-    static var reportDefault: Self {
+    static var reportDefault_: Self {
         .init(
             leading: [.action(.resolve), .action(.lock)],
             trailing: [.action(.ban), .action(.remove)],
@@ -150,4 +150,6 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             availableWidgets: .init(ActionType.defaultReportWidgets.map { .action($0) })
         )
     }
+    
+    static var reportDefault: Self? { .reportDefault_ }
 }

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -117,9 +117,5 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
         )
     }
     
-    static var reportDefault: Self {
-        // this is a slightly degenerate case since these don't go on reports, but it makes the protocol simple
-        assertionFailure("ReplyBarConfiguration cannot apply to reports")
-        return .default
-    }
+    static var reportDefault: Self? { nil }
 }

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -116,4 +116,10 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             availableWidgets: .init(CounterType.defaultWidgets.map { .counter($0) } + ActionType.defaultWidgets.map { .action($0) })
         )
     }
+    
+    static var reportDefault: Self {
+        // this is a slightly degenerate case since these don't go on reports, but it makes the protocol simple
+        assertionFailure("ReplyBarConfiguration cannot apply to reports")
+        return .default
+    }
 }

--- a/Mlem/App/Legacy/LegacyInteractionBarConfigurations.swift
+++ b/Mlem/App/Legacy/LegacyInteractionBarConfigurations.swift
@@ -109,7 +109,7 @@ extension InteractionBarConfigurations {
 extension PostBarConfiguration {
     init(legacyItems: [LegacyInterationBarItem]?, moderator: Bool) {
         guard let legacyItems else {
-            self = moderator ? .reportDefault : .default
+            self = moderator ? .reportDefault_ : .default
             return
         }
         
@@ -122,7 +122,7 @@ extension PostBarConfiguration {
         guard legacyItems.count(where: { $0 == .infoStack }) == 1,
               let infoStackIndex = legacyItems.firstIndex(of: .infoStack) else {
             assertionFailure("Invalid legacy items")
-            self = moderator ? .reportDefault : .default
+            self = moderator ? .reportDefault_ : .default
             return
         }
         
@@ -157,7 +157,7 @@ extension PostBarConfiguration {
 extension CommentBarConfiguration {
     init(legacyItems: [LegacyInterationBarItem]?, moderator: Bool) {
         guard let legacyItems else {
-            self = moderator ? .reportDefault : .default
+            self = moderator ? .reportDefault_ : .default
             return
         }
         
@@ -170,7 +170,7 @@ extension CommentBarConfiguration {
         guard legacyItems.count(where: { $0 == .infoStack }) == 1,
               let infoStackIndex = legacyItems.firstIndex(of: .infoStack) else {
             assertionFailure("Invalid legacy items")
-            self = moderator ? .reportDefault : .default
+            self = moderator ? .reportDefault_ : .default
             return
         }
         

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -208,7 +208,7 @@ extension ActionAppearance {
         .init(
             label: isOn ? "Unresolve" : "Resolve",
             isOn: isOn,
-            color: isOn ? Palette.main.negative : Palette.main.positive,
+            color: isOn ? Palette.main.positive : Palette.main.negative,
             icon: isOn ? Icons.unresolve : Icons.resolve,
             barIcon: isOn ? Icons.resolveFill : Icons.resolve,
             swipeIcon2: isOn ? Icons.unresolveFill : Icons.resolveFill

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Views.swift
@@ -290,6 +290,7 @@ extension InteractionBarEditorView {
     var buttons: some View {
         HStack {
             Button("Reset") {
+                assert(!(isReport && Configuration.reportDefault == nil), "isReport is true but no reportDefault found")
                 configuration = isReport ? .reportDefault ?? .default : .default
                 barItems = (configuration.leading + [nil] + configuration.trailing).map { item in
                     .init(item: item, expanded: true, visible: true)

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Views.swift
@@ -290,7 +290,7 @@ extension InteractionBarEditorView {
     var buttons: some View {
         HStack {
             Button("Reset") {
-                configuration = isReport ? .reportDefault : .default
+                configuration = isReport ? .reportDefault ?? .default : .default
                 barItems = (configuration.leading + [nil] + configuration.trailing).map { item in
                     .init(item: item, expanded: true, visible: true)
                 }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Views.swift
@@ -290,7 +290,7 @@ extension InteractionBarEditorView {
     var buttons: some View {
         HStack {
             Button("Reset") {
-                configuration = .default
+                configuration = isReport ? .reportDefault : .default
                 barItems = (configuration.leading + [nil] + configuration.trailing).map { item in
                     .init(item: item, expanded: true, visible: true)
                 }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView.swift
@@ -34,6 +34,8 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
     @State var showingApplyToAllConfirmation: Bool = false
     
     let onSet: (Configuration) -> Void
+    let configurationType: ConfigurationType
+    let isReport: Bool
     
     let barAnimationDuration: CGFloat = 0.15
     let trayItemDuration: CGFloat = 0.5
@@ -41,11 +43,10 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
     @ScaledMetric(relativeTo: .body) var baseInfoCapsuleHeight: CGFloat = 22
     var infoCapsuleHeight: CGFloat { baseInfoCapsuleHeight + Constants.main.doubleSpacing }
     
-    let configurationType: ConfigurationType
-    
-    init(configuration: Configuration, onSet: @escaping (Configuration) -> Void) {
-        self.configuration = configuration
+    init(configuration: Configuration, isReport: Bool, onSet: @escaping (Configuration) -> Void) {
         self.onSet = onSet
+        self.configuration = configuration
+        self.isReport = isReport
         let configurationItems: [Configuration.Item?] = configuration.leading + [nil] + configuration.trailing
         self.configurationType = configuration is PostBarConfiguration ? .post : .comment
         
@@ -60,8 +61,8 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
         )
     }
     
-    init(setting: WritableKeyPath<InteractionBarTracker, Configuration>) {
-        self.init(configuration: InteractionBarTracker.main[keyPath: setting]) {
+    init(setting: WritableKeyPath<InteractionBarTracker, Configuration>, isReport: Bool) {
+        self.init(configuration: InteractionBarTracker.main[keyPath: setting], isReport: isReport) {
             var main = InteractionBarTracker.main
             main[keyPath: setting] = $0
         }
@@ -85,7 +86,6 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
         }
         .onChange(of: configuration.availableWidgets, initial: true) {
             onSet(configuration)
-            let configurationItems: [Configuration.Item?] = configuration.leading + [nil] + configuration.trailing
             trayItems = Configuration.Item.allCases
                 .filter { configuration.availableWidgets.contains($0) }
                 .map { TrayItem(item: $0, visible: true) }
@@ -100,7 +100,7 @@ struct InteractionBarEditorView<Configuration: InteractionBarConfiguration>: Vie
 
 #Preview {
     NavigationStack {
-        InteractionBarEditorView(configuration: PostBarConfiguration.default, onSet: { _ in })
+        InteractionBarEditorView(configuration: PostBarConfiguration.default, isReport: false, onSet: { _ in })
     }
     .environment(Palette.main)
 }

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -142,23 +142,23 @@ enum SettingsPage: Hashable {
         case .inboxBadge:
             InboxBadgeSettingsView()
         case .postInteractionBar:
-            InteractionBarEditorView(setting: \.postInteractionBar)
+            InteractionBarEditorView(setting: \.postInteractionBar, isReport: false)
         case let .postBarWidgetPicker(configuration):
             InteractionBarWidgetPickerView<PostBarConfiguration>(configuration: configuration.wrappedValue)
         case .commentInteractionBar:
-            InteractionBarEditorView(setting: \.commentInteractionBar)
+            InteractionBarEditorView(setting: \.commentInteractionBar, isReport: false)
         case let .commentBarWidgetPicker(configuration):
             InteractionBarWidgetPickerView<CommentBarConfiguration>(configuration: configuration.wrappedValue)
         case .replyInteractionBar:
-            InteractionBarEditorView(setting: \.replyInteractionBar)
+            InteractionBarEditorView(setting: \.replyInteractionBar, isReport: false)
         case let .replyBarWidgetPicker(configuration):
             InteractionBarWidgetPickerView<ReplyBarConfiguration>(configuration: configuration.wrappedValue)
         case .postReportInteractionBar:
-            InteractionBarEditorView(setting: \.postReportInteractionBar)
+            InteractionBarEditorView(setting: \.postReportInteractionBar, isReport: true)
         case let .postReportBarWidgetPicker(configuration):
             InteractionBarWidgetPickerView<PostBarConfiguration>(configuration: configuration.wrappedValue)
         case .commentReportInteractionBar:
-            InteractionBarEditorView(setting: \.commentReportInteractionBar)
+            InteractionBarEditorView(setting: \.commentReportInteractionBar, isReport: true)
         case let .commentReportBarWidgetPicker(configuration):
             InteractionBarWidgetPickerView<CommentBarConfiguration>(configuration: configuration.wrappedValue)
         case let .document(doc):


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1781 

## Description

The interaction bar editor now properly resets to report defaults in report contexts. This requires a couple of changes:
- `InteractionBarConfiguration` now has `reportDefaults` defined in the protocol. Because this is not meaningful for all configurations, this property is optional.
- `PostBarConfiguration` and `CommentBarConfiguration` expose a non-optional `reportDefaults_`, which backs their protocol-conformant `reportDefaults` and can be used directly in contexts where the type is known
- `InteractionBarEditorView` now takes in an `isReport` flag. When true, it will attempt to reset to `reportDefaults`.