### PR TITLE
"Tap to collapse" setting for posts

### DIFF
--- a/Mlem/App/Configuration/User Settings/CodableSettings.swift
+++ b/Mlem/App/Configuration/User Settings/CodableSettings.swift
@@ -71,6 +71,7 @@ struct CodableSettings: Codable { // swiftlint:disable:this type_body_length
     var post_webPreview_showHost: Bool
     var post_webPreview_showIcon: Bool
     var post_showDownvotesCompact: Bool
+    var post_gestures_tapToCollapse: Bool
     var profile_showBanner: Bool
     var privacy_autoBypassImageProxy: Bool
     var privacy_showFavicons: Bool
@@ -194,6 +195,7 @@ struct CodableSettings: Codable { // swiftlint:disable:this type_body_length
         self.post_thumbnailLocation = try container.decodeIfPresent(ThumbnailLocation.self, forKey: .post_thumbnailLocation) ?? .left
         self.post_webPreview_showHost = try container.decodeIfPresent(Bool.self, forKey: .post_webPreview_showHost) ?? true
         self.post_webPreview_showIcon = try container.decodeIfPresent(Bool.self, forKey: .post_webPreview_showIcon) ?? true
+        self.post_gestures_tapToCollapse = try container.decodeIfPresent(Bool.self, forKey: .post_gestures_tapToCollapse) ?? true
         self.privacy_autoBypassImageProxy = try container.decodeIfPresent(Bool.self, forKey: .privacy_autoBypassImageProxy) ?? false
         self.privacy_showFavicons = try container.decodeIfPresent(Bool.self, forKey: .privacy_showFavicons) ?? true
         self.profile_showBanner = try container.decodeIfPresent(Bool.self, forKey: .profile_showBanner) ?? true
@@ -278,6 +280,7 @@ struct CodableSettings: Codable { // swiftlint:disable:this type_body_length
         self.post_webPreview_showHost = true // Removed in 2.0
         self.post_webPreview_showIcon = settings.showFavicons
         self.post_showDownvotesCompact = settings.showDownvotesCompact
+        self.post_gestures_tapToCollapse = true
         self.profile_showBanner = true // Removed in 2.0
         self.safety_blurNsfw = settings.blurNsfw
         self.safety_enableNsfwCommunityWarning = settings.showNsfwCommunityWarning

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -32,7 +32,8 @@ class Settings: ObservableObject {
     @AppStorage("post.showCreator") var showPostCreator: Bool = false
     @AppStorage("post.showSubscribedStatus") var showSubscribedStatus: Bool = true
     @AppStorage("post.showDownvotesCompact") var showDownvotesCompact: Bool = false
-    
+    @AppStorage("post.gestures.tapToCollapse") var tapPostsToCollapse: Bool = true
+
     @AppStorage("quickSwipes.enabled") var quickSwipesEnabled: Bool = true
     
     @AppStorage("behavior.hapticLevel") var hapticLevel: HapticPriority = .low
@@ -144,6 +145,7 @@ class Settings: ObservableObject {
         thumbnailLocation = settings.post_thumbnailLocation
         showPostCreator = settings.post_showCreator
         showSubscribedStatus = settings.post_showSubscribedStatus
+        tapPostsToCollapse = settings.post_gestures_tapToCollapse
         quickSwipesEnabled = settings.behavior_enableQuickSwipes
         hapticLevel = settings.behavior_hapticLevel
         upvoteOnSave = settings.behavior_upvoteOnSave

--- a/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
@@ -18,6 +18,7 @@ struct PostSettingsView: View {
     @Setting(\.showPostCreator) var showCreator
     @Setting(\.showSubscribedStatus) var showSubscribedStatus
     @Setting(\.showDownvotesCompact) var showDownvotesCompact
+    @Setting(\.tapPostsToCollapse) var tapPostsToCollapse
     
     @Setting(\.readPostIndicator) var readPostIndicator
     
@@ -66,6 +67,10 @@ struct PostSettingsView: View {
                         destination: .settings(.postReadIndicator)
                     )
                 }
+            }
+            
+            Section {
+                Toggle("Tap to Collapse", systemImage: Icons.collapseComment, isOn: $tapPostsToCollapse)
             }
             
             if postSize != .tile, postSize != .compact {

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Logic.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Logic.swift
@@ -29,6 +29,12 @@ extension ExpandedPostView {
         !(scrollTargetedComment == nil || (post is any Post3Providing && scrolledToscrollTargetedComment))
     }
     
+    func togglePostCollapsed() {
+        withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .default) {
+            postCollapsed.toggle()
+        }
+    }
+    
     func generateViewTree(for nodes: [CommentTreeNode]) -> [CommentTreeViewType] {
         nodes.reduce([]) { $0 + generateViewTree(for: $1) }
     }

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -203,7 +203,7 @@ struct ExpandedPostView<Content: View>: View {
                     Section {
                         Button(
                             postCollapsed ? "Expand Post" : "Collapse Post",
-                            systemImage: postCollapsed ? Icons.collapseComment : Icons.expandComment,
+                            systemImage: postCollapsed ? Icons.expandComment : Icons.collapseComment,
                             action: togglePostCollapsed
                         )
                     }

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -27,6 +27,7 @@ struct ExpandedPostView<Content: View>: View {
     
     @Setting(\.jumpButton) var jumpButton
     @Setting(\.compactComments) var compactComments
+    @Setting(\.tapPostsToCollapse) var tapPostsToCollapse
     
     var post: (any PostStubProviding)?
     var contentLoaderError: Error?
@@ -176,25 +177,39 @@ struct ExpandedPostView<Content: View>: View {
                 }
             }
         }
-        .toolbar {
-            if let tracker {
-                sortPicker(tracker: tracker)
-            }
-            if isLoading || post.shouldShowLoadingSymbol() {
-                ProgressView()
-            } else {
-                ToolbarEllipsisMenu(
+        .toolbar { toolbarContent(post: post, isLoading: isLoading) }
+        .environment(tracker)
+        .environment(\.feedContext, .post)
+    }
+    
+    @ViewBuilder
+    func toolbarContent(post: any Post, isLoading: Bool) -> some View {
+        if let tracker {
+            sortPicker(tracker: tracker)
+        }
+        if isLoading || post.shouldShowLoadingSymbol() {
+            ProgressView()
+        } else {
+            ToolbarEllipsisMenu {
+                MenuButtons {
                     post.allMenuActions(
                         appState: appState,
                         expanded: true,
                         navigation: navigation,
                         commentTreeTracker: tracker
                     )
-                )
+                }
+                if !tapPostsToCollapse {
+                    Section {
+                        Button(
+                            postCollapsed ? "Expand Post" : "Collapse Post",
+                            systemImage: postCollapsed ? Icons.collapseComment : Icons.expandComment,
+                            action: togglePostCollapsed
+                        )
+                    }
+                }
             }
         }
-        .environment(tracker)
-        .environment(\.feedContext, .post)
     }
     
     @ViewBuilder
@@ -228,8 +243,8 @@ struct ExpandedPostView<Content: View>: View {
         }
         .paletteBorder(cornerRadius: PostSize.large.swipeBehavior.cornerRadius)
         .onTapGesture {
-            withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .default) {
-                postCollapsed.toggle()
+            if tapPostsToCollapse || postCollapsed {
+                togglePostCollapsed()
             }
         }
         .id(post.actorId)

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1890,6 +1890,9 @@
         }
       }
     },
+    "Collapse Post" : {
+
+    },
     "Comment" : {
       "localizations" : {
         "fr" : {
@@ -3022,6 +3025,9 @@
           }
         }
       }
+    },
+    "Expand Post" : {
+
     },
     "Expires:" : {
       "localizations" : {


### PR DESCRIPTION
When this setting is off, there is a "Collapse post" button in the ellipsis menu in the top corner of the page.

Closes #1751