### PR TITLE
Better haptic failure recovery

### DIFF
--- a/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
+++ b/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 class HapticManager {
     @Setting(\.hapticLevel) var hapticLevel
+    @Setting(\.developerMode) var developerMode
     
     // generators/engines
     let rigidImpactGenerator: UIImpactFeedbackGenerator = .init(style: .rigid)
@@ -49,7 +50,7 @@ class HapticManager {
                 try engine.start()
             } catch {
                 // silently log error, re-create the engine, and retry
-                handleError(error, silent: true)
+                handleError(error, silent: !developerMode)
                 hapticEngine = initEngine()
                 loadPlayers()
             }
@@ -87,7 +88,7 @@ class HapticManager {
                 try ret.start()
                 return ret
             } catch {
-                handleError(error, silent: true)
+                handleError(error, silent: !developerMode)
             }
         }
         return nil

--- a/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
+++ b/Mlem/App/Globals/Definitions/HapticManager/HapticManager.swift
@@ -44,11 +44,14 @@ class HapticManager {
     }
     
     func startEngine() {
-        if let hapticEngine {
+        if let engine = hapticEngine {
             do {
-                try hapticEngine.start()
+                try engine.start()
             } catch {
-                handleError(error)
+                // silently log error, re-create the engine, and retry
+                handleError(error, silent: true)
+                hapticEngine = initEngine()
+                loadPlayers()
             }
         }
     }


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- progress towards #1790 

## Description

Adds some more sophisticated failure recovery to `startEngine()`--if the engine fails to start, the catch block now re-creates the engine from scratch. The initial error is now silent, but will show a haptic if developer mode is enabled. I also have [a couple changes planned](https://github.com/mlemgroup/mlem/issues/1828) to make developer mode less obnoxious to daily drive, so if it pops up again it should be easy enough to spot.

This issue is insanely hard to reproduce, so I don't know if any of this will actually fix it.