### PR TITLE
"Jump to last position" button in expanded post view

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		033FCB2A2C5E3933007B7CD1 /* AlternateIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033FCB232C5E3933007B7CD1 /* AlternateIconCell.swift */; };
 		033FCB3E2C5E7FA9007B7CD1 /* View+OutdatedFeedPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033FCB3D2C5E7FA9007B7CD1 /* View+OutdatedFeedPopup.swift */; };
 		034065C32D83742900637308 /* View+NavigtionStackPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034065C22D83742900637308 /* View+NavigtionStackPreview.swift */; };
+		034147FD2D8F5844005503AF /* ExpandedPostHistoryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034147FC2D8F5844005503AF /* ExpandedPostHistoryTracker.swift */; };
 		0343C0482D3AD6DB001CF709 /* Set+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0343C0472D3AD6DB001CF709 /* Set+Extensions.swift */; };
 		034690932D0F4D720073E664 /* RemovableProviding+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034690922D0F4D720073E664 /* RemovableProviding+Extensions.swift */; };
 		034690992D105DFD0073E664 /* InboxView+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034690982D105DFD0073E664 /* InboxView+Types.swift */; };
@@ -635,6 +636,7 @@
 		033FCB252C5E3933007B7CD1 /* IconSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconSettingsView.swift; sourceTree = "<group>"; };
 		033FCB3D2C5E7FA9007B7CD1 /* View+OutdatedFeedPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+OutdatedFeedPopup.swift"; sourceTree = "<group>"; };
 		034065C22D83742900637308 /* View+NavigtionStackPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NavigtionStackPreview.swift"; sourceTree = "<group>"; };
+		034147FC2D8F5844005503AF /* ExpandedPostHistoryTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedPostHistoryTracker.swift; sourceTree = "<group>"; };
 		0343C0472D3AD6DB001CF709 /* Set+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Extensions.swift"; sourceTree = "<group>"; };
 		034690922D0F4D720073E664 /* RemovableProviding+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemovableProviding+Extensions.swift"; sourceTree = "<group>"; };
 		034690982D105DFD0073E664 /* InboxView+Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InboxView+Types.swift"; sourceTree = "<group>"; };
@@ -1518,6 +1520,7 @@
 				03AD09E72CF88007001EF9F7 /* MoreRepliesButton.swift */,
 				039F58852C7A810100C61658 /* ExpandedPostView+Logic.swift */,
 				03E0EF422CA73D7A002CB66C /* PostPage.swift */,
+				034147FC2D8F5844005503AF /* ExpandedPostHistoryTracker.swift */,
 			);
 			path = ExpandedPost;
 			sourceTree = "<group>";
@@ -2702,6 +2705,7 @@
 				CDE1F1982C63DFC9008AF042 /* PadConstants.swift in Sources */,
 				03B25B312CC4403500EB6DF5 /* Fediseer.swift in Sources */,
 				038028F82CB097A10091A8A2 /* SearchView+InstancePicker.swift in Sources */,
