### PR TITLE
Lemmyverse.link support

### DIFF
--- a/Mlem/App/Utility/Extensions/Content Models/Sharable+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Sharable+Extensions.swift
@@ -10,11 +10,18 @@ import MlemMiddleware
 import SwiftUI
 
 extension Sharable {
+    var lemmyverseUrl: URL? {
+        (URL(string: "https://lemmyverse.link/")?
+            .appendingPathComponent(actorId.host)
+            .appendingPathComponent(actorId.url.path()))
+    }
+    
     func shareAction(navigation: NavigationLayer?) -> BasicAction {
         .init(id: "share\(actorId)", appearance: .share(), callback: {
             let url: URL? = switch Settings.main.linkSharingMode {
             case .myInstance: self.url()
             case .originalInstance: self.actorId.url
+            case .lemmyverse: self.lemmyverseUrl
             case .askEveryTime: nil
             }
             if let url, let navigation {

--- a/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
@@ -82,6 +82,7 @@ struct LinkSettingsView: View {
         switch linkSharingMode {
         case .myInstance: "My Instance"
         case .originalInstance: "Original Instance"
+        case .lemmyverse: "Universal"
         case .askEveryTime: "Ask Every Time"
         }
     }

--- a/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
@@ -38,7 +38,7 @@ struct SharingLinksSettingsView: View {
             pickerItemView(
                 mode: .lemmyverse,
                 title: "Universal Link",
-                description: "Share links using https://lemmyverse.link. When someone opens the link, they can choose which instance to use.",
+                description: "Share links using \("https://lemmyverse.link"). When someone opens the link, they can choose which instance to use.",
                 systemImage: "globe"
             )
             pickerItemView(

--- a/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
@@ -9,39 +9,81 @@ import SwiftUI
 
 struct SharingLinksSettingsView: View {
     @Setting(\.linkSharingMode) var linkSharingMode
-    
+    @Setting(\.showSettingsIcons) var showSettingsIcons
+
     var body: some View {
         Form {
-            Section("Share links using...") {
-                Picker("Share links using...", selection: $linkSharingMode) {
-                    ForEach(LinkSharingMode.allCases, id: \.self) { mode in
-                        Label(String(localized: mode.label), systemImage: mode.systemImage)
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.inline)
-            }
+            SettingsHeaderView(
+                title: "Share Links",
+                // swiftlint:disable:next line_length
+                description: "In the Fediverse, many different links can point to the same piece of content. Choose which site to use when sharing content.",
+                systemImage: Icons.share
+            )
+            .tint(.themedColorfulAccent(3))
+            
+            pickerItemView(
+                mode: .myInstance,
+                title: "My Instance",
+                description: "Share links using the instance you are currently connected to.",
+                systemImage: Icons.instance
+            )
+            
+            pickerItemView(
+                mode: .originalInstance,
+                title: "Original Instance",
+                description: "Share links using the instance that the content originated from.",
+                systemImage: "signature"
+            )
+
+            pickerItemView(
+                mode: .lemmyverse,
+                title: "Universal Link",
+                description: "Share links using https://lemmyverse.link. When someone opens the link, they can choose which instance to use.",
+                systemImage: "globe"
+            )
+            pickerItemView(
+                mode: .askEveryTime,
+                title: "Ask Every Time",
+                description: "Every time I share a link, show a popup asking which instance to use.",
+                systemImage: "questionmark.circle"
+            )
         }
+        .contentMargins(.top, 16)
         .labelStyle(.conditional)
+        .animation(.easeInOut(duration: 0.1), value: linkSharingMode)
+    }
+    
+    @ViewBuilder
+    func pickerItemView(
+        mode: LinkSharingMode,
+        title: LocalizedStringResource,
+        description: LocalizedStringResource,
+        systemImage: String
+    ) -> some View {
+        HStack(alignment: .top) {
+            if showSettingsIcons {
+                Image(systemName: systemImage)
+                    .foregroundStyle(.themedAccent)
+                    .frame(width: 30)
+                    .padding(.top, 2)
+            }
+            VStack(alignment: .leading) {
+                Text(title)
+                Text(description)
+                    .font(.footnote)
+                    .foregroundStyle(.themedSecondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Checkbox(isOn: linkSharingMode == mode)
+        }
+        .contentShape(.rect)
+        .onTapGesture {
+            linkSharingMode = mode
+        }
+        .listRowInsets(.init(top: 10, leading: 10, bottom: 10, trailing: 15))
     }
 }
 
 enum LinkSharingMode: String, Codable, CaseIterable {
-    case myInstance, originalInstance, askEveryTime
-    
-    var label: LocalizedStringResource {
-        switch self {
-        case .myInstance: "My Instance"
-        case .originalInstance: "Original Instance"
-        case .askEveryTime: "Ask Every Time"
-        }
-    }
-    
-    var systemImage: String {
-        switch self {
-        case .myInstance: Icons.instance
-        case .originalInstance: "signature"
-        case .askEveryTime: "questionmark.circle"
-        }
-    }
+    case myInstance, originalInstance, lemmyverse, askEveryTime
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
@@ -80,7 +80,7 @@ struct SharingLinksSettingsView: View {
         .onTapGesture {
             linkSharingMode = mode
         }
-        .listRowInsets(.init(top: 10, leading: 10, bottom: 10, trailing: 15))
+        .listRowInsets(.init(top: 10, leading: showSettingsIcons ? 10 : 16, bottom: 10, trailing: 16))
     }
 }
 

--- a/Mlem/App/Views/Shared/HandleLemmyLinksModifier.swift
+++ b/Mlem/App/Views/Shared/HandleLemmyLinksModifier.swift
@@ -61,6 +61,15 @@ struct HandleLemmyLinksModifier: ViewModifier {
             return .handled
         }
         
+        // Handles https://lemmyverse.link
+        if host == "lemmyverse.link", url.pathComponents.count > 3 {
+            var components = URLComponents()
+            components.scheme = "https"
+            components.host = url.pathComponents[1]
+            components.path = "/" + url.pathComponents.dropFirst(2).joined(separator: "/")
+            if let newUrl = components.url, interpretLemmyUrlPath(url: newUrl) { return .handled }
+        }
+        
         // If the link is in our Lemmy domain list, push a page to the NavigationStack straight away
         if isLemmyHost(host), interpretLemmyUrlPath(url: url) {
             return .handled

--- a/Mlem/App/Views/Shared/ShareInstancePickerView.swift
+++ b/Mlem/App/Views/Shared/ShareInstancePickerView.swift
@@ -30,6 +30,10 @@ struct ShareInstancePickerView: View {
                 instanceTargetRow(entity.api.host, label: "My Instance", url: entity.url())
                 Divider()
                 instanceTargetRow(entity.actorId.host, label: "Original Instance", url: entity.actorId.url)
+                if let lemmyverseUrl = entity.lemmyverseUrl {
+                    Divider()
+                    instanceTargetRow("lemmyverse.link", label: "Universal", url: lemmyverseUrl)
+                }
             }
             .frame(maxWidth: .infinity)
             .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 16))
@@ -58,7 +62,14 @@ struct ShareInstancePickerView: View {
             }
         } label: {
             HStack(spacing: 16) {
-                CircleCroppedImageView(url: faviconUrl(for: url), frame: 42, fallback: .instanceAvatar)
+                if host == "lemmyverse.link" {
+                    Image(systemName: "globe")
+                        .foregroundStyle(.themedAccent)
+                        .frame(width: 42, height: 42)
+                        .background(.themedAccent.opacity(0.2), in: .circle)
+                } else {
+                    CircleCroppedImageView(url: faviconUrl(for: url), frame: 42, fallback: .instanceAvatar)
+                }
                 VStack(alignment: .leading, spacing: 5) {
                     Text(host)
                         .foregroundStyle(.themedPrimary)
@@ -72,7 +83,7 @@ struct ShareInstancePickerView: View {
             .padding(.vertical, 12)
         }
     }
-    
+
     func faviconUrl(for instanceUrl: URL) -> URL? {
         guard let host = instanceUrl.host() else { return nil }
         let summary = MlemStats.main.instances?.first(where: { $0.host == host })

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -692,6 +692,9 @@
         }
       }
     },
+    "Add an image..." : {
+
+    },
     "Add Guest" : {
       "localizations" : {
         "fr" : {
@@ -2928,6 +2931,9 @@
         }
       }
     },
+    "Every time I share a link, show a popup asking which instance to use." : {
+
+    },
     "example.com" : {
       "localizations" : {
         "fr" : {
@@ -3726,6 +3732,9 @@
           }
         }
       }
+    },
+    "In the Fediverse, many different links can point to the same piece of content. Choose which site to use when sharing content." : {
+
     },
     "In-App" : {
       "extractionState" : "stale",
@@ -6731,7 +6740,13 @@
     "Share Links" : {
 
     },
-    "Share links using..." : {
+    "Share links using https://lemmyverse.link. When someone opens the link, they can choose which instance to use." : {
+
+    },
+    "Share links using the instance that the content originated from." : {
+
+    },
+    "Share links using the instance you are currently connected to." : {
 
     },
     "Share using..." : {
@@ -8239,6 +8254,12 @@
         }
       }
     },
+    "Universal" : {
+
+    },
+    "Universal Link" : {
+
+    },
     "Unknown" : {
       "localizations" : {
         "fr" : {
@@ -8350,6 +8371,7 @@
       }
     },
     "Upload an image..." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -6740,7 +6740,7 @@
     "Share Links" : {
 
     },
-    "Share links using https://lemmyverse.link. When someone opens the link, they can choose which instance to use." : {
+    "Share links using %@. When someone opens the link, they can choose which instance to use." : {
 
     },
     "Share links using the instance that the content originated from." : {


### PR DESCRIPTION
Closes #1867 

- If you tap on a link from `lemmyverse.link`, it now opens in-app
- Added lemmyverse.link to the list of sharing options in Settings, and to the "ask every time" share sheet

<img src="https://github.com/user-attachments/assets/1e1870b6-ed6c-40b8-b96a-e6be160b760b" width=40%>
<img src="https://github.com/user-attachments/assets/b0b45ef9-25ce-4af7-a38e-8a27d77c527b" width=40%>
