### PR TITLE
Minor l12n fix

### DIFF
--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -208,7 +208,7 @@ struct ModlogEntryView: View {
     @ViewBuilder
     func reasonView(_ reason: String?) -> some View {
         if let reason {
-            Text("Reason: ").foregroundStyle(.secondary) + Text(reason)
+            Text("Reason:").foregroundStyle(.secondary) + Text(verbatim: " \(reason)")
         } else {
             Text("No reason given")
                 .foregroundStyle(.secondary)

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -5901,7 +5901,7 @@
         }
       }
     },
-    "Reason: " : {
+    "Reason:" : {
       "localizations" : {
         "fr" : {
           "stringUnit" : {


### PR DESCRIPTION
We were using the string `Reason: ` (with a trailing space). The french translation didn't have the trailing space, so it was displayed incorrectly. I've fixed this by removing the trailing space for the english translation, and hard-coding that space instead.