### PR TITLE
Fix links in the format `[label text](/c/comm@example.com)` not opening when tapped

### DIFF
--- a/Mlem/App/Views/Shared/HandleLemmyLinksModifier.swift
+++ b/Mlem/App/Views/Shared/HandleLemmyLinksModifier.swift
@@ -41,6 +41,16 @@ struct HandleLemmyLinksModifier: ViewModifier {
         // TODO: Consider handling links to alternative frontends such as `old.lemmy.world` or `oldsh.itjust.works`.
         
         guard let scheme = url.scheme else {
+            // LemmyMarkdownUI parses the `/c/comm@example.com` and `!comm@example.com` link formats in to regular links,
+            // so those don't need to be handled in this method. However, it doesn't parse links written in the format
+            // [Some text](/c/comm@example.com), which some instances use. Those links are handled here. Later, it might
+            // be better to move that into LemmyMarkdownUI, but I think we'd need to modify the core cmark code rather
+            // than just the extensions, which isn't ideal.
+            
+            if let newUrl = createLemmyUrlFromShortcut(parts: url.pathComponents), interpretLemmyUrlPath(url: newUrl) {
+                return .handled
+            }
+            
             openRegularLink(url: url)
             return .handled
         }
@@ -54,11 +64,6 @@ struct HandleLemmyLinksModifier: ViewModifier {
         }
         
         guard let host = url.host(), scheme.starts(with: "http") else {
-            // LemmyMarkdownUI parses the `/c/comm@example.com` and `!comm@example.com` link formats in to regular links,
-            // so those don't need to be handled in this method. However, it doesn't parse links written in the format
-            // [Some text](/c/comm@example.com), which some instances use. Those links are handled here. Later, it might
-            // be better to move that into LemmyMarkdownUI, but I think we'd need to modify the core cmark
-            
             openRegularLink(url: url)
             return .handled
         }
@@ -85,6 +90,20 @@ struct HandleLemmyLinksModifier: ViewModifier {
         // If all else fails, fallback to opening in browser
         openRegularLink(url: url)
         return .handled
+    }
+    
+    // Creates https://example.com/c/comm from /c/comm@example.com
+    func createLemmyUrlFromShortcut(parts: [String]) -> URL? {
+        var parts = parts
+        parts.removeFirst()
+        guard parts.count == 2 else { return nil }
+        guard parts[0] == "c" || parts[0] == "u" else { return nil }
+        var components = URLComponents()
+        components.scheme = "https"
+        let fullNameParts = parts[1].split(separator: "@")
+        components.host = String(fullNameParts[1])
+        components.path = "/\(parts[0])/\(fullNameParts[0])"
+        return components.url
     }
     
     func interpretLemmyUrlPath(url: URL) -> Bool {

--- a/Mlem/App/Views/Shared/HandleLemmyLinksModifier.swift
+++ b/Mlem/App/Views/Shared/HandleLemmyLinksModifier.swift
@@ -38,9 +38,6 @@ struct HandleLemmyLinksModifier: ViewModifier {
     
     @MainActor
     func didReceiveURL(_ url: URL) -> OpenURLAction.Result {
-        // We don't need to decode `/c/comm@example.com` or `!comm@example.com` formats in this method
-        // - LemmyMarkdownUI converts those links into `https://example.com/c/comm` format during parsing.
-        
         // TODO: Consider handling links to alternative frontends such as `old.lemmy.world` or `oldsh.itjust.works`.
         
         guard let scheme = url.scheme else {
@@ -57,6 +54,11 @@ struct HandleLemmyLinksModifier: ViewModifier {
         }
         
         guard let host = url.host(), scheme.starts(with: "http") else {
+            // LemmyMarkdownUI parses the `/c/comm@example.com` and `!comm@example.com` link formats in to regular links,
+            // so those don't need to be handled in this method. However, it doesn't parse links written in the format
+            // [Some text](/c/comm@example.com), which some instances use. Those links are handled here. Later, it might
+            // be better to move that into LemmyMarkdownUI, but I think we'd need to modify the core cmark
+            
             openRegularLink(url: url)
             return .handled
         }

--- a/Mlem/App/Views/Shared/HandleLemmyLinksModifier.swift
+++ b/Mlem/App/Views/Shared/HandleLemmyLinksModifier.swift
@@ -41,11 +41,11 @@ struct HandleLemmyLinksModifier: ViewModifier {
         // TODO: Consider handling links to alternative frontends such as `old.lemmy.world` or `oldsh.itjust.works`.
         
         guard let scheme = url.scheme else {
-            // LemmyMarkdownUI parses the `/c/comm@example.com` and `!comm@example.com` link formats in to regular links,
+            // LemmyMarkdownUI parses the `/c/comm@example.com` and `!comm@example.com` link formats into regular links,
             // so those don't need to be handled in this method. However, it doesn't parse links written in the format
-            // [Some text](/c/comm@example.com), which some instances use. Those links are handled here. Later, it might
-            // be better to move that into LemmyMarkdownUI, but I think we'd need to modify the core cmark code rather
-            // than just the extensions, which isn't ideal.
+            // [Some text](/c/comm@example.com), which is a format that lemmy-ui supports. Those links are handled here.
+            // Later, it might  be better to move that into LemmyMarkdownUI, but I think we'd need to modify the core
+            // cmark code rather than just the extensions, which isn't ideal.
             
             if let newUrl = createLemmyUrlFromShortcut(parts: url.pathComponents), interpretLemmyUrlPath(url: newUrl) {
                 return .handled


### PR DESCRIPTION
Closes #1874