### PR TITLE
Fix visit history error on app load

### DIFF
--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -158,7 +158,7 @@ class PersistenceRepository {
     
     func loadVisitHistory(for account: UserAccount) async throws -> VisitHistory {
         let path = PersistencePath.visitHistory(for: account)
-        let data = load(VisitHistory.CodedData.self, from: path) ?? .init()
+        let data = load(VisitHistory.CodedData.self, from: path, silentError: true) ?? .init()
         return try await .init(data: data, api: account.api)
     }
     


### PR DESCRIPTION
Closes #1805

Tbh we should probably rewrite some of this at some point... handling errors within `loadVisitHistory` *and* making the function throwing is a little confusing