+				034147FD2D8F5844005503AF /* ExpandedPostHistoryTracker.swift in Sources */,
 				03D284082D2AF05200A6659B /* Checkbox.swift in Sources */,
 				CD9CFA2C2C2E1EF300739BBC /* FeedIconView.swift in Sources */,
 				038188992D43E0F30073E88D /* SafetySettingsView.swift in Sources */,

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -351,6 +351,7 @@ enum Icons {
     static let easterEgg: String = "gift.fill"
     static let jumpButton: String = "chevron.down"
     static let jumpButtonCircle: String = "chevron.down.circle"
+    static let jumpToLastPositionButton: String = "chevron.down.2"
     static let browser: String = "safari"
     static let emptySquare: String = "square"
     static let dropDown: String = "chevron.down"

--- a/Mlem/App/Enums/CommentJumpButtonLocation.swift
+++ b/Mlem/App/Enums/CommentJumpButtonLocation.swift
@@ -15,7 +15,7 @@ enum CommentJumpButtonLocation: String, CaseIterable, Codable {
         case .bottomLeading: .bottomLeading
         case .bottomTrailing: .bottomTrailing
         case .bottomCenter: .bottom
-        case .none: .bottom
+        case .none: .bottomTrailing
         }
     }
     

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -36,6 +36,8 @@ struct ContentView: View {
     @State var avatarImage: UIImage?
     @State var selectedAvatarImage: UIImage?
     
+    @State var expandedPostHistoryTracker: ExpandedPostHistoryTracker = .init()
+    
     var body: some View {
         if appState.appRefreshToggle {
             content
@@ -66,6 +68,7 @@ struct ContentView: View {
                 .environment(appState)
                 .environment(filtersTracker)
                 .environment(errorsTracker)
+                .environment(expandedPostHistoryTracker)
                 .task {
                     do {
                         try await MlemStats.main.loadInstances()

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostHistoryTracker.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostHistoryTracker.swift
@@ -1,0 +1,32 @@
+//
+//  ExpandedPostHistoryTracker.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-03-22.
+//
+
+import Foundation
+import MlemMiddleware
+
+// This needs to be Observable in order for it to work in the envrionment,
+// but we aren't actually using any Observable properties at present
+@Observable
+class ExpandedPostHistoryTracker {
+    @ObservationIgnored private var postActorIds: [ActorIdentifier] = []
+    @ObservationIgnored private var postToCommentMap: [ActorIdentifier: ActorIdentifier] = [:]
+    
+    func insert(postActorId: ActorIdentifier, commentActorId: ActorIdentifier) {
+        if let index = postActorIds.firstIndex(of: postActorId) {
+            postActorIds.remove(at: index)
+        }
+        postActorIds.append(postActorId)
+        postToCommentMap[postActorId] = commentActorId
+        
+        if postActorIds.count > 10 {
+            let removedId = postActorIds.removeFirst()
+            postToCommentMap[removedId] = nil
+        }
+    }
+    
+    func retrieve(for postActorId: ActorIdentifier) -> ActorIdentifier? { postToCommentMap[postActorId] }
+}

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Logic.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Logic.swift
@@ -63,9 +63,24 @@ extension ExpandedPostView {
         return ret
     }
     
+    func updateAnchors(_ anchors: AnchorsKey.Value, in proxy: GeometryProxy) {
+        guard let postActorId = post?.actorId_ else { return }
+        topVisibleItem.wrappedValue = topCommentRow(of: anchors, in: proxy)
+        if (topVisibleItem.wrappedValue == postActorId) != topVisibleItem.isAtPost {
+            topVisibleItem.isAtPost.toggle()
+        }
+        if let commentActorId = topVisibleItem.wrappedValue, topVisibleItem.wrappedValue != postActorId {
+            expandedPostHistoryTracker.insert(postActorId: postActorId, commentActorId: commentActorId)
+        }
+    }
+    
+    func scrollToLastVisitedPosition() {
+        if let topVisibleCommentAtLastVisit { jumpButtonTarget = topVisibleCommentAtLastVisit }
+    }
+    
     func scrollToNextComment() {
         guard let tracker, let postActorId = post?.actorId_ else { return }
-        if let topVisibleItem {
+        if let topVisibleItem = topVisibleItem.wrappedValue {
             if topVisibleItem == postActorId, let first = tracker.nodes.first {
                 jumpButtonTarget = first.actorId
                 return
@@ -81,7 +96,7 @@ extension ExpandedPostView {
     
     func scrollToPreviousComment() {
         guard let tracker, let postActorId = post?.actorId_ else { return }
-        if let topVisibleItem, topVisibleItem != postActorId {
+        if let topVisibleItem = topVisibleItem.wrappedValue, topVisibleItem != postActorId {
             if let comment = tracker.nodesKeyedByActorId[topVisibleItem] {
                 if var topLevelIndex = tracker.nodes.firstIndex(of: comment.topParent) {
                     if topLevelIndex < 0 || comment == tracker.nodes.first {

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -175,7 +175,7 @@ struct ExpandedPostView<Content: View>: View {
                 .overlay(alignment: jumpButton.alignment) {
                     let shouldShow = topVisibleCommentAtLastVisit == nil && (post.commentCount_ ?? 0) > 10
                     JumpButtonsView(
-                        showJumpButton: true,
+                        showJumpButton: (tracker?.nodes.count ?? 0) > 1,
                         topVisibleItem: topVisibleItem,
                         scrollToLastVisitedPosition: shouldShow ? nil : scrollToLastVisitedPosition,
                         scrollToNextComment: scrollToNextComment,
@@ -280,14 +280,14 @@ private struct JumpButtonsView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            if let scrollToLastVisitedPosition, topVisibleItem.isAtPost {
+            if let scrollToLastVisitedPosition, topVisibleItem.isAtPost, showJumpButton {
                 JumpButtonView(
-                    systemImage: "chevron.down.2",
+                    systemImage: Icons.jumpToLastPositionButton,
                     onShortPress: scrollToLastVisitedPosition,
                     onLongPress: nil
                 )
             }
-            if jumpButton != .none, showJumpButton { // (tracker?.nodes.count ?? 0) > 1
+            if jumpButton != .none, showJumpButton {
                 JumpButtonView(
                     onShortPress: scrollToNextComment,
                     onLongPress: scrollToPreviousComment

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -173,10 +173,11 @@ struct ExpandedPostView<Content: View>: View {
                     }
                 }
                 .overlay(alignment: jumpButton.alignment) {
+                    let shouldShow = topVisibleCommentAtLastVisit == nil && (post.commentCount_ ?? 0) > 10
                     JumpButtonsView(
                         showJumpButton: true,
                         topVisibleItem: topVisibleItem,
-                        scrollToLastVisitedPosition: topVisibleCommentAtLastVisit == nil ? nil : scrollToLastVisitedPosition,
+                        scrollToLastVisitedPosition: shouldShow ? nil : scrollToLastVisitedPosition,
                         scrollToNextComment: scrollToNextComment,
                         scrollToPreviousComment: scrollToPreviousComment
                     )

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -8,6 +8,13 @@
 import MlemMiddleware
 import SwiftUI
 
+@Observable
+class TopVisibleItemContainer {
+    // This doesn't need to trigger view updates
+    @ObservationIgnored var wrappedValue: ActorIdentifier?
+    var isAtPost: Bool = true
+}
+
 struct ExpandedPostView<Content: View>: View {
     struct AnchorsKey: PreferenceKey {
         // swiftlint:disable:next nesting
@@ -19,8 +26,9 @@ struct ExpandedPostView<Content: View>: View {
             value.merge(nextValue()) { $1 }
         }
     }
-
+    
     @Environment(AppState.self) var appState
+    @Environment(ExpandedPostHistoryTracker.self) var expandedPostHistoryTracker
     @Environment(NavigationLayer.self) var navigation
     @Environment(\.palette) var palette
     @Environment(\.dismiss) var dismiss
@@ -40,8 +48,10 @@ struct ExpandedPostView<Content: View>: View {
 
     @State var scrolledToscrollTargetedComment: Bool = false
     @State var jumpButtonTarget: ActorIdentifier?
-    @State var topVisibleItem: ActorIdentifier?
+    @State var topVisibleItem: TopVisibleItemContainer = .init()
     @State var postCollapsed: Bool = false
+    
+    @State var topVisibleCommentAtLastVisit: ActorIdentifier?
     
     init(
         post: (any PostStubProviding)?,
@@ -162,18 +172,18 @@ struct ExpandedPostView<Content: View>: View {
                         self.jumpButtonTarget = nil
                     }
                 }
-                .overlay {
-                    if jumpButton != .none, (tracker?.nodes.count ?? 0) > 1 {
-                        JumpButtonView(onShortPress: scrollToNextComment, onLongPress: scrollToPreviousComment)
-                            .frame(
-                                maxWidth: .infinity,
-                                maxHeight: .infinity,
-                                alignment: jumpButton.alignment
-                            )
-                    }
+                .overlay(alignment: jumpButton.alignment) {
+                    JumpButtonsView(
+                        showJumpButton: true,
+                        topVisibleItem: topVisibleItem,
+                        scrollToLastVisitedPosition: topVisibleCommentAtLastVisit == nil ? nil : scrollToLastVisitedPosition,
+                        scrollToNextComment: scrollToNextComment,
+                        scrollToPreviousComment: scrollToPreviousComment
+                    )
                 }
-                .onPreferenceChange(AnchorsKey.self) { anchors in
-                    topVisibleItem = topCommentRow(of: anchors, in: geo)
+                .onPreferenceChange(AnchorsKey.self) { updateAnchors($0, in: geo) }
+                .onAppear {
+                    topVisibleCommentAtLastVisit = expandedPostHistoryTracker.retrieve(for: post.actorId)
                 }
             }
         }
@@ -254,5 +264,36 @@ struct ExpandedPostView<Content: View>: View {
             key: AnchorsKey.self,
             value: .center
         ) { [post.actorId: $0] }
+    }
+}
+
+private struct JumpButtonsView: View {
+    @Setting(\.jumpButton) var jumpButton
+    
+    var showJumpButton: Bool
+    var topVisibleItem: TopVisibleItemContainer
+    
+    var scrollToLastVisitedPosition: (() -> Void)?
+    var scrollToNextComment: () -> Void
+    var scrollToPreviousComment: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if let scrollToLastVisitedPosition, topVisibleItem.isAtPost {
+                JumpButtonView(
+                    systemImage: "chevron.down.2",
+                    onShortPress: scrollToLastVisitedPosition,
+                    onLongPress: nil
+                )
+            }
+            if jumpButton != .none, showJumpButton { // (tracker?.nodes.count ?? 0) > 1
+                JumpButtonView(
+                    onShortPress: scrollToNextComment,
+                    onLongPress: scrollToPreviousComment
+                )
+            }
+        }
+        .padding(Constants.main.standardSpacing)
+        .animation(.default, value: topVisibleItem.isAtPost)
     }
 }

--- a/Mlem/App/Views/Shared/Images/Core/MediaControlState.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaControlState.swift
@@ -65,6 +65,8 @@ class MediaControlState {
         return (position: minuteSecondString(from: playbackPosition * duration), duration: minuteSecondString(from: duration))
     }
     
+    var url: URL?
+    
     /// Creates a new MediaControlState
     /// - Parameters:
     ///   - blurred: true if the media should be blurred

--- a/Mlem/App/Views/Shared/Images/Core/MediaView.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaView.swift
@@ -88,6 +88,7 @@ struct MediaView: View {
                 overlays: [.controls, .error]
             ))
         }
+        _controlState.wrappedValue.url = url
     }
     
     static func largeImage(url: URL, shouldBlur: Bool, onTapActions: (() -> Void)? = nil) -> MediaView {

--- a/Mlem/App/Views/Shared/JumpButtonView.swift
+++ b/Mlem/App/Views/Shared/JumpButtonView.swift
@@ -8,24 +8,28 @@
 import SwiftUI
 
 struct JumpButtonView: View {
+    @Environment(\.colorScheme) var colorScheme
+    
     @State private var pressed: Bool = false
     
+    var systemImage: String = Icons.jumpButton
     var onShortPress: () -> Void
-    var onLongPress: () -> Void
+    var onLongPress: (() -> Void)?
     
     var body: some View {
         Button {} label: {
-            Image(systemName: Icons.jumpButton)
+            Image(systemName: systemImage)
                 .fontWeight(.semibold)
                 .foregroundStyle(.secondary)
                 .aspectRatio(contentMode: .fit)
-                .padding(16)
+                .frame(width: 44, height: 44)
                 .background(
                     Circle()
                         .stroke(.tertiary.opacity(0.3))
-                        .background(.ultraThinMaterial)
-                        .clipShape(Circle())
+                        .background(colorScheme == .light ? .themedSecondaryGroupedBackground : .themedTertiaryGroupedBackground)
+                        .clipShape(.circle)
                 )
+                .shadow(radius: 10)
                 .padding(10)
                 .scaleEffect(pressed ? 1.2 : 1.0)
                 .onTapGesture {
@@ -35,7 +39,9 @@ struct JumpButtonView: View {
                 .onLongPressGesture(
                     perform: {
                         HapticManager.main.play(haptic: .gentleInfo, priority: .high)
-                        onLongPress()
+                        if let onLongPress {
+                            onLongPress()
+                        }
                     },
                     onPressingChanged: { pressing in
                         withAnimation(.interactiveSpring()) {
@@ -45,6 +51,5 @@ struct JumpButtonView: View {
                 )
         }
         .buttonStyle(.empty)
-        .padding(10)
     }
 }

--- a/Mlem/App/Views/Shared/JumpButtonView.swift
+++ b/Mlem/App/Views/Shared/JumpButtonView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct JumpButtonView: View {
-    @Environment(\.colorScheme) var colorScheme
-    
     @State private var pressed: Bool = false
     
     var systemImage: String = Icons.jumpButton
@@ -26,10 +24,9 @@ struct JumpButtonView: View {
                 .background(
                     Circle()
                         .stroke(.tertiary.opacity(0.3))
-                        .background(colorScheme == .light ? .themedSecondaryGroupedBackground : .themedTertiaryGroupedBackground)
+                        .background(.bar)
                         .clipShape(.circle)
                 )
-                .shadow(radius: 10)
                 .padding(10)
                 .scaleEffect(pressed ? 1.2 : 1.0)
                 .onTapGesture {


### PR DESCRIPTION
Added a button that takes you to the comment you were looking at last time you were at the page. This only has a short-term memory of 10 posts at the moment, which doesn't persist across restarts. This is intended to be a fix for the scenario where a user accidentally taps back from the post and loses their place.

<img src="https://github.com/user-attachments/assets/2999bea0-5fa0-49ba-b182-7105beada1af" width=50%>

Also changed the design of the jump button a bit - what do you think? Is this better or worse?

Closes #1912