### PR TITLE
Mixed feed comments design

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
@@ -16,7 +16,8 @@ struct FeedCommentView<EmbeddedContent: View>: View {
     @Environment(\.reportContext) var reportContext: Report?
     
     @Setting(\.postSize) var settingsPostSize
-    
+    @Setting(\.blurNsfw) var blurNsfw
+
     let comment: any Comment
     var overriddenSize: PostSize?
     @ViewBuilder var embeddedContent: () -> EmbeddedContent

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
@@ -87,7 +87,7 @@ struct FeedCommentView<EmbeddedContent: View>: View {
             VStack(alignment: .leading) {
                 Text(post.title)
                     .bold()
-                Text(comment.community_?.fullNameWithPrefix ?? "")
+                Text(comment.community_?.fullName ?? "")
             }
             .lineLimit(1)
             .font(.footnote)

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
@@ -78,6 +78,11 @@ struct FeedCommentView<EmbeddedContent: View>: View {
             MediaView(
                 url: headerUrl(post: post),
                 size: .init(width: 40, height: 40),
+                controlState: .constant(.init(
+                    blurred: post.nsfw && blurNsfw != .never,
+                    animating: false,
+                    overlays: []
+                )),
                 aspectRatioBounds: .absoluteSquare,
                 contentMode: .fill,
                 cornerRadius: 10,

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Comments/FeedCommentView.swift
@@ -34,17 +34,24 @@ struct FeedCommentView<EmbeddedContent: View>: View {
     var postSize: PostSize { overriddenSize ?? settingsPostSize }
     
     var body: some View {
-        content
-            .contentShape(.interaction, .rect)
-            .quickSwipes(comment.swipeActions(appState: appState, behavior: postSize.swipeBehavior, commentTreeTracker: commentTreeTracker))
-            .contextMenu { comment.allMenuActions(
-                appState: appState,
-                showAllActions: false,
-                navigation: navigation,
-                commentTreeTracker: commentTreeTracker,
-                report: reportContext
-            ) }
-            .paletteBorder(cornerRadius: postSize.swipeBehavior.cornerRadius)
+        VStack(spacing: Constants.main.standardSpacing) {
+            if !postSize.tiled, let post = comment.post_ {
+                headerView(post: post)
+            }
+            content
+                .contentShape(.interaction, .rect)
+                .quickSwipes(
+                    comment.swipeActions(appState: appState, behavior: postSize.swipeBehavior, commentTreeTracker: commentTreeTracker)
+                )
+                .contextMenu { comment.allMenuActions(
+                    appState: appState,
+                    showAllActions: false,
+                    navigation: navigation,
+                    commentTreeTracker: commentTreeTracker,
+                    report: reportContext
+                ) }
+                .paletteBorder(cornerRadius: postSize.swipeBehavior.cornerRadius)
+        }
     }
     
     @ViewBuilder
@@ -53,6 +60,43 @@ struct FeedCommentView<EmbeddedContent: View>: View {
             TileCommentView(comment: comment)
         } else {
             CommentView(comment: comment, inFeed: true, embeddedContent: embeddedContent)
+                .padding(.bottom, 5)
+        }
+    }
+    
+    func headerUrl(post: any Post) -> URL? {
+        switch post.type {
+        case let .media(url), let .embedded(url, _): url
+        case let .link(link): link.thumbnail
+        default: nil
+        }
+    }
+    
+    @ViewBuilder
+    func headerView(post: any Post) -> some View {
+        HStack {
+            MediaView(
+                url: headerUrl(post: post),
+                size: .init(width: 40, height: 40),
+                aspectRatioBounds: .absoluteSquare,
+                contentMode: .fill,
+                cornerRadius: 10,
+                fallback: post.imageFallback
+            )
+            .frame(width: 40, height: 40)
+            VStack(alignment: .leading) {
+                Text(post.title)
+                    .bold()
+                Text(comment.community_?.fullNameWithPrefix ?? "")
+            }
+            .lineLimit(1)
+            .font(.footnote)
+            .foregroundStyle(.themedSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.top, 5)
+        .onTapGesture {
+            navigation.push(.post(post))
         }
     }
 }

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -76,9 +76,7 @@ struct CommentView<EmbeddedContent: View>: View {
         let collapsed = treeNode?.collapsed ?? false
         
         HStack(spacing: 12) {
-            if !inFeed, comment.depth != 0 {
-                CommentBarView(depth: comment.depth)
-            }
+            CommentBarView(depth: comment.depth, inFeed: inFeed)
             VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
                 HStack(spacing: 0) {
                     FullyQualifiedLinkView(comment.creator_, labelStyle: .small)
@@ -106,12 +104,6 @@ struct CommentView<EmbeddedContent: View>: View {
                 if !collapsed {
                     CommentBodyView(comment: comment)
                         .padding(.trailing, 2)
-                    if inFeed, let post = comment.post_ {
-                        NavigationLink(.post(post)) {
-                            FooterLinkView(title: post.title, subtitle: comment.community_?.fullNameWithPrefix)
-                        }
-                        .id("\(comment.id)_commment_footer")
-                    }
                     embeddedContent
                     if !compact {
                         InteractionBarView(
@@ -132,7 +124,7 @@ struct CommentView<EmbeddedContent: View>: View {
             .padding(.vertical, Constants.main.standardSpacing)
             .padding(.top, compact || collapsed ? 0 : 3)
         }
-        .padding(depth == 0 ? .horizontal : .trailing, Constants.main.standardSpacing)
+        .padding(.trailing, Constants.main.standardSpacing)
         .background(highlight ? palette.accent.opacity(0.2) : .clear)
         .background(.themedSecondaryGroupedBackground)
         .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
@@ -184,10 +176,11 @@ struct CommentView<EmbeddedContent: View>: View {
 
 struct CommentBarView: View {
     let depth: Int
+    var inFeed: Bool = false
     
     var body: some View {
         Capsule()
-            .fill(.themedCommentIndentColor(depth))
+            .fill(inFeed ? .themedTertiary : .themedCommentIndentColor(depth))
             .frame(width: 3)
             .frame(maxHeight: .infinity)
             .padding(.leading, 8)

--- a/Mlem/App/Views/Shared/PersonContentGridView.swift
+++ b/Mlem/App/Views/Shared/PersonContentGridView.swift
@@ -63,7 +63,7 @@ struct PersonContentGridView: View {
     
     var content: some View {
         VStack(spacing: 0) {
-            LazyVGrid(columns: columns, spacing: postSize.sectionSpacing) {
+            LazyVGrid(columns: columns, spacing: spacing) {
                 ForEach(items, id: \.hashValue) { item in
                     if !item.shouldHideInFeed {
                         personContentItem(item)
@@ -84,6 +84,15 @@ struct PersonContentGridView: View {
             }
             .animation(.easeOut(duration: 0.1), value: items.isEmpty)
             EndOfFeedView(loadingState: loadingState, viewType: .hobbit)
+        }
+    }
+    
+    var spacing: CGFloat {
+        switch contentType {
+        case .all, .comments:
+            Constants.main.standardSpacing
+        case .posts:
+            postSize.sectionSpacing
         }
     }
     


### PR DESCRIPTION
Closes #1837

Moved the post context for comments to the top rather than the bottom.

I think having the comment bar always shown for comments is a good distinguishing mark to separate them from posts. The comment bar is now shown for top-level comments on a post, and for comments in a combined feed. 

If this change is well-received I'd like to expand this design to the Inbox and Mod Mail, too.