### PR TITLE
Local MlemMiddleware

### DIFF
--- a/.github/workflows/ci_build_16.yml
+++ b/.github/workflows/ci_build_16.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        submodules: true
+        submodules: 'true'
 
     - name: Build
       uses: "./.github/actions/ci_xcodebuild"

--- a/.github/workflows/ci_build_16.yml
+++ b/.github/workflows/ci_build_16.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Build
       uses: "./.github/actions/ci_xcodebuild"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "/Users/kidsaccount/Documents/XCode projects/mlem-UPSTREAM/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/MlemApiTypes"]
-	path = /Users/kidsaccount/Documents/XCode projects/mlem-UPSTREAM/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/MlemApiTypes
+[submodule "Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/MlemApiTypes"]
+	path = Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/MlemApiTypes
 	url = https://github.com/mlemgroup/MlemApiTypes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "/Users/kidsaccount/Documents/XCode projects/mlem-UPSTREAM/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/MlemApiTypes"]
+	path = /Users/kidsaccount/Documents/XCode projects/mlem-UPSTREAM/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/MlemApiTypes
+	url = https://github.com/mlemgroup/MlemApiTypes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/MlemApiTypes"]
 	path = Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/MlemApiTypes
-	url = https://github.com/mlemgroup/MlemApiTypes
+	url = https://github.com/mlemgroup/MlemApiTypes.git

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,3 +15,6 @@ identifier_name:
     - x
     - y
   allowed_symbols: ["_"] # these are allowed in type names as we use them in API body arguments
+
+excluded:
+  - Mlem/Packages/MlemMiddleware

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		033FCB2A2C5E3933007B7CD1 /* AlternateIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033FCB232C5E3933007B7CD1 /* AlternateIconCell.swift */; };
 		033FCB3E2C5E7FA9007B7CD1 /* View+OutdatedFeedPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033FCB3D2C5E7FA9007B7CD1 /* View+OutdatedFeedPopup.swift */; };
 		034065C32D83742900637308 /* View+NavigtionStackPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034065C22D83742900637308 /* View+NavigtionStackPreview.swift */; };
+		0341480D2D8F63A6005503AF /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = 0341480C2D8F63A6005503AF /* MlemMiddleware */; };
 		0343C0482D3AD6DB001CF709 /* Set+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0343C0472D3AD6DB001CF709 /* Set+Extensions.swift */; };
 		034690932D0F4D720073E664 /* RemovableProviding+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034690922D0F4D720073E664 /* RemovableProviding+Extensions.swift */; };
 		034690992D105DFD0073E664 /* InboxView+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034690982D105DFD0073E664 /* InboxView+Types.swift */; };
@@ -396,7 +397,6 @@
 		CD1DF63E2D387E8500F7851E /* MediaView+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1DF63D2D387E8300F7851E /* MediaView+Views.swift */; };
 		CD24CAFC2D5568FE0032B5E8 /* DiscussionLanguageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD24CAFB2D5568F90032B5E8 /* DiscussionLanguageSettingsView.swift */; };
 		CD2C86542D5556C00034CD8A /* MlemError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2C86532D5556BE0034CD8A /* MlemError.swift */; };
-		CD2CEF922D7690E30003E53A /* MlemMiddleware in Frameworks */ = {isa = PBXBuildFile; productRef = CD2CEF912D7690E30003E53A /* MlemMiddleware */; };
 		CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */; };
 		CD332D792CA7175500A53988 /* PlayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D782CA7175200A53988 /* PlayButton.swift */; };
 		CD332D7E2CA7486000A53988 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D7D2CA7485D00A53988 /* String+Extensions.swift */; };
@@ -1065,13 +1065,13 @@
 				03A9FD162D7CEC09007A734D /* Theming in Frameworks */,
 				03FA318C2C6FECAE00D47FA3 /* Flow in Frameworks */,
 				030FF6792BC84F7E00F6BFAC /* SwiftUIIntrospect in Frameworks */,
+				0341480D2D8F63A6005503AF /* MlemMiddleware in Frameworks */,
 				B104A6DA2A59BF3C00B3E725 /* NukeExtensions in Frameworks */,
 				037386472BDAFE81007492B5 /* LemmyMarkdownUI in Frameworks */,
 				B104A6D82A59BF3C00B3E725 /* Nuke in Frameworks */,
 				50C99B562A61D792005D57DD /* Dependencies in Frameworks */,
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
-				CD2CEF922D7690E30003E53A /* MlemMiddleware in Frameworks */,
 				B104A6DE2A59BF3C00B3E725 /* NukeVideo in Frameworks */,
 				CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */,
 				B104A6DC2A59BF3C00B3E725 /* NukeUI in Frameworks */,
@@ -2354,8 +2354,8 @@
 				037386462BDAFE81007492B5 /* LemmyMarkdownUI */,
 				03FA318B2C6FECAE00D47FA3 /* Flow */,
 				CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */,
-				CD2CEF912D7690E30003E53A /* MlemMiddleware */,
 				03A9FD152D7CEC09007A734D /* Theming */,
+				0341480C2D8F63A6005503AF /* MlemMiddleware */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -2442,7 +2442,6 @@
 				037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */,
 				03FA318A2C6FEC5400D47FA3 /* XCRemoteSwiftPackageReference "SwiftUI-Flow" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
-				CD2CEF902D7690BC0003E53A /* XCRemoteSwiftPackageReference "MlemMiddleware" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -3429,14 +3428,6 @@
 				minimumVersion = 12.1.2;
 			};
 		};
-		CD2CEF902D7690BC0003E53A /* XCRemoteSwiftPackageReference "MlemMiddleware" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mlemgroup/MlemMiddleware";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.87.0;
-			};
-		};
 		CD4368BF2AE23FD400BD8BD1 /* XCRemoteSwiftPackageReference "Semaphore" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/groue/Semaphore";
@@ -3460,6 +3451,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = SwiftUIIntrospect;
+		};
+		0341480C2D8F63A6005503AF /* MlemMiddleware */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MlemMiddleware;
 		};
 		037386462BDAFE81007492B5 /* LemmyMarkdownUI */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -3504,11 +3499,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B104A6D62A59BF3C00B3E725 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeVideo;
-		};
-		CD2CEF912D7690E30003E53A /* MlemMiddleware */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CD2CEF902D7690BC0003E53A /* XCRemoteSwiftPackageReference "MlemMiddleware" */;
-			productName = MlemMiddleware;
 		};
 		CD4368C02AE23FD400BD8BD1 /* Semaphore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem/Packages/MlemMiddleware/.gitignore
+++ b/Mlem/Packages/MlemMiddleware/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Mlem/Packages/MlemMiddleware/CODEOWNERS
+++ b/Mlem/Packages/MlemMiddleware/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @mlemgroup/mlem-dev-team

--- a/Mlem/Packages/MlemMiddleware/LICENSE
+++ b/Mlem/Packages/MlemMiddleware/LICENSE
@@ -1,0 +1,680 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.
+
+----
+
+The MlemMiddleware iOS developers are aware that the terms of service that apply to apps distributed via Apple's App Store services may conflict with rights granted under
+the MlemMiddleware iOS license, the "GNU GPLv3". We have committed not to pursue any license violation that results solely from the conflict between
+the "GNU GPLv3" or any later version and the Apple App Store terms of service.

--- a/Mlem/Packages/MlemMiddleware/NOTICE.md
+++ b/Mlem/Packages/MlemMiddleware/NOTICE.md
@@ -1,0 +1,71 @@
+# NOTICE
+
+This project makes use of several other open source projects; their names and licenses are listed below. We thank all of the developers for their hard work.
+
+## Semaphore
+
+https://github.com/groue/Semaphore
+
+```
+MIT License
+
+Copyright (c) 2022 Gwendal Roué
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Nuke
+
+https://github.com/kean/Nuke
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015-2024 Alexander Grebenyuk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## ReactiveSwift
+
+https://github.com/ReactiveCocoa/ReactiveSwift
+
+```
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/Mlem/Packages/MlemMiddleware/Package.resolved
+++ b/Mlem/Packages/MlemMiddleware/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "gifu",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kaishin/Gifu",
+      "state" : {
+        "branch" : "master",
+        "revision" : "639e40d5dbd86dfa94fc61296c270b49af6f8a2a"
+      }
+    },
+    {
       "identity" : "keychainaccess",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kishikawakatsumi/KeychainAccess.git",
@@ -32,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/LemmyMarkdownUI",
       "state" : {
-        "revision" : "958ab436dce0ed4050fb65f1122e19eeef036e1c",
-        "version" : "0.11.0"
+        "revision" : "3f9fb02b44f36524a71c35cb745766c9cfdb4ec7",
+        "version" : "0.10.1"
       }
     },
     {
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "0ead44350d2737db384908569c012fe67c421e4d",
-        "version" : "12.8.0"
+        "revision" : "8e431251dea0081b6ab154dab61a6ec74e4b6577",
+        "version" : "12.6.0"
       }
     },
     {
@@ -61,6 +70,15 @@
       "state" : {
         "revision" : "8a1be70a625683bc04d6903e2935bf23f3c6d609",
         "version" : "5.19.7"
+      }
+    },
+    {
+      "identity" : "sdwebimageswiftui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImageSwiftUI",
+      "state" : {
+        "revision" : "5aa947356f4ea49a0c3b9968564267f6ea5abea7",
+        "version" : "3.1.2"
       }
     },
     {
@@ -77,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/Semaphore",
       "state" : {
-        "revision" : "2543679282aa6f6c8ecf2138acd613ed20790bc2",
-        "version" : "0.1.0"
+        "revision" : "f1c4a0acabeb591068dea6cffdd39660b86dec28",
+        "version" : "0.0.8"
       }
     },
     {

--- a/Mlem/Packages/MlemMiddleware/Package.swift
+++ b/Mlem/Packages/MlemMiddleware/Package.swift
@@ -1,0 +1,40 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MlemMiddleware",
+    platforms: [.iOS(.v17)],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "MlemMiddleware",
+            targets: ["MlemMiddleware"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/groue/Semaphore.git", .upToNextMajor(from: "0.0.8")),
+        .package(url: "https://github.com/kean/Nuke.git", .upToNextMajor(from: "12.6.0")),
+        .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", .upToNextMajor(from: "4.0.0")),
+        .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit.git", .upToNextMajor(from: "0.2.0"))
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "MlemMiddleware",
+            dependencies: [
+                .product(name: "Semaphore", package: "Semaphore"),
+                .product(name: "Nuke", package: "Nuke"),
+                .product(name: "SwiftyJSON", package: "SwiftyJSON"),
+                .product(name: "CollectionConcurrencyKit", package: "CollectionConcurrencyKit")
+            ],
+            swiftSettings: [.enableUpcomingFeature("BareSlashRegexLiterals")]
+        ),
+        .testTarget(
+            name: "MlemMiddlewareTests",
+            dependencies: ["MlemMiddleware"]
+        )
+    ]
+)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Caches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Caches.swift
@@ -1,0 +1,81 @@
+//
+//  ApiClient+Caches.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-01.
+//
+
+import Foundation
+
+public struct WeakReference<Content: AnyObject> {
+    public weak var content: Content?
+    
+    public init(content: Content) {
+        self.content = content
+    }
+}
+
+public protocol CacheIdentifiable {
+    var cacheId: Int { get }
+}
+
+extension ApiClient {
+    struct BaseCacheGroup {
+        var instance1: Instance1Cache = .init()
+        var instance2: Instance2Cache = .init()
+        var instance3: Instance3Cache = .init()
+        
+        var community1: Community1Cache = .init()
+        var community2: Community2Cache = .init()
+        var community3: Community3Cache = .init()
+        
+        var person1: Person1Cache = .init()
+        var person2: Person2Cache = .init()
+        var person3: Person3Cache = .init()
+        var person4: Person4Cache = .init()
+        
+        var post1: Post1Cache = .init()
+        var post2: Post2Cache = .init()
+        var post3: Post3Cache = .init()
+        
+        var comment1: Comment1Cache = .init()
+        var comment2: Comment2Cache = .init()
+        
+        var reply1: Reply1Cache = .init()
+        var reply2: Reply2Cache = .init()
+        
+        var message1: Message1Cache = .init()
+        var message2: Message2Cache = .init()
+        
+        var imageUpload1: ImageUpload1Cache = .init()
+        
+        var report: ReportCache = .init()
+        
+        var personVote: PersonVoteCache = .init()
+        
+        var registrationApplication: RegistrationApplicationCache = .init()
+        
+        func clean() {
+            community1.clean()
+            community2.clean()
+            community3.clean()
+            person1.clean()
+            person2.clean()
+            person3.clean()
+            person4.clean()
+            post1.clean()
+            post2.clean()
+            post3.clean()
+            comment1.clean()
+            comment2.clean()
+            reply1.clean()
+            reply2.clean()
+            message1.clean()
+            message2.clean()
+            imageUpload1.clean()
+            report.clean()
+            personVote.clean()
+            registrationApplication.clean()
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
@@ -1,0 +1,273 @@
+//
+//  ApiClient+Comment.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+
+public extension ApiClient {
+    func getComment(id: Int) async throws -> Comment2 {
+        let request = GetCommentRequest(endpoint: .v3, id: id)
+        let response = try await perform(request)
+        return await caches.comment2.getModel(api: self, from: response.commentView)
+    }
+    
+    func getComment(url: URL) async throws -> Comment2 {
+        let request = ResolveObjectRequest(endpoint: .v3, q: url.absoluteString)
+        do {
+            if let response = try await perform(request).comment {
+                return await caches.comment2.getModel(api: self, from: response)
+            }
+        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
+            throw ApiClientError.noEntityFound
+        }
+        throw ApiClientError.noEntityFound
+    }
+    
+    func getComments(
+        postId: Int,
+        sort: ApiCommentSortType,
+        page: Int,
+        maxDepth: Int? = nil,
+        limit: Int,
+        filter: GetContentFilter? = nil
+    ) async throws -> [Comment2] {
+        let request = GetCommentsRequest(
+            endpoint: .v3,
+            type_: .all,
+            sort: sort,
+            maxDepth: maxDepth,
+            page: page,
+            limit: limit,
+            communityId: nil,
+            communityName: nil,
+            postId: postId,
+            parentId: nil,
+            savedOnly: filter == .saved,
+            likedOnly: filter == .upvoted,
+            dislikedOnly: filter == .downvoted,
+            timeRangeSeconds: nil
+        )
+        let response = try await perform(request)
+        return await caches.comment2.getModels(api: self, from: response.comments)
+    }
+    
+    func getComments(
+        parentId: Int,
+        sort: CommentSortType,
+        page: Int,
+        maxDepth: Int? = nil,
+        limit: Int,
+        filter: GetContentFilter? = nil
+    ) async throws -> [Comment2] {
+        let request = GetCommentsRequest(
+            endpoint: .v3,
+            type_: .all,
+            sort: sort.apiSortType,
+            maxDepth: maxDepth,
+            page: page,
+            limit: limit,
+            communityId: nil,
+            communityName: nil,
+            postId: nil,
+            parentId: parentId,
+            savedOnly: filter == .saved,
+            likedOnly: filter == .upvoted,
+            dislikedOnly: filter == .downvoted,
+            timeRangeSeconds: nil
+        )
+        let response = try await perform(request)
+        return await caches.comment2.getModels(api: self, from: response.comments)
+    }
+    
+    // This method should be removed in favor of the below method once we drop support for versions before Lemmy 1.0
+    func searchComments(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int? = nil,
+        creatorId: Int? = nil,
+        filter: ApiListingType = .all,
+        sort: CommentSortType = .top(.allTime)
+    ) async throws -> [Comment2] {
+        try await searchComments(
+            query: query,
+            page: page,
+            limit: limit,
+            communityId: communityId,
+            creatorId: creatorId,
+            filter: filter,
+            legacySort: sort.legacyApiSortType,
+            sort: sort.apiSearchSortType,
+            timeRangeSeconds: sort.timeRangeSeconds
+        )
+    }
+    
+    func searchComments(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int? = nil,
+        creatorId: Int? = nil,
+        filter: ApiListingType = .all,
+        sort: SearchSortType = .top(.allTime)
+    ) async throws -> [Comment2] {
+        try await searchComments(
+            query: query,
+            page: page,
+            limit: limit,
+            communityId: communityId,
+            creatorId: creatorId,
+            filter: filter,
+            legacySort: sort.legacyApiSortType,
+            sort: sort.apiSortType,
+            timeRangeSeconds: sort.timeRangeSeconds
+        )
+    }
+
+    private func searchComments(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int?,
+        creatorId: Int?,
+        filter: ApiListingType,
+        legacySort: ApiSortType?,
+        sort: ApiSearchSortType?,
+        timeRangeSeconds: Int?
+    ) async throws -> [Comment2] {
+        let endpointVersion = try await version.endpointVersion
+        let request = SearchRequest(
+            endpoint: .v3,
+            q: query,
+            communityId: communityId,
+            communityName: nil,
+            creatorId: creatorId,
+            type_: .comments,
+            sort: .init(oldSortType: endpointVersion == .v3 ? legacySort : nil, newSortType: endpointVersion == .v4 ? sort : nil),
+            listingType: filter,
+            page: page,
+            limit: limit,
+            postTitleOnly: false,
+            searchTerm: nil,
+            timeRangeSeconds: timeRangeSeconds,
+            titleOnly: nil,
+            postUrlOnly: nil,
+            likedOnly: nil,
+            dislikedOnly: nil,
+            pageCursor: nil,
+            pageBack: nil
+        )
+        let response = try await perform(request)
+        return await caches.comment2.getModels(api: self, from: response.comments ?? [])
+    }
+    
+    @discardableResult
+    func voteOnComment(id: Int, score: ScoringOperation, semaphore: UInt? = nil) async throws -> Comment2 {
+        let request = LikeCommentRequest(endpoint: .v3, commentId: id, score: score.rawValue)
+        let response = try await perform(request)
+        return await caches.comment2.getModel(api: self, from: response.commentView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func saveComment(id: Int, save: Bool, semaphore: UInt? = nil) async throws -> Comment2 {
+        let request = SaveCommentRequest(endpoint: .v3, commentId: id, save: save)
+        let response = try await perform(request)
+        return await caches.comment2.getModel(api: self, from: response.commentView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func deleteComment(id: Int, delete: Bool, semaphore: UInt? = nil) async throws -> Comment2 {
+        let request = DeleteCommentRequest(endpoint: .v3, commentId: id, deleted: delete)
+        let response = try await perform(request)
+        return await caches.comment2.getModel(api: self, from: response.commentView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func editComment(
+        id: Int,
+        content: String,
+        languageId: Int?
+    ) async throws -> Comment2 {
+        let request = EditCommentRequest(
+            endpoint: .v3,
+            commentId: id,
+            content: content,
+            languageId: languageId,
+            formId: nil
+        )
+        let response = try await perform(request)
+        return await caches.comment2.getModel(api: self, from: response.commentView)
+    }
+    
+    // There's also a `replyToPost` method in `ApiClient+Post` for creating a comment on a post
+    func replyToComment(postId: Int, parentId: Int?, content: String, languageId: Int? = nil) async throws -> Comment2 {
+        let request = CreateCommentRequest(
+            endpoint: .v3,
+            content: content,
+            postId: postId,
+            parentId: parentId,
+            languageId: languageId,
+            formId: nil
+        )
+        let response = try await perform(request)
+        let comment = await caches.comment2.getModel(api: self, from: response.commentView)
+        comment.getCachedInboxReply()?.setKnownReadState(newValue: true)
+        return comment
+    }
+    
+    @discardableResult
+    func reportComment(id: Int, reason: String) async throws -> Report {
+        let request = CreateCommentReportRequest(
+            endpoint: .v3,
+            commentId: id,
+            reason: reason,
+            violatesInstanceRules: nil
+        )
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.report.getModel(
+            api: self,
+            from: response.commentReportView,
+            myPersonId: myPersonId
+        )
+    }
+    
+    func purgeComment(id: Int, reason: String?) async throws {
+        let request = PurgeCommentRequest(endpoint: .v3, commentId: id, reason: reason)
+        let response = try await perform(request)
+        guard response.success else { throw ApiClientError.unsuccessful }
+        caches.comment1.retrieveModel(cacheId: id)?.purged = true
+    }
+    
+    @discardableResult
+    func removeComment(
+        id: Int,
+        remove: Bool,
+        reason: String?,
+        semaphore: UInt? = nil
+    ) async throws -> Comment2 {
+        let request = RemoveCommentRequest(endpoint: .v3, commentId: id, removed: remove, reason: reason)
+        let response = try await perform(request)
+        return await caches.comment2.getModel(api: self, from: response.commentView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func getCommentVotes(
+        id: Int,
+        communityId: Int,
+        page: Int = 1,
+        limit: Int = 20
+    ) async throws -> [PersonVote] {
+        let request = ListCommentLikesRequest(endpoint: .v3, commentId: id, page: page, limit: limit)
+        let response = try await perform(request)
+        return await caches.personVote.getModels(
+            api: self,
+            from: response.commentLikes,
+            target: .comment(id: id),
+            communityId: communityId
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
@@ -138,7 +138,7 @@ public extension ApiClient {
         sort: ApiSearchSortType?,
         timeRangeSeconds: Int?
     ) async throws -> [Comment2] {
-        let endpointVersion = try await version.endpointVersion
+        let endpointVersion = try await version.highestSupportedEndpointVersion
         let request = SearchRequest(
             endpoint: .v3,
             q: query,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
@@ -58,7 +58,7 @@ public extension ApiClient {
         filter: ApiListingType = .all,
         sort: SearchSortType = .top(.allTime)
     ) async throws -> [Community2] {
-        let endpointVersion = try await version.endpointVersion
+        let endpointVersion = try await version.highestSupportedEndpointVersion
         let request = SearchRequest(
             endpoint: .v3,
             q: query,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
@@ -1,0 +1,199 @@
+//
+//  NewApiClient+Requests.swift
+//  Mlem
+//
+//  Created by Sjmarf on 10/02/2024.
+//
+
+import Foundation
+
+public extension ApiClient {
+    func decodeCommunity(_ data: Community1.CodedData) async throws -> Community1 {
+        guard data.apiUrl == baseUrl else {
+            throw ApiClientError.mismatchingUrl
+        }
+        guard try await data.apiMyPersonId == myPersonId else {
+            throw ApiClientError.mismatchingPersonId
+        }
+        return await caches.community1.getModel(api: self, from: data.apiCommunity, isStale: true)
+    }
+    
+    func decodeCommunity(_ data: Community2.CodedData) async throws -> Community2 {
+        guard data.apiUrl == baseUrl else {
+            throw ApiClientError.mismatchingUrl
+        }
+        guard try await data.apiMyPersonId == myPersonId else {
+            throw ApiClientError.mismatchingPersonId
+        }
+        return await caches.community2.getModel(api: self, from: data.apiCommunityView, isStale: true)
+    }
+    
+    func getCommunity(id: Int) async throws -> Community3 {
+        let request = GetCommunityRequest(endpoint: .v3, id: id, name: nil)
+        let response = try await perform(request)
+        return await caches.community3.getModel(api: self, from: response)
+    }
+    
+    func getCommunity(url: URL) async throws -> Community2 {
+        let request = ResolveObjectRequest(endpoint: .v3, q: url.absoluteString)
+        do {
+            if let response = try await perform(request).community {
+                return await caches.community2.getModel(api: self, from: response)
+            }
+        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
+            throw ApiClientError.noEntityFound
+        }
+        throw ApiClientError.noEntityFound
+    }
+    
+    func getCommunity(url: URL) async throws -> Community3 {
+        let comm: Community2 = try await getCommunity(url: url)
+        return try await getCommunity(id: comm.id)
+    }
+    
+    func searchCommunities(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        filter: ApiListingType = .all,
+        sort: SearchSortType = .top(.allTime)
+    ) async throws -> [Community2] {
+        let endpointVersion = try await version.endpointVersion
+        let request = SearchRequest(
+            endpoint: .v3,
+            q: query,
+            communityId: nil,
+            communityName: nil,
+            creatorId: nil,
+            type_: .communities,
+            sort: .init(
+                oldSortType: endpointVersion == .v3 ? sort.legacyApiSortType : nil,
+                newSortType: endpointVersion == .v4 ? sort.apiSortType : nil
+            ),
+            listingType: filter,
+            page: page,
+            limit: limit,
+            postTitleOnly: false,
+            searchTerm: query,
+            timeRangeSeconds: sort.timeRangeSeconds,
+            titleOnly: nil,
+            postUrlOnly: nil,
+            likedOnly: nil,
+            dislikedOnly: nil,
+            pageCursor: nil,
+            pageBack: nil
+        )
+        
+        let response = try await perform(request).communities
+        return await caches.community2.getModels(api: self, from: response ?? [])
+    }
+    
+    func setupSubscriptionList(
+        getFavorites: @escaping () -> Set<Int> = { [] },
+        setFavorites: @escaping (Set<Int>) -> Void = { _ in }
+    ) -> SubscriptionList {
+        if let subscriptions {
+            return subscriptions
+        } else {
+            let new: SubscriptionList = .init(apiClient: self, getFavorites: getFavorites, setFavorites: setFavorites)
+            subscriptions = new
+            return new
+        }
+    }
+    
+    @discardableResult
+    func getSubscriptionList() async throws -> SubscriptionList {
+        let subscriptionList = setupSubscriptionList()
+        
+        let limit = 50
+        var page = 1
+        var hasMorePages = true
+        var communities = [ApiCommunityView]()
+        
+        repeat {
+            let request = ListCommunitiesRequest(
+                endpoint: .v3,
+                type_: .subscribed,
+                sort: nil,
+                page: page,
+                limit: limit,
+                showNsfw: true,
+                timeRangeSeconds: nil
+            )
+            let response = try await perform(request)
+            communities.append(contentsOf: response.communities)
+            hasMorePages = response.communities.count >= limit
+            page += 1
+        } while hasMorePages
+            
+        let models: Set<Community2> = await Set(caches.community2.getModels(api: self, from: communities))
+        await subscriptionList.updateCommunities(with: models)
+        subscriptionList.hasLoaded = true
+        return subscriptionList
+    }
+    
+    @discardableResult
+    func subscribeToCommunity(id: Int, subscribe: Bool, semaphore: UInt?) async throws -> Community2 {
+        let request = FollowCommunityRequest(endpoint: .v3, communityId: id, follow: subscribe)
+        let response = try await perform(request)
+        return await caches.community2.getModel(api: self, from: response.communityView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func blockCommunity(id: Int, block: Bool, semaphore: UInt? = nil) async throws -> Community2 {
+        let request = BlockCommunityRequest(endpoint: .v3, communityId: id, block: block)
+        let response = try await perform(request)
+        let person = await caches.community2.getModel(api: self, from: response.communityView, semaphore: semaphore)
+        return person
+    }
+    
+    @discardableResult
+    func removeCommunity(
+        id: Int,
+        remove: Bool,
+        reason: String?,
+        semaphore: UInt? = nil
+    ) async throws -> Community2 {
+        let request = RemoveCommunityRequest(endpoint: .v3, communityId: id, removed: remove, reason: reason, expires: nil)
+        let response = try await perform(request)
+        return await caches.community2.getModel(api: self, from: response.communityView, semaphore: semaphore)
+    }
+    
+    func purgeCommunity(id: Int, reason: String?) async throws {
+        let request = PurgeCommunityRequest(endpoint: .v3, communityId: id, reason: reason)
+        let response = try await perform(request)
+        guard response.success else { throw ApiClientError.unsuccessful }
+        caches.community1.retrieveModel(cacheId: id)?.purged = true
+    }
+    
+    func hideCommunity(id: Int, hide: Bool, reason: String?) async throws {
+        let request = HideCommunityRequest(endpoint: .v3, communityId: id, hidden: hide, reason: reason)
+        let response = try await perform(request)
+        guard response.success else { throw ApiClientError.unsuccessful }
+    }
+    
+    @discardableResult
+    func addModerator(communityId: Int, personId: Int, added: Bool) async throws -> [Person1] {
+        let request = AddModToCommunityRequest(endpoint: .v3, communityId: communityId, personId: personId, added: added)
+        let response = try await perform(request)
+        
+        let updatedModerators = await caches.person1.getModels(api: self, from: response.moderators.map(\.moderator))
+        
+        if let community = caches.community3.retrieveModel(cacheId: communityId) {
+            community.moderators = updatedModerators
+        }
+        
+        if let person = caches.person3.retrieveModel(cacheId: personId) {
+            let newModerator = response.moderators.first(where: { $0.moderator.id == personId })
+            if added {
+                guard let newModerator else { throw ApiClientError.unsuccessful }
+                await person.moderatedCommunities.append(caches.community1.getModel(api: self, from: newModerator.community))
+            } else {
+                guard newModerator == nil else { throw ApiClientError.unsuccessful }
+                await person.moderatedCommunities.removeAll(where: { $0.id == communityId })
+            }
+        }
+        
+        return updatedModerators
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -1,0 +1,195 @@
+//
+//  ApiClient+General.swift
+//
+//
+//  Created by Sjmarf on 25/06/2024.
+//
+
+import Foundation
+
+public extension ApiClient {
+    var isAdmin: Bool {
+        myInstance?.administrators.contains(where: { $0.id == myPerson?.id }) ?? false
+    }
+    
+    /// Returns true if both myPerson and the given person are admins on this instance and myPerson outranks the given person, false otherwise
+    func isHigherAdmin(than person: any Person1Providing) -> Bool {
+        guard person.api.actorId == actorId,
+              let myPerson,
+              let myAdminIndex = myInstance?.administrators.firstIndex(of: myPerson.person2),
+              let targetAdminIndex = myInstance?.administrators.firstIndex(where: { $0.actorId == person.actorId }) else {
+            return false
+        }
+        return myAdminIndex < targetAdminIndex
+    }
+    
+    // Returns a raw API type :(
+    // Probably OK because it's part of onboarding, which is cursed and bootstrappy
+    func getAccountToken(usernameOrEmail: String, password: String, totpToken: String?) async throws -> ApiLoginResponse {
+        let request = try await LoginRequest(
+            endpoint: version.endpointVersion,
+            usernameOrEmail: usernameOrEmail,
+            password: password,
+            totp2faToken: totpToken
+        )
+        return try await perform(request, requiresToken: false)
+    }
+    
+    func getUsernameFromToken(token: String) async throws -> String {
+        let request = GetSiteRequest(endpoint: .v3)
+        let response = try await perform(request, tokenOverride: token)
+        if let name = response.myUser?.localUserView.person.name {
+            return name
+        }
+        throw ApiClientError.notLoggedIn
+    }
+    
+    func login(password: String, totpToken: String?) async throws {
+        guard let username else { throw ApiClientError.notLoggedIn }
+        let response = try await getAccountToken(usernameOrEmail: username, password: password, totpToken: totpToken)
+        if let jwt = response.jwt {
+            updateToken(jwt)
+        } else {
+            throw ApiClientError.unsuccessful
+        }
+    }
+    
+    func signUp(
+        username: String,
+        password: String,
+        confirmPassword: String,
+        showNsfw: Bool,
+        email: String?,
+        captcha: Captcha?,
+        captchaAnswer: String?,
+        applicationQuestionResponse: String?
+    ) async throws -> ApiLoginResponse {
+        let request = RegisterRequest(
+            endpoint: .v3,
+            username: username,
+            password: password,
+            passwordVerify: confirmPassword,
+            showNsfw: showNsfw,
+            email: email,
+            captchaUuid: captcha?.id.uuidString,
+            captchaAnswer: captchaAnswer,
+            honeypot: nil,
+            answer: applicationQuestionResponse
+        )
+        return try await perform(request)
+    }
+    
+    @discardableResult
+    func changePassword(
+        newPassword: String,
+        confirmNewPassword: String,
+        oldPassword: String
+    ) async throws -> ApiLoginResponse {
+        let request = ChangePasswordRequest(
+            endpoint: .v3,
+            newPassword: newPassword,
+            newPasswordVerify: confirmNewPassword,
+            oldPassword: oldPassword
+        )
+        let response = try await perform(request)
+        if let token = response.jwt {
+            updateToken(token)
+        }
+        return response
+    }
+    
+    func getCaptcha() async throws -> Captcha {
+        let request = GetCaptchaRequest(endpoint: .v3)
+        let response = try await perform(request)
+        
+        guard let info = response.ok,
+              let uuid = UUID(uuidString: info.uuid),
+              let data = Data(base64Encoded: info.png)
+        else { throw ApiClientError.unsuccessful }
+        
+        return .init(id: uuid, imageData: data)
+    }
+    
+    /// Returns an object associated with the given URL.
+    ///
+    /// ## Overview
+    ///
+    /// The backend performs two steps to do this:
+    /// 1) Check it already has the given actorId mapped in the database, in which case it returns the entity.
+    /// 2) If the entity is not present in the database, it contacts the URL host to ask for it, then returns it back to us.
+    ///   When this happens, the call will take longer to resolve.
+    ///
+    /// **Importantly, step 2) is only performed if the `ApiClient` is authenticated.**
+    ///
+    func resolve(url: URL) async throws -> (any ActorIdentifiable & Sharable) {
+        let request = ResolveObjectRequest(endpoint: .v3, q: url.absoluteString)
+        let response = try await perform(request)
+        if let post = response.post {
+            return await caches.post2.getModel(api: self, from: post)
+        }
+        if let comment = response.comment {
+            return await caches.comment2.getModel(api: self, from: comment)
+        }
+        if let person = response.person {
+            return await caches.person2.getModel(api: self, from: person)
+        }
+        if let community = response.community {
+            return await caches.community2.getModel(api: self, from: community)
+        }
+        throw ApiClientError.noEntityFound
+    }
+    
+    func getBlocked() async throws -> (people: [Person1], communities: [Community1], instances: [Instance1]) {
+        let request = GetSiteRequest(endpoint: .v3)
+        let response = try await perform(request)
+        
+        guard let myUser = response.myUser else { return ([], [], []) }
+        
+        return await (
+            people: caches.person1.getModels(api: self, from: myUser.personBlocks.map(\.target)),
+            communities: caches.community1.getModels(api: self, from: myUser.communityBlocks.map(\.community)),
+            instances: caches.instance1.getModels(api: self, from: myUser.instanceBlocks?.compactMap(\.site) ?? [])
+        )
+    }
+    
+    func getModlog(
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int? = nil,
+        moderatorId: Int? = nil,
+        subjectPersonId: Int? = nil,
+        postId: Int? = nil,
+        commentId: Int? = nil,
+        type: ApiModlogActionType = .all
+    ) async throws -> [ModlogEntry] {
+        let request = GetModlogRequest(
+            endpoint: .v3,
+            modPersonId: moderatorId,
+            communityId: communityId,
+            page: page,
+            limit: limit,
+            type_: type,
+            otherPersonId: subjectPersonId,
+            postId: postId,
+            commentId: commentId,
+            listingType: nil,
+            pageCursor: nil,
+            pageBack: nil
+        )
+        let response = try await perform(request)
+        return await createModlogEntries(response.getEntries(ofType: type))
+    }
+    
+    @MainActor
+    private func createModlogEntries(_ entries: [any ModlogEntryApiBacker]) -> [ModlogEntry] {
+        entries.map { entry in
+            ModlogEntry(
+                api: self,
+                created: entry.published,
+                moderator: caches.person1.getOptionalModel(api: self, from: entry.moderator),
+                moderatorId: entry.moderatorId,
+                type: entry.type(api: self)
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -26,8 +26,8 @@ public extension ApiClient {
     // Returns a raw API type :(
     // Probably OK because it's part of onboarding, which is cursed and bootstrappy
     func getAccountToken(usernameOrEmail: String, password: String, totpToken: String?) async throws -> ApiLoginResponse {
-        let request = try await LoginRequest(
-            endpoint: version.endpointVersion,
+        let request = LoginRequest(
+            endpoint: .v3,
             usernameOrEmail: usernameOrEmail,
             password: password,
             totp2faToken: totpToken

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Image.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Image.swift
@@ -1,0 +1,104 @@
+//
+//  ApiClient+Image.swift
+//
+//
+//  Created by Sjmarf on 26/08/2024.
+//
+
+import Foundation
+
+public extension ApiClient {
+    func uploadImage(
+        _ imageData: Data,
+        onProgress progressCallback: @escaping (_ progress: Double) -> Void = { _ in }
+    ) async throws -> ImageUpload1 {
+        guard let token else { throw ApiClientError.notLoggedIn }
+        var request = mlemUrlRequest(url: baseUrl.appending(path: "pictrs/image"))
+        request.httpMethod = "POST"
+        
+        let boundary = UUID().uuidString
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        
+        // This is required pre 0.19.0
+        // TODO: 0.18 deprecation: possibly remove this? Haven't tested how >0.19 behaves without this,
+        // but I assume it's not required anymore since they're now requiring a different format instead
+        request.setValue("jwt=\(token)", forHTTPHeaderField: "Cookie")
+        
+        // This is required post 0.19.0
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        
+        let encodedData = createMultiPartForm(
+            boundary: boundary,
+            mimeType: "image/png",
+            fileName: "image/png",
+            imageData: imageData,
+            auth: token
+        )
+        
+        let (data, _) = try await urlSession.upload(
+            for: request,
+            from: encodedData,
+            delegate: ImageUploadDelegate(callback: progressCallback)
+        )
+        
+        do {
+            let response = try decoder.decode(ApiPictrsUploadResponse.self, from: data)
+            guard let file = response.files?.first else { throw ApiClientError.noEntityFound }
+            return caches.imageUpload1.getModel(api: self, from: file)
+        } catch DecodingError.dataCorrupted {
+            let text = String(decoding: data, as: UTF8.self)
+            if text.contains("413 Request Entity Too Large") {
+                throw ApiClientError.imageTooLarge
+            }
+            throw ApiClientError.decoding(data, nil)
+        }
+    }
+    
+    func deleteImage(alias: String, deleteToken: String) async throws {
+        guard let token else { throw ApiClientError.notLoggedIn }
+        var request = mlemUrlRequest(url: baseUrl.appending(path: "pictrs/image/delete/\(deleteToken)/\(alias)"))
+        // TODO: 0.18 deprecation: see comments in method above
+        request.setValue("jwt=\(token)", forHTTPHeaderField: "Cookie")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        let response = try await execute(request)
+        if let response = response.1 as? HTTPURLResponse {
+            if response.statusCode != 204 {
+                throw ApiClientError.response(.init(error: "Unexpected status code"), response.statusCode)
+            }
+        }
+    }
+}
+
+private func createMultiPartForm(
+    boundary: String,
+    mimeType: String,
+    fileName: String,
+    imageData: Data,
+    auth: String
+) -> Data {
+    var data = Data()
+    data.append(Data("--\(boundary)\r\n".utf8))
+    data.append(Data("Content-Disposition: form-data; name=\"images[]\"; filename=\"\(fileName)\"\r\n".utf8))
+    data.append(Data("Content-Type: \(mimeType)\r\n\r\n".utf8))
+    data.append(imageData)
+    data.append(Data("\r\n--\(boundary)--\r\n".utf8))
+    return data
+}
+
+private class ImageUploadDelegate: NSObject, URLSessionTaskDelegate {
+    let callback: (Double) -> Void
+    
+    init(callback: @escaping (Double) -> Void) {
+        self.callback = callback
+    }
+    
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didSendBodyData bytesSent: Int64,
+        totalBytesSent: Int64,
+        totalBytesExpectedToSend: Int64
+    ) {
+        callback(Double(totalBytesSent) / Double(totalBytesExpectedToSend))
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -1,0 +1,159 @@
+//
+//  ApiClient+Inbox.swift
+//
+//
+//  Created by Sjmarf on 04/07/2024.
+//
+
+import Foundation
+
+public extension ApiClient {
+    func getReplies(
+        sort: ApiCommentSortType = .new,
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool = false
+    ) async throws -> [Reply2] {
+        let request = GetRepliesRequest(sort: sort, page: page, limit: limit, unreadOnly: unreadOnly)
+        let response = try await perform(request)
+        return await caches.reply2.getModels(api: self, from: response.replies)
+    }
+    
+    func getMentions(
+        sort: ApiCommentSortType = .new,
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool = false
+    ) async throws -> [Reply2] {
+        let request = GetPersonMentionsRequest(sort: sort, page: page, limit: limit, unreadOnly: unreadOnly)
+        let response = try await perform(request)
+        return await caches.reply2.getModels(api: self, from: response.mentions)
+    }
+    
+    func getMessages(
+        creatorId: Int? = nil,
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool = false
+    ) async throws -> [Message2] {
+        let request = GetPrivateMessagesRequest(unreadOnly: unreadOnly, page: page, limit: limit, creatorId: creatorId)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.message2.getModels(
+            api: self,
+            from: response.privateMessages,
+            myPersonId: myPersonId
+        )
+    }
+    
+    func markAllAsRead() async throws {
+        let request = MarkAllNotificationsAsReadRequest(endpoint: .v3)
+        try await perform(request)
+        for reply in caches.reply1.itemCache.value.values {
+            reply.content?.readManager.updateWithReceivedValue(true, semaphore: nil)
+        }
+        for message in caches.message1.itemCache.value.values {
+            message.content?.readManager.updateWithReceivedValue(true, semaphore: nil)
+        }
+        unreadCount?.clear(.personal)
+    }
+    
+    @discardableResult
+    func markReplyAsRead(
+        id: Int,
+        read: Bool = true,
+        semaphore: UInt? = nil
+    ) async throws -> Reply2 {
+        let request = MarkCommentReplyAsReadRequest(endpoint: .v3, commentReplyId: id, read: read)
+        let response = try await perform(request)
+        return await caches.reply2.getModel(api: self, from: response.commentReplyView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func markMentionAsRead(
+        id: Int,
+        read: Bool = true,
+        semaphore: UInt? = nil
+    ) async throws -> Reply2 {
+        let request = MarkPersonMentionAsReadRequest(personMentionId: id, read: read)
+        let response = try await perform(request)
+        return await caches.reply2.getModel(api: self, from: response.personMentionView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func markMessageAsRead(
+        id: Int,
+        read: Bool = true,
+        semaphore: UInt? = nil
+    ) async throws -> Message2 {
+        let request = MarkPrivateMessageAsReadRequest(endpoint: .v3, privateMessageId: id, read: read)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.message2.getModel(
+            api: self,
+            from: response.privateMessageView,
+            myPersonId: myPersonId,
+            semaphore: semaphore
+        )
+    }
+    
+    func getPersonalUnreadCount() async throws -> ApiGetUnreadCountResponse {
+        try await perform(GetUnreadCountRequest(endpoint: .v3))
+    }
+    
+    /// Get an ``UnreadCount`` object that continues to be updated by the ``ApiClient`` whenever an inbox item is marked read/unread.
+    func getUnreadCount() async throws -> UnreadCount {
+        let unreadCount = unreadCount ?? .init(api: self)
+        try await unreadCount.refresh()
+        self.unreadCount = unreadCount
+        return unreadCount
+    }
+    
+    func createMessage(personId: Int, content: String) async throws -> Message2 {
+        let request = CreatePrivateMessageRequest(endpoint: .v3, content: content, recipientId: personId)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.message2.getModel(
+            api: self,
+            from: response.privateMessageView,
+            myPersonId: myPersonId
+        )
+    }
+    
+    @discardableResult
+    func editMessage(id: Int, content: String) async throws -> Message2 {
+        let request = EditPrivateMessageRequest(endpoint: .v3, privateMessageId: id, content: content)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.message2.getModel(
+            api: self,
+            from: response.privateMessageView,
+            myPersonId: myPersonId
+        )
+    }
+    
+    @discardableResult
+    func reportMessage(id: Int, reason: String) async throws -> Report {
+        let request = CreatePrivateMessageReportRequest(endpoint: .v3, privateMessageId: id, reason: reason)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.report.getModel(
+            api: self,
+            from: response.privateMessageReportView,
+            myPersonId: myPersonId
+        )
+    }
+    
+    @discardableResult
+    func deleteMessage(id: Int, delete: Bool, semaphore: UInt? = nil) async throws -> Message2 {
+        let request = DeletePrivateMessageRequest(endpoint: .v3, privateMessageId: id, deleted: delete)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.message2.getModel(
+            api: self,
+            from: response.privateMessageView,
+            myPersonId: myPersonId,
+            semaphore: semaphore
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Instance.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Instance.swift
@@ -1,0 +1,92 @@
+//
+//  NewApiClient+Site.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public extension ApiClient {
+    func getMyInstance() async throws -> Instance3 {
+        async let response3 = perform(GetSiteRequest(endpoint: .v3))
+        async let response4 = perform(GetSiteRequest(endpoint: .v4))
+        
+        let response: ApiGetSiteResponse
+        if let response4 = try? await response4 {
+            response = response4
+        } else {
+            response = try await response3
+        }
+        
+        let model = await caches.instance3.getModel(api: self, from: response)
+        model.local = true
+        _ = await Task { @MainActor in
+            myInstance = model
+        }.result
+        return model
+    }
+    
+    func getFederatedInstances() async throws -> ApiFederatedInstances {
+        let request = GetFederatedInstancesRequest(endpoint: .v3)
+        let response = try await perform(request)
+        if let federatedInstances = response.federatedInstances {
+            return federatedInstances
+        }
+        throw ApiClientError.noEntityFound
+    }
+    
+    /// Returns `true` if federated, `false` if not federated, or `nil` if the status could not be determined.
+    func federatedWith(with url: URL) async throws -> FederationStatus? {
+        guard let domain = url.host() else { throw ApiClientError.invalidInput }
+        let federatedInstances = try await getFederatedInstances()
+        if !federatedInstances.blocked.isEmpty {
+            return federatedInstances.blocked.contains(where: { $0.domain == domain }) ? .explicitlyBlocked : .implicitlyAllowed
+        } else if !federatedInstances.allowed.isEmpty {
+            return federatedInstances.allowed.contains(where: { $0.domain == domain }) ? .explicitlyAllowed : .implicitlyBlocked
+        }
+        return nil
+    }
+    
+    /// `instanceId` is distinct from `id`. Make sure to pass `instance.instanceId` and not `id`.
+    ///  Technically only `instanceId` is needed to perform this request, but `actorId` is also needed to properly update the `BlockList`.
+    func blockInstance(url: URL, instanceId: Int, block: Bool, semaphore: UInt? = nil) async throws {
+        guard let host = url.host() else { throw ApiClientError.invalidInput }
+        let actorId: ActorIdentifier = .instance(host: host)
+        let request = UserBlockInstanceRequest(endpoint: .v3, instanceId: instanceId, block: block)
+        let response = try await perform(request)
+        if let instance = caches.instance1.retrieveModel(instanceId: instanceId) {
+            instance.blockedManager.updateWithReceivedValue(response.blocked, semaphore: semaphore)
+        }
+        if response.blocked {
+            blocks?.instances[actorId] = instanceId
+        } else {
+            blocks?.instances.removeValue(forKey: actorId)
+        }
+    }
+    
+    /// Adds or removes an admin from this API's instance
+    @discardableResult
+    func addAdmin(personId: Int, added: Bool) async throws -> [Person2] {
+        let request = AddAdminRequest(endpoint: .v3, personId: personId, added: added)
+        let response = try await perform(request)
+        
+        let updatedAdministrators = await caches.person2.getModels(
+            api: self,
+            from: response.admins
+        )
+        
+        // update person's admin status
+        // only need to do this manually if removing admin, otherwise handled by above caching logic
+        if !added, let person = caches.person2.retrieveModel(cacheId: personId) {
+            person.isAdmin = false
+        }
+        
+        // update instance admins
+        if let myInstance {
+            myInstance.administrators = updatedAdministrators
+        }
+        
+        return updatedAdministrators
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Instance.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Instance.swift
@@ -9,16 +9,8 @@ import Foundation
 
 public extension ApiClient {
     func getMyInstance() async throws -> Instance3 {
-        async let response3 = perform(GetSiteRequest(endpoint: .v3))
-        async let response4 = perform(GetSiteRequest(endpoint: .v4))
-        
-        let response: ApiGetSiteResponse
-        if let response4 = try? await response4 {
-            response = response4
-        } else {
-            response = try await response3
-        }
-        
+        let request = GetSiteRequest(endpoint: .v3)
+        let response = try await perform(request)
         let model = await caches.instance3.getModel(api: self, from: response)
         model.local = true
         _ = await Task { @MainActor in

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Mock.swift
@@ -1,0 +1,91 @@
+//
+//  ApiClient+Mock.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-02.
+//
+
+import Foundation
+
+#if DEBUG
+    public extension ApiClient {
+        static let mock: MockApiClient = .init()
+    }
+
+    public class MockApiClient: ApiClient {
+        public var posts: [Post2]
+        public var communities: [Community2]
+        public var people: [Person2]
+        public var comments: [Comment2]
+    
+        public init(
+            posts: [Post2] = [],
+            communities: [Community2] = [],
+            people: [Person2] = [],
+            comments: [Comment2] = []
+        ) {
+            self.posts = posts
+            self.communities = communities
+            self.people = people
+            self.comments = comments
+            super.init(
+                url: URL(string: "https://lemmy.world/")!,
+                username: "",
+                permissions: .all
+            )
+            contextDataManager.fetchedValue = .init(siteVersion: .v0_19_9, myPersonId: nil)
+            self.token = "" // Not nil so that the views are interactable
+        }
+    
+        override func perform<Request: ApiRequest>(
+            _ request: Request,
+            tokenOverride: String? = nil,
+            requiresToken: Bool = true
+        ) async throws -> Request.Response {
+            if let request = request as? GetPostsRequest, let params = request.parameters {
+                return ApiGetPostsResponse(posts: posts.map(\.apiPostView)) as! Request.Response
+            }
+        
+            if let request = request as? GetCommentsRequest, let params = request.parameters {
+                return ApiGetCommentsResponse(comments: comments.map(\.apiCommentView)) as! Request.Response
+            }
+        
+            if let request = request as? GetPersonDetailsRequest, let params = request.parameters {
+                if let person = people.first(where: { $0.id == params.personId })?.apiPersonView {
+                    return ApiGetPersonDetailsResponse(
+                        personView: person,
+                        posts: posts.filter { $0.creator.id == params.personId }.map(\.apiPostView),
+                        moderates: []
+                    ) as! Request.Response
+                }
+            }
+        
+            if let request = request as? ResolveObjectRequest, let params = request.parameters {
+                return ApiResolveObjectResponse(
+                    comment: comments.first(where: { $0.actorId.description == params.q })?.apiCommentView,
+                    post: posts.first(where: { $0.actorId.description == params.q })?.apiPostView,
+                    community: communities.first(where: { $0.actorId.description == params.q })?.apiCommunityView,
+                    person: people.first(where: { $0.actorId.description == params.q })?.apiPersonView
+                ) as! Request.Response
+            }
+        
+            if let request = request as? GetCommunityRequest, let params = request.parameters {
+                if let community = communities.first(where: { $0.id == params.id })?.apiCommunityView {
+                    return ApiGetCommunityResponse(communityView: community, moderators: [], discussionLanguages: []) as! Request.Response
+                }
+            }
+        
+            if let request = request as? SearchRequest, let params = request.parameters {
+                return ApiSearchResponse(
+                    type_: params.type_,
+                    comments: [],
+                    posts: [],
+                    communities: params.type_ == .communities ? communities.map(\.apiCommunityView) : [],
+                    users: params.type_ == .users ? people.map(\.apiPersonView) : []
+                ) as! Request.Response
+            }
+        
+            throw ApiClientError.insufficientPermissions
+        }
+    }
+#endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
@@ -12,7 +12,7 @@ public extension ApiClient {
         guard data.apiUrl == baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
-        guard data.apiMyPersonId == (try await myPersonId) else {
+        guard try await data.apiMyPersonId == myPersonId else {
             throw ApiClientError.mismatchingPersonId
         }
         return await caches.person1.getModel(api: self, from: data.apiPerson, isStale: true)
@@ -22,7 +22,7 @@ public extension ApiClient {
         guard data.apiUrl == baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
-        guard data.apiMyPersonId == (try await myPersonId) else {
+        guard try await data.apiMyPersonId == myPersonId else {
             throw ApiClientError.mismatchingPersonId
         }
         return await caches.person2.getModel(api: self, from: data.apiPersonView, isStale: true)
@@ -88,7 +88,7 @@ public extension ApiClient {
         filter: ApiListingType = .all,
         sort: SearchSortType = .top(.allTime)
     ) async throws -> [Person2] {
-        let endpointVersion = try await self.version.highestSupportedEndpointVersion
+        let endpointVersion = try await version.highestSupportedEndpointVersion
         let request = SearchRequest(
             endpoint: .v3,
             q: query,
@@ -222,14 +222,14 @@ public extension ApiClient {
         let request = GetSiteRequest(endpoint: .v3)
         let response = try await perform(request)
         
-        guard response.myUser?.localUserView.person.name == self.username else {
+        guard response.myUser?.localUserView.person.name == username else {
             assertionFailure()
             throw ApiClientError.mismatchingToken
         }
         
         let instance = await caches.instance3.getModel(api: self, from: response)
         
-        var blocks: BlockList? = self.blocks
+        var blocks: BlockList? = blocks
         var person: Person4?
         if let myUser = response.myUser {
             person = await caches.person4.getModel(api: self, from: myUser)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
@@ -1,0 +1,348 @@
+//
+//  NewApiClient+User.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public extension ApiClient {
+    func decodePerson(_ data: Person1.CodedData) async throws -> Person1 {
+        guard data.apiUrl == baseUrl else {
+            throw ApiClientError.mismatchingUrl
+        }
+        guard try await data.apiMyPersonId == myPersonId else {
+            throw ApiClientError.mismatchingPersonId
+        }
+        return await caches.person1.getModel(api: self, from: data.apiPerson, isStale: true)
+    }
+    
+    func decodePerson(_ data: Person2.CodedData) async throws -> Person2 {
+        guard data.apiUrl == baseUrl else {
+            throw ApiClientError.mismatchingUrl
+        }
+        guard try await data.apiMyPersonId == myPersonId else {
+            throw ApiClientError.mismatchingPersonId
+        }
+        return await caches.person2.getModel(api: self, from: data.apiPersonView, isStale: true)
+    }
+    
+    func getPerson(id: Int) async throws -> Person3 {
+        let request = GetPersonDetailsRequest(
+            endpoint: .v3,
+            personId: id,
+            username: nil,
+            sort: .new,
+            page: 1,
+            limit: 1,
+            communityId: nil,
+            savedOnly: nil
+        )
+        let response = try await perform(request)
+        return await caches.person3.getModel(api: self, from: response)
+    }
+    
+    func getPerson(url: URL) async throws -> Person2 {
+        let request = ResolveObjectRequest(endpoint: .v3, q: url.absoluteString)
+        do {
+            if let response = try await perform(request).person {
+                return await caches.person2.getModel(api: self, from: response)
+            }
+        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
+            throw ApiClientError.noEntityFound
+        }
+        throw ApiClientError.noEntityFound
+    }
+    
+    func getPerson(username: String) async throws -> Person3 {
+        try await getPerson(username: username, endpoint: version.endpointVersion)
+    }
+    
+    internal func getPerson(username: String, endpoint: SiteVersion.EndpointVersion) async throws -> Person3 {
+        let request = GetPersonDetailsRequest(
+            endpoint: endpoint,
+            personId: nil,
+            username: username,
+            sort: nil,
+            page: nil,
+            limit: nil,
+            communityId: nil,
+            savedOnly: nil
+        )
+        
+        do {
+            let response = try await perform(request)
+            return await caches.person3.getModel(api: self, from: response)
+        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
+            throw ApiClientError.noEntityFound
+        }
+    }
+    
+    func getPerson(url: URL) async throws -> Person3 {
+        let person: Person2 = try await getPerson(url: url)
+        return try await getPerson(id: person.id)
+    }
+    
+    /// `filter` can be set to `.local` from 0.19.4 onwards.
+    func searchPeople(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        filter: ApiListingType = .all,
+        sort: SearchSortType = .top(.allTime)
+    ) async throws -> [Person2] {
+        let endpointVersion = try await version.endpointVersion
+        let request = SearchRequest(
+            endpoint: .v3,
+            q: query,
+            communityId: nil,
+            communityName: nil,
+            creatorId: nil,
+            type_: .users,
+            sort: .init(
+                oldSortType: endpointVersion == .v3 ? sort.legacyApiSortType : nil,
+                newSortType: endpointVersion == .v4 ? sort.apiSortType : nil
+            ),
+            listingType: filter,
+            page: page,
+            limit: limit,
+            postTitleOnly: false,
+            searchTerm: query,
+            timeRangeSeconds: sort.timeRangeSeconds,
+            titleOnly: nil,
+            postUrlOnly: nil,
+            likedOnly: nil,
+            dislikedOnly: nil,
+            pageCursor: nil,
+            pageBack: nil
+        )
+        let response = try await perform(request)
+        return await caches.person2.getModels(api: self, from: response.users ?? [])
+    }
+    
+    @discardableResult
+    func blockPerson(id: Int, block: Bool, semaphore: UInt? = nil) async throws -> Person2 {
+        let request = BlockPersonRequest(endpoint: .v3, personId: id, block: block)
+        let response = try await perform(request)
+        let person = await caches.person2.getModel(api: self, from: response.personView, semaphore: semaphore)
+        person.person1.blockedManager.updateWithReceivedValue(response.blocked, semaphore: semaphore)
+        return person
+    }
+    
+    @discardableResult
+    func banPersonFromCommunity(
+        personId: Int,
+        communityId: Int,
+        ban: Bool,
+        removeContent: Bool,
+        reason: String?,
+        expires: Date? = nil
+    ) async throws -> Person2 {
+        let expiryTimestamp: Int?
+        if let expires {
+            expiryTimestamp = Int(expires.timeIntervalSince1970)
+        } else {
+            expiryTimestamp = nil
+        }
+        let request = BanFromCommunityRequest(
+            endpoint: .v3,
+            communityId: communityId,
+            personId: personId,
+            ban: ban,
+            removeOrRestoreData: removeContent,
+            reason: reason,
+            expires: expiryTimestamp
+        )
+        let response = try await perform(request)
+        guard response.banned == ban else { throw ApiClientError.unsuccessful }
+        let person = await caches.person2.getModel(api: self, from: response.personView)
+        person.person1.updateKnownCommunityBanState(id: communityId, banned: response.banned)
+        return person
+    }
+    
+    @discardableResult
+    func banPersonFromInstance(
+        personId: Int,
+        ban: Bool,
+        removeContent: Bool,
+        reason: String?,
+        expires: Date? = nil
+    ) async throws -> Person2 {
+        let expiryTimestamp: Int?
+        if let expires {
+            expiryTimestamp = Int(expires.timeIntervalSince1970)
+        } else {
+            expiryTimestamp = nil
+        }
+        let request = BanPersonRequest(
+            endpoint: .v3,
+            personId: personId,
+            ban: ban,
+            removeOrRestoreData: removeContent,
+            reason: reason,
+            expires: expiryTimestamp
+        )
+        let response = try await perform(request)
+        guard response.banned == ban else { throw ApiClientError.unsuccessful }
+        let person = await caches.person2.getModel(api: self, from: response.personView)
+        return person
+    }
+    
+    func purgePerson(id: Int, reason: String?) async throws {
+        let request = PurgePersonRequest(endpoint: .v3, personId: id, reason: reason)
+        let response = try await perform(request)
+        guard response.success else { throw ApiClientError.unsuccessful }
+        caches.person1.retrieveModel(cacheId: id)?.purged = true
+    }
+    
+    func getContent(
+        authorId id: Int,
+        sort: ApiSortType,
+        page: Int,
+        limit: Int,
+        savedOnly: Bool? = nil,
+        communityId: Int? = nil
+    ) async throws -> (person: Person3, posts: [Post2], comments: [Comment2]) {
+        let request = GetPersonDetailsRequest(
+            endpoint: .v3,
+            personId: id,
+            username: nil,
+            sort: sort,
+            page: page,
+            limit: limit,
+            communityId: nil,
+            savedOnly: savedOnly
+        )
+        let response = try await perform(request)
+        return await (
+            person: caches.person3.getModel(api: self, from: response),
+            posts: caches.post2.getModels(api: self, from: response.posts ?? []),
+            comments: caches.comment2.getModels(api: self, from: response.comments ?? [])
+        )
+    }
+    
+    func getMyPerson() async throws -> (person: Person4?, instance: Instance3, blocks: BlockList?) {
+        // We can't use `try await version` here to decide on the endpoint, because the `version` is
+        // found by calling this method. Instead, we try both the v3 and v4 endpoints and see what we
+        // get back.
+        
+        async let response3 = perform(GetSiteRequest(endpoint: .v3))
+        async let response4 = perform(GetSiteRequest(endpoint: .v4))
+        async let myUser4 = perform(GetMyUserRequest())
+        
+        let response: ApiGetSiteResponse
+        let myUser: ApiMyUserInfo?
+        if let response4 = try? await response4 {
+            response = response4
+            myUser = try await myUser4
+        } else {
+            response = try await response3
+            myUser = response.myUser
+        }
+
+        guard myUser?.localUserView.person.name == username else {
+            assertionFailure("Username received from response (\(String(describing: response.myUser?.localUserView.person.name ?? "nil"))) does not match expected username (\(String(describing: username ?? "nil")))")
+            throw ApiClientError.mismatchingToken
+        }
+        
+        let instance = await caches.instance3.getModel(api: self, from: response)
+        
+        var blocks: BlockList? = blocks
+        var person: Person4?
+        if let myUser {
+            person = await caches.person4.getModel(api: self, from: myUser)
+            if let blocks {
+                blocks.update(myUserInfo: myUser)
+            } else {
+                blocks = .init(api: self, myUserInfo: myUser)
+            }
+        }
+        _ = await Task { @MainActor in
+            self.blocks = blocks
+            myPerson = person
+            myInstance = instance
+        }.result
+        return (person: person, instance: instance, blocks: blocks)
+    }
+    
+    func deleteAccount(password: String, deleteContent: Bool?) async throws {
+        let request = DeleteAccountRequest(endpoint: .v3, password: password, deleteContent: deleteContent)
+        try await perform(request)
+    }
+    
+    func editAccountSettings(
+        showNsfw: Bool?,
+        showScores: Bool?,
+        theme: String?,
+        defaultSortType: ApiSortType?,
+        defaultListingType: ApiListingType?,
+        interfaceLanguage: String?,
+        avatar: String?,
+        banner: String?,
+        displayName: String?,
+        email: String?,
+        bio: String?,
+        matrixUserId: String?,
+        showAvatars: Bool?,
+        sendNotificationsToEmail: Bool?,
+        botAccount: Bool?,
+        showBotAccounts: Bool?,
+        showReadPosts: Bool?,
+        discussionLanguages: [Int]?,
+        openLinksInNewTab: Bool?,
+        blurNsfw: Bool?,
+        autoExpand: Bool?,
+        infiniteScrollEnabled: Bool?,
+        postListingMode: ApiPostListingMode?,
+        enableKeyboardNavigation: Bool?,
+        enableAnimatedImages: Bool?,
+        collapseBotComments: Bool?,
+        showUpvotes: Bool?,
+        showDownvotes: Bool?,
+        showUpvotePercentage: Bool?
+    ) async throws {
+        let request = SaveUserSettingsRequest(
+            endpoint: .v3,
+            showNsfw: showNsfw,
+            showScores: showScores,
+            theme: theme,
+            defaultSortType: defaultSortType,
+            defaultListingType: defaultListingType,
+            interfaceLanguage: interfaceLanguage,
+            avatar: avatar,
+            banner: banner,
+            displayName: displayName,
+            email: email,
+            bio: bio,
+            matrixUserId: matrixUserId,
+            showAvatars: showAvatars,
+            sendNotificationsToEmail: sendNotificationsToEmail,
+            botAccount: botAccount,
+            showBotAccounts: showBotAccounts,
+            showReadPosts: showReadPosts,
+            showNewPostNotifs: nil,
+            discussionLanguages: discussionLanguages,
+            generateTotp2fa: nil,
+            openLinksInNewTab: openLinksInNewTab,
+            blurNsfw: blurNsfw,
+            autoExpand: autoExpand,
+            infiniteScrollEnabled: infiniteScrollEnabled,
+            postListingMode: postListingMode,
+            enableKeyboardNavigation: enableKeyboardNavigation,
+            enableAnimatedImages: enableAnimatedImages,
+            collapseBotComments: collapseBotComments,
+            showUpvotes: showUpvotes,
+            showDownvotes: showDownvotes,
+            showUpvotePercentage: showUpvotePercentage,
+            defaultPostSortType: nil,
+            defaultPostTimeRangeSeconds: nil,
+            defaultCommentSortType: nil,
+            enablePrivateMessages: nil,
+            autoMarkFetchedPostsAsRead: nil,
+            hideMedia: nil
+        )
+        let response = try await perform(request)
+        guard response.success else { throw ApiClientError.unsuccessful }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
@@ -12,7 +12,7 @@ public extension ApiClient {
         guard data.apiUrl == baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
-        guard try await data.apiMyPersonId == myPersonId else {
+        guard data.apiMyPersonId == (try await myPersonId) else {
             throw ApiClientError.mismatchingPersonId
         }
         return await caches.person1.getModel(api: self, from: data.apiPerson, isStale: true)
@@ -22,7 +22,7 @@ public extension ApiClient {
         guard data.apiUrl == baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
-        guard try await data.apiMyPersonId == myPersonId else {
+        guard data.apiMyPersonId == (try await myPersonId) else {
             throw ApiClientError.mismatchingPersonId
         }
         return await caches.person2.getModel(api: self, from: data.apiPersonView, isStale: true)
@@ -56,12 +56,8 @@ public extension ApiClient {
     }
     
     func getPerson(username: String) async throws -> Person3 {
-        try await getPerson(username: username, endpoint: version.endpointVersion)
-    }
-    
-    internal func getPerson(username: String, endpoint: SiteVersion.EndpointVersion) async throws -> Person3 {
         let request = GetPersonDetailsRequest(
-            endpoint: endpoint,
+            endpoint: .v3,
             personId: nil,
             username: username,
             sort: nil,
@@ -92,7 +88,7 @@ public extension ApiClient {
         filter: ApiListingType = .all,
         sort: SearchSortType = .top(.allTime)
     ) async throws -> [Person2] {
-        let endpointVersion = try await version.endpointVersion
+        let endpointVersion = try await self.version.highestSupportedEndpointVersion
         let request = SearchRequest(
             endpoint: .v3,
             q: query,
@@ -223,34 +219,19 @@ public extension ApiClient {
     }
     
     func getMyPerson() async throws -> (person: Person4?, instance: Instance3, blocks: BlockList?) {
-        // We can't use `try await version` here to decide on the endpoint, because the `version` is
-        // found by calling this method. Instead, we try both the v3 and v4 endpoints and see what we
-        // get back.
+        let request = GetSiteRequest(endpoint: .v3)
+        let response = try await perform(request)
         
-        async let response3 = perform(GetSiteRequest(endpoint: .v3))
-        async let response4 = perform(GetSiteRequest(endpoint: .v4))
-        async let myUser4 = perform(GetMyUserRequest())
-        
-        let response: ApiGetSiteResponse
-        let myUser: ApiMyUserInfo?
-        if let response4 = try? await response4 {
-            response = response4
-            myUser = try await myUser4
-        } else {
-            response = try await response3
-            myUser = response.myUser
-        }
-
-        guard myUser?.localUserView.person.name == username else {
-            assertionFailure("Username received from response (\(String(describing: response.myUser?.localUserView.person.name ?? "nil"))) does not match expected username (\(String(describing: username ?? "nil")))")
+        guard response.myUser?.localUserView.person.name == self.username else {
+            assertionFailure()
             throw ApiClientError.mismatchingToken
         }
         
         let instance = await caches.instance3.getModel(api: self, from: response)
         
-        var blocks: BlockList? = blocks
+        var blocks: BlockList? = self.blocks
         var person: Person4?
-        if let myUser {
+        if let myUser = response.myUser {
             person = await caches.person4.getModel(api: self, from: myUser)
             if let blocks {
                 blocks.update(myUserInfo: myUser)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -1,0 +1,467 @@
+//
+//  NewApiClient+Post.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+
+public extension ApiClient {
+    // swiftlint:disable:next function_parameter_count
+    func getPosts(
+        communityId: Int,
+        sort: PostSortType,
+        page: Int,
+        cursor: String?,
+        limit: Int,
+        filter: GetContentFilter? = nil,
+        showHidden: Bool = false
+    ) async throws -> (posts: [Post2], cursor: String?) {
+        let request = try await GetPostsRequest(
+            endpoint: version.endpointVersion,
+            type_: .all,
+            sort: sort.legacyApiSortType,
+            page: cursor == nil ? page : nil,
+            limit: limit,
+            communityId: communityId,
+            communityName: nil,
+            savedOnly: filter == .saved,
+            likedOnly: filter == .upvoted,
+            dislikedOnly: filter == .downvoted,
+            pageCursor: cursor,
+            showHidden: showHidden,
+            showRead: nil,
+            showNsfw: nil,
+            timeRangeSeconds: nil,
+            readOnly: nil,
+            hideMedia: nil,
+            markAsRead: nil,
+            noCommentsOnly: nil,
+            pageBack: nil
+        )
+        let response = try await perform(request)
+        let posts = await caches.post2.getModels(api: self, from: response.posts)
+        return (posts: posts, cursor: response.nextPage)
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func getPosts(
+        feed: ApiListingType,
+        sort: PostSortType,
+        page: Int,
+        cursor: String?,
+        limit: Int,
+        filter: GetContentFilter? = nil,
+        showHidden: Bool = false
+    ) async throws -> (posts: [Post2], cursor: String?) {
+        let request = try await GetPostsRequest(
+            endpoint: version.endpointVersion,
+            type_: feed,
+            sort: sort.legacyApiSortType,
+            page: cursor == nil ? page : nil,
+            limit: limit,
+            communityId: nil,
+            communityName: nil,
+            savedOnly: filter == .saved,
+            likedOnly: filter == .upvoted,
+            dislikedOnly: filter == .downvoted,
+            pageCursor: cursor,
+            showHidden: showHidden,
+            showRead: nil,
+            showNsfw: nil,
+            timeRangeSeconds: nil,
+            readOnly: nil,
+            hideMedia: nil,
+            markAsRead: nil,
+            noCommentsOnly: nil,
+            pageBack: nil
+        )
+        let response = try await perform(request)
+        let posts = await caches.post2.getModels(api: self, from: response.posts)
+        return (posts: posts, cursor: response.nextPage)
+    }
+    
+    func getPosts(
+        personId: Int,
+        communityId: Int? = nil,
+        sort: PostSortType = .new,
+        page: Int,
+        limit: Int,
+        savedOnly: Bool = false
+    ) async throws -> (person: Person3, posts: [Post2]) {
+        let request = GetPersonDetailsRequest(
+            endpoint: .v3,
+            personId: personId,
+            username: nil,
+            sort: sort.legacyApiSortType,
+            page: page,
+            limit: limit,
+            communityId: communityId,
+            savedOnly: savedOnly
+        )
+        let response = try await perform(request)
+        return await (
+            person: caches.person3.getModel(api: self, from: response),
+            posts: caches.post2.getModels(api: self, from: response.posts ?? [])
+        )
+    }
+        
+    func getPost(id: Int) async throws -> Post3 {
+        let request = GetPostRequest(endpoint: .v3, id: id, commentId: nil)
+        let response = try await perform(request)
+        return await caches.post3.getModel(api: self, from: response)
+    }
+    
+    func getPost(url: URL) async throws -> Post2 {
+        let request = ResolveObjectRequest(endpoint: .v3, q: url.absoluteString)
+        do {
+            if let response = try await perform(request).post {
+                return await caches.post2.getModel(api: self, from: response)
+            }
+        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
+            throw ApiClientError.noEntityFound
+        }
+        throw ApiClientError.noEntityFound
+    }
+    
+    // This method should be removed in favor of the below method once we drop support for versions before Lemmy 1.0
+    func searchPosts(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int? = nil,
+        creatorId: Int? = nil,
+        filter: ApiListingType = .all,
+        sort: PostSortType
+    ) async throws -> [Post2] {
+        try await searchPosts(
+            query: query,
+            page: page,
+            limit: limit,
+            communityId: communityId,
+            creatorId: creatorId,
+            filter: filter,
+            legacySort: sort.legacyApiSortType,
+            sort: sort.apiSearchSortType,
+            timeRangeSeconds: nil
+        )
+    }
+    
+    func searchPosts(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int? = nil,
+        creatorId: Int? = nil,
+        filter: ApiListingType = .all,
+        sort: SearchSortType
+    ) async throws -> [Post2] {
+        try await searchPosts(
+            query: query,
+            page: page,
+            limit: limit,
+            communityId: communityId,
+            creatorId: creatorId,
+            filter: filter,
+            legacySort: sort.legacyApiSortType,
+            sort: sort.apiSortType,
+            timeRangeSeconds: sort.timeRangeSeconds
+        )
+    }
+    
+    private func searchPosts(
+        query: String,
+        page: Int,
+        limit: Int,
+        communityId: Int?,
+        creatorId: Int?,
+        filter: ApiListingType,
+        legacySort: ApiSortType?,
+        sort: ApiSearchSortType?,
+        timeRangeSeconds: Int?
+    ) async throws -> [Post2] {
+        let endpointVersion = try await version.endpointVersion
+        let request = SearchRequest(
+            endpoint: .v3,
+            q: query,
+            communityId: communityId,
+            communityName: nil,
+            creatorId: creatorId,
+            type_: .posts,
+            sort: .init(oldSortType: endpointVersion == .v3 ? legacySort : nil, newSortType: endpointVersion == .v4 ? sort : nil),
+            listingType: filter,
+            page: page,
+            limit: limit,
+            postTitleOnly: false,
+            searchTerm: query,
+            timeRangeSeconds: timeRangeSeconds,
+            titleOnly: nil,
+            postUrlOnly: nil,
+            likedOnly: nil,
+            dislikedOnly: nil,
+            pageCursor: nil,
+            pageBack: nil
+        )
+        let response = try await perform(request)
+        return await caches.post2.getModels(api: self, from: response.posts ?? [])
+    }
+    
+    /// Mark the given post as read. Works on all versions.
+    /// On v0.19.0 and above, if `includeQueuedPosts` is set to `true`, any queued posts will be marked read as well.
+    func markPostAsRead(
+        id: Int,
+        read: Bool = true,
+        includeQueuedPosts: Bool = true,
+        semaphore: UInt? = nil
+    ) async throws {
+        // We *must* use `postId` in 0.18 versions, and we *must* use `postIds` from 0.19.4 onwards.
+        // On versions 0.19.0 to 0.19.3, either parameter is allowed.
+        let request: MarkPostAsReadRequest
+        if try await supports(.batchMarkRead) {
+            try await markPostsAsRead(
+                ids: [id],
+                read: read,
+                includeQueuedPosts: includeQueuedPosts,
+                semaphore: semaphore
+            )
+        } else {
+            request = MarkPostAsReadRequest(endpoint: .v3, postId: id, read: read, postIds: nil)
+            let response = try await perform(request)
+            if !response.success {
+                throw ApiClientError.unsuccessful
+            }
+            await markReadQueue.remove(id)
+            Task { @MainActor in
+                if let post = caches.post2.retrieveModel(cacheId: id) {
+                    post.readManager.updateWithReceivedValue(read, semaphore: semaphore)
+                    post.updateReadQueued(false)
+                }
+            }
+        }
+    }
+    
+    /// Mark the given posts as read. Only works on v0.19.0 and above; on lower versions, use `markPostAsRead` instead.
+    /// Calling this will also mark any queued posts as read unless `includeQueuedPosts` is set to `false`.
+    func markPostsAsRead(
+        ids: Set<Int>,
+        read: Bool = true,
+        includeQueuedPosts: Bool = true,
+        semaphore: UInt? = nil
+    ) async throws {
+        let version = try await version
+        guard version >= .v0_19_0 else { throw ApiClientError.unsupportedLemmyVersion }
+        
+        let idsToSend: Set<Int>
+        let markReadQueueCopy: Set<Int>
+        if read, includeQueuedPosts {
+            markReadQueueCopy = await markReadQueue.popAll()
+            idsToSend = ids.union(markReadQueueCopy)
+        } else {
+            markReadQueueCopy = []
+            idsToSend = ids
+        }
+        
+        guard !idsToSend.isEmpty else { return }
+        
+        do {
+            let request = MarkPostAsReadRequest(endpoint: .v3, postId: nil, read: read, postIds: Array(idsToSend))
+            let response = try await perform(request)
+            if !response.success {
+                throw ApiClientError.unsuccessful
+            }
+            if read {
+                await markReadQueue.subtract(ids)
+            }
+        } catch {
+            await markReadQueue.union(markReadQueueCopy)
+            throw error
+        }
+        Task { @MainActor in
+            for post in idsToSend.compactMap({ caches.post2.retrieveModel(cacheId: $0) }) {
+                post.readManager.updateWithReceivedValue(read, semaphore: semaphore)
+                post.updateReadQueued(false)
+            }
+        }
+    }
+    
+    func flushPostReadQueue() async throws {
+        if await !markReadQueue.ids.isEmpty {
+            try await markPostsAsRead(ids: [], read: true)
+        }
+    }
+    
+    @discardableResult
+    func voteOnPost(id: Int, score: ScoringOperation, semaphore: UInt? = nil) async throws -> Post2 {
+        let request = try await LikePostRequest(endpoint: version.endpointVersion, postId: id, score: score.rawValue)
+        let response = try await perform(request)
+        return await caches.post2.getModel(api: self, from: response.postView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func savePost(id: Int, save: Bool, semaphore: UInt? = nil) async throws -> Post2 {
+        let request = SavePostRequest(endpoint: .v3, postId: id, save: save)
+        let response = try await perform(request)
+        return await caches.post2.getModel(api: self, from: response.postView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func deletePost(id: Int, delete: Bool, semaphore: UInt? = nil) async throws -> Post2 {
+        let request = DeletePostRequest(endpoint: .v3, postId: id, deleted: delete)
+        let response = try await perform(request)
+        return await caches.post2.getModel(api: self, from: response.postView, semaphore: semaphore)
+    }
+    
+    /// Added in 0.19.4
+    func hidePosts(
+        ids: any Collection<Int>,
+        hide: Bool,
+        semaphore: UInt? = nil
+    ) async throws {
+        let request = HidePostRequest(endpoint: .v3, postIds: Array(ids), hide: hide, postId: nil)
+        let response = try await perform(request)
+        if !response.success {
+            throw ApiClientError.unsuccessful
+        }
+        for post in ids.compactMap({ caches.post2.retrieveModel(cacheId: $0) }) {
+            post.hiddenManager.updateWithReceivedValue(hide, semaphore: semaphore)
+        }
+    }
+    
+    func hidePost(id: Int, hide: Bool, semaphore: UInt? = nil) async throws {
+        try await hidePosts(ids: [id], hide: hide, semaphore: semaphore)
+    }
+    
+    func createPost(
+        communityId: Int,
+        title: String,
+        content: String? = nil,
+        linkUrl: URL? = nil,
+        altText: String? = nil,
+        thumbnail: URL? = nil,
+        nsfw: Bool,
+        languageId: Int? = nil
+    ) async throws -> Post2 {
+        let request = CreatePostRequest(
+            endpoint: .v3,
+            name: title,
+            communityId: communityId,
+            url: linkUrl?.absoluteString,
+            body: content,
+            honeypot: nil,
+            nsfw: nsfw,
+            languageId: languageId,
+            altText: altText,
+            customThumbnail: thumbnail?.absoluteString,
+            tags: nil,
+            scheduledPublishTime: nil
+        )
+        let response = try await perform(request)
+        return await caches.post2.getModel(api: self, from: response.postView)
+    }
+    
+    @discardableResult
+    func editPost(
+        id: Int,
+        title: String,
+        content: String? = nil,
+        linkUrl: URL? = nil,
+        altText: String? = nil,
+        thumbnail: URL? = nil,
+        nsfw: Bool,
+        languageId: Int? = nil
+    ) async throws -> Post2 {
+        let request = EditPostRequest(
+            endpoint: .v3,
+            postId: id,
+            name: title,
+            url: linkUrl?.absoluteString,
+            body: content,
+            nsfw: nsfw,
+            languageId: languageId,
+            altText: altText,
+            customThumbnail: thumbnail?.absoluteString,
+            tags: nil,
+            scheduledPublishTime: nil
+        )
+        let response = try await perform(request)
+        return await caches.post2.getModel(api: self, from: response.postView)
+    }
+
+    func replyToPost(id: Int, content: String, languageId: Int? = nil) async throws -> Comment2 {
+        let request = CreateCommentRequest(
+            endpoint: .v3,
+            content: content,
+            postId: id,
+            parentId: nil,
+            languageId: languageId,
+            formId: nil
+        )
+        let response = try await perform(request)
+        let comment = await caches.comment2.getModel(api: self, from: response.commentView)
+        comment.getCachedInboxReply()?.setKnownReadState(newValue: true)
+        return comment
+    }
+    
+    @discardableResult
+    func reportPost(id: Int, reason: String) async throws -> Report {
+        let request = CreatePostReportRequest(endpoint: .v3, postId: id, reason: reason, violatesInstanceRules: nil)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.report.getModel(
+            api: self,
+            from: response.postReportView,
+            myPersonId: myPersonId
+        )
+    }
+    
+    func purgePost(id: Int, reason: String?) async throws {
+        let request = PurgePostRequest(endpoint: .v3, postId: id, reason: reason)
+        let response = try await perform(request)
+        guard response.success else { throw ApiClientError.unsuccessful }
+        caches.post1.retrieveModel(cacheId: id)?.purged = true
+    }
+    
+    @discardableResult
+    func removePost(
+        id: Int,
+        remove: Bool,
+        reason: String?,
+        semaphore: UInt? = nil
+    ) async throws -> Post2 {
+        let request = RemovePostRequest(endpoint: .v3, postId: id, removed: remove, reason: reason)
+        let response = try await perform(request)
+        return await caches.post2.getModel(api: self, from: response.postView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func pinPost(id: Int, pin: Bool, to target: ApiPostFeatureType, semaphore: UInt? = nil) async throws -> Post2 {
+        let request = FeaturePostRequest(endpoint: .v3, postId: id, featured: pin, featureType: target)
+        let response = try await perform(request)
+        return await caches.post2.getModel(api: self, from: response.postView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func lockPost(id: Int, lock: Bool, semaphore: UInt? = nil) async throws -> Post2 {
+        let request = LockPostRequest(endpoint: .v3, postId: id, locked: lock)
+        let response = try await perform(request)
+        return await caches.post2.getModel(api: self, from: response.postView, semaphore: semaphore)
+    }
+    
+    @discardableResult
+    func getPostVotes(
+        id: Int,
+        communityId: Int,
+        page: Int = 1,
+        limit: Int = 20
+    ) async throws -> [PersonVote] {
+        let request = ListPostLikesRequest(endpoint: .v3, postId: id, page: page, limit: limit)
+        let response = try await perform(request)
+        return await caches.personVote.getModels(
+            api: self,
+            from: response.postLikes,
+            target: .post(id: id),
+            communityId: communityId
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -18,8 +18,8 @@ public extension ApiClient {
         filter: GetContentFilter? = nil,
         showHidden: Bool = false
     ) async throws -> (posts: [Post2], cursor: String?) {
-        let request = try await GetPostsRequest(
-            endpoint: version.endpointVersion,
+        let request = GetPostsRequest(
+            endpoint: .v3,
             type_: .all,
             sort: sort.legacyApiSortType,
             page: cursor == nil ? page : nil,
@@ -55,8 +55,8 @@ public extension ApiClient {
         filter: GetContentFilter? = nil,
         showHidden: Bool = false
     ) async throws -> (posts: [Post2], cursor: String?) {
-        let request = try await GetPostsRequest(
-            endpoint: version.endpointVersion,
+        let request = GetPostsRequest(
+            endpoint: .v3,
             type_: feed,
             sort: sort.legacyApiSortType,
             page: cursor == nil ? page : nil,
@@ -181,7 +181,7 @@ public extension ApiClient {
         sort: ApiSearchSortType?,
         timeRangeSeconds: Int?
     ) async throws -> [Post2] {
-        let endpointVersion = try await version.endpointVersion
+        let endpointVersion = try await version.highestSupportedEndpointVersion
         let request = SearchRequest(
             endpoint: .v3,
             q: query,
@@ -293,7 +293,7 @@ public extension ApiClient {
     
     @discardableResult
     func voteOnPost(id: Int, score: ScoringOperation, semaphore: UInt? = nil) async throws -> Post2 {
-        let request = try await LikePostRequest(endpoint: version.endpointVersion, postId: id, score: score.rawValue)
+        let request = LikePostRequest(endpoint: .v3, postId: id, score: score.rawValue)
         let response = try await perform(request)
         return await caches.post2.getModel(api: self, from: response.postView, semaphore: semaphore)
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+RegistrationApplication.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+RegistrationApplication.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-01-12.
-//
+//  
 
 import Foundation
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+RegistrationApplication.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+RegistrationApplication.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-01-12.
-//  
+//
 
 import Foundation
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+RegistrationApplication.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+RegistrationApplication.swift
@@ -1,0 +1,58 @@
+//
+//  ApiClient+RegistrationApplication.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-12.
+//
+
+import Foundation
+
+public extension ApiClient {
+    func getRegistrationApplicationCount() async throws -> ApiGetUnreadRegistrationApplicationCountResponse {
+        try await perform(GetUnreadRegistrationApplicationCountRequest(endpoint: .v3))
+    }
+    
+    func getRegistrationApplications(
+        page: Int = 1,
+        limit: Int = 20,
+        unreadOnly: Bool = false
+    ) async throws -> [RegistrationApplication] {
+        let request = ListRegistrationApplicationsRequest(
+            endpoint: .v3,
+            unreadOnly: unreadOnly,
+            page: page,
+            limit: limit
+        )
+        let response = try await perform(request)
+        return await caches.registrationApplication.getModels(api: self, from: response.registrationApplications)
+    }
+    
+    @discardableResult
+    func approveRegistrationApplication(
+        id: Int,
+        semaphore: UInt? = nil
+    ) async throws -> RegistrationApplication {
+        let request = ApproveRegistrationApplicationRequest(endpoint: .v3, id: id, approve: true, denyReason: nil)
+        let response = try await perform(request)
+        return await caches.registrationApplication.getModel(
+            api: self,
+            from: response.registrationApplication,
+            semaphore: semaphore
+        )
+    }
+    
+    @discardableResult
+    func denyRegistrationApplication(
+        id: Int,
+        reason: String?,
+        semaphore: UInt? = nil
+    ) async throws -> RegistrationApplication {
+        let request = ApproveRegistrationApplicationRequest(endpoint: .v3, id: id, approve: false, denyReason: reason)
+        let response = try await perform(request)
+        return await caches.registrationApplication.getModel(
+            api: self,
+            from: response.registrationApplication,
+            semaphore: semaphore
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Report.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Report.swift
@@ -1,0 +1,130 @@
+//
+//  ApiClient+Report.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-16.
+//
+
+import Foundation
+
+public extension ApiClient {
+    func getReportCount(communityId: Int? = nil) async throws -> ApiGetReportCountResponse {
+        try await perform(GetReportCountRequest(endpoint: .v3, communityId: communityId))
+    }
+    
+    func getPostReports(
+        page: Int = 1,
+        limit: Int = 20,
+        unresolvedOnly: Bool = false,
+        communityId: Int? = nil,
+        postId: Int? = nil
+    ) async throws -> [Report] {
+        let request = ListPostReportsRequest(
+            page: page,
+            limit: limit,
+            unresolvedOnly: unresolvedOnly,
+            communityId: communityId,
+            postId: postId
+        )
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.report.getModels(
+            api: self,
+            from: response.postReports,
+            myPersonId: myPersonId
+        )
+    }
+    
+    func getCommentReports(
+        page: Int = 1,
+        limit: Int = 20,
+        unresolvedOnly: Bool = false,
+        communityId: Int? = nil,
+        commentId: Int? = nil
+    ) async throws -> [Report] {
+        let request = ListCommentReportsRequest(
+            page: page,
+            limit: limit,
+            unresolvedOnly: unresolvedOnly,
+            communityId: communityId,
+            commentId: commentId
+        )
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.report.getModels(
+            api: self,
+            from: response.commentReports,
+            myPersonId: myPersonId
+        )
+    }
+    
+    func getMessageReports(
+        page: Int = 1,
+        limit: Int = 20,
+        unresolvedOnly: Bool = false
+    ) async throws -> [Report] {
+        let request = ListPrivateMessageReportsRequest(
+            page: page,
+            limit: limit,
+            unresolvedOnly: unresolvedOnly
+        )
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.report.getModels(
+            api: self,
+            from: response.privateMessageReports,
+            myPersonId: myPersonId
+        )
+    }
+    
+    @discardableResult
+    func resolvePostReport(
+        id: Int,
+        resolved: Bool,
+        semaphore: UInt? = nil
+    ) async throws -> Report {
+        let request = ResolvePostReportRequest(endpoint: .v3, reportId: id, resolved: resolved)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.report.getModel(
+            api: self,
+            from: response.postReportView,
+            myPersonId: myPersonId,
+            semaphore: semaphore
+        )
+    }
+    
+    @discardableResult
+    func resolveCommentReport(
+        id: Int,
+        resolved: Bool,
+        semaphore: UInt? = nil
+    ) async throws -> Report {
+        let request = ResolveCommentReportRequest(endpoint: .v3, reportId: id, resolved: resolved)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.report.getModel(
+            api: self,
+            from: response.commentReportView,
+            myPersonId: myPersonId,
+            semaphore: semaphore
+        )
+    }
+    
+    @discardableResult
+    func resolveMessageReport(
+        id: Int,
+        resolved: Bool,
+        semaphore: UInt? = nil
+    ) async throws -> Report {
+        let request = ResolvePrivateMessageReportRequest(endpoint: .v3, reportId: id, resolved: resolved)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return try await caches.report.getModel(
+            api: self,
+            from: response.privateMessageReportView,
+            myPersonId: myPersonId,
+            semaphore: semaphore
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -38,7 +38,7 @@ public class ApiClient {
     public internal(set) weak var unreadCount: UnreadCount?
     
     /// Stores the IDs of posts that are queued to be marked read.
-    internal var markReadQueue: MarkReadQueue = .init()
+    var markReadQueue: MarkReadQueue = .init()
     
     public var fetchedVersion: SiteVersion? {
         contextDataManager.fetchedValue?.siteVersion
@@ -68,7 +68,7 @@ public class ApiClient {
     
     /// Returns whether the fetched version supports the given feature. Defaults to false if no fetched version available.
     public func fetchedVersionSupports(_ feature: SiteVersion.Feature) -> Bool {
-        return fetchedVersion?.suppports(feature) ?? false
+        fetchedVersion?.suppports(feature) ?? false
     }
     
     // MARK: caching
@@ -87,7 +87,7 @@ public class ApiClient {
     }
     
     /// This should never be used outside of ApiClientCache (and MockApiClient), as the caching system depends on one ApiClient existing for any given session.
-    internal init(
+    init(
         url: URL,
         username: String? = nil,
         permissions: RequestPermissions = .all
@@ -108,12 +108,12 @@ public class ApiClient {
     
     /// Return a new guest `ApiClient`.
     public func asGuest() -> ApiClient {
-        .getApiClient(url: self.baseUrl, username: nil)
+        .getApiClient(url: baseUrl, username: nil)
     }
     
     /// Return a new `ApiClient` targeting the given user.
     public func asUser(name: String) -> ApiClient {
-        .getApiClient(url: self.baseUrl, username: name)
+        .getApiClient(url: baseUrl, username: name)
     }
     
     /// This should **only** be used when we get a new token for **the same** account!
@@ -122,7 +122,7 @@ public class ApiClient {
             assertionFailure()
             return
         }
-        self.token = newToken
+        token = newToken
     }
     
     @discardableResult
@@ -131,9 +131,9 @@ public class ApiClient {
         tokenOverride: String? = nil,
         requiresToken: Bool = true // This should be `true` for the vast majority of requests, even GET requests
     ) async throws -> Request.Response {
-        let token = tokenOverride ?? self.token
+        let token = tokenOverride ?? token
         
-        guard !requiresToken || self.username == nil || token != nil else {
+        guard !requiresToken || username == nil || token != nil else {
             throw ApiClientError.noToken
         }
         
@@ -167,12 +167,12 @@ public class ApiClient {
         return try decode(Request.Response.self, from: data)
     }
     
-    internal func execute(
+    func execute(
         _ urlRequest: URLRequest,
         tokenOverride: String? = nil
     ) async throws -> (Data, URLResponse) {
         var urlRequest: URLRequest = urlRequest // make mutable
-        let token = tokenOverride ?? self.token
+        let token = tokenOverride ?? token
         
         if urlRequest.httpMethod != "GET", // GET requests do not support body
            !fetchedVersionSupports(.headerAuthentication),
@@ -203,7 +203,7 @@ public class ApiClient {
         from definition: any ApiRequest,
         tokenOverride: String? = nil
     ) throws -> URLRequest {
-        let token = tokenOverride ?? self.token
+        let token = tokenOverride ?? token
         guard permissions != .none else { throw ApiClientError.insufficientPermissions }
         let url = try definition.endpoint(base: baseUrl)
         var urlRequest = mlemUrlRequest(url: url)
@@ -265,8 +265,8 @@ extension ApiClient: ActorIdentifiable {
 
 extension ApiClient: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.baseUrl)
-        hasher.combine(self.username)
+        hasher.combine(baseUrl)
+        hasher.combine(username)
     }
     
     public static func == (lhs: ApiClient, rhs: ApiClient) -> Bool {
@@ -280,15 +280,15 @@ extension ApiClient: CustomDebugStringConvertible {
     }
 }
 
-extension ApiClient {
-    public struct Context {
+public extension ApiClient {
+    struct Context {
         let siteVersion: SiteVersion
         let myPersonId: Int?
     }
 }
 
-extension ApiClient.Context {
-    public init(instance: Instance3, person: Person4?) {
+public extension ApiClient.Context {
+    init(instance: Instance3, person: Person4?) {
         self.siteVersion = instance.version
         self.myPersonId = person?.id
     }
@@ -307,6 +307,7 @@ extension ApiClient {
             hasher.combine(username)
             return hasher.finalize()
         }
+
         func createOrRetrieveApiClient(url: URL, username: String?) -> ApiClient {
             let url = url.removingPathComponents().appendingPathComponent("/")
             if let client = retrieveModel(cacheId: getCacheId(url: url, username: username)) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -38,7 +38,7 @@ public class ApiClient {
     public internal(set) weak var unreadCount: UnreadCount?
     
     /// Stores the IDs of posts that are queued to be marked read.
-    var markReadQueue: MarkReadQueue = .init()
+    internal var markReadQueue: MarkReadQueue = .init()
     
     public var fetchedVersion: SiteVersion? {
         contextDataManager.fetchedValue?.siteVersion
@@ -68,7 +68,7 @@ public class ApiClient {
     
     /// Returns whether the fetched version supports the given feature. Defaults to false if no fetched version available.
     public func fetchedVersionSupports(_ feature: SiteVersion.Feature) -> Bool {
-        fetchedVersion?.suppports(feature) ?? false
+        return fetchedVersion?.suppports(feature) ?? false
     }
     
     // MARK: caching
@@ -87,7 +87,7 @@ public class ApiClient {
     }
     
     /// This should never be used outside of ApiClientCache (and MockApiClient), as the caching system depends on one ApiClient existing for any given session.
-    init(
+    internal init(
         url: URL,
         username: String? = nil,
         permissions: RequestPermissions = .all
@@ -96,18 +96,8 @@ public class ApiClient {
         self.username = username
         self.permissions = permissions
         contextDataManager.fetchTask = {
-            // Be careful not to cause an infinite loop in this method - don't call anything that reads from the context!
             let (person, instance, _) = try await self.getMyPerson()
-            let personId: Int?
-            if let person {
-                personId = person.id
-            } else if let username {
-                // This handles the case where the `ApiClient` has a `username`, but not a `token` yet.
-                personId = try await self.getPerson(username: username, endpoint: instance.version.endpointVersion).id
-            } else {
-                personId = nil
-            }
-            return .init(siteVersion: instance.version, myPersonId: personId)
+            return .init(instance: instance, person: person)
         }
     }
     
@@ -118,12 +108,12 @@ public class ApiClient {
     
     /// Return a new guest `ApiClient`.
     public func asGuest() -> ApiClient {
-        .getApiClient(url: baseUrl, username: nil)
+        .getApiClient(url: self.baseUrl, username: nil)
     }
     
     /// Return a new `ApiClient` targeting the given user.
     public func asUser(name: String) -> ApiClient {
-        .getApiClient(url: baseUrl, username: name)
+        .getApiClient(url: self.baseUrl, username: name)
     }
     
     /// This should **only** be used when we get a new token for **the same** account!
@@ -132,7 +122,7 @@ public class ApiClient {
             assertionFailure()
             return
         }
-        token = newToken
+        self.token = newToken
     }
     
     @discardableResult
@@ -141,19 +131,15 @@ public class ApiClient {
         tokenOverride: String? = nil,
         requiresToken: Bool = true // This should be `true` for the vast majority of requests, even GET requests
     ) async throws -> Request.Response {
-        let token = tokenOverride ?? token
+        let token = tokenOverride ?? self.token
         
-        guard !requiresToken || username == nil || token != nil else {
+        guard !requiresToken || self.username == nil || token != nil else {
             throw ApiClientError.noToken
         }
         
         let urlRequest = try urlRequest(from: request, tokenOverride: tokenOverride)
         // this line intentionally left commented for convenient future debugging
-        urlRequest.debug()
-        
-        // For debugging
-        if request.path.starts(with: "api/v3") { throw ApiClientError.invalidInput }
-        
+        // urlRequest.debug()
         let (data, response) = try await execute(urlRequest, tokenOverride: tokenOverride)
         if let response = response as? HTTPURLResponse {
             if response.statusCode >= 500 { // Error code for server being offline.
@@ -181,12 +167,12 @@ public class ApiClient {
         return try decode(Request.Response.self, from: data)
     }
     
-    func execute(
+    internal func execute(
         _ urlRequest: URLRequest,
         tokenOverride: String? = nil
     ) async throws -> (Data, URLResponse) {
         var urlRequest: URLRequest = urlRequest // make mutable
-        let token = tokenOverride ?? token
+        let token = tokenOverride ?? self.token
         
         if urlRequest.httpMethod != "GET", // GET requests do not support body
            !fetchedVersionSupports(.headerAuthentication),
@@ -217,7 +203,7 @@ public class ApiClient {
         from definition: any ApiRequest,
         tokenOverride: String? = nil
     ) throws -> URLRequest {
-        let token = tokenOverride ?? token
+        let token = tokenOverride ?? self.token
         guard permissions != .none else { throw ApiClientError.insufficientPermissions }
         let url = try definition.endpoint(base: baseUrl)
         var urlRequest = mlemUrlRequest(url: url)
@@ -279,8 +265,8 @@ extension ApiClient: ActorIdentifiable {
 
 extension ApiClient: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(baseUrl)
-        hasher.combine(username)
+        hasher.combine(self.baseUrl)
+        hasher.combine(self.username)
     }
     
     public static func == (lhs: ApiClient, rhs: ApiClient) -> Bool {
@@ -294,15 +280,17 @@ extension ApiClient: CustomDebugStringConvertible {
     }
 }
 
-public extension ApiClient {
-    struct Context {
+extension ApiClient {
+    public struct Context {
         let siteVersion: SiteVersion
         let myPersonId: Int?
-        
-        public init(siteVersion: SiteVersion, myPersonId: Int?) {
-            self.siteVersion = siteVersion
-            self.myPersonId = myPersonId
-        }
+    }
+}
+
+extension ApiClient.Context {
+    public init(instance: Instance3, person: Person4?) {
+        self.siteVersion = instance.version
+        self.myPersonId = person?.id
     }
 }
 
@@ -319,7 +307,6 @@ extension ApiClient {
             hasher.combine(username)
             return hasher.finalize()
         }
-
         func createOrRetrieveApiClient(url: URL, username: String?) -> ApiClient {
             let url = url.removingPathComponents().appendingPathComponent("/")
             if let client = retrieveModel(cacheId: getCacheId(url: url, username: username)) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -1,0 +1,334 @@
+//
+//  ApiClient.swift
+//  Mlem
+//
+//  Created by Sjmarf on 10/02/2024.
+//
+
+import Combine
+import Foundation
+import SwiftyJSON
+
+@Observable
+public class ApiClient {
+    public enum RequestPermissions {
+        case all, getOnly, none
+    }
+    
+    let decoder: JSONDecoder = .defaultDecoder
+    let urlSession: URLSession = .init(configuration: .default)
+    
+    // url and username MAY NOT be modified! Downstream code expects that a given ApiClient will *always* submit requests from the same user to the same instance.
+    public let baseUrl: URL
+    public let username: String?
+    
+    public internal(set) var token: String?
+    
+    public private(set) var contextDataManager: SharedTaskManager<Context> = .init()
+    
+    /// When `true`, the token will not be attatched to any API requests. This is useful for ensuring that inactive accounts don't accidentally make requests
+    public var permissions: RequestPermissions = .all
+    
+    public var willSendToken: Bool { permissions == .all && token != nil }
+    
+    public internal(set) weak var myInstance: Instance3?
+    public internal(set) weak var myPerson: Person4?
+    public internal(set) weak var subscriptions: SubscriptionList?
+    public internal(set) weak var blocks: BlockList?
+    public internal(set) weak var unreadCount: UnreadCount?
+    
+    /// Stores the IDs of posts that are queued to be marked read.
+    var markReadQueue: MarkReadQueue = .init()
+    
+    public var fetchedVersion: SiteVersion? {
+        contextDataManager.fetchedValue?.siteVersion
+    }
+    
+    /// Returns the `fetchedVersion` if the version has already been fetched. Otherwise, waits until the version has been fetched before returning the received value.
+    public var version: SiteVersion {
+        get async throws {
+            try await contextDataManager.getValue().siteVersion
+        }
+    }
+    
+    public var myPersonId: Int? {
+        get async throws {
+            try await contextDataManager.getValue().myPersonId
+        }
+    }
+    
+    public func ensureContextPresence() async throws {
+        try await contextDataManager.getValue()
+    }
+    
+    /// Returns whether the version supports the given feature
+    public func supports(_ feature: SiteVersion.Feature) async throws -> Bool {
+        try await version.suppports(feature)
+    }
+    
+    /// Returns whether the fetched version supports the given feature. Defaults to false if no fetched version available.
+    public func fetchedVersionSupports(_ feature: SiteVersion.Feature) -> Bool {
+        fetchedVersion?.suppports(feature) ?? false
+    }
+    
+    // MARK: caching
+    
+    /// Caches of objects stored per ApiClient instance
+    /// - Warning: DO NOT access this outside of ApiClient!
+    var caches: BaseCacheGroup = .init()
+    
+    /// Caches of Instance objects, shared across all ApiClient instances
+    /// - Warning: DO NOT access this outside of ApiClient!
+    static var apiClientCache: ApiClientCache = .init()
+    
+    /// Creates or retrieves an API client for the given connection parameters
+    public static func getApiClient(url: URL, username: String?) -> ApiClient {
+        apiClientCache.createOrRetrieveApiClient(url: url, username: username)
+    }
+    
+    /// This should never be used outside of ApiClientCache (and MockApiClient), as the caching system depends on one ApiClient existing for any given session.
+    init(
+        url: URL,
+        username: String? = nil,
+        permissions: RequestPermissions = .all
+    ) {
+        self.baseUrl = url
+        self.username = username
+        self.permissions = permissions
+        contextDataManager.fetchTask = {
+            // Be careful not to cause an infinite loop in this method - don't call anything that reads from the context!
+            let (person, instance, _) = try await self.getMyPerson()
+            let personId: Int?
+            if let person {
+                personId = person.id
+            } else if let username {
+                // This handles the case where the `ApiClient` has a `username`, but not a `token` yet.
+                personId = try await self.getPerson(username: username, endpoint: instance.version.endpointVersion).id
+            } else {
+                personId = nil
+            }
+            return .init(siteVersion: instance.version, myPersonId: personId)
+        }
+    }
+    
+    public func cleanCaches() {
+        caches.clean()
+        ApiClient.apiClientCache.clean()
+    }
+    
+    /// Return a new guest `ApiClient`.
+    public func asGuest() -> ApiClient {
+        .getApiClient(url: baseUrl, username: nil)
+    }
+    
+    /// Return a new `ApiClient` targeting the given user.
+    public func asUser(name: String) -> ApiClient {
+        .getApiClient(url: baseUrl, username: name)
+    }
+    
+    /// This should **only** be used when we get a new token for **the same** account!
+    public func updateToken(_ newToken: String) {
+        guard username != nil else {
+            assertionFailure()
+            return
+        }
+        token = newToken
+    }
+    
+    @discardableResult
+    func perform<Request: ApiRequest>(
+        _ request: Request,
+        tokenOverride: String? = nil,
+        requiresToken: Bool = true // This should be `true` for the vast majority of requests, even GET requests
+    ) async throws -> Request.Response {
+        let token = tokenOverride ?? token
+        
+        guard !requiresToken || username == nil || token != nil else {
+            throw ApiClientError.noToken
+        }
+        
+        let urlRequest = try urlRequest(from: request, tokenOverride: tokenOverride)
+        // this line intentionally left commented for convenient future debugging
+        urlRequest.debug()
+        
+        // For debugging
+        if request.path.starts(with: "api/v3") { throw ApiClientError.invalidInput }
+        
+        let (data, response) = try await execute(urlRequest, tokenOverride: tokenOverride)
+        if let response = response as? HTTPURLResponse {
+            if response.statusCode >= 500 { // Error code for server being offline.
+                throw ApiClientError.response(
+                    ApiErrorResponse(error: "Instance appears to be offline.\nTry again later."),
+                    response.statusCode
+                )
+            }
+        }
+        
+        if let apiError = try? decoder.decode(ApiErrorResponse.self, from: data) {
+            // at present we have a single error model which appears to be used throughout
+            // the API, however we may way to consider adding the error model type as an
+            // associated value in the same was as the response to allow requests to define
+            // their own error models when necessary, or drop back to this as the default...
+            
+            if apiError.isNotLoggedIn {
+                throw token == nil ? ApiClientError.notLoggedIn : ApiClientError.invalidSession(self)
+            }
+            
+            let statusCode = (response as? HTTPURLResponse)?.statusCode
+            throw ApiClientError.response(apiError, statusCode)
+        }
+        
+        return try decode(Request.Response.self, from: data)
+    }
+    
+    func execute(
+        _ urlRequest: URLRequest,
+        tokenOverride: String? = nil
+    ) async throws -> (Data, URLResponse) {
+        var urlRequest: URLRequest = urlRequest // make mutable
+        let token = tokenOverride ?? token
+        
+        if urlRequest.httpMethod != "GET", // GET requests do not support body
+           !fetchedVersionSupports(.headerAuthentication),
+           let token { // only add if we have a token
+            let authBody: JSON = .init(dictionaryLiteral: ("auth", token))
+            let newBody: JSON
+            if let httpBody = urlRequest.httpBody {
+                newBody = try JSON(httpBody).merged(with: authBody)
+            } else {
+                newBody = authBody
+            }
+            
+            urlRequest.httpBody = try newBody.rawData()
+        }
+        
+        do {
+            return try await urlSession.data(for: urlRequest)
+        } catch {
+            if case URLError.cancelled = error as NSError {
+                throw ApiClientError.cancelled
+            } else {
+                throw ApiClientError.networking(error)
+            }
+        }
+    }
+    
+    func urlRequest(
+        from definition: any ApiRequest,
+        tokenOverride: String? = nil
+    ) throws -> URLRequest {
+        let token = tokenOverride ?? token
+        guard permissions != .none else { throw ApiClientError.insufficientPermissions }
+        let url = try definition.endpoint(base: baseUrl)
+        var urlRequest = mlemUrlRequest(url: url)
+        for header in definition.headers {
+            urlRequest.setValue(header.value, forHTTPHeaderField: header.key)
+        }
+        
+        if definition as? any ApiGetRequest != nil {
+            urlRequest.httpMethod = "GET"
+        } else if let postDefinition = definition as? any ApiPostRequest {
+            urlRequest.httpMethod = "POST"
+            urlRequest.httpBody = try createBodyData(for: postDefinition)
+        } else if let putDefinition = definition as? any ApiPutRequest {
+            urlRequest.httpMethod = "PUT"
+            urlRequest.httpBody = try createBodyData(for: putDefinition)
+        } else if let deleteDefinition = definition as? any ApiDeleteRequest {
+            urlRequest.httpMethod = "DELETE"
+            urlRequest.httpBody = try createBodyData(for: deleteDefinition)
+        }
+        
+        if let token, permissions == .all {
+            // TODO: 0.18 deprecation remove this
+            urlRequest.url?.append(queryItems: [.init(name: "auth", value: token)])
+            
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        
+        return urlRequest
+    }
+    
+    func createBodyData(for defintion: any ApiRequestBodyProviding) throws -> Data {
+        do {
+            let encoder = JSONEncoder()
+            let body = defintion.body ?? ""
+            return try encoder.encode(body)
+        } catch {
+            throw ApiClientError.encoding(error)
+        }
+    }
+    
+    private func decode<T: Decodable>(_ model: T.Type, from data: Data) throws -> T {
+        do {
+            return try decoder.decode(model, from: data)
+        } catch {
+            throw ApiClientError.decoding(data, error)
+        }
+    }
+}
+
+extension ApiClient: CacheIdentifiable {
+    public var cacheId: Int {
+        ApiClient.apiClientCache.getCacheId(url: baseUrl, username: username)
+    }
+}
+
+extension ApiClient: ActorIdentifiable {
+    public var actorId: ActorIdentifier { .instance(host: baseUrl.host()!) }
+}
+
+extension ApiClient: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(baseUrl)
+        hasher.combine(username)
+    }
+    
+    public static func == (lhs: ApiClient, rhs: ApiClient) -> Bool {
+        lhs === rhs
+    }
+}
+
+extension ApiClient: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        "ApiClient(\(host), authenticated: \(token != nil))"
+    }
+}
+
+public extension ApiClient {
+    struct Context {
+        let siteVersion: SiteVersion
+        let myPersonId: Int?
+        
+        public init(siteVersion: SiteVersion, myPersonId: Int?) {
+            self.siteVersion = siteVersion
+            self.myPersonId = myPersonId
+        }
+    }
+}
+
+// MARK: ApiClientCache
+
+// This needs to be declared in this file to have access to the private initializer
+
+extension ApiClient {
+    /// Cache for ApiClient--exception case because there's no ApiType and it may need to perform ApiClient bootstrapping
+    class ApiClientCache: CoreCache<ApiClient> {
+        func getCacheId(url: URL, username: String?) -> Int {
+            var hasher: Hasher = .init()
+            hasher.combine(url.removingPathComponents().appendingPathComponent("/"))
+            hasher.combine(username)
+            return hasher.finalize()
+        }
+
+        func createOrRetrieveApiClient(url: URL, username: String?) -> ApiClient {
+            let url = url.removingPathComponents().appendingPathComponent("/")
+            if let client = retrieveModel(cacheId: getCacheId(url: url, username: username)) {
+                return client
+            }
+            
+            let ret: ApiClient = .init(url: url, username: username)
+            itemCache.put(ret)
+            return ret
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
@@ -1,0 +1,86 @@
+//
+//  ApiClientError.swift
+//  Mlem
+//
+//  Created by Sjmarf on 17/02/2024.
+//
+
+import Foundation
+
+enum HTTPMethod {
+    case get
+    case post(Data)
+}
+
+public enum ApiClientError: Error {
+    case encoding(Error)
+    case networking(Error)
+    case response(ApiErrorResponse, Int?)
+    case cancelled
+    case notLoggedIn
+    case invalidSession(ApiClient)
+    case decoding(Data, Error?)
+    case insufficientPermissions
+    /// Thrown when a `false` value of `SuccessResponse` is returned
+    case unsuccessful
+    case unsupportedLemmyVersion
+    case noEntityFound
+    case invalidInput
+    case imageTooLarge
+    case mismatchingUrl
+    case mismatchingPersonId
+    case mismatchingToken
+    case noToken
+}
+
+extension ApiClientError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .insufficientPermissions:
+            return "Insufficient permissions. Check `ApiClient.permissions`"
+        case let .encoding(error):
+            return "Unable to encode: \(error)"
+        case let .networking(error):
+            return "Networking error: \(error)"
+        case let .response(errorResponse, status):
+            if let status {
+                return "Response error: \(errorResponse) with status \(status)"
+            }
+            return "Response error: \(errorResponse)"
+        case .cancelled:
+            return "Cancelled"
+        case .invalidSession:
+            return "Invalid session. There is a token applied to the ApiClient, but it has expired."
+        case .notLoggedIn:
+            return "Tried to perform an action that requires authentication on a guest ApiClient."
+        case .imageTooLarge:
+            return "Image too large"
+        case let .decoding(data, error):
+            guard let string = String(data: data, encoding: .utf8) else {
+                return localizedDescription
+            }
+            
+            if let error {
+                return "Unable to decode: \(string)\nError: \(error)"
+            }
+            
+            return "Unable to decode: \(string)"
+        case .unsuccessful:
+            return "Operation was unsuccessful."
+        case .unsupportedLemmyVersion:
+            return "This version of Lemmy doesn't support that operation."
+        case .noEntityFound:
+            return "No entity returned in response."
+        case .invalidInput:
+            return "Invalid input"
+        case .mismatchingUrl:
+            return "URL of the decoding ApiClient doesn't match the URL of the ApiClient that encoded the data"
+        case .mismatchingPersonId:
+            return "Person ID of the decoding ApiClient doesn't match the Person ID of the ApiClient that encoded the data"
+        case .mismatchingToken:
+            return "A valid token was assigned to an ApiClient for the wrong account."
+        case .noToken:
+            return "A call was made to an ApiClient that doesn't have a token yet."
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiErrorResponse.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiErrorResponse.swift
@@ -1,0 +1,49 @@
+//
+//  ApiErrorResponse.swift
+//  Mlem
+//
+//  Created by Nicholas Lawson on 06/06/2023.
+//
+
+import Foundation
+
+// TODO: 0.19 support add all the error types (https://github.com/LemmyNet/lemmy-js-client/blob/b2edfeeaffd189a51150362cc8ead03c65ee2652/src/types/LemmyErrorType.ts)
+
+public struct ApiErrorResponse: Decodable {
+    public let error: String
+}
+
+private let possibleCredentialErrors: Set<String> = [
+    "incorrect_password",
+    "password_incorrect",
+    "incorrect_login",
+    "couldnt_find_that_username_or_email"
+]
+
+private let possibleAuthenticationErrors: Set<String> = [
+    "incorrect_password",
+    "password_incorrect",
+    "incorrect_login",
+    "not_logged_in"
+]
+
+private let possible2FAErrors: Set<String> = [
+    "missing_totp_token",
+    "incorrect_totp_token"
+]
+
+private let couldntFindObjectErrors: Set<String> = [
+    "couldnt_find_person",
+    "couldnt_find_object"
+]
+
+public extension ApiErrorResponse {
+    var requires2FA: Bool { possible2FAErrors.contains(error) }
+    var isNotLoggedIn: Bool { possibleAuthenticationErrors.contains(error) }
+    var instanceIsPrivate: Bool { error == "instance_is_private" }
+    var registrationApplicationIsPending: Bool { error == "registration_application_is_pending" }
+    var emailNotVerified: Bool { error == "email_not_verified" }
+    var couldntFindObject: Bool { couldntFindObjectErrors.contains(error) }
+    var notModOrAdmin: Bool { error == "not_a_mod_or_admin" }
+    var notAdmin: Bool { error == "not_an_admin" }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiRequest.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiRequest.swift
@@ -48,9 +48,9 @@ extension ApiRequest {
 extension ApiGetRequest {
     func endpoint(base: URL) throws -> URL {
         if let parameters {
-            base
+            try base
                 .appending(path: path)
-                .appending(queryItems: try URLQueryItemEncoder.encode(parameters))
+                .appending(queryItems: URLQueryItemEncoder.encode(parameters))
         } else {
             base
                 .appending(path: path)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiRequest.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiRequest.swift
@@ -48,9 +48,9 @@ extension ApiRequest {
 extension ApiGetRequest {
     func endpoint(base: URL) throws -> URL {
         if let parameters {
-            try base
+            base
                 .appending(path: path)
-                .appending(queryItems: URLQueryItemEncoder.encode(parameters))
+                .appending(queryItems: try URLQueryItemEncoder.encode(parameters))
         } else {
             base
                 .appending(path: path)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiRequest.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiRequest.swift
@@ -1,0 +1,70 @@
+//
+//  ApiRequest.swift
+//  Mlem
+//
+//  Created by Nicholas Lawson on 06/06/2023.
+//
+
+import Foundation
+
+// MARK: - ApiRequest
+
+enum ApiRequestError: Error {
+    case authenticationRequired
+    case undefinedSession
+}
+
+protocol ApiRequest {
+    associatedtype Response: Decodable
+
+    var path: String { get }
+    var headers: [String: String] { get }
+    
+    func endpoint(base: URL) throws -> URL
+}
+
+extension ApiRequest {
+    var headers: [String: String] { defaultHeaders }
+
+    var defaultHeaders: [String: String] {
+        ["Content-Type": "application/json"]
+    }
+}
+
+// MARK: - ApiGetRequest
+
+protocol ApiGetRequest: ApiRequest {
+    associatedtype Parameters: Encodable
+    var parameters: Parameters? { get }
+}
+
+extension ApiRequest {
+    func endpoint(base: URL) throws -> URL {
+        base
+            .appending(path: path)
+    }
+}
+
+extension ApiGetRequest {
+    func endpoint(base: URL) throws -> URL {
+        if let parameters {
+            try base
+                .appending(path: path)
+                .appending(queryItems: URLQueryItemEncoder.encode(parameters))
+        } else {
+            base
+                .appending(path: path)
+        }
+    }
+}
+
+// MARK: - ApiRequestBodyProviding
+
+protocol ApiRequestBodyProviding: ApiRequest {
+    associatedtype Body: Encodable
+    var body: Body? { get }
+}
+
+protocol ApiPostRequest: ApiRequestBodyProviding {}
+protocol ApiPutRequest: ApiRequestBodyProviding {}
+protocol ApiDeleteRequest: ApiRequestBodyProviding {}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiSession.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiSession.swift
@@ -1,0 +1,44 @@
+//
+//  ApiSession.swift
+//  Mlem
+//
+//  Created by mormaer on 02/09/2023.
+//
+//
+
+import Foundation
+
+enum ApiSessionError: Error {
+    case authenticationNotPresent
+    case undefined
+}
+
+/// An enumeration representing possible session states
+enum ApiSession {
+    case authenticated(URL, String)
+    case unauthenticated(URL)
+    case undefined
+    
+    var token: String {
+        get throws {
+            guard case let .authenticated(_, token) = self else {
+                throw ApiSessionError.authenticationNotPresent
+            }
+            
+            return token
+        }
+    }
+    
+    var instanceUrl: URL {
+        get throws {
+            switch self {
+            case let .authenticated(url, _):
+                return url
+            case let .unauthenticated(url):
+                return url
+            case .undefined:
+                throw ApiSessionError.undefined
+            }
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/ApiTypeBackedCache.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/ApiTypeBackedCache.swift
@@ -1,0 +1,66 @@
+//
+//  ContentCache.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-01.
+//
+
+import Foundation
+
+/// Class providing caching behavior for models associated with API types
+class ApiTypeBackedCache<Content: CacheIdentifiable & AnyObject & ContentModel, ApiType: CacheIdentifiable>: CoreCache<Content> {
+    @MainActor func getModel(
+        api: ApiClient,
+        from apiType: ApiType,
+        // If `true`, the model will not be updated with the incoming data if the model already exists.
+        isStale: Bool = false,
+        semaphore: UInt? = nil
+    ) -> Content {
+        if let item = retrieveModel(cacheId: apiType.cacheId) {
+            if !isStale {
+                updateModel(item, with: apiType, semaphore: semaphore)
+            }
+            return item
+        }
+        
+        let newItem: Content = performModelTranslation(api: api, from: apiType)
+        itemCache.put(newItem)
+        return newItem
+    }
+    
+    @MainActor
+    func getModels(
+        api: ApiClient,
+        from apiTypes: any Sequence<ApiType>,
+        isStale: Bool = false,
+        semaphore: UInt? = nil
+    ) -> [Content] {
+        apiTypes.map { getModel(api: api, from: $0, isStale: isStale, semaphore: semaphore) }
+    }
+    
+    @MainActor
+    func getOptionalModel(
+        api: ApiClient,
+        from apiType: ApiType?,
+        isStale: Bool = false,
+        semaphore: UInt? = nil
+    ) -> Content? {
+        if let apiType {
+            return getModel(api: api, from: apiType, isStale: isStale, semaphore: semaphore)
+        }
+        return nil
+    }
+    
+    /// Initializes a new middleware model from the associated API type
+    /// - Warning: This method DOES NOT CACHE! You almost certainly want to be using `getModel` instead.
+    @MainActor
+    func performModelTranslation(api: ApiClient, from apiType: ApiType) -> Content {
+        // the name of this method is intentionally unwieldy to further discourage accidental use
+        preconditionFailure("This method must be overridden by the instantiating class: \(self)")
+    }
+    
+    @MainActor
+    func updateModel(_ item: Content, with apiType: ApiType, semaphore: UInt? = nil) {
+        preconditionFailure("This method must be overridden by the instantiating class: \(self)")
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Atomic.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Atomic.swift
@@ -1,0 +1,286 @@
+//
+//  Atomic.swift
+//  ReactiveSwift
+//
+//  Created by Justin Spahr-Summers on 2014-06-10.
+//  Copyright (c) 2014 GitHub. All rights reserved.
+//
+// See NOTICE.md for license
+
+import Foundation
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    import MachO
+#endif
+
+/// A simple, generic lock-free finite state machine.
+///
+/// - warning: `deinitialize` must be called to dispose of the consumed memory.
+private struct UnsafeAtomicState<State: RawRepresentable> where State.RawValue == Int32 {
+    typealias Transition = (expected: State, next: State)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        private let value: UnsafeMutablePointer<Int32>
+
+        /// Create a finite state machine with the specified initial state.
+        ///
+        /// - parameters:
+        ///   - initial: The desired initial state.
+        init(_ initial: State) {
+            self.value = UnsafeMutablePointer<Int32>.allocate(capacity: 1)
+            value.initialize(to: initial.rawValue)
+        }
+
+        /// Deinitialize the finite state machine.
+        func deinitialize() {
+            value.deinitialize(count: 1)
+            value.deallocate()
+        }
+
+        /// Compare the current state with the specified state.
+        ///
+        /// - parameters:
+        ///   - expected: The expected state.
+        ///
+        /// - returns: `true` if the current state matches the expected state.
+        ///            `false` otherwise.
+        func `is`(_ expected: State) -> Bool {
+            expected.rawValue == value.pointee
+        }
+
+        /// Try to transition from the expected current state to the specified next
+        /// state.
+        ///
+        /// - parameters:
+        ///   - expected: The expected state.
+        ///   - next: The state to transition to.
+        ///
+        /// - returns: `true` if the transition succeeds. `false` otherwise.
+        func tryTransition(from expected: State, to next: State) -> Bool {
+            OSAtomicCompareAndSwap32Barrier(
+                expected.rawValue,
+                next.rawValue,
+                value
+            )
+        }
+    #else
+        private let value: Atomic<Int32>
+
+        /// Create a finite state machine with the specified initial state.
+        ///
+        /// - parameters:
+        ///   - initial: The desired initial state.
+        init(_ initial: State) {
+            self.value = Atomic(initial.rawValue)
+        }
+
+        /// Deinitialize the finite state machine.
+        func deinitialize() {}
+
+        /// Compare the current state with the specified state.
+        ///
+        /// - parameters:
+        ///   - expected: The expected state.
+        ///
+        /// - returns: `true` if the current state matches the expected state.
+        ///            `false` otherwise.
+        func `is`(_ expected: State) -> Bool {
+            value.value == expected.rawValue
+        }
+
+        /// Try to transition from the expected current state to the specified next
+        /// state.
+        ///
+        /// - parameters:
+        ///   - expected: The expected state.
+        ///
+        /// - returns: `true` if the transition succeeds. `false` otherwise.
+        func tryTransition(from expected: State, to next: State) -> Bool {
+            value.modify { value in
+                if value == expected.rawValue {
+                    value = next.rawValue
+                    return true
+                }
+                return false
+            }
+        }
+    #endif
+}
+
+/// `Lock` exposes `os_unfair_lock` on supported platforms, with pthread mutex as the
+/// fallback.
+private class Lock {
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        @available(iOS 10.0, *)
+        @available(macOS 10.12, *)
+        @available(tvOS 10.0, *)
+        @available(watchOS 3.0, *)
+        final class UnfairLock: Lock {
+            private let _lock: os_unfair_lock_t
+
+            override init() {
+                self._lock = .allocate(capacity: 1)
+                _lock.initialize(to: os_unfair_lock())
+                super.init()
+            }
+
+            override func lock() {
+                os_unfair_lock_lock(_lock)
+            }
+
+            override func unlock() {
+                os_unfair_lock_unlock(_lock)
+            }
+
+            override func `try`() -> Bool {
+                os_unfair_lock_trylock(_lock)
+            }
+
+            deinit {
+                _lock.deinitialize(count: 1)
+                _lock.deallocate()
+            }
+        }
+    #endif
+
+    final class PthreadLock: Lock {
+        private let _lock: UnsafeMutablePointer<pthread_mutex_t>
+
+        init(recursive: Bool = false) {
+            self._lock = .allocate(capacity: 1)
+            _lock.initialize(to: pthread_mutex_t())
+
+            let attr = UnsafeMutablePointer<pthread_mutexattr_t>.allocate(capacity: 1)
+            attr.initialize(to: pthread_mutexattr_t())
+            pthread_mutexattr_init(attr)
+
+            defer {
+                pthread_mutexattr_destroy(attr)
+                attr.deinitialize(count: 1)
+                attr.deallocate()
+            }
+
+            pthread_mutexattr_settype(attr, Int32(recursive ? PTHREAD_MUTEX_RECURSIVE : PTHREAD_MUTEX_ERRORCHECK))
+
+            let status = pthread_mutex_init(_lock, attr)
+            assert(status == 0, "Unexpected pthread mutex error code: \(status)")
+
+            super.init()
+        }
+
+        override func lock() {
+            let status = pthread_mutex_lock(_lock)
+            assert(status == 0, "Unexpected pthread mutex error code: \(status)")
+        }
+
+        override func unlock() {
+            let status = pthread_mutex_unlock(_lock)
+            assert(status == 0, "Unexpected pthread mutex error code: \(status)")
+        }
+
+        override func `try`() -> Bool {
+            let status = pthread_mutex_trylock(_lock)
+            switch status {
+            case 0:
+                return true
+            case EBUSY, EAGAIN:
+                return false
+            default:
+                assertionFailure("Unexpected pthread mutex error code: \(status)")
+                return false
+            }
+        }
+
+        deinit {
+            let status = pthread_mutex_destroy(_lock)
+            assert(status == 0, "Unexpected pthread mutex error code: \(status)")
+
+            _lock.deinitialize(count: 1)
+            _lock.deallocate()
+        }
+    }
+
+    static func make() -> Lock {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+            if #available(*, iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0) {
+                return UnfairLock()
+            }
+        #endif
+
+        return PthreadLock()
+    }
+
+    private init() {}
+
+    func lock() { fatalError() }
+    func unlock() { fatalError() }
+    func `try`() -> Bool { fatalError() }
+}
+
+/// An atomic variable.
+public final class Atomic<Value> {
+    private let lock: Lock
+    private var _value: Value
+
+    /// Atomically get or set the value of the variable.
+    public var value: Value {
+        get {
+            withValue { $0 }
+        }
+
+        set(newValue) {
+            swap(newValue)
+        }
+    }
+
+    /// Initialize the variable with the given initial value.
+    ///
+    /// - parameters:
+    ///   - value: Initial value for `self`.
+    public init(_ value: Value) {
+        self._value = value
+        self.lock = Lock.make()
+    }
+
+    /// Atomically modifies the variable.
+    ///
+    /// - parameters:
+    ///   - action: A closure that takes the current value.
+    ///
+    /// - returns: The result of the action.
+    @discardableResult
+    public func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return try action(&_value)
+    }
+
+    /// Atomically perform an arbitrary action using the current value of the
+    /// variable.
+    ///
+    /// - parameters:
+    ///   - action: A closure that takes the current value.
+    ///
+    /// - returns: The result of the action.
+    @discardableResult
+    public func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return try action(_value)
+    }
+
+    /// Atomically replace the contents of the variable.
+    ///
+    /// - parameters:
+    ///   - newValue: A new value for the variable.
+    ///
+    /// - returns: The old value.
+    @discardableResult
+    public func swap(_ newValue: Value) -> Value {
+        modify { (value: inout Value) in
+            let oldValue = value
+            value = newValue
+            return oldValue
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/CommentCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/CommentCaches.swift
@@ -1,0 +1,68 @@
+//
+//  CommentCaches.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+
+class Comment1Cache: ApiTypeBackedCache<Comment1, ApiComment> {
+    override func performModelTranslation(api: ApiClient, from apiType: ApiComment) -> Comment1 {
+        .init(
+            api: api,
+            actorId: apiType.actorId,
+            id: apiType.id,
+            content: apiType.content,
+            removed: apiType.removed,
+            created: apiType.published,
+            updated: apiType.updated,
+            deleted: apiType.deleted,
+            creatorId: apiType.creatorId,
+            postId: apiType.postId,
+            parentCommentIds: Array(apiType.path.split(separator: ".").compactMap { Int($0) }.dropFirst().dropLast()),
+            distinguished: apiType.distinguished,
+            languageId: apiType.languageId
+        )
+    }
+    
+    override func updateModel(_ item: Comment1, with apiType: ApiComment, semaphore: UInt? = nil) {
+        item.update(with: apiType)
+    }
+}
+
+class Comment2Cache: ApiTypeBackedCache<Comment2, ApiCommentView> {
+    override func performModelTranslation(api: ApiClient, from apiType: ApiCommentView) -> Comment2 {
+        let votesManager: StateManager<VotesModel>
+        let savedManager: StateManager<Bool>
+        
+        if let comment = api.caches.reply2.retrieveModel(commentId: apiType.id) {
+            votesManager = comment.votesManager
+            savedManager = comment.savedManager
+        } else {
+            votesManager = .init(wrappedValue: .init(
+                from: apiType.counts,
+                myVote: ScoringOperation.guaranteedInit(from: apiType.myVote)
+            ))
+            savedManager = .init(wrappedValue: apiType.saved ?? false)
+        }
+        
+        return .init(
+            api: api,
+            comment1: api.caches.comment1.getModel(api: api, from: apiType.comment),
+            creator: api.caches.person1.getModel(api: api, from: apiType.creator),
+            post: api.caches.post1.getModel(api: api, from: apiType.post),
+            community: api.caches.community1.getModel(api: api, from: apiType.community),
+            votesManager: votesManager,
+            savedManager: savedManager,
+            creatorIsModerator: apiType.creatorIsModerator,
+            creatorIsAdmin: apiType.creatorIsAdmin,
+            bannedFromCommunity: apiType.creatorBannedFromCommunity,
+            commentCount: apiType.counts.childCount
+        )
+    }
+    
+    override func updateModel(_ item: Comment2, with apiType: ApiCommentView, semaphore: UInt? = nil) {
+        item.update(with: apiType, semaphore: semaphore)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/CommunityCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/CommunityCaches.swift
@@ -1,0 +1,82 @@
+//
+//  CommunityCaches.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-01.
+//
+
+import Foundation
+
+class Community1Cache: ApiTypeBackedCache<Community1, ApiCommunity> {
+    @MainActor
+    override func performModelTranslation(api: ApiClient, from apiType: ApiCommunity) -> Community1 {
+        .init(
+            api: api,
+            actorId: apiType.actorId,
+            id: apiType.id,
+            name: apiType.name,
+            created: apiType.published,
+            instanceId: apiType.instanceId,
+            updated: apiType.updated,
+            displayName: apiType.title,
+            description: apiType.description,
+            removed: apiType.removed,
+            deleted: apiType.deleted,
+            nsfw: apiType.nsfw,
+            avatar: apiType.icon,
+            banner: apiType.banner,
+            hidden: apiType.hidden,
+            onlyModeratorsCanPost: apiType.postingRestrictedToMods,
+            blocked: nil,
+            visibility: apiType.visibility
+        )
+    }
+    
+    @MainActor
+    override func updateModel(_ item: Community1, with apiType: ApiCommunity, semaphore: UInt? = nil) {
+        item.update(with: apiType)
+    }
+}
+
+class Community2Cache: ApiTypeBackedCache<Community2, ApiCommunityView> {
+    @MainActor
+    override func performModelTranslation(api: ApiClient, from apiType: ApiCommunityView) -> Community2 {
+        .init(
+            api: api,
+            community1: api.caches.community1.getModel(api: api, from: apiType.community),
+            subscription: .init(from: apiType.counts, subscribedType: apiType.subscribed),
+            postCount: apiType.counts.posts,
+            commentCount: apiType.counts.comments,
+            activeUserCount: .init(
+                sixMonths: apiType.counts.usersActiveHalfYear,
+                month: apiType.counts.usersActiveMonth,
+                week: apiType.counts.usersActiveWeek,
+                day: apiType.counts.usersActiveDay
+            ),
+            bannedFromCommunity: apiType.bannedFromCommunity
+        )
+    }
+    
+    @MainActor
+    override func updateModel(_ item: Community2, with apiType: ApiCommunityView, semaphore: UInt? = nil) {
+        item.update(with: apiType, semaphore: semaphore)
+    }
+}
+
+class Community3Cache: ApiTypeBackedCache<Community3, ApiGetCommunityResponse> {
+    @MainActor
+    override func performModelTranslation(api: ApiClient, from apiType: ApiGetCommunityResponse) -> Community3 {
+        .init(
+            api: api,
+            community2: api.caches.community2.getModel(api: api, from: apiType.communityView),
+            instance: api.caches.instance1.getOptionalModel(api: api, from: apiType.site),
+            moderators: apiType.moderators.map { api.caches.person1.getModel(api: api, from: $0.moderator) },
+            discussionLanguages: apiType.discussionLanguages
+        )
+    }
+    
+    @MainActor
+    override func updateModel(_ item: Community3, with apiType: ApiGetCommunityResponse, semaphore: UInt? = nil) {
+        item.update(with: apiType, semaphore: semaphore)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/ImageUploadCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/ImageUploadCaches.swift
@@ -1,0 +1,23 @@
+//
+//  File.swift
+//
+//
+//  Created by Sjmarf on 26/08/2024.
+//
+
+import Foundation
+
+class ImageUpload1Cache: CoreCache<ImageUpload1> {
+    func getModel(api: ApiClient, from apiType: any ImageUpload1Backer, semaphore: UInt? = nil) -> ImageUpload1 {
+        if let item = retrieveModel(cacheId: apiType.cacheId) { return item }
+        
+        let newItem: ImageUpload1 = .init(
+            api: api,
+            alias: apiType.alias,
+            deleteToken: apiType.deleteToken
+        )
+
+        itemCache.put(newItem)
+        return newItem
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/InstanceCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/InstanceCaches.swift
@@ -1,0 +1,137 @@
+//
+//  InstanceCaches.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-01.
+//
+
+import Foundation
+
+class Instance1Cache: CoreCache<Instance1> {
+    public var instanceIdCache: ItemCache = .init()
+    
+    @MainActor
+    func getModel(api: ApiClient, from apiType: ApiSite, semaphore: UInt? = nil) -> Instance1 {
+        if let item = retrieveModel(cacheId: apiType.cacheId) {
+            item.update(with: apiType)
+            return item
+        }
+    
+        let newItem: Instance1 = .init(
+            api: api,
+            actorId: apiType.actorId,
+            id: apiType.id,
+            instanceId: apiType.instanceId,
+            created: apiType.published,
+            updated: apiType.updated,
+            publicKey: apiType.publicKey,
+            displayName: apiType.name,
+            description: apiType.sidebar,
+            shortDescription: apiType.description,
+            avatar: apiType.icon,
+            banner: apiType.banner,
+            lastRefresh: apiType.lastRefreshedAt,
+            contentWarning: apiType.contentWarning,
+            blocked: nil
+        )
+        
+        itemCache.put(newItem)
+        instanceIdCache.put(newItem, overrideCacheId: newItem.instanceId)
+        return newItem
+    }
+    
+    @MainActor
+    func getModels(api: ApiClient, from apiTypes: [ApiSite], semaphore: UInt? = nil) -> [Instance1] {
+        apiTypes.map { getModel(api: api, from: $0, semaphore: semaphore) }
+    }
+    
+    /// Get an instance with the given `instanceId` - this is different from the `id` of the instance.
+    public func retrieveModel(instanceId: Int) -> Instance1? {
+        instanceIdCache.get(instanceId)
+    }
+    
+    override func clean() {
+        Task {
+            await itemCache.clean()
+            await instanceIdCache.clean()
+        }
+    }
+    
+    /// Convenience method for getting an optional site
+    @MainActor
+    func getOptionalModel(api: ApiClient, from apiType: ApiSite?) -> Instance1? {
+        if let apiType {
+            return getModel(api: api, from: apiType)
+        }
+        return nil
+    }
+}
+
+class Instance2Cache: ApiTypeBackedCache<Instance2, ApiSiteView> {
+    @MainActor
+    override func performModelTranslation(api: ApiClient, from apiType: ApiSiteView) -> Instance2 {
+        .init(
+            api: api,
+            instance1: api.caches.instance1.getModel(api: api, from: apiType.site),
+            setup: apiType.localSite.siteSetup,
+            downvotesEnabled: apiType.localSite.enableDownvotes ?? true, // TODO: 0.20 support: we shouldn't be coalescing to true here
+            nsfwContentEnabled: apiType.localSite.enableNsfw ?? false, // TODO: 0.20 support: we shouldn't be coalescing to false here
+            communityCreationRestrictedToAdmins: apiType.localSite.communityCreationAdminOnly,
+            emailVerificationRequired: apiType.localSite.requireEmailVerification,
+            applicationQuestion: apiType.localSite.applicationQuestion,
+            isPrivate: apiType.localSite.privateInstance,
+            defaultTheme: apiType.localSite.defaultTheme,
+            defaultFeed: apiType.localSite.defaultPostListingType,
+            legalInformation: apiType.localSite.legalInformation,
+            hideModlogNames: apiType.localSite.hideModlogModNames,
+            emailApplicationsToAdmins: apiType.localSite.applicationEmailAdmins,
+            emailReportsToAdmins: apiType.localSite.reportsEmailAdmins,
+            slurFilterRegex: apiType.localSite.slurFilterRegex,
+            actorNameMaxLength: apiType.localSite.actorNameMaxLength,
+            federationEnabled: apiType.localSite.federationEnabled,
+            captchaEnabled: apiType.localSite.captchaEnabled,
+            captchaDifficulty: .init(rawValue: apiType.localSite.captchaDifficulty),
+            registrationMode: apiType.localSite.registrationMode,
+            federationSignedFetch: apiType.localSite.federationSignedFetch,
+            defaultPostListingMode: apiType.localSite.defaultPostListingMode,
+            defaultSortType: apiType.localSite.defaultSortType,
+            userCount: apiType.counts.users,
+            postCount: apiType.counts.posts,
+            commentCount: apiType.counts.comments,
+            communityCount: apiType.counts.communities,
+            activeUserCount: .init(
+                sixMonths: apiType.counts.usersActiveHalfYear,
+                month: apiType.counts.usersActiveMonth,
+                week: apiType.counts.usersActiveWeek,
+                day: apiType.counts.usersActiveDay
+            )
+        )
+    }
+    
+    @MainActor
+    override func updateModel(_ item: Instance2, with apiType: ApiSiteView, semaphore: UInt? = nil) {
+        item.update(with: apiType)
+    }
+}
+
+class Instance3Cache: ApiTypeBackedCache<Instance3, ApiGetSiteResponse> {
+    @MainActor
+    override func performModelTranslation(api: ApiClient, from apiType: ApiGetSiteResponse) -> Instance3 {
+        .init(
+            api: api,
+            instance2: api.caches.instance2.getModel(api: api, from: apiType.siteView),
+            version: .init(apiType.version),
+            allLanguages: apiType.allLanguages.compactMap { .init($0) },
+            allowedLanguageIds: Set(apiType.discussionLanguages).subtracting([0]),
+            taglines: apiType.taglines ?? [apiType.tagline].compactMap { $0 },
+            customEmojis: apiType.customEmojis ?? [], // TODO: 0.20 support: we shouldn't be coalescing to [] here
+            blockedUrls: apiType.blockedUrls,
+            administrators: apiType.admins.map { api.caches.person2.getModel(api: api, from: $0) }
+        )
+    }
+    
+    @MainActor
+    override func updateModel(_ item: Instance3, with apiType: ApiGetSiteResponse, semaphore: UInt? = nil) {
+        item.update(with: apiType)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/MessageCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/MessageCaches.swift
@@ -1,0 +1,83 @@
+//
+//  MessageCaches.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+class Message1Cache: CoreCache<Message1> {
+    @MainActor
+    func getModel(
+        api: ApiClient,
+        from apiType: ApiPrivateMessage,
+        myPersonId: Int,
+        semaphore: UInt? = nil
+    ) -> Message1 {
+        if let item = retrieveModel(cacheId: apiType.cacheId) {
+            item.update(with: apiType, semaphore: semaphore)
+            return item
+        }
+        
+        let newItem: Message1 = .init(
+            api: api,
+            actorId: apiType.actorId,
+            id: apiType.id,
+            creatorId: apiType.creatorId,
+            recipientId: apiType.recipientId,
+            isOwnMessage: myPersonId == apiType.creatorId,
+            content: apiType.content,
+            deleted: apiType.deleted,
+            created: apiType.published,
+            updated: apiType.updated,
+            read: apiType.read
+        )
+        itemCache.put(newItem)
+        return newItem
+    }
+    
+    @MainActor
+    func getModels(
+        api: ApiClient,
+        from apiTypes: [ApiPrivateMessage],
+        myPersonId: Int,
+        semaphore: UInt? = nil
+    ) -> [Message1] {
+        apiTypes.map { getModel(api: api, from: $0, myPersonId: myPersonId, semaphore: semaphore) }
+    }
+}
+
+class Message2Cache: CoreCache<Message2> {
+    @MainActor
+    func getModel(
+        api: ApiClient,
+        from apiType: ApiPrivateMessageView,
+        myPersonId: Int,
+        semaphore: UInt? = nil
+    ) -> Message2 {
+        if let item = retrieveModel(cacheId: apiType.cacheId) {
+            item.update(with: apiType, semaphore: semaphore)
+            return item
+        }
+        
+        let newItem: Message2 = .init(
+            api: api,
+            message1: api.caches.message1.getModel(api: api, from: apiType.privateMessage, myPersonId: myPersonId),
+            creator: api.caches.person1.getModel(api: api, from: apiType.creator),
+            recipient: api.caches.person1.getModel(api: api, from: apiType.recipient)
+        )
+        itemCache.put(newItem)
+        return newItem
+    }
+    
+    @MainActor
+    func getModels(
+        api: ApiClient,
+        from apiTypes: [ApiPrivateMessageView],
+        myPersonId: Int,
+        semaphore: UInt? = nil
+    ) -> [Message2] {
+        apiTypes.map { getModel(api: api, from: $0, myPersonId: myPersonId, semaphore: semaphore) }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/PersonCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/PersonCaches.swift
@@ -1,0 +1,151 @@
+//
+//  PersonCaches.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-01.
+//
+
+import Foundation
+
+class Person1Cache: ApiTypeBackedCache<Person1, ApiPerson> {
+    @MainActor
+    override func performModelTranslation(api: ApiClient, from apiType: ApiPerson) -> Person1 {
+        let instanceBan: InstanceBanType
+        if apiType.banned {
+            if let expires = apiType.banExpires {
+                instanceBan = .temporarilyBanned(expires: expires)
+            } else {
+                instanceBan = .permanentlyBanned
+            }
+        } else {
+            instanceBan = .notBanned
+        }
+
+        return .init(
+            api: api,
+            actorId: apiType.actorId,
+            id: apiType.id,
+            name: apiType.name,
+            created: apiType.published,
+            instanceId: apiType.instanceId,
+            updated: apiType.updated,
+            displayName: apiType.displayName ?? apiType.name,
+            description: apiType.bio,
+            matrixId: apiType.matrixUserId,
+            avatar: apiType.avatar,
+            banner: apiType.banner,
+            deleted: apiType.deleted,
+            isBot: apiType.botAccount,
+            instanceBan: instanceBan,
+            blocked: nil
+        )
+    }
+    
+    @MainActor
+    override func updateModel(_ item: Person1, with apiType: ApiPerson, semaphore: UInt? = nil) {
+        item.update(with: apiType, semaphore: semaphore)
+    }
+}
+
+// Person2 can be created from any Person2ApiBacker, so we can't use ApiTypeBackedCache
+class Person2Cache: CoreCache<Person2> {
+    @MainActor
+    func getModel(
+        api: ApiClient,
+        from apiType: any Person2ApiBacker,
+        isStale: Bool = false,
+        semaphore: UInt? = nil
+    ) -> Person2 {
+        if let item = retrieveModel(cacheId: apiType.cacheId) {
+            if !isStale {
+                item.update(with: apiType, semaphore: semaphore)
+            }
+            return item
+        }
+        
+        let newItem: Person2 = .init(
+            api: api,
+            person1: api.caches.person1.getModel(api: api, from: apiType.person),
+            postCount: apiType.counts.postCount,
+            commentCount: apiType.counts.commentCount,
+            isAdmin: apiType.admin
+        )
+        itemCache.put(newItem)
+        return newItem
+    }
+    
+    @MainActor
+    func getModels(
+        api: ApiClient,
+        from apiTypes: [any Person2ApiBacker],
+        isStale: Bool = false,
+        semaphore: UInt? = nil
+    ) -> [Person2] {
+        apiTypes.map { getModel(api: api, from: $0, isStale: isStale, semaphore: semaphore) }
+    }
+}
+
+// Person3 can be created from any Person3ApiBacker, so can't use ApiTypeBackedCache
+class Person3Cache: CoreCache<Person3> {
+    @MainActor
+    func getModel(api: ApiClient, from apiType: any Person3ApiBacker) -> Person3 {
+        let moderatedCommunities = apiType.moderates.map { moderatedCommunity in
+            api.caches.community1.getModel(api: api, from: moderatedCommunity.community)
+        }
+        
+        if let item = retrieveModel(cacheId: apiType.cacheId) {
+            item.update(moderatedCommunities: moderatedCommunities, person2ApiBacker: apiType.person2ApiBacker)
+            return item
+        }
+        
+        let newItem: Person3 = .init(
+            api: api,
+            person2: api.caches.person2.getModel(api: api, from: apiType.person2ApiBacker),
+            instance: api.caches.instance1.getOptionalModel(api: api, from: apiType.site),
+            moderatedCommunities: moderatedCommunities
+        )
+        itemCache.put(newItem)
+        return newItem
+    }
+}
+
+class Person4Cache: ApiTypeBackedCache<Person4, ApiMyUserInfo> {
+    @MainActor
+    override func performModelTranslation(api: ApiClient, from apiType: ApiMyUserInfo) -> Person4 {
+        let user = apiType.localUserView.localUser
+        return .init(
+            api: api,
+            person3: api.caches.person3.getModel(api: api, from: apiType),
+            voteDisplayMode: apiType.localUserView.localUserVoteDisplayMode,
+            email: user.email,
+            showNsfw: user.showNsfw,
+            theme: user.theme,
+            defaultSortType: user.defaultSortType ?? .hot, // TODO: 0.20 support: we shouldn't be coalescing to .hot here
+            defaultListingType: user.defaultListingType,
+            interfaceLanguage: user.interfaceLanguage,
+            showAvatars: user.showAvatars,
+            sendNotificationsToEmail: user.sendNotificationsToEmail,
+            showScores: user.showScores ?? true, // TODO: 0.20 support: we shouldn't be coalescing to true here
+            showBotAccounts: user.showBotAccounts,
+            showReadPosts: user.showReadPosts,
+            discussionLanguageIds: .init(apiType.discussionLanguages.filter { $0 != 0 }),
+            showNewPostNotifs: user.showNewPostNotifs,
+            emailVerified: user.emailVerified,
+            acceptedApplication: user.acceptedApplication,
+            openLinksInNewTab: user.openLinksInNewTab,
+            blurNsfw: user.blurNsfw,
+            autoExpandImages: user.autoExpand,
+            infiniteScrollEnabled: user.infiniteScrollEnabled,
+            postListingMode: user.postListingMode,
+            totp2faEnabled: user.totp2faEnabled,
+            enableKeyboardNavigation: user.enableKeyboardNavigation,
+            enableAnimatedImages: user.enableAnimatedImages,
+            collapseBotComments: user.collapseBotComments
+        )
+    }
+    
+    @MainActor
+    override func updateModel(_ item: Person4, with apiType: ApiMyUserInfo, semaphore: UInt? = nil) {
+        item.update(with: apiType, semaphore: semaphore)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/PersonVoteCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/PersonVoteCaches.swift
@@ -1,0 +1,61 @@
+//
+//  PersonVoteCaches.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-18.
+//
+
+import Foundation
+
+class PersonVoteCache: CoreCache<PersonVote> {
+    @MainActor
+    func getModel(
+        api: ApiClient,
+        from apiType: ApiVoteView,
+        target: PersonVote.Target,
+        communityId: Int,
+        semaphore: UInt? = nil
+    ) -> PersonVote {
+        if let item = retrieveModel(cacheId: getCacheId(target: target, creatorId: apiType.creator.id)) {
+            item.update(with: apiType, semaphore: semaphore)
+            return item
+        }
+        
+        let newItem: PersonVote = .init(
+            api: api,
+            target: target,
+            communityId: communityId,
+            creator: api.caches.person1.getModel(api: api, from: apiType.creator),
+            vote: .init(rawValue: apiType.score) ?? .none,
+            creatorBannedFromCommunity: apiType.creatorBannedFromCommunity
+        )
+        itemCache.put(newItem)
+        return newItem
+    }
+    
+    @MainActor
+    func getModels(
+        api: ApiClient,
+        from apiTypes: [ApiVoteView],
+        target: PersonVote.Target,
+        communityId: Int,
+        semaphore: UInt? = nil
+    ) -> [PersonVote] {
+        apiTypes.map {
+            getModel(
+                api: api,
+                from: $0,
+                target: target,
+                communityId: communityId,
+                semaphore: semaphore
+            )
+        }
+    }
+    
+    private func getCacheId(target: PersonVote.Target, creatorId: Int) -> Int {
+        var hasher = Hasher()
+        hasher.combine(target)
+        hasher.combine(creatorId)
+        return hasher.finalize()
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/PostCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/PostCaches.swift
@@ -1,0 +1,79 @@
+//
+//  PostCaches.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-01.
+//
+
+import Foundation
+
+class Post1Cache: ApiTypeBackedCache<Post1, ApiPost> {
+    override func performModelTranslation(api: ApiClient, from apiType: ApiPost) -> Post1 {
+        .init(
+            api: api,
+            actorId: apiType.actorId,
+            id: apiType.id,
+            creatorId: apiType.creatorId,
+            communityId: apiType.communityId,
+            created: apiType.published,
+            title: apiType.name,
+            content: apiType.body,
+            linkUrl: apiType.linkUrl,
+            deleted: apiType.deleted,
+            embed: apiType.embed,
+            pinnedCommunity: apiType.featuredCommunity,
+            pinnedInstance: apiType.featuredLocal,
+            locked: apiType.locked,
+            nsfw: apiType.nsfw,
+            removed: apiType.removed,
+            thumbnailUrl: apiType.thumbnailImageUrl,
+            updated: apiType.updated,
+            languageId: apiType.languageId,
+            altText: apiType.altText
+        )
+    }
+    
+    override func updateModel(_ item: Post1, with apiType: ApiPost, semaphore: UInt? = nil) {
+        item.update(with: apiType, semaphore: semaphore)
+    }
+}
+
+class Post2Cache: ApiTypeBackedCache<Post2, ApiPostView> {
+    override func performModelTranslation(api: ApiClient, from apiType: ApiPostView) -> Post2 {
+        .init(
+            api: api,
+            post1: api.caches.post1.getModel(api: api, from: apiType.post),
+            creator: api.caches.person1.getModel(api: api, from: apiType.creator),
+            community: api.caches.community1.getModel(api: api, from: apiType.community),
+            votes: .init(from: apiType.counts, myVote: ScoringOperation.guaranteedInit(from: apiType.myVote)),
+            creatorIsModerator: apiType.creatorIsModerator,
+            creatorIsAdmin: apiType.creatorIsAdmin,
+            bannedFromCommunity: apiType.creatorBannedFromCommunity,
+            commentCount: apiType.counts.comments,
+            unreadCommentCount: apiType.unreadComments,
+            saved: apiType.saved ?? false,
+            read: apiType.read,
+            hidden: apiType.hidden ?? false
+        )
+    }
+    
+    override func updateModel(_ item: Post2, with apiType: ApiPostView, semaphore: UInt? = nil) {
+        item.update(with: apiType, semaphore: semaphore)
+    }
+}
+
+class Post3Cache: ApiTypeBackedCache<Post3, ApiGetPostResponse> {
+    override func performModelTranslation(api: ApiClient, from apiType: ApiGetPostResponse) -> Post3 {
+        .init(
+            api: api,
+            post2: api.caches.post2.getModel(api: api, from: apiType.postView),
+            community: api.caches.community2.getModel(api: api, from: apiType.communityView),
+            communityModerators: apiType.moderators?.map { api.caches.person1.getModel(api: api, from: $0.moderator) } ?? [],
+            crossPosts: apiType.crossPosts.map { api.caches.post2.getModel(api: api, from: $0) }
+        )
+    }
+    
+    override func updateModel(_ item: Post3, with apiType: ApiGetPostResponse, semaphore: UInt? = nil) {
+        item.update(with: apiType, semaphore: semaphore)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/RegistrationApplicationCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/RegistrationApplicationCaches.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-01-12.
-//
+//  
 
 import Foundation
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/RegistrationApplicationCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/RegistrationApplicationCaches.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-01-12.
-//  
+//
 
 import Foundation
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/RegistrationApplicationCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/RegistrationApplicationCaches.swift
@@ -1,0 +1,47 @@
+//
+//  RegistrationApplicationCaches.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-12.
+//
+
+import Foundation
+
+class RegistrationApplicationCache: ApiTypeBackedCache<RegistrationApplication, ApiRegistrationApplicationView> {
+    @MainActor
+    override func performModelTranslation(
+        api: ApiClient,
+        from apiType: ApiRegistrationApplicationView
+    ) -> RegistrationApplication {
+        let resolution: RegistrationApplication.ResolutionState
+        if apiType.creatorLocalUser.acceptedApplication {
+            resolution = .approved
+        } else if apiType.admin != nil {
+            resolution = .denied(reason: apiType.registrationApplication.denyReason)
+        } else {
+            resolution = .unresolved
+        }
+        
+        return .init(
+            api: api,
+            id: apiType.registrationApplication.id,
+            questionResponse: apiType.registrationApplication.answer,
+            creator: api.caches.person1.getModel(api: api, from: apiType.creator),
+            resolver: api.caches.person1.getOptionalModel(api: api, from: apiType.admin),
+            email: apiType.creatorLocalUser.email,
+            emailVerified: apiType.creatorLocalUser.emailVerified,
+            showNsfw: apiType.creatorLocalUser.showNsfw,
+            created: apiType.registrationApplication.published,
+            resolution: resolution
+        )
+    }
+    
+    @MainActor
+    override func updateModel(
+        _ item: RegistrationApplication,
+        with apiType: ApiRegistrationApplicationView,
+        semaphore: UInt? = nil
+    ) {
+        item.update(with: apiType, semaphore: semaphore)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/ReplyCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/ReplyCaches.swift
@@ -1,0 +1,94 @@
+//
+//  ReplyCaches.swift
+//
+//
+//  Created by Sjmarf on 04/07/2024.
+//
+
+import Foundation
+
+class Reply1Cache: CoreCache<Reply1> {
+    @MainActor
+    func getModel(api: ApiClient, from apiType: any Reply1ApiBacker, semaphore: UInt? = nil) -> Reply1 {
+        if let item = retrieveModel(cacheId: apiType.cacheId) {
+            item.update(with: apiType)
+            return item
+        }
+        
+        let newItem: Reply1 = .init(
+            api: api,
+            id: apiType.id,
+            recipientId: apiType.recipientId,
+            commentId: apiType.commentId,
+            created: apiType.published,
+            read: apiType.read,
+            isMention: apiType is ApiPersonMention
+        )
+
+        itemCache.put(newItem)
+        return newItem
+    }
+}
+
+class Reply2Cache: CoreCache<Reply2> {
+    public var commentIdItemCache: ItemCache = .init()
+    
+    @MainActor
+    func getModel(api: ApiClient, from apiType: any Reply2ApiBacker, semaphore: UInt? = nil) -> Reply2 {
+        if let item = retrieveModel(cacheId: apiType.cacheId) {
+            item.update(with: apiType, semaphore: semaphore)
+            return item
+        }
+        
+        let votesManager: StateManager<VotesModel>
+        let savedManager: StateManager<Bool>
+        
+        if let comment = api.caches.comment2.retrieveModel(cacheId: apiType.comment.id) {
+            votesManager = comment.votesManager
+            savedManager = comment.savedManager
+        } else {
+            votesManager = .init(wrappedValue: .init(
+                from: apiType.counts,
+                myVote: ScoringOperation.guaranteedInit(from: apiType.myVote)
+            ))
+            savedManager = .init(wrappedValue: apiType.resolvedSaved)
+        }
+        
+        let newItem: Reply2 = .init(
+            api: api,
+            reply1: api.caches.reply1.getModel(api: api, from: apiType.reply),
+            comment: api.caches.comment1.getModel(api: api, from: apiType.comment),
+            creator: api.caches.person1.getModel(api: api, from: apiType.creator),
+            post: api.caches.post1.getModel(api: api, from: apiType.post),
+            community: api.caches.community1.getModel(api: api, from: apiType.community),
+            recipient: api.caches.person1.getModel(api: api, from: apiType.recipient),
+            subscribed: apiType.subscribed.isSubscribed,
+            commentCount: apiType.counts.childCount,
+            creatorIsModerator: apiType.creatorIsModerator,
+            creatorIsAdmin: apiType.creatorIsAdmin,
+            bannedFromCommunity: apiType.creatorBannedFromCommunity,
+            votesManager: votesManager,
+            savedManager: savedManager
+        )
+
+        itemCache.put(newItem)
+        commentIdItemCache.put(newItem, overrideCacheId: newItem.commentId)
+        return newItem
+    }
+    
+    public func retrieveModel(commentId: Int) -> Reply2? {
+        commentIdItemCache.get(commentId)
+    }
+    
+    @MainActor
+    func getModels(api: ApiClient, from apiTypes: [any Reply2ApiBacker], semaphore: UInt? = nil) -> [Reply2] {
+        apiTypes.map { getModel(api: api, from: $0, semaphore: semaphore) }
+    }
+    
+    override func clean() {
+        Task {
+            await itemCache.clean()
+            await commentIdItemCache.clean()
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/ReportCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/ReportCaches.swift
@@ -1,0 +1,48 @@
+//
+//  ReportCaches.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-16.
+//
+
+import Foundation
+
+// Report can be created from any ReportApiBacker, so we can't use ApiTypeBackedCache
+class ReportCache: CoreCache<Report> {
+    @MainActor
+    func getModel(
+        api: ApiClient,
+        from apiType: any ReportApiBacker,
+        myPersonId: Int,
+        semaphore: UInt? = nil
+    ) -> Report {
+        if let item = retrieveModel(cacheId: apiType.cacheId) {
+            item.update(with: apiType, semaphore: semaphore)
+            return item
+        }
+        
+        let newItem: Report = .init(
+            api: api,
+            id: apiType.id,
+            creator: api.caches.person1.getModel(api: api, from: apiType.creator, semaphore: semaphore),
+            resolver: api.caches.person1.getOptionalModel(api: api, from: apiType.resolver, semaphore: semaphore),
+            target: apiType.createTarget(api: api, myPersonId: myPersonId),
+            resolved: apiType.resolved,
+            reason: apiType.reason,
+            created: apiType.published,
+            updated: apiType.updated
+        )
+        itemCache.put(newItem)
+        return newItem
+    }
+    
+    @MainActor
+    func getModels(
+        api: ApiClient,
+        from apiTypes: [any ReportApiBacker],
+        myPersonId: Int,
+        semaphore: UInt? = nil
+    ) -> [Report] {
+        apiTypes.map { getModel(api: api, from: $0, myPersonId: myPersonId, semaphore: semaphore) }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Comment+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Comment+CacheExtensions.swift
@@ -1,0 +1,47 @@
+//
+//  Comment+CacheExtensions.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+
+extension Comment1: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with comment: ApiComment, semaphore: UInt? = nil) {
+        setIfChanged(\.content, comment.content)
+        setIfChanged(\.created, comment.published)
+        setIfChanged(\.updated, comment.updated)
+        setIfChanged(\.distinguished, comment.distinguished)
+        setIfChanged(\.languageId, comment.languageId)
+
+        deletedManager.updateWithReceivedValue(comment.deleted, semaphore: semaphore)
+        removedManager.updateWithReceivedValue(comment.removed, semaphore: semaphore)
+    }
+}
+
+extension Comment2: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with comment: ApiCommentView, semaphore: UInt? = nil) {
+        setIfChanged(\.creatorIsModerator, comment.creatorIsModerator)
+        setIfChanged(\.creatorIsAdmin, comment.creatorIsAdmin)
+        creator.updateKnownCommunityBanState(id: community.id, banned: comment.creatorBannedFromCommunity)
+        setIfChanged(\.commentCount, comment.counts.childCount)
+
+        votesManager.updateWithReceivedValue(
+            .init(from: comment.counts, myVote: ScoringOperation.guaranteedInit(from: comment.myVote)),
+            semaphore: semaphore
+        )
+        savedManager.updateWithReceivedValue(comment.saved ?? false, semaphore: semaphore)
+        
+        comment1.update(with: comment.comment, semaphore: semaphore)
+        creator.update(with: comment.creator, semaphore: semaphore)
+        post.update(with: comment.post, semaphore: semaphore)
+        community.update(with: comment.community, semaphore: semaphore)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Community+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Community+CacheExtensions.swift
@@ -1,0 +1,63 @@
+//
+//  Community+CacheExtensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-02.
+//
+
+import Foundation
+
+extension Community1: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with community: ApiCommunity, semaphore: UInt? = nil) {
+        setIfChanged(\.updated, community.updated)
+        setIfChanged(\.displayName, community.title)
+        setIfChanged(\.description, community.description)
+        removedManager.updateWithReceivedValue(community.removed, semaphore: semaphore)
+        setIfChanged(\.deleted, community.deleted)
+        setIfChanged(\.nsfw, community.nsfw)
+        setIfChanged(\.avatar, community.icon)
+        setIfChanged(\.banner, community.banner)
+        setIfChanged(\.hidden, community.hidden)
+        setIfChanged(\.onlyModeratorsCanPost, community.postingRestrictedToMods)
+    }
+}
+
+extension Community2: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with communityView: ApiCommunityView, semaphore: UInt? = nil) {
+        setIfChanged(\.postCount, communityView.counts.posts)
+        setIfChanged(\.commentCount, communityView.counts.comments)
+        setIfChanged(\.activeUserCount, .init(
+            sixMonths: communityView.counts.usersActiveHalfYear,
+            month: communityView.counts.usersActiveMonth,
+            week: communityView.counts.usersActiveWeek,
+            day: communityView.counts.usersActiveDay
+        ))
+        
+        subscriptionManager.updateWithReceivedValue(
+            .init(from: communityView.counts, subscribedType: communityView.subscribed),
+            semaphore: semaphore
+        )
+        
+        community1.update(with: communityView.community, semaphore: semaphore)
+    }
+}
+
+extension Community3: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with response: ApiGetCommunityResponse, semaphore: UInt? = nil) {
+        setIfChanged(\.moderators, response.moderators.map { moderatorView in
+            api.caches.person1.performModelTranslation(api: api, from: moderatorView.moderator)
+        })
+        setIfChanged(\.discussionLanguages, response.discussionLanguages)
+
+        community2.update(with: response.communityView, semaphore: semaphore)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/ImageUpload+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/ImageUpload+CacheExtensions.swift
@@ -1,0 +1,12 @@
+//
+//  ImageUpload+CacheExtensions.swift
+//
+//
+//  Created by Sjmarf on 26/08/2024.
+//
+
+import Foundation
+
+extension ImageUpload1: CacheIdentifiable {
+    public var cacheId: Int { alias.hashValue }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Instance+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Instance+CacheExtensions.swift
@@ -28,8 +28,8 @@ extension Instance2: CacheIdentifiable {
     @MainActor
     func update(with siteView: ApiSiteView) {
         setIfChanged(\.setup, siteView.localSite.siteSetup)
-        setIfChanged(\.downvotesEnabled, siteView.localSite.enableDownvotes ?? true) // TODO 0.20 support: we shouldn't be coalescing to true here
-        setIfChanged(\.nsfwContentEnabled, siteView.localSite.enableNsfw ?? false) // TODO 0.20 support: we shouldn't be coalescing to false here
+        setIfChanged(\.downvotesEnabled, siteView.localSite.enableDownvotes ?? true) // TODO: 0.20 support: we shouldn't be coalescing to true here
+        setIfChanged(\.nsfwContentEnabled, siteView.localSite.enableNsfw ?? false) // TODO: 0.20 support: we shouldn't be coalescing to false here
         setIfChanged(\.communityCreationRestrictedToAdmins, siteView.localSite.communityCreationAdminOnly)
         setIfChanged(\.emailVerificationRequired, siteView.localSite.requireEmailVerification)
         setIfChanged(\.applicationQuestion, siteView.localSite.applicationQuestion)
@@ -72,7 +72,7 @@ extension Instance3: CacheIdentifiable {
         setIfChanged(\.version, SiteVersion(response.version))
         setIfChanged(\.allowedLanguageIds, Set(response.discussionLanguages).subtracting([0]))
         setIfChanged(\.taglines, response.taglines ?? [response.tagline].compactMap { $0 })
-        setIfChanged(\.customEmojis, response.customEmojis ?? []) // TODO 0.20 support: we shouldn't be coalescing to [] here
+        setIfChanged(\.customEmojis, response.customEmojis ?? []) // TODO: 0.20 support: we shouldn't be coalescing to [] here
         setIfChanged(\.blockedUrls, response.blockedUrls)
         setIfChanged(\.administrators, response.admins.map { api.caches.person2.getModel(api: api, from: $0) })
         

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Instance+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Instance+CacheExtensions.swift
@@ -28,8 +28,8 @@ extension Instance2: CacheIdentifiable {
     @MainActor
     func update(with siteView: ApiSiteView) {
         setIfChanged(\.setup, siteView.localSite.siteSetup)
-        setIfChanged(\.downvotesEnabled, siteView.localSite.enableDownvotes ?? true) // TODO: 0.20 support: we shouldn't be coalescing to true here
-        setIfChanged(\.nsfwContentEnabled, siteView.localSite.enableNsfw ?? false) // TODO: 0.20 support: we shouldn't be coalescing to false here
+        setIfChanged(\.downvotesEnabled, siteView.localSite.enableDownvotes ?? true) // TODO 0.20 support: we shouldn't be coalescing to true here
+        setIfChanged(\.nsfwContentEnabled, siteView.localSite.enableNsfw ?? false) // TODO 0.20 support: we shouldn't be coalescing to false here
         setIfChanged(\.communityCreationRestrictedToAdmins, siteView.localSite.communityCreationAdminOnly)
         setIfChanged(\.emailVerificationRequired, siteView.localSite.requireEmailVerification)
         setIfChanged(\.applicationQuestion, siteView.localSite.applicationQuestion)
@@ -72,7 +72,7 @@ extension Instance3: CacheIdentifiable {
         setIfChanged(\.version, SiteVersion(response.version))
         setIfChanged(\.allowedLanguageIds, Set(response.discussionLanguages).subtracting([0]))
         setIfChanged(\.taglines, response.taglines ?? [response.tagline].compactMap { $0 })
-        setIfChanged(\.customEmojis, response.customEmojis ?? []) // TODO: 0.20 support: we shouldn't be coalescing to [] here
+        setIfChanged(\.customEmojis, response.customEmojis ?? []) // TODO 0.20 support: we shouldn't be coalescing to [] here
         setIfChanged(\.blockedUrls, response.blockedUrls)
         setIfChanged(\.administrators, response.admins.map { api.caches.person2.getModel(api: api, from: $0) })
         

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Instance+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Instance+CacheExtensions.swift
@@ -1,0 +1,81 @@
+//
+//  Instance+CacheExtensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-02.
+//
+
+import Foundation
+
+extension Instance1: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with site: ApiSite) {
+        setIfChanged(\.displayName, site.name)
+        setIfChanged(\.description, site.sidebar)
+        setIfChanged(\.shortDescription, site.description)
+        setIfChanged(\.avatar, site.icon)
+        setIfChanged(\.banner, site.banner)
+        setIfChanged(\.lastRefresh, site.lastRefreshedAt)
+        setIfChanged(\.contentWarning, site.contentWarning)
+    }
+}
+
+extension Instance2: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with siteView: ApiSiteView) {
+        setIfChanged(\.setup, siteView.localSite.siteSetup)
+        setIfChanged(\.downvotesEnabled, siteView.localSite.enableDownvotes ?? true) // TODO: 0.20 support: we shouldn't be coalescing to true here
+        setIfChanged(\.nsfwContentEnabled, siteView.localSite.enableNsfw ?? false) // TODO: 0.20 support: we shouldn't be coalescing to false here
+        setIfChanged(\.communityCreationRestrictedToAdmins, siteView.localSite.communityCreationAdminOnly)
+        setIfChanged(\.emailVerificationRequired, siteView.localSite.requireEmailVerification)
+        setIfChanged(\.applicationQuestion, siteView.localSite.applicationQuestion)
+        setIfChanged(\.isPrivate, siteView.localSite.privateInstance)
+        setIfChanged(\.defaultTheme, siteView.localSite.defaultTheme)
+        setIfChanged(\.defaultFeed, siteView.localSite.defaultPostListingType)
+        setIfChanged(\.legalInformation, siteView.localSite.legalInformation)
+        setIfChanged(\.hideModlogNames, siteView.localSite.hideModlogModNames)
+        setIfChanged(\.emailApplicationsToAdmins, siteView.localSite.applicationEmailAdmins)
+        setIfChanged(\.emailReportsToAdmins, siteView.localSite.reportsEmailAdmins)
+        setIfChanged(\.slurFilterRegex, siteView.localSite.slurFilterRegex)
+        setIfChanged(\.actorNameMaxLength, siteView.localSite.actorNameMaxLength)
+        setIfChanged(\.federationEnabled, siteView.localSite.federationEnabled)
+        setIfChanged(\.captchaEnabled, siteView.localSite.captchaEnabled)
+        setIfChanged(\.captchaDifficulty, .init(rawValue: siteView.localSite.captchaDifficulty))
+        setIfChanged(\.registrationMode, siteView.localSite.registrationMode)
+        setIfChanged(\.federationSignedFetch, siteView.localSite.federationSignedFetch)
+        setIfChanged(\.defaultPostListingMode, siteView.localSite.defaultPostListingMode)
+        setIfChanged(\.defaultSortType, siteView.localSite.defaultSortType)
+        setIfChanged(\.userCount, siteView.counts.users)
+        setIfChanged(\.postCount, siteView.counts.posts)
+        setIfChanged(\.commentCount, siteView.counts.comments)
+        setIfChanged(\.communityCount, siteView.counts.communities)
+        setIfChanged(\.activeUserCount, .init(
+            sixMonths: siteView.counts.usersActiveHalfYear,
+            month: siteView.counts.usersActiveMonth,
+            week: siteView.counts.usersActiveWeek,
+            day: siteView.counts.usersActiveDay
+        ))
+        
+        instance1.update(with: siteView.site)
+    }
+}
+
+extension Instance3: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with response: ApiGetSiteResponse) {
+        setIfChanged(\.version, SiteVersion(response.version))
+        setIfChanged(\.allowedLanguageIds, Set(response.discussionLanguages).subtracting([0]))
+        setIfChanged(\.taglines, response.taglines ?? [response.tagline].compactMap { $0 })
+        setIfChanged(\.customEmojis, response.customEmojis ?? []) // TODO: 0.20 support: we shouldn't be coalescing to [] here
+        setIfChanged(\.blockedUrls, response.blockedUrls)
+        setIfChanged(\.administrators, response.admins.map { api.caches.person2.getModel(api: api, from: $0) })
+        
+        instance2.update(with: response.siteView)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Message+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Message+CacheExtensions.swift
@@ -1,0 +1,34 @@
+//
+//  Message+CacheExtensions.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+extension Message1: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with message: ApiPrivateMessage, semaphore: UInt? = nil) {
+        setIfChanged(\.content, message.content)
+        setIfChanged(\.updated, message.updated)
+        
+        deletedManager.updateWithReceivedValue(message.deleted, semaphore: semaphore)
+        if !isOwnMessage {
+            readManager.updateWithReceivedValue(message.read, semaphore: semaphore)
+        }
+    }
+}
+
+extension Message2: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with message: ApiPrivateMessageView, semaphore: UInt? = nil) {
+        message1.update(with: message.privateMessage, semaphore: semaphore)
+        creator.update(with: message.creator, semaphore: semaphore)
+        recipient.update(with: message.recipient, semaphore: semaphore)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Person+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Person+CacheExtensions.swift
@@ -1,0 +1,106 @@
+//
+//  Person+CacheExtensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-02.
+//
+
+import Foundation
+
+extension Person1: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with person: ApiPerson, semaphore: UInt? = nil) {
+        setIfChanged(\.updated, person.updated)
+        setIfChanged(\.displayName, person.displayName ?? person.name)
+        setIfChanged(\.description, person.bio)
+        setIfChanged(\.avatar, person.avatar)
+        setIfChanged(\.banner, person.banner)
+        
+        setIfChanged(\.deleted, person.deleted)
+        setIfChanged(\.isBot, person.botAccount)
+        
+        let newInstanceBan: InstanceBanType
+        if person.banned {
+            if let expires = person.banExpires {
+                newInstanceBan = .temporarilyBanned(expires: expires)
+            } else {
+                newInstanceBan = .permanentlyBanned
+            }
+        } else {
+            newInstanceBan = .notBanned
+        }
+        setIfChanged(\.instanceBan, newInstanceBan)
+    }
+}
+
+extension Person2: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with apiType: any Person2ApiBacker, semaphore: UInt? = nil) {
+        setIfChanged(\.isAdmin, apiType.admin)
+        setIfChanged(\.postCount, apiType.counts.postCount)
+        setIfChanged(\.commentCount, apiType.counts.commentCount)
+        person1.update(with: apiType.person, semaphore: semaphore)
+    }
+}
+
+extension Person3: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(moderatedCommunities: [Community1], person2ApiBacker: any Person2ApiBacker, semaphore: UInt? = nil) {
+        setIfChanged(\.self.moderatedCommunities, moderatedCommunities)
+        person2.update(with: person2ApiBacker, semaphore: semaphore)
+    }
+}
+
+extension Person4: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with apiMyUserInfo: ApiMyUserInfo, semaphore: UInt? = nil) {
+        let moderates = apiMyUserInfo.moderates.map { moderatorView in
+            api.caches.community1.performModelTranslation(api: api, from: moderatorView.community)
+        }
+        
+        let user = apiMyUserInfo.localUserView.localUser
+        
+        if let admin = user.admin {
+            setIfChanged(\.person2.isAdmin, admin)
+        }
+        setIfChanged(\.voteDisplayMode, apiMyUserInfo.localUserView.localUserVoteDisplayMode)
+        setIfChanged(\.email, user.email)
+        setIfChanged(\.showNsfw, user.showNsfw)
+        setIfChanged(\.theme, user.theme)
+        setIfChanged(\.defaultSortType, user.defaultSortType ?? .hot) // TODO: 0.20 support: we shouldn't be .hot to true here
+        setIfChanged(\.defaultListingType, user.defaultListingType)
+        setIfChanged(\.interfaceLanguage, user.interfaceLanguage)
+        setIfChanged(\.showAvatars, user.showAvatars)
+        setIfChanged(\.sendNotificationsToEmail, user.sendNotificationsToEmail)
+        setIfChanged(\.showScores, user.showScores ?? true) // // TODO 0.20 support: we shouldn't be coalescing to true here
+        setIfChanged(\.showBotAccounts, user.showBotAccounts)
+        setIfChanged(\.showReadPosts, user.showReadPosts)
+        setIfChanged(\.discussionLanguageIds, .init(apiMyUserInfo.discussionLanguages.filter { $0 != 0 }))
+        setIfChanged(\.showNewPostNotifs, user.showNewPostNotifs)
+        setIfChanged(\.emailVerified, user.emailVerified)
+        setIfChanged(\.acceptedApplication, user.acceptedApplication)
+        setIfChanged(\.openLinksInNewTab, user.openLinksInNewTab)
+        setIfChanged(\.blurNsfw, user.blurNsfw)
+        setIfChanged(\.autoExpandImages, user.autoExpand)
+        setIfChanged(\.infiniteScrollEnabled, user.infiniteScrollEnabled)
+        setIfChanged(\.postListingMode, user.postListingMode)
+        setIfChanged(\.totp2faEnabled, user.totp2faEnabled)
+        setIfChanged(\.enableKeyboardNavigation, user.enableKeyboardNavigation)
+        setIfChanged(\.enableAnimatedImages, user.enableAnimatedImages)
+        setIfChanged(\.collapseBotComments, user.collapseBotComments)
+        
+        person3.update(
+            moderatedCommunities: moderates,
+            person2ApiBacker: apiMyUserInfo.localUserView,
+            semaphore: semaphore
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Post+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Post+CacheExtensions.swift
@@ -1,0 +1,75 @@
+//
+//  Post+CacheExtensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-02.
+//
+
+import Foundation
+
+extension Post1: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with post: ApiPost, semaphore: UInt? = nil) {
+        setIfChanged(\.updated, post.updated)
+        setIfChanged(\.title, post.name)
+        // We can't name this 'body' because @Observable uses that property name already
+        setIfChanged(\.content, post.body)
+        setIfChanged(\.linkUrl, post.linkUrl)
+        setIfChanged(\.embed, post.embed)
+        
+        setIfChanged(\.nsfw, post.nsfw)
+        setIfChanged(\.thumbnailUrl, post.thumbnailImageUrl)
+        
+        deletedManager.updateWithReceivedValue(post.deleted, semaphore: semaphore)
+        pinnedCommunityManager.updateWithReceivedValue(post.featuredCommunity, semaphore: semaphore)
+        pinnedInstanceManager.updateWithReceivedValue(post.featuredLocal, semaphore: semaphore)
+        lockedManager.updateWithReceivedValue(post.locked, semaphore: semaphore)
+        removedManager.updateWithReceivedValue(post.removed, semaphore: semaphore)
+    }
+}
+
+extension Post2: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with post: ApiPostView, semaphore: UInt? = nil) {
+        setIfChanged(\.creatorIsModerator, post.creatorIsModerator)
+        setIfChanged(\.creatorIsAdmin, post.creatorIsAdmin)
+        creator.updateKnownCommunityBanState(id: community.id, banned: post.creatorBannedFromCommunity)
+        setIfChanged(\.commentCount, post.counts.comments)
+        setIfChanged(\.unreadCommentCount, post.unreadComments)
+        
+        savedManager.updateWithReceivedValue(post.saved ?? false, semaphore: semaphore)
+        readManager.updateWithReceivedValue(post.read, semaphore: semaphore)
+        hiddenManager.updateWithReceivedValue(post.hidden ?? false, semaphore: semaphore)
+        votesManager.updateWithReceivedValue(
+            .init(from: post.counts, myVote: ScoringOperation.guaranteedInit(from: post.myVote)),
+            semaphore: semaphore
+        )
+        creator.blockedManager.updateWithReceivedValue(post.creatorBlocked, semaphore: semaphore)
+
+        post1.update(with: post.post, semaphore: semaphore)
+        creator.update(with: post.creator, semaphore: semaphore)
+        community.update(with: post.community, semaphore: semaphore)
+    }
+}
+
+extension Post3: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with post: ApiGetPostResponse, semaphore: UInt? = nil) {
+        setIfChanged(\.communityModerators, post.moderators?.map { moderatorView in
+            api.caches.person1.performModelTranslation(api: api, from: moderatorView.moderator)
+        } ?? [])
+        
+        setIfChanged(\.crossPosts, post.crossPosts.map { crossPost in
+            api.caches.post2.performModelTranslation(api: api, from: crossPost)
+        })
+        
+        post2.update(with: post.postView, semaphore: semaphore)
+        community.update(with: post.communityView, semaphore: semaphore)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/RegistrationApplication+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/RegistrationApplication+CacheExtensions.swift
@@ -1,0 +1,32 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-12.
+//
+
+import Foundation
+
+extension RegistrationApplication: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with applicationView: ApiRegistrationApplicationView, semaphore: UInt? = nil) {
+        let resolution: RegistrationApplication.ResolutionState
+        if applicationView.creatorLocalUser.acceptedApplication {
+            resolution = .approved
+        } else if applicationView.admin != nil {
+            resolution = .denied(reason: applicationView.registrationApplication.denyReason)
+        } else {
+            resolution = .unresolved
+        }
+        
+        setIfChanged(\.questionResponse, applicationView.registrationApplication.answer)
+        resolutionManager.updateWithReceivedValue(resolution, semaphore: semaphore)
+        setIfChanged(\.resolver, api.caches.person1.getOptionalModel(api: api, from: applicationView.admin))
+        setIfChanged(\.email, applicationView.creatorLocalUser.email)
+        setIfChanged(\.emailVerified, applicationView.creatorLocalUser.emailVerified)
+        setIfChanged(\.showNsfw, applicationView.creatorLocalUser.showNsfw)
+        creator.update(with: applicationView.creator)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Reply+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Reply+CacheExtensions.swift
@@ -1,0 +1,40 @@
+//
+//  Reply+CacheExtensions.swift
+//
+//
+//  Created by Sjmarf on 04/07/2024.
+//
+
+import Foundation
+
+extension Reply1: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with reply: any Reply1ApiBacker, semaphore: UInt? = nil) {
+        readManager.updateWithReceivedValue(reply.read, semaphore: semaphore)
+    }
+}
+
+extension Reply2: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    @MainActor
+    func update(with reply: any Reply2ApiBacker, semaphore: UInt? = nil) {
+        setIfChanged(\.subscribed, reply.subscribed.isSubscribed)
+        setIfChanged(\.commentCount, reply.counts.childCount)
+        setIfChanged(\.creatorIsModerator, reply.creatorIsModerator)
+        setIfChanged(\.creatorIsAdmin, reply.creatorIsAdmin)
+        creator.updateKnownCommunityBanState(id: community.id, banned: reply.creatorBannedFromCommunity)
+        
+        votesManager.updateWithReceivedValue(votes, semaphore: semaphore)
+        savedManager.updateWithReceivedValue(saved, semaphore: semaphore)
+        
+        reply1.update(with: reply.reply, semaphore: semaphore)
+        comment.update(with: reply.comment)
+        creator.update(with: reply.creator)
+        post.update(with: reply.post)
+        community.update(with: reply.community)
+        recipient.update(with: reply.recipient)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Report+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Report+CacheExtensions.swift
@@ -1,0 +1,62 @@
+//
+//  Report.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-16.
+//
+
+import Foundation
+
+extension Report {
+    public var cacheId: Int {
+        var hasher = Hasher()
+        hasher.combine(target.type)
+        hasher.combine(id)
+        return hasher.finalize()
+    }
+    
+    @MainActor
+    func update(with report: any ReportApiBacker, semaphore: UInt? = nil) {
+        setIfChanged(\.updated, report.updated)
+        setIfChanged(\.reason, report.reason)
+        
+        setIfChanged(\.resolver, api.caches.person1.getOptionalModel(api: api, from: report.resolver))
+        
+        creator.update(with: report.creator)
+        
+        resolvedManager.updateWithReceivedValue(report.resolved, semaphore: semaphore)
+        
+        switch target {
+        case let .post(post):
+            if let postView = (report as? ApiPostReportView)?.toPostView() {
+                post.update(with: postView, semaphore: semaphore)
+            }
+        case let .comment(comment):
+            if let commentView = (report as? ApiCommentReportView)?.toCommentView() {
+                comment.update(with: commentView, semaphore: semaphore)
+            }
+        case let .message(message):
+            if let messageView = (report as? ApiPrivateMessageReportView)?.toPrivateMessageView() {
+                message.update(with: messageView, semaphore: semaphore)
+            } else {
+                assertionFailure()
+            }
+        case let .legacyPost(post, community, creator):
+            if let report = report as? ApiPostReportView {
+                post.update(with: report.post)
+                community.update(with: report.community)
+                creator.update(with: report.postCreator)
+            } else {
+                assertionFailure()
+            }
+        case let .legacyComment(comment, community, creator):
+            if let report = report as? ApiCommentReportView {
+                comment.update(with: report.comment)
+                community.update(with: report.community)
+                creator.update(with: report.commentCreator)
+            } else {
+                assertionFailure()
+            }
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/CoreCache.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/CoreCache.swift
@@ -1,0 +1,63 @@
+//
+//  CoreCache.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-01.
+//
+
+import Foundation
+import Semaphore
+
+/// Class providing common caching behavior
+open class CoreCache<Content: CacheIdentifiable & AnyObject> {
+    public var itemCache: ItemCache = .init()
+    
+    public init() {
+        self.itemCache = .init()
+    }
+    
+    public class ItemCache {
+        private var cachedItems: Atomic<[Int: WeakReference<Content>]> = .init(.init())
+        private let cleaningSemaphore: AsyncSemaphore = .init(value: 1)
+        
+        var value: [Int: WeakReference<Content>] {
+            cachedItems.value
+        }
+        
+        public func put(_ item: Content, overrideCacheId: Int? = nil) {
+            let cacheId = overrideCacheId ?? item.cacheId
+            cachedItems.value[cacheId] = .init(content: item)
+        }
+        
+        public func get(_ cacheId: Int) -> Content? {
+            cachedItems.value[cacheId]?.content
+        }
+        
+        public func remove(_ cacheId: Int) {
+            // print("Removed \(cacheId)")
+            cachedItems.value[cacheId] = nil
+        }
+        
+        public func clean() async {
+            await cleaningSemaphore.wait()
+            defer { cleaningSemaphore.signal() }
+            for (key, value) in cachedItems.value where value.content == nil {
+                remove(key)
+            }
+        }
+    }
+    
+    /// Retrieves the cached model with the given cacheId, if present
+    /// - Parameter cacheId: cacheId of the model to retrieve
+    /// - Returns: cached model if present, nil otherwise
+    public func retrieveModel(cacheId: Int) -> Content? {
+        itemCache.get(cacheId)
+    }
+    
+    /// Remove dead references
+    public func clean() {
+        Task {
+            await itemCache.clean()
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Helpers/MarkReadQueue.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Helpers/MarkReadQueue.swift
@@ -1,0 +1,33 @@
+//
+//  MarkReadQueue.swift
+//
+//
+//  Created by Sjmarf on 29/05/2024.
+//
+
+import Foundation
+
+actor MarkReadQueue {
+    var ids: Set<Int> = .init()
+    
+    func popAll() -> Set<Int> {
+        defer { ids.removeAll() }
+        return ids
+    }
+    
+    func add(_ postId: Int) {
+        ids.insert(postId)
+    }
+    
+    func remove(_ postId: Int) {
+        ids.remove(postId)
+    }
+    
+    func union(_ other: Set<Int>) {
+        ids.formUnion(other)
+    }
+    
+    func subtract(_ other: Set<Int>) {
+        ids.subtract(other)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Helpers/MlemUrlRequest.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Helpers/MlemUrlRequest.swift
@@ -1,0 +1,14 @@
+//
+//  MlemUrlRequest.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-03-12.
+//
+
+import Foundation
+
+public func mlemUrlRequest(url: URL) -> URLRequest {
+    var ret = URLRequest(url: url)
+    ret.addValue("MlemUserAgent", forHTTPHeaderField: "User-Agent")
+    return ret
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Helpers/SharedTaskManager.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Helpers/SharedTaskManager.swift
@@ -1,0 +1,38 @@
+//
+//  SharedTaskManager.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-27.
+//
+
+import Foundation
+
+public class SharedTaskManager<Value> {
+    var fetchTask: (() async throws -> Value)!
+    
+    private var ongoingTask: Task<Value, Error>?
+    var fetchedValue: Value?
+    
+    init(fetchTask: (() async throws -> Value)? = nil) {
+        self.fetchTask = fetchTask
+    }
+    
+    @discardableResult
+    public func getValue(task: Task<Value, Error>? = nil) async throws -> Value {
+        if let fetchedValue {
+            return fetchedValue
+        } else {
+            if let ongoingTask {
+                let result = await ongoingTask.result
+                return try result.get()
+            } else {
+                defer { ongoingTask = nil }
+                let task = task ?? ongoingTask ?? Task { try await fetchTask() }
+                ongoingTask = task
+                let result = await task.result
+                fetchedValue = try result.get()
+                return try await fetchTask()
+            }
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Helpers/URLQueryItemEncoder.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Helpers/URLQueryItemEncoder.swift
@@ -1,0 +1,155 @@
+//
+//  URLQueryItemEncoder.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-20.
+//
+
+import Foundation
+
+enum URLQueryItemEncoder {
+    static func encode(_ value: some Encodable) throws -> [URLQueryItem] {
+        let encoder = InternalURLQueryItemEncoder()
+        try value.encode(to: encoder)
+        return encoder.queryParams
+    }
+}
+
+protocol URLQueryItemEncodable {
+    func encodeInQueryItemFormat() -> String?
+}
+
+enum URLQueryItemEncoderError: Error {
+    case nestedContainersUnsupported
+    case singleValueContainerUnsupported
+    case unkeyedContainerUnsupported
+}
+
+private class InternalURLQueryItemEncoder: Encoder {
+    var queryParams: [URLQueryItem] = .init()
+
+    // This is just for conformance to Encoder. This never gets modified because we
+    // disallow nested containers
+    let codingPath: [CodingKey] = []
+    
+    // Just for conformance; unused
+    let userInfo: [CodingUserInfoKey: Any] = [:]
+
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        // This value throws an error as soon as you try to encode with it
+        SingleValueContainer(encoder: self)
+    }
+
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        // This value throws an error as soon as you try to encode with it
+        UnkeyedContainer(encoder: self)
+    }
+
+    func container<Key: CodingKey>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
+        KeyedEncodingContainer(KeyedContainer<Key>(encoder: self))
+    }
+}
+
+private class KeyedContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
+    var encoder: InternalURLQueryItemEncoder
+
+    init(encoder: InternalURLQueryItemEncoder) {
+        self.encoder = encoder
+    }
+
+    var codingPath: [CodingKey] = []
+
+    func encodeNil(forKey key: K) throws {}
+
+    func encode(_ value: some Encodable, forKey key: K) throws {
+        if let valueString = convertValueToString(value) {
+            let key = key.stringValue.camelToSnakeCase()
+            encoder.queryParams.append(.init(name: key, value: valueString))
+        } else {
+            throw URLQueryItemEncoderError.nestedContainersUnsupported
+        }
+    }
+    
+    func convertValueToString(_ value: some Encodable) -> String? {
+        if let value = value as? String {
+            value
+        } else if let value = value as? Int {
+            String(value)
+        } else if let value = value as? Double {
+            String(value)
+        } else if let value = value as? Bool {
+            value ? "true" : "false"
+        } else if let value = value as? any RawRepresentable<String> {
+            value.rawValue
+        } else if let value = value as? any RawRepresentable<Int> {
+            String(value.rawValue)
+        } else if let value = value as? any URLQueryItemEncodable {
+            value.encodeInQueryItemFormat()
+        } else {
+            nil
+        }
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+        assertionFailure("We should throw an error *before* this gets called")
+        return KeyedEncodingContainer(KeyedContainer<NestedKey>(encoder: encoder))
+    }
+
+    func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
+        assertionFailure("We should throw an error *before* this gets called")
+        return UnkeyedContainer(encoder: encoder)
+    }
+
+    func superEncoder() -> Encoder { encoder }
+    func superEncoder(forKey key: K) -> Encoder { encoder }
+}
+
+// This simply throws an error as soon as you try to encode with it.
+private class SingleValueContainer: SingleValueEncodingContainer {
+    let encoder: InternalURLQueryItemEncoder
+    let codingPath: [CodingKey] = []
+
+    init(encoder: InternalURLQueryItemEncoder) {
+        self.encoder = encoder
+    }
+
+    func encodeNil() throws {}
+
+    func encode(_ value: some Encodable) throws {
+        throw URLQueryItemEncoderError.singleValueContainerUnsupported
+    }
+}
+
+// This simply throws an error as soon as you try to encode with it.
+private class UnkeyedContainer: UnkeyedEncodingContainer {
+    let encoder: InternalURLQueryItemEncoder
+    let codingPath: [any CodingKey] = []
+    let count: Int = 0
+    
+    init(encoder: InternalURLQueryItemEncoder) {
+        self.encoder = encoder
+    }
+    
+    func encodeNil() throws {}
+    
+    func encode(_ value: some Encodable) throws { throw URLQueryItemEncoderError.unkeyedContainerUnsupported }
+    
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+        assertionFailure("We should throw an error *before* this gets called")
+        return KeyedEncodingContainer(KeyedContainer(encoder: encoder))
+    }
+    
+    func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+        assertionFailure("We should throw an error *before* this gets called")
+        return UnkeyedContainer(encoder: encoder)
+    }
+    
+    func superEncoder() -> any Encoder { encoder }
+}
+
+private extension String {
+    func camelToSnakeCase() -> String {
+        replacing(/([a-z])([A-Z])/) { "\($0.output.1)_\($0.output.2)"
+        }.lowercased()
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Constants/MiddlewareConstants.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Constants/MiddlewareConstants.swift
@@ -1,0 +1,13 @@
+//
+//  App Constants.swift
+//  Mlem
+//
+//  Created by David Bureš on 03.05.2023.
+//
+
+import Foundation
+
+enum MiddlewareConstants {
+    static let infiniteLoadThresholdOffset: Int = 10
+    static let maxRetries: Int = 3
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ActiveUserCount.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ActiveUserCount.swift
@@ -1,0 +1,24 @@
+//
+//  ActiveUserCount.swift
+//
+//
+//  Created by Sjmarf on 29/05/2024.
+//
+
+import Foundation
+
+public struct ActiveUserCount: Equatable {
+    public let sixMonths: Int
+    public let month: Int
+    public let week: Int
+    public let day: Int
+    
+    public init(sixMonths: Int, month: Int, week: Int, day: Int) {
+        self.sixMonths = sixMonths
+        self.month = month
+        self.week = week
+        self.day = day
+    }
+    
+    public static let zero: ActiveUserCount = .init(sixMonths: 0, month: 0, week: 0, day: 0)
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ActorIdentifiable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ActorIdentifiable.swift
@@ -1,0 +1,19 @@
+//
+//  ActorIdentifiable.swift
+//  Mlem
+//
+//  Created by Sjmarf on 15/02/2024.
+//
+
+import Foundation
+
+/// Represents a Lemmy entity that can be represented by an ``ActorIdentifier``.
+public protocol ActorIdentifiable {
+    // An identifier that is unique across Lemmy instances.
+    var actorId: ActorIdentifier { get }
+}
+
+public extension ActorIdentifiable {
+    @inlinable
+    var host: String { actorId.host }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ActorIdentifier.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ActorIdentifier.swift
@@ -1,0 +1,103 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-25.
+//
+
+import Foundation
+
+/// An identifier for an ActivityPub entity that is unique across all federated instances. This is a wrapper of `URL`.
+///
+/// ## Discussion
+///
+/// Avoid instantiating`ActorIdentifier`directly, and instead obtain
+/// instances by interacting with `ApiClient`.
+///
+/// Lemmy uses the following ActorIdentifier formats (this list may be incomplete, I'm not sure):
+/// - `https://example.com`
+/// - `https://example.com/c/name`
+/// - `https://example.com/u/name`
+/// - `https://example.com/post/123`
+/// - `https://example.com/comment/123`
+/// - `https://example.com/private_message/123`
+///
+/// In addition to these formats, an ActorIdentifier may use a non-Lemmy format such as:
+/// - `https://fedia.io/m/fedia` (Community URL for Kbin/Mbin)
+/// - `https://misskey.io/users/9h75uqwaa8` (Person URL for Misskey)
+///
+/// It should be noted that private messages cannot be resolved using ``ResolveObjectRequest``.
+///
+public struct ActorIdentifier: Hashable, Sendable {
+    public let url: URL
+    public let host: String
+    
+    /// Create an `ActorIdentifier` from a given URL.
+    ///
+    /// When you use this method, you *must* be sure that the provided URL is the actual ActivityPub
+    /// ID for the given entity, and not just any URL pointing to it. If possible, avoid using this initialiser.
+    ///
+    public init?(url: URL) {
+        guard let host = url.host() else { return nil }
+        self.init(url: url, host: host)
+    }
+    
+    private init(url: URL, host: String) {
+        if url.pathComponents.isEmpty {
+            self.url = url.appendingPathComponent("/")
+        } else {
+            self.url = url
+        }
+        self.host = host
+    }
+    
+    public static func instance(host: String) -> Self {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        return ActorIdentifier(url: components.url!, host: host)
+    }
+
+    public var hostUrl: URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        return components.url! // This will always succeed
+    }
+}
+
+extension ActorIdentifier: Codable {
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+        guard let url = URL(string: string) else { throw Self.DecodingError.invalidUrl }
+        if let actorId = ActorIdentifier(url: url) {
+            self = actorId
+        } else {
+            throw Self.DecodingError.invalidUrl
+        }
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(url)
+    }
+}
+
+extension ActorIdentifier: CustomStringConvertible {
+    public var description: String { url.description }
+}
+
+extension ActorIdentifier: CustomDebugStringConvertible {
+    public var debugDescription: String { "ActorIdentifier(\(url.description))" }
+}
+
+public extension ActorIdentifier {
+    enum EntityType {
+        case post, comment, message, person, community, instance
+    }
+    
+    enum DecodingError: Error {
+        case invalidUrl
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/BlockList.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/BlockList.swift
@@ -1,0 +1,163 @@
+//
+//  BlockList.swift
+//
+//
+//  Created by Sjmarf on 08/07/2024.
+//
+
+import Foundation
+
+@Observable
+public class BlockList {
+    private let api: ApiClient
+
+    /// Mapping `actorId` to `id`.
+    var people: [ActorIdentifier: Int] = .init()
+    /// Mapping `actorId` to `id`.
+    var communities: [ActorIdentifier: Int] = .init()
+    /// Mapping `actorId` to `instanceId`.
+    var instances: [ActorIdentifier: Int] = .init()
+
+    init(
+        api: ApiClient,
+        people: [ActorIdentifier: Int],
+        communities: [ActorIdentifier: Int],
+        instances: [ActorIdentifier: Int]
+    ) {
+        self.api = api
+        self.people = people
+        self.communities = communities
+        self.instances = instances
+    }
+    
+    convenience init(
+        api: ApiClient,
+        people: [ApiPersonBlockView],
+        communities: [ApiCommunityBlockView],
+        instances: [ApiInstanceBlockView]
+    ) {
+        self.init(
+            api: api,
+            people: [ActorIdentifier: Int](),
+            communities: [ActorIdentifier: Int](),
+            instances: [ActorIdentifier: Int]()
+        )
+        
+        update(people: people, communities: communities, instances: instances)
+    }
+    
+    convenience init(api: ApiClient, myUserInfo: ApiMyUserInfo) {
+        self.init(
+            api: api,
+            people: myUserInfo.personBlocks,
+            communities: myUserInfo.communityBlocks,
+            instances: myUserInfo.instanceBlocks ?? []
+        )
+    }
+    
+    func update(
+        people newPeople: [ApiPersonBlockView],
+        communities newCommunities: [ApiCommunityBlockView],
+        instances newInstances: [ApiInstanceBlockView]
+    ) {
+        let newPeople: [ActorIdentifier: Int] = newPeople.reduce(into: [:]) {
+            $0[$1.target.actorId] = $1.target.id
+        }
+        let newCommunities: [ActorIdentifier: Int] = newCommunities.reduce(into: [:]) {
+            $0[$1.community.actorId] = $1.community.id
+        }
+        
+        let newInstances: [ActorIdentifier: Int] = newInstances.reduce(into: [:]) {
+            let actorId: ActorIdentifier = .instance(host: $1.instance.domain)
+            $0[actorId] = $1.instance.id
+        }
+        
+        // People
+        
+        let oldPeopleKeys = Set(people.keys)
+        let newPeopleKeys = Set(newPeople.keys)
+
+        for key in newPeopleKeys.subtracting(oldPeopleKeys) {
+            if let id = newPeople[key], let person = api.caches.person1.retrieveModel(cacheId: id) {
+                person.blockedManager.updateWithReceivedValue(true, semaphore: nil)
+            }
+        }
+        for key in oldPeopleKeys.subtracting(newPeopleKeys) {
+            if let id = people[key], let person = api.caches.person1.retrieveModel(cacheId: id) {
+                person.blockedManager.updateWithReceivedValue(false, semaphore: nil)
+            }
+        }
+        
+        // Communities
+        
+        let oldCommunitiesKeys = Set(people.keys)
+        let newCommunitiesKeys = Set(newPeople.keys)
+
+        for key in newCommunitiesKeys.subtracting(oldCommunitiesKeys) {
+            if let id = newCommunities[key], let community = api.caches.community1.retrieveModel(cacheId: id) {
+                community.blockedManager.updateWithReceivedValue(true, semaphore: nil)
+            }
+        }
+        for key in oldCommunitiesKeys.subtracting(newCommunitiesKeys) {
+            if let id = communities[key], let community = api.caches.community1.retrieveModel(cacheId: id) {
+                community.blockedManager.updateWithReceivedValue(false, semaphore: nil)
+            }
+        }
+        
+        // Instances
+        
+        let oldInstancesKeys = Set(instances.keys)
+        let newInstancesKeys = Set(newInstances.keys)
+
+        for key in newInstancesKeys.subtracting(oldInstancesKeys) {
+            if let id = newInstances[key], let instance = api.caches.instance1.retrieveModel(instanceId: id) {
+                instance.blockedManager.updateWithReceivedValue(true, semaphore: nil)
+            }
+        }
+        for key in oldInstancesKeys.subtracting(newInstancesKeys) {
+            if let id = instances[key], let instance = api.caches.instance1.retrieveModel(instanceId: id) {
+                instance.blockedManager.updateWithReceivedValue(false, semaphore: nil)
+            }
+        }
+
+        people = newPeople
+        communities = newCommunities
+        instances = newInstances
+    }
+    
+    func update(myUserInfo: ApiMyUserInfo) {
+        update(
+            people: myUserInfo.personBlocks,
+            communities: myUserInfo.communityBlocks,
+            instances: myUserInfo.instanceBlocks ?? []
+        )
+    }
+    
+    public func contains(personActorId: ActorIdentifier) -> Bool {
+        people.keys.contains(personActorId)
+    }
+    
+    public func contains(_ person: any Person) -> Bool {
+        people.keys.contains(person.actorId)
+    }
+    
+    public func contains(communityActorId: ActorIdentifier) -> Bool {
+        communities.keys.contains(communityActorId)
+    }
+    
+    public func contains(_ community: any Community) -> Bool {
+        communities.keys.contains(community.actorId)
+    }
+    
+    public func contains(_ instance: any InstanceStubProviding) -> Bool {
+        instances.keys.contains(instance.actorId)
+    }
+    
+    public func idOfBlockedPerson(actorId: ActorIdentifier) -> Int? { people[actorId] }
+    public func idOfBlockedCommunity(actorId: ActorIdentifier) -> Int? { communities[actorId] }
+    public func instanceIdOfBlockedInstance(actorId: ActorIdentifier) -> Int? { instances[actorId] }
+    
+    public var personCount: Int { people.count }
+    public var communityCount: Int { communities.count }
+    public var instanceCount: Int { instances.count }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Captcha.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Captcha.swift
@@ -1,0 +1,18 @@
+//
+//  Captcha.swift
+//
+//
+//  Created by Sjmarf on 06/09/2024.
+//
+
+import Foundation
+
+public struct Captcha: Identifiable {
+    public let id: UUID
+    public let imageData: Data
+    
+    init(id: UUID, imageData: Data) {
+        self.id = id
+        self.imageData = imageData
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CaptchaDifficulty.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CaptchaDifficulty.swift
@@ -1,0 +1,12 @@
+//
+//  CaptchaDifficulty.swift
+//
+//
+//  Created by Sjmarf on 28/05/2024.
+//
+
+import Foundation
+
+public enum CaptchaDifficulty: String, Codable {
+    case easy, medium, hard
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/AnyComment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/AnyComment.swift
@@ -1,0 +1,79 @@
+//
+//  AnyComment.swift
+//
+//
+//  Created by Sjmarf on 25/06/2024.
+//
+
+import Foundation
+
+@Observable
+public class AnyComment: Hashable, Upgradable {
+    public typealias Base = CommentStubProviding
+    public typealias MinimumRenderable = Comment1Providing
+    public typealias Upgraded = Comment2Providing
+    
+    public var wrappedValue: any CommentStubProviding
+    
+    public required init(_ wrappedValue: any CommentStubProviding) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+/// Hashable, Equatable conformance
+public extension AnyComment {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+    
+    static func == (lhs: AnyComment, rhs: AnyComment) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+}
+
+/// Upgradable conformance
+public extension AnyComment {
+    internal func upgrade(
+        initialValue: (any Base)? = nil,
+        upgradeOperation: (any Base) async throws -> any Base
+    ) async throws {
+        var lastValue = initialValue ?? wrappedValue
+        while !(lastValue is any Upgraded) {
+            lastValue = try await upgradeOperation(lastValue)
+            if type(of: lastValue).tierNumber >= type(of: wrappedValue).tierNumber {
+                let task = Task { @MainActor [lastValue] in
+                    self.wrappedValue = lastValue
+                }
+                _ = await task.value
+            }
+        }
+    }
+    
+    func upgrade(
+        api: ApiClient?,
+        upgradeOperation: ((any Base) async throws -> any Base)?
+    ) async throws {
+        let initialValue: any Base
+        if let api {
+            initialValue = api === wrappedValue.api ? wrappedValue : CommentStub(
+                api: api,
+                url: wrappedValue.allResolvableUrls[0]
+            )
+        } else {
+            initialValue = wrappedValue
+        }
+        try await upgrade(
+            initialValue: initialValue,
+            upgradeOperation: upgradeOperation ?? { try await $0.upgrade() }
+        )
+    }
+    
+    func refresh(upgradeOperation: ((any Base) async throws -> any Base)?) async throws {
+        if let wrappedValue = wrappedValue as? any Upgraded {
+            try await upgrade(
+                initialValue: wrappedValue.comment1,
+                upgradeOperation: upgradeOperation ?? { try await $0.upgrade() }
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1+Codable.swift
@@ -3,12 +3,12 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-03-17.
-//  
+//
 
 import Foundation
 
 extension Comment1 {
-    internal var apiComment: ApiComment {
+    var apiComment: ApiComment {
         ApiComment(
             id: id,
             creatorId: creatorId,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1+Codable.swift
@@ -3,12 +3,12 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-03-17.
-//
+//  
 
 import Foundation
 
 extension Comment1 {
-    var apiComment: ApiComment {
+    internal var apiComment: ApiComment {
         ApiComment(
             id: id,
             creatorId: creatorId,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1+Codable.swift
@@ -1,0 +1,28 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-03-17.
+//
+
+import Foundation
+
+extension Comment1 {
+    var apiComment: ApiComment {
+        ApiComment(
+            id: id,
+            creatorId: creatorId,
+            postId: postId,
+            content: content,
+            removed: removed,
+            published: created,
+            updated: updated,
+            deleted: deleted,
+            actorId: actorId,
+            local: actorId.host == api.actorId.host,
+            path: ([0] + parentCommentIds + [id]).map(String.init).joined(separator: "."),
+            distinguished: distinguished,
+            languageId: languageId
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1+Mock.swift
@@ -1,0 +1,44 @@
+//
+//  Comment1+Mock.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-03-15.
+//
+
+import Foundation
+
+#if DEBUG
+    public extension Comment1 {
+        static func mock(
+            api: MockApiClient = .mock,
+            actorId: ActorIdentifier? = nil,
+            id: Int,
+            content: String,
+            removed: Bool,
+            created: Date,
+            updated: Date?,
+            deleted: Bool,
+            creatorId: Int,
+            postId: Int,
+            parentCommentIds: [Int],
+            distinguished: Bool,
+            languageId: Int
+        ) -> Comment1 {
+            .init(
+                api: api,
+                actorId: actorId ?? .init(url: URL(string: "https://\(api.host)/comment/\(id)")!)!,
+                id: id,
+                content: content,
+                removed: removed,
+                created: created,
+                updated: updated,
+                deleted: deleted,
+                creatorId: creatorId,
+                postId: postId,
+                parentCommentIds: parentCommentIds,
+                distinguished: distinguished,
+                languageId: languageId
+            )
+        }
+    }
+#endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1.swift
@@ -1,0 +1,66 @@
+//
+//  Comment1.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Comment1: Comment1Providing {
+    public static let tierNumber: Int = 1
+    public var api: ApiClient
+    public var comment1: Comment1 { self }
+    
+    public let actorId: ActorIdentifier
+    public let id: Int
+    public let parentCommentIds: [Int]
+    public let creatorId: Int
+    public let postId: Int
+    
+    public var content: String
+    public var created: Date
+    public var updated: Date?
+    public var distinguished: Bool
+    public var languageId: Int
+    
+    public var purged: Bool = false
+    
+    var deletedManager: StateManager<Bool>
+    public var deleted: Bool { deletedManager.wrappedValue }
+    
+    public var removedManager: StateManager<Bool>
+    public var removed: Bool { removedManager.wrappedValue }
+    
+    init(
+        api: ApiClient,
+        actorId: ActorIdentifier,
+        id: Int,
+        content: String,
+        removed: Bool,
+        created: Date,
+        updated: Date?,
+        deleted: Bool,
+        creatorId: Int,
+        postId: Int,
+        parentCommentIds: [Int],
+        distinguished: Bool,
+        languageId: Int
+    ) {
+        self.api = api
+        self.actorId = actorId
+        self.id = id
+        self.content = content
+        self.removedManager = .init(wrappedValue: removed)
+        self.created = created
+        self.updated = updated
+        self.deletedManager = .init(wrappedValue: deleted)
+        self.creatorId = creatorId
+        self.postId = postId
+        self.parentCommentIds = parentCommentIds
+        self.distinguished = distinguished
+        self.languageId = languageId
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment1Providing.swift
@@ -1,0 +1,216 @@
+//
+//  Comment1Providing.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+import Observation
+
+public protocol Comment1Providing:
+    CommentStubProviding,
+    ActorIdentifiable,
+    ContentIdentifiable,
+    Interactable1Providing,
+    DeletableProviding,
+    RemovableProviding,
+    PurgableProviding,
+    SelectableContentProviding,
+    Sharable,
+    FeedLoadable where FilterType == CommentFilterType {
+    var comment1: Comment1 { get }
+    var content: String { get }
+    var created: Date { get }
+    var updated: Date? { get }
+    var deleted: Bool { get }
+    var creatorId: Int { get }
+    var postId: Int { get }
+    var parentCommentIds: [Int] { get }
+    var distinguished: Bool { get }
+    var languageId: Int { get }
+}
+
+public typealias Comment = Comment1Providing
+
+public extension Comment1Providing {
+    static var modelTypeId: ContentType { .comment }
+    
+    var actorId: ActorIdentifier { comment1.actorId }
+    var id: Int { comment1.id }
+    var content: String { comment1.content }
+    var created: Date { comment1.created }
+    var updated: Date? { comment1.updated }
+    var deleted: Bool { comment1.deleted }
+    var creatorId: Int { comment1.creatorId }
+    var postId: Int { comment1.postId }
+    var parentCommentIds: [Int] { comment1.parentCommentIds }
+    var distinguished: Bool { comment1.distinguished }
+    var removed: Bool { comment1.removed }
+    var removedManager: StateManager<Bool> { comment1.removedManager }
+    var languageId: Int { comment1.languageId }
+    var purged: Bool { comment1.purged }
+    
+    var actorId_: ActorIdentifier? { comment1.actorId }
+    var content_: String? { comment1.content }
+    var created_: Date? { comment1.created }
+    var updated_: Date? { comment1.updated }
+    var deleted_: Bool? { comment1.deleted }
+    var creatorId_: Int? { comment1.creatorId }
+    var postId_: Int? { comment1.postId }
+    var parentCommentIds_: [Int]? { comment1.parentCommentIds }
+    var distinguished_: Bool? { comment1.distinguished }
+    var removed_: Bool? { comment1.distinguished }
+    var removedManager_: StateManager<Bool>? { comment1.removedManager }
+    var languageId_: Int? { comment1.languageId }
+}
+
+// Resolvable conformance
+public extension Comment1Providing {
+    @inlinable
+    var allResolvableUrls: [URL] {
+        ContentModelUrlType.allCases.map { resolvableUrl(from: $0) }
+    }
+}
+
+// Sharable conformance
+public extension Comment1Providing {
+    func url() -> URL { api.baseUrl.appending(path: "comment/\(id)") }
+}
+
+// SelectableContentProviding conformance
+public extension Comment1Providing {
+    var selectableContent: String? { content }
+}
+
+// FeedLoadable conformance
+public extension Comment1Providing {
+    func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        switch sortType {
+        case .new:
+            return .new(created)
+        }
+    }
+}
+
+public extension Comment1Providing {
+    private var deletedManager: StateManager<Bool> { comment1.deletedManager }
+
+    /// Returns a `URL` that can be resolved by another `ApiClient`.
+    func resolvableUrl(from instance: ContentModelUrlType) -> URL {
+        switch instance {
+        case .host: actorId.url
+        case .provider: .comment(host: api.host, id: id)
+        }
+    }
+    
+    var depth: Int { parentCommentIds.count }
+    
+    func upgrade() async throws -> any Comment {
+        try await api.getComment(id: id)
+    }
+    
+    func getChildren(
+        sort: CommentSortType = .hot,
+        includedParentCount: Int = 0,
+        page: Int,
+        maxDepth: Int? = nil,
+        limit: Int,
+        filter: GetContentFilter? = nil
+    ) async throws -> [Comment2] {
+        let parentId: Int
+        if includedParentCount <= 0 {
+            parentId = id
+        } else {
+            parentId = parentCommentIds.dropLast(includedParentCount - 1).last ?? parentCommentIds.first ?? id
+        }
+        let comments = try await api.getComments(
+            parentId: parentId,
+            sort: sort,
+            page: page,
+            maxDepth: maxDepth,
+            limit: limit,
+            filter: filter
+        )
+        if includedParentCount <= 0 {
+            return comments
+        }
+        
+        return comments.filter { $0.parentCommentIds.contains(id) || self.parentCommentIds.contains($0.id) || $0.id == self.id }
+    }
+    
+    @discardableResult
+    func updateRemoved(_ newValue: Bool, reason: String?) -> Task<StateUpdateResult, Never> {
+        removedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.removeComment(id: self.id, remove: newValue, reason: reason, semaphore: semaphore)
+        }
+    }
+    
+    func reply(content: String, languageId: Int? = nil) async throws -> Comment2 {
+        try await api.replyToComment(postId: postId, parentId: id, content: content, languageId: languageId)
+    }
+    
+    func report(reason: String) async throws {
+        try await api.reportComment(id: id, reason: reason)
+    }
+    
+    func purge(reason: String?) async throws {
+        try await api.purgeComment(id: id, reason: reason)
+    }
+    
+    @discardableResult
+    func updateDeleted(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        deletedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.deleteComment(id: self.id, delete: newValue, semaphore: semaphore)
+        }
+    }
+    
+    func edit(
+        content: String,
+        languageId: Int?
+    ) async throws {
+        try await api.editComment(id: id, content: content, languageId: languageId)
+    }
+    
+    // Get the parent comment, or return `nil` if there is no parent
+    func getParent(cachedValueAcceptable: Bool = false) async throws -> Comment2? {
+        if let parentId = parentCommentIds.last {
+            if cachedValueAcceptable, let comment = api.caches.comment2.retrieveModel(cacheId: parentId) { return comment }
+            return try await api.getComment(id: parentId)
+        }
+        return nil
+    }
+    
+    func getParents() async throws -> [Comment2] {
+        guard let first = parentCommentIds.first else { return [] }
+        let comments = try await api.getComments(
+            parentId: first,
+            sort: .new,
+            page: 1,
+            maxDepth: parentCommentIds.count,
+            limit: 1000
+        )
+        var i = 0
+        return comments.filter { comment in
+            if comment.id == parentCommentIds[i] {
+                i += 1
+                return true
+            }
+            return false
+        }
+    }
+    
+    var parentCommentId: Int? { parentCommentIds.last }
+    
+    /// If one is cached, return the `Reply2` matching this model.
+    func getCachedInboxReply() -> Reply2? {
+        if let parentCommentId {
+            return api.caches.reply2.retrieveModel(commentId: parentCommentId)
+        }
+        return nil
+    }
+    
+    func getVotes(page: Int, limit: Int, communityId: Int) async throws -> [PersonVote] {
+        try await api.getCommentVotes(id: id, communityId: communityId, page: page, limit: limit)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2+Codable.swift
@@ -1,0 +1,40 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-03-17.
+//
+
+import Foundation
+
+extension Comment2 {
+    var apiCommentView: ApiCommentView {
+        ApiCommentView(
+            comment: comment1.apiComment,
+            creator: creator.apiPerson,
+            post: post.apiPost,
+            community: community.apiCommunity,
+            counts: .init(
+                id: nil,
+                commentId: id,
+                score: votes.total,
+                upvotes: votes.upvotes,
+                downvotes: votes.downvotes,
+                published: created,
+                childCount: commentCount,
+                hotRank: nil,
+                reportCount: nil,
+                unresolvedReportCount: nil
+            ),
+            creatorBannedFromCommunity: bannedFromCommunity,
+            subscribed: .notSubscribed,
+            saved: saved,
+            creatorBlocked: creator.blocked,
+            myVote: votes.myVote.rawValue,
+            creatorIsModerator: creatorIsModerator,
+            creatorIsAdmin: creatorIsAdmin,
+            bannedFromCommunity: false,
+            canMod: nil
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2+Mock.swift
@@ -1,0 +1,44 @@
+//
+//  Comment2+Mock.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-03-15.
+//
+
+import Foundation
+
+#if DEBUG
+    public extension Comment2 {
+        static func mock(
+            api: ApiClient,
+            comment1: Comment1,
+            creator: Person1,
+            post: Post1,
+            community: Community1,
+            votes: VotesModel,
+            saved: Bool,
+            creatorIsModerator: Bool?,
+            creatorIsAdmin: Bool?,
+            bannedFromCommunity: Bool,
+            commentCount: Int
+        ) -> Comment2 {
+            assert(api == comment1.api)
+            assert(api == creator.api)
+            assert(api == community.api)
+            assert(api == post.api)
+            return .init(
+                api: api,
+                comment1: comment1,
+                creator: creator,
+                post: post,
+                community: community,
+                votesManager: .init(wrappedValue: votes),
+                savedManager: .init(wrappedValue: saved),
+                creatorIsModerator: creatorIsModerator,
+                creatorIsAdmin: creatorIsAdmin,
+                bannedFromCommunity: bannedFromCommunity,
+                commentCount: commentCount
+            )
+        }
+    }
+#endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2.swift
@@ -1,0 +1,66 @@
+//
+//  Comment2.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Comment2: Comment2Providing {
+    public static let tierNumber: Int = 2
+    public var api: ApiClient
+    public var comment2: Comment2 { self }
+    
+    public let comment1: Comment1
+    
+    public let creator: Person1
+    public let post: Post1
+    public let community: Community1
+    
+    public var creatorIsModerator: Bool?
+    public var creatorIsAdmin: Bool?
+    public var commentCount: Int
+    
+    var votesManager: StateManager<VotesModel>
+    public var votes: VotesModel { votesManager.wrappedValue }
+    
+    var savedManager: StateManager<Bool>
+    public var saved: Bool { savedManager.wrappedValue }
+    
+    public var bannedFromCommunity: Bool {
+        guard let state = creator.isBannedFromCommunity(community) else {
+            assertionFailure("Ban status should be present at this point")
+            return false
+        }
+        return state
+    }
+    
+    init(
+        api: ApiClient,
+        comment1: Comment1,
+        creator: Person1,
+        post: Post1,
+        community: Community1,
+        votesManager: StateManager<VotesModel>,
+        savedManager: StateManager<Bool>,
+        creatorIsModerator: Bool?,
+        creatorIsAdmin: Bool?,
+        bannedFromCommunity: Bool,
+        commentCount: Int
+    ) {
+        self.api = api
+        self.comment1 = comment1
+        self.creator = creator
+        self.post = post
+        self.community = community
+        self.votesManager = votesManager
+        self.savedManager = savedManager
+        self.creatorIsModerator = creatorIsModerator
+        self.creatorIsAdmin = creatorIsAdmin
+        self.commentCount = commentCount
+        creator.updateKnownCommunityBanState(id: community.id, banned: bannedFromCommunity)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2Providing.swift
@@ -1,0 +1,73 @@
+//
+//  Comment2Providing.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+
+public protocol Comment2Providing: Comment1Providing, Interactable2Providing, PersonContentProviding {
+    var comment2: Comment2 { get }
+    
+    var creator: any Person { get }
+    var post: Post1 { get }
+    var community: any Community { get }
+    var creatorIsModerator: Bool? { get }
+    var creatorIsAdmin: Bool? { get }
+    var bannedFromCommunity: Bool { get }
+}
+
+public extension Comment2Providing {
+    var comment1: Comment1 { comment2.comment1 }
+    
+    var creator: any Person { comment2.creator }
+    var post: Post1 { comment2.post }
+    var community: any Community { comment2.community }
+    var votes: VotesModel { comment2.votes }
+    var saved: Bool { comment2.saved }
+    var creatorIsModerator: Bool? { comment2.creatorIsModerator }
+    var creatorIsAdmin: Bool? { comment2.creatorIsAdmin }
+    var bannedFromCommunity: Bool { comment2.bannedFromCommunity }
+    var commentCount: Int { comment2.commentCount }
+    
+    var creator_: (any Person)? { comment2.creator }
+    var post_: Post1? { comment2.post }
+    var community_: (any Community)? { comment2.community }
+    var votes_: VotesModel? { comment2.votes }
+    var saved_: Bool? { comment2.saved }
+    var creatorIsModerator_: Bool? { comment2.creatorIsModerator }
+    var creatorIsAdmin_: Bool? { comment2.creatorIsAdmin }
+    var bannedFromCommunity_: Bool? { comment2.bannedFromCommunity }
+    var commentCount_: Int? { comment2.commentCount }
+}
+
+public extension Comment2Providing {
+    private var votesManager: StateManager<VotesModel> { comment2.votesManager }
+    private var savedManager: StateManager<Bool> { comment2.savedManager }
+    
+    func upgrade() async throws -> any Comment { self }
+    
+    @discardableResult
+    func updateVote(_ newValue: ScoringOperation) -> Task<StateUpdateResult, Never> {
+        votesManager.performRequest(expectedResult: votes.applyScoringOperation(operation: newValue)) { semaphore in
+            try await self.api.voteOnComment(id: self.id, score: newValue, semaphore: semaphore)
+        }
+    }
+    
+    @discardableResult
+    func updateSaved(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        savedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.saveComment(id: self.id, save: newValue, semaphore: semaphore)
+        }
+    }
+    
+    func getVotes(page: Int, limit: Int) async throws -> [PersonVote] {
+        try await api.getCommentVotes(id: id, communityId: community.id, page: page, limit: limit)
+    }
+}
+
+/// PersonContentProviding conformance
+public extension Comment2Providing {
+    var userContent: PersonContent { .init(wrappedValue: .comment(comment2)) }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/CommentStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/CommentStub.swift
@@ -1,0 +1,43 @@
+//
+//  CommentStub.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+
+public struct CommentStub: CommentStubProviding, Hashable {
+    public static let tierNumber: Int = 0
+    public var api: ApiClient
+    public let url: URL
+    
+    public init(api: ApiClient, url: URL) {
+        self.api = api
+        self.url = url
+    }
+    
+    public func asLocal() -> Self {
+        .init(api: .getApiClient(url: url.removingPathComponents(), username: nil), url: url)
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(url)
+    }
+    
+    public static func == (lhs: CommentStub, rhs: CommentStub) -> Bool {
+        lhs.url == rhs.url
+    }
+    
+    public func upgrade() async throws -> any Comment {
+        try await api.getComment(url: resolvableUrl)
+    }
+}
+
+// Resolvable conformance
+public extension CommentStub {
+    var resolvableUrl: URL { url }
+    
+    @inlinable
+    var allResolvableUrls: [URL] { [resolvableUrl] }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/CommentStubProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/CommentStubProviding.swift
@@ -1,0 +1,64 @@
+//
+//  CommentStubProviding.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+
+public protocol CommentStubProviding: ContentModel, Resolvable {
+    // From Comment1Providing. These are defined as nil in the extension below
+    var actorId_: ActorIdentifier? { get }
+    var content_: String? { get }
+    var created_: Date? { get }
+    var updated_: Date? { get }
+    var deleted_: Bool? { get }
+    var creatorId_: Int? { get }
+    var postId_: Int? { get }
+    var parentCommentIds_: [Int]? { get }
+    var distinguished_: Bool? { get }
+    var removed_: Bool? { get }
+    var removedManager_: StateManager<Bool>? { get }
+    var languageId_: Int? { get }
+    
+    // From Comment2Providing. These are defined as nil in the extension below
+    var creator_: (any Person)? { get }
+    var post_: Post1? { get }
+    var community_: (any Community)? { get }
+    var votes_: VotesModel? { get }
+    var saved_: Bool? { get }
+    var creatorIsModerator_: Bool? { get }
+    var creatorIsAdmin_: Bool? { get }
+    var bannedFromCommunity_: Bool? { get }
+    var commentCount_: Int? { get }
+    
+    func upgrade() async throws -> any Comment
+}
+
+public extension CommentStubProviding {
+    var actorId_: ActorIdentifier? { nil }
+    var content_: String? { nil }
+    var created_: Date? { nil }
+    var updated_: Date? { nil }
+    var deleted_: Bool? { nil }
+    var creatorId_: Int? { nil }
+    var postId_: Int? { nil }
+    var parentCommentIds_: [Int]? { nil }
+    var distinguished_: Bool? { nil }
+    var removed_: Bool? { nil }
+    var removedManager_: StateManager<Bool>? { nil }
+    var languageId_: Int? { nil }
+    
+    var creator_: (any Person)? { nil }
+    var post_: Post1? { nil }
+    var community_: (any Community)? { nil }
+    var votes_: VotesModel? { nil }
+    var saved_: Bool? { nil }
+    var creatorIsModerator_: Bool? { nil }
+    var creatorIsAdmin_: Bool? { nil }
+    var bannedFromCommunity_: Bool? { nil }
+    var commentCount_: Int? { nil }
+    
+    var depth_: Int? { parentCommentIds_?.count }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/AnyCommunity.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/AnyCommunity.swift
@@ -1,0 +1,79 @@
+//
+//  AnyCommunity.swift
+//
+//
+//  Created by Sjmarf on 23/06/2024.
+//
+
+import Foundation
+
+@Observable
+public class AnyCommunity: Hashable, Upgradable {
+    public typealias Base = CommunityStubProviding
+    public typealias MinimumRenderable = Community1Providing
+    public typealias Upgraded = Community3Providing
+    
+    public var wrappedValue: any CommunityStubProviding
+    
+    public required init(_ wrappedValue: any CommunityStubProviding) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+/// Hashable, Equatable conformance
+public extension AnyCommunity {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+    
+    static func == (lhs: AnyCommunity, rhs: AnyCommunity) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+}
+
+/// Upgradable conformance
+public extension AnyCommunity {
+    internal func upgrade(
+        initialValue: (any Base)? = nil,
+        upgradeOperation: (any Base) async throws -> any Base
+    ) async throws {
+        var lastValue = initialValue ?? wrappedValue
+        while !(lastValue is any Upgraded) {
+            lastValue = try await upgradeOperation(lastValue)
+            if type(of: lastValue).tierNumber >= type(of: wrappedValue).tierNumber {
+                let task = Task { @MainActor [lastValue] in
+                    self.wrappedValue = lastValue
+                }
+                _ = await task.value
+            }
+        }
+    }
+    
+    func upgrade(
+        api: ApiClient?,
+        upgradeOperation: ((any Base) async throws -> any Base)?
+    ) async throws {
+        let initialValue: any Base
+        if let api {
+            initialValue = api === wrappedValue.api ? wrappedValue : CommunityStub(
+                api: api,
+                url: wrappedValue.allResolvableUrls[0]
+            )
+        } else {
+            initialValue = wrappedValue
+        }
+        try await upgrade(
+            initialValue: initialValue,
+            upgradeOperation: upgradeOperation ?? { try await $0.upgrade() }
+        )
+    }
+    
+    func refresh(upgradeOperation: ((any Base) async throws -> any Base)?) async throws {
+        if let wrappedValue = wrappedValue as? any Upgraded {
+            try await upgrade(
+                initialValue: wrappedValue.community2,
+                upgradeOperation: upgradeOperation ?? { try await $0.upgrade() }
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community1+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community1+Codable.swift
@@ -1,0 +1,50 @@
+//
+//  Community1+Codable.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-01.
+//
+
+import Foundation
+
+public extension Community1 {
+    struct CodedData: Codable {
+        let apiUrl: URL
+        let apiMyPersonId: Int?
+        let apiCommunity: ApiCommunity
+    }
+    
+    internal var apiCommunity: ApiCommunity {
+        ApiCommunity(
+            id: id,
+            name: name,
+            title: displayName,
+            description: description,
+            removed: removed,
+            published: created,
+            updated: updated,
+            deleted: deleted,
+            nsfw: nsfw,
+            actorId: actorId,
+            local: apiIsLocal,
+            icon: avatar,
+            banner: banner,
+            hidden: hidden,
+            postingRestrictedToMods: onlyModeratorsCanPost,
+            instanceId: instanceId,
+            followersUrl: nil,
+            inboxUrl: nil,
+            onlyFollowersCanVote: nil,
+            visibility: visibility,
+            sidebar: nil
+        )
+    }
+    
+    func codedData() async throws -> CodedData {
+        try await .init(
+            apiUrl: api.baseUrl,
+            apiMyPersonId: api.myPersonId,
+            apiCommunity: apiCommunity
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community1+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community1+Mock.swift
@@ -1,0 +1,54 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-03.
+//
+
+import Foundation
+
+#if DEBUG
+    public extension Community1 {
+        static func mock(
+            api: MockApiClient = .mock,
+            actorId: ActorIdentifier? = nil,
+            id: Int,
+            name: String,
+            created: Date,
+            instanceId: Int,
+            updated: Date?,
+            displayName: String,
+            description: String?,
+            removed: Bool,
+            deleted: Bool,
+            nsfw: Bool,
+            avatar: URL?,
+            banner: URL?,
+            hidden: Bool,
+            onlyModeratorsCanPost: Bool,
+            blocked: Bool,
+            visibility: ApiCommunityVisibility?
+        ) -> Community1 {
+            .init(
+                api: api,
+                actorId: actorId ?? .init(url: URL(string: "https://\(api.host)/u/\(id)")!)!,
+                id: id,
+                name: name,
+                created: created,
+                instanceId: instanceId,
+                updated: updated,
+                displayName: displayName,
+                description: description,
+                removed: removed,
+                deleted: deleted,
+                nsfw: nsfw,
+                avatar: avatar,
+                banner: banner,
+                hidden: hidden,
+                onlyModeratorsCanPost: onlyModeratorsCanPost,
+                blocked: blocked,
+                visibility: visibility
+            )
+        }
+    }
+#endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community1.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community1.swift
@@ -1,0 +1,92 @@
+//
+//  CommunityTier1.swift
+//  Mlem
+//
+//  Created by Sjmarf on 03/02/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Community1: Community1Providing {
+    public static let tierNumber: Int = 1
+    public var community1: Community1 { self }
+    public var api: ApiClient
+
+    public let actorId: ActorIdentifier
+    public let id: Int
+    
+    public let name: String
+    public let created: Date
+    public let instanceId: Int
+    
+    public var updated: Date? = .distantPast
+    public var displayName: String = ""
+    public var description: String?
+    public var deleted: Bool = false
+    public var nsfw: Bool = false
+    public var avatar: URL?
+    public var banner: URL?
+    public var hidden: Bool = false
+    public var onlyModeratorsCanPost: Bool = false
+    public var visibility: ApiCommunityVisibility?
+    
+    public var purged: Bool = false
+    
+    // This isn't included in ApiCommunity - it's included in ApiCommunityView, but defined here to maintain similarity with Person models. Person models don't have the `blocked` property defined in any of the Api types, annoyingly. Instead, certain parent models such as ApiPostView contain the value.
+    var blockedManager: StateManager<Bool>
+    public var blocked: Bool { blockedManager.wrappedValue }
+    
+    public var removedManager: StateManager<Bool>
+    public var removed: Bool { removedManager.wrappedValue }
+  
+    init(
+        api: ApiClient,
+        actorId: ActorIdentifier,
+        id: Int,
+        name: String,
+        created: Date,
+        instanceId: Int,
+        updated: Date?,
+        displayName: String,
+        description: String?,
+        removed: Bool,
+        deleted: Bool,
+        nsfw: Bool,
+        avatar: URL?,
+        banner: URL?,
+        hidden: Bool,
+        onlyModeratorsCanPost: Bool,
+        blocked: Bool?,
+        visibility: ApiCommunityVisibility?
+    ) {
+        self.api = api
+        self.actorId = actorId
+        self.id = id
+        self.name = name
+        self.created = created
+        self.instanceId = instanceId
+        self.updated = updated
+        self.displayName = displayName
+        self.description = description
+        self.removedManager = .init(wrappedValue: removed)
+        self.deleted = deleted
+        self.nsfw = nsfw
+        self.avatar = avatar
+        self.banner = banner
+        self.hidden = hidden
+        self.onlyModeratorsCanPost = onlyModeratorsCanPost
+        self.visibility = visibility
+        self.blockedManager = .init(wrappedValue: blocked ?? api.blocks?.communities.keys.contains(actorId) ?? false)
+        blockedManager.onSet = { newValue, type, _ in
+            if type != .receive {
+                if newValue {
+                    api.blocks?.communities[actorId] = id
+                } else {
+                    api.blocks?.communities.removeValue(forKey: actorId)
+                }
+            }
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community1Providing.swift
@@ -1,0 +1,174 @@
+//
+//  Community1Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public protocol Community1Providing:
+    CommunityStubProviding,
+    Profile2Providing,
+    CommunityOrPerson,
+    ContentIdentifiable,
+    RemovableProviding,
+    PurgableProviding,
+    Sharable,
+    FeedLoadable where FilterType == CommunityFilterType {
+    var community1: Community1 { get }
+    
+    var name: String { get }
+    var deleted: Bool { get }
+    var nsfw: Bool { get }
+    var hidden: Bool { get }
+    var onlyModeratorsCanPost: Bool { get }
+    var blocked: Bool { get }
+}
+
+public typealias Community = Community1Providing
+
+public extension Community1Providing {
+    static var modelTypeId: ContentType { .community }
+    
+    var actorId: ActorIdentifier { community1.actorId }
+    var name: String { community1.name }
+    
+    var id: Int { community1.id }
+    var created: Date { community1.created }
+    var instanceId: Int { community1.instanceId }
+    var updated: Date? { community1.updated }
+    var displayName: String { community1.displayName }
+    var description: String? { community1.description }
+    var removed: Bool { community1.removed }
+    var removedManager: StateManager<Bool> { community1.removedManager }
+    var deleted: Bool { community1.deleted }
+    var nsfw: Bool { community1.nsfw }
+    var avatar: URL? { community1.avatar }
+    var banner: URL? { community1.banner }
+    var hidden: Bool { community1.hidden }
+    var onlyModeratorsCanPost: Bool { community1.onlyModeratorsCanPost }
+    var blocked: Bool { community1.blocked }
+    var purged: Bool { community1.purged }
+    var visibility: ApiCommunityVisibility? { community1.visibility }
+    
+    var actorId_: ActorIdentifier? { community1.actorId }
+    var id_: Int? { community1.id }
+    var created_: Date? { community1.created }
+    var instanceId_: Int? { community1.instanceId }
+    var updated_: Date? { community1.updated }
+    var name_: String? { community1.name }
+    var displayName_: String? { community1.displayName }
+    var description_: String? { community1.description }
+    var removed_: Bool? { community1.removed }
+    var removedManager_: StateManager<Bool>? { community1.removedManager }
+    var deleted_: Bool? { community1.deleted }
+    var nsfw_: Bool? { community1.nsfw }
+    var avatar_: URL? { community1.avatar }
+    var banner_: URL? { community1.banner }
+    var hidden_: Bool? { community1.hidden }
+    var onlyModeratorsCanPost_: Bool? { community1.onlyModeratorsCanPost }
+    var blocked_: Bool? { community1.blocked }
+    var purged_: Bool? { community1.purged }
+    var visibility_: ApiCommunityVisibility? { community1.visibility }
+}
+
+// Resolvable conformance
+public extension Community1Providing {
+    @inlinable
+    var allResolvableUrls: [URL] {
+        ContentModelUrlType.allCases.map { resolvableUrl(from: $0) }
+    }
+}
+
+// Sharable conformance
+public extension Community1Providing {
+    func url() -> URL {
+        if apiIsLocal {
+            api.baseUrl.appending(path: "c/\(name)")
+        } else {
+            api.baseUrl.appending(path: "c/\(name)@\(host)")
+        }
+    }
+}
+
+// FeedLoadable conformance
+public extension Community1Providing {
+    func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        switch sortType {
+        case .new:
+            return .new(created)
+        }
+    }
+}
+
+// SelectableContentProviding conformance
+public extension Community1Providing {
+    var selectableContent: String? { description }
+}
+
+public extension Community1Providing {
+    private var blockedManager: StateManager<Bool> { community1.blockedManager }
+    
+    /// Returns a `URL` that can be resolved by another `ApiClient`.
+    func resolvableUrl(from instance: ContentModelUrlType) -> URL {
+        switch instance {
+        case .host: actorId.url
+        case .provider: .community(host: api.host, name: name)
+        }
+    }
+    
+    func upgrade() async throws -> any Community {
+        try await api.getCommunity(id: id)
+    }
+    
+    func getPosts(
+        sort: PostSortType,
+        page: Int = 1,
+        cursor: String? = nil,
+        limit: Int,
+        filter: GetContentFilter? = nil,
+        showHidden: Bool = false
+    ) async throws -> (posts: [Post2], cursor: String?) {
+        try await api.getPosts(
+            communityId: id,
+            sort: sort,
+            page: page,
+            cursor: cursor,
+            limit: limit,
+            filter: filter,
+            showHidden: showHidden
+        )
+    }
+    
+    @discardableResult
+    func updateBlocked(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        blockedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.blockCommunity(id: self.id, block: newValue, semaphore: semaphore)
+        }
+    }
+    
+    @discardableResult
+    func toggleBlocked() -> Task<StateUpdateResult, Never> {
+        updateBlocked(!blocked)
+    }
+    
+    @discardableResult
+    func updateRemoved(_ newValue: Bool, reason: String?) -> Task<StateUpdateResult, Never> {
+        removedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.removeCommunity(id: self.id, remove: newValue, reason: reason, semaphore: semaphore)
+        }
+    }
+    
+    func purge(reason: String?) async throws {
+        try await api.purgeCommunity(id: id, reason: reason)
+    }
+    
+    func addModerator(personId: Int, added: Bool) async throws {
+        try await api.addModerator(communityId: id, personId: personId, added: added)
+    }
+    
+    func addModerator(_ person: any Person, added: Bool) async throws {
+        try await api.addModerator(communityId: id, personId: person.id, added: added)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2+Codable.swift
@@ -1,0 +1,50 @@
+//
+//  Community2+Codable.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-01.
+//
+
+import Foundation
+
+public extension Community2 {
+    struct CodedData: Codable {
+        let apiUrl: URL
+        let apiMyPersonId: Int?
+        let apiCommunityView: ApiCommunityView
+    }
+    
+    internal var apiCommunityView: ApiCommunityView {
+        .init(
+            community: community1.apiCommunity,
+            subscribed: subscription.subscribedType,
+            blocked: blocked,
+            counts: .init(
+                id: nil,
+                communityId: id,
+                subscribers: subscription.actualTotal,
+                posts: postCount,
+                comments: commentCount,
+                published: created,
+                usersActiveDay: activeUserCount.day,
+                usersActiveWeek: activeUserCount.week,
+                usersActiveMonth: activeUserCount.month,
+                usersActiveHalfYear: activeUserCount.sixMonths,
+                hotRank: nil,
+                subscribersLocal: subscription.actualLocal
+            ),
+            // Our current architecture doesn't allow us to guarantee that the ban status is present here.
+            // Once we drop support for 0.19.3 `nil` won't be allowed here anymore; this will become a
+            // problem and we'll have to work around it somehow
+            bannedFromCommunity: api.myPerson?.isBannedFromCommunity(self)
+        )
+    }
+    
+    func codedData() async throws -> CodedData {
+        try await .init(
+            apiUrl: api.baseUrl,
+            apiMyPersonId: api.myPersonId,
+            apiCommunityView: apiCommunityView
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2+Mock.swift
@@ -3,37 +3,37 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-02-03.
-//  
+//
 
 import Foundation
 
 #if DEBUG
-public extension Community2 {
-    static func mock(
-        community1: Community1,
-        subscriberCount: Int,
-        localSubscriberCount: Int,
-        subscribed: Bool,
-        subscriptionPending: Bool,
-        postCount: Int,
-        commentCount: Int,
-        activeUserCount: ActiveUserCount,
-        bannedFromCommunity: Bool?
-    ) -> Community2 {
-        return .init(
-            api: community1.api,
-            community1: community1,
-            subscription: .init(
-                total: subscriberCount,
-                local: localSubscriberCount,
-                subscribed: subscribed,
-                pending: subscriptionPending
-            ),
-            postCount: postCount,
-            commentCount: commentCount,
-            activeUserCount: activeUserCount,
-            bannedFromCommunity: bannedFromCommunity
-        )
+    public extension Community2 {
+        static func mock(
+            community1: Community1,
+            subscriberCount: Int,
+            localSubscriberCount: Int,
+            subscribed: Bool,
+            subscriptionPending: Bool,
+            postCount: Int,
+            commentCount: Int,
+            activeUserCount: ActiveUserCount,
+            bannedFromCommunity: Bool?
+        ) -> Community2 {
+            .init(
+                api: community1.api,
+                community1: community1,
+                subscription: .init(
+                    total: subscriberCount,
+                    local: localSubscriberCount,
+                    subscribed: subscribed,
+                    pending: subscriptionPending
+                ),
+                postCount: postCount,
+                commentCount: commentCount,
+                activeUserCount: activeUserCount,
+                bannedFromCommunity: bannedFromCommunity
+            )
+        }
     }
-}
 #endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2+Mock.swift
@@ -3,37 +3,37 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-02-03.
-//
+//  
 
 import Foundation
 
 #if DEBUG
-    public extension Community2 {
-        static func mock(
-            community1: Community1,
-            subscriberCount: Int,
-            localSubscriberCount: Int,
-            subscribed: Bool,
-            subscriptionPending: Bool,
-            postCount: Int,
-            commentCount: Int,
-            activeUserCount: ActiveUserCount,
-            bannedFromCommunity: Bool?
-        ) -> Community2 {
-            .init(
-                api: community1.api,
-                community1: community1,
-                subscription: .init(
-                    total: subscriberCount,
-                    local: localSubscriberCount,
-                    subscribed: subscribed,
-                    pending: subscriptionPending
-                ),
-                postCount: postCount,
-                commentCount: commentCount,
-                activeUserCount: activeUserCount,
-                bannedFromCommunity: bannedFromCommunity
-            )
-        }
+public extension Community2 {
+    static func mock(
+        community1: Community1,
+        subscriberCount: Int,
+        localSubscriberCount: Int,
+        subscribed: Bool,
+        subscriptionPending: Bool,
+        postCount: Int,
+        commentCount: Int,
+        activeUserCount: ActiveUserCount,
+        bannedFromCommunity: Bool?
+    ) -> Community2 {
+        return .init(
+            api: community1.api,
+            community1: community1,
+            subscription: .init(
+                total: subscriberCount,
+                local: localSubscriberCount,
+                subscribed: subscribed,
+                pending: subscriptionPending
+            ),
+            postCount: postCount,
+            commentCount: commentCount,
+            activeUserCount: activeUserCount,
+            bannedFromCommunity: bannedFromCommunity
+        )
     }
+}
 #endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2+Mock.swift
@@ -1,0 +1,39 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-03.
+//
+
+import Foundation
+
+#if DEBUG
+    public extension Community2 {
+        static func mock(
+            community1: Community1,
+            subscriberCount: Int,
+            localSubscriberCount: Int,
+            subscribed: Bool,
+            subscriptionPending: Bool,
+            postCount: Int,
+            commentCount: Int,
+            activeUserCount: ActiveUserCount,
+            bannedFromCommunity: Bool?
+        ) -> Community2 {
+            .init(
+                api: community1.api,
+                community1: community1,
+                subscription: .init(
+                    total: subscriberCount,
+                    local: localSubscriberCount,
+                    subscribed: subscribed,
+                    pending: subscriptionPending
+                ),
+                postCount: postCount,
+                commentCount: commentCount,
+                activeUserCount: activeUserCount,
+                bannedFromCommunity: bannedFromCommunity
+            )
+        }
+    }
+#endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2.swift
@@ -1,0 +1,60 @@
+//
+//  CommunityTier2.swift
+//  Mlem
+//
+//  Created by Sjmarf on 03/02/2024.
+//
+
+import Observation
+
+@Observable
+public final class Community2: Community2Providing {
+    public static let tierNumber: Int = 2
+    public var community2: Community2 { self }
+    public var api: ApiClient
+
+    public let community1: Community1
+    
+    var subscriptionManager: StateManager<SubscriptionModel>
+    var subscription: SubscriptionModel { subscriptionManager.wrappedValue }
+    
+    public var favorited: Bool {
+        api.subscriptions?.isFavorited(self) ?? false
+    }
+    
+    /// Used to state-fake internally.
+    var shouldBeFavorited: Bool = false
+
+    public var postCount: Int
+    public var commentCount: Int
+    public var activeUserCount: ActiveUserCount
+
+    init(
+        api: ApiClient,
+        community1: Community1,
+        subscription: SubscriptionModel,
+        postCount: Int,
+        commentCount: Int,
+        activeUserCount: ActiveUserCount,
+        bannedFromCommunity: Bool?
+    ) {
+        self.api = api
+        self.community1 = community1
+        self.subscriptionManager = .init(wrappedValue: subscription)
+        self.postCount = postCount
+        self.commentCount = commentCount
+        self.activeUserCount = activeUserCount
+        
+        if favorited, !subscribed {
+            self.api.subscriptions?.favoriteIDs.remove(id)
+        }
+        subscriptionManager.onSet = { _, _, _ in
+            self.api.subscriptions?.updateCommunitySubscription(community: self)
+        }
+        self.shouldBeFavorited = favorited
+        subscriptionManager.onSet(subscription, .receive, nil)
+        if let bannedFromCommunity {
+            api.myPerson?.person1.updateKnownCommunityBanState(id: id, banned: bannedFromCommunity)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community2Providing.swift
@@ -1,0 +1,102 @@
+//
+//  Community2Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public protocol Community2Providing: Community1Providing {
+    var community2: Community2 { get }
+    
+    var subscribed: Bool { get }
+    var favorited: Bool { get }
+    var subscriberCount: Int { get }
+    var localSubscriberCount: Int? { get }
+    var postCount: Int { get }
+    var commentCount: Int { get }
+    var activeUserCount: ActiveUserCount { get }
+    
+    @discardableResult
+    func toggleSubscribe() -> Task<StateUpdateResult, Never>
+    
+    /// Favoriting a community also subscribes to it, if it is not subscribed already.
+    @discardableResult
+    func toggleFavorite() -> Task<StateUpdateResult, Never>
+}
+
+public extension Community2Providing {
+    var community1: Community1 { community2.community1 }
+    
+    var subscribed: Bool { community2.subscription.subscribed }
+    var favorited: Bool { community2.favorited }
+    var subscriberCount: Int { community2.subscription.total }
+    var localSubscriberCount: Int? { community2.subscription.local }
+    var postCount: Int { community2.postCount }
+    var commentCount: Int { community2.commentCount }
+    var activeUserCount: ActiveUserCount { community2.activeUserCount }
+    
+    var subscribed_: Bool? { community2.subscription.subscribed }
+    var favorited_: Bool? { community2.favorited }
+    var subscriberCount_: Int? { community2.subscription.total }
+    var localSubscriberCount_: Int? { community2.subscription.local }
+    var postCount_: Int? { community2.postCount }
+    var commentCount_: Int? { community2.commentCount }
+    var activeUserCount_: ActiveUserCount? { community2.activeUserCount }
+    var subscriptionTier_: SubscriptionTier? { community2.subscriptionTier }
+}
+
+public extension Community2Providing {
+    private var subscriptionManager: StateManager<SubscriptionModel> { community2.subscriptionManager }
+    
+    var subscriptionTier: SubscriptionTier {
+        if favorited { return .favorited }
+        if subscribed { return .subscribed }
+        return .unsubscribed
+    }
+    
+    @discardableResult
+    func toggleSubscribe() -> Task<StateUpdateResult, Never> {
+        updateSubscribe(!subscribed)
+    }
+    
+    @discardableResult
+    func updateSubscribe(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        subscriptionManager.performRequest(
+            expectedResult: community2.subscription.withSubscriptionStatus(subscribed: newValue, isLocal: apiIsLocal)
+        ) { semaphore in
+            if !newValue {
+                self.community2.shouldBeFavorited = false
+            }
+            try await self.api.subscribeToCommunity(id: self.id, subscribe: newValue, semaphore: semaphore)
+        }
+    }
+    
+    @discardableResult
+    func toggleFavorite() -> Task<StateUpdateResult, Never> {
+        updateFavorite(!favorited)
+    }
+    
+    @discardableResult
+    func updateFavorite(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        guard let subscriptions = api.subscriptions else {
+            assertionFailure("Tried to toggle favorite, but no SubscriptionList found!")
+            return Task { .failed }
+        }
+        community2.shouldBeFavorited = newValue
+        if !subscribed, newValue {
+            return subscriptionManager.performRequest(
+                expectedResult: community2.subscription.withSubscriptionStatus(subscribed: true, isLocal: apiIsLocal)
+            ) { semaphore in
+                subscriptions.updateCommunitySubscription(community: self.community2)
+                try await self.api.subscribeToCommunity(id: self.id, subscribe: true, semaphore: semaphore)
+            } onRollback: { _ in
+                self.community2.shouldBeFavorited = false
+            }
+        } else {
+            subscriptions.updateCommunitySubscription(community: community2)
+            return Task { .succeeded }
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community3.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community3.swift
@@ -1,0 +1,35 @@
+//
+//  CommunityTier3.swift
+//  Mlem
+//
+//  Created by Sjmarf on 03/02/2024.
+//
+
+import Observation
+
+@Observable
+public final class Community3: Community3Providing {
+    public static let tierNumber: Int = 3
+    public var community3: Community3 { self }
+    public let api: ApiClient
+    
+    public let community2: Community2
+    
+    public var instance: Instance1?
+    public var moderators: [Person1] = .init()
+    public var discussionLanguages: [Int] = .init()
+  
+    init(
+        api: ApiClient,
+        community2: Community2,
+        instance: Instance1?,
+        moderators: [Person1] = .init(),
+        discussionLanguages: [Int] = .init()
+    ) {
+        self.api = api
+        self.community2 = community2
+        self.instance = instance
+        self.moderators = moderators
+        self.discussionLanguages = discussionLanguages
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community3Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community3Providing.swift
@@ -1,0 +1,36 @@
+//
+//  Community3Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public protocol Community3Providing: Community2Providing {
+    var community3: Community3 { get }
+    
+    var instance: Instance1? { get }
+    var moderators: [Person1] { get }
+    var discussionLanguages: [Int] { get }
+    // var defaultPostLanguage: Int? { get }
+}
+
+public extension Community3Providing {
+    var community2: Community2 { community3.community2 }
+    
+    /// This is optional because it's defined as such on ``ApiGetCommunityResponse``. I'm not sure when it actually returns `nil`.
+    var instance: Instance1? { community3.instance }
+    var moderators: [Person1] { community3.moderators }
+    var discussionLanguages: [Int] { community3.discussionLanguages }
+    // var defaultPostLanguage: Int? { community3.defaultPostLanguage }
+    
+    var instance_: Instance1? { community3.instance }
+    var moderators_: [Person1]? { community3.moderators }
+    var discussionLanguages_: [Int]? { community3.discussionLanguages }
+    // var defaultPostLanguage_: Int? { community3.defaultPostLanguage }
+}
+
+public extension Community3Providing {
+    func upgrade() async throws -> any Community { self }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/CommunityStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/CommunityStub.swift
@@ -1,0 +1,43 @@
+//
+//  CommunityStub.swift
+//  Mlem
+//
+//  Created by Sjmarf on 03/02/2024.
+//
+
+import Foundation
+
+public struct CommunityStub: CommunityStubProviding, Hashable {
+    public static let tierNumber: Int = 0
+    public var api: ApiClient
+    public let url: URL
+    
+    public init(api: ApiClient, url: URL) {
+        self.api = api
+        self.url = url
+    }
+    
+    public func asLocal() -> Self {
+        .init(api: .getApiClient(url: url.removingPathComponents(), username: nil), url: url)
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(url)
+    }
+    
+    public static func == (lhs: CommunityStub, rhs: CommunityStub) -> Bool {
+        lhs.url == rhs.url
+    }
+    
+    public func upgrade() async throws -> any Community {
+        try await api.getCommunity(url: url) as Community2
+    }
+}
+
+// Resolvable conformance
+public extension CommunityStub {
+    var resolvableUrl: URL { url }
+    
+    @inlinable
+    var allResolvableUrls: [URL] { [resolvableUrl] }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/CommunityStubProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/CommunityStubProviding.swift
@@ -1,0 +1,90 @@
+//
+//  CommunityStubProviding.swift
+//  Mlem
+//
+//  Created by Sjmarf on 15/02/2024.
+//
+
+import Foundation
+
+public protocol CommunityStubProviding: ContentModel, Resolvable {
+    // From Community1Providing.
+    var actorId_: ActorIdentifier? { get }
+    var id_: Int? { get }
+    var created_: Date? { get }
+    var instanceId_: Int? { get }
+    var updated_: Date? { get }
+    var name_: String? { get }
+    var displayName_: String? { get }
+    var description_: String? { get }
+    var removed_: Bool? { get }
+    var removedManager_: StateManager<Bool>? { get }
+    var deleted_: Bool? { get }
+    var nsfw_: Bool? { get }
+    var avatar_: URL? { get }
+    var banner_: URL? { get }
+    var hidden_: Bool? { get }
+    var onlyModeratorsCanPost_: Bool? { get }
+    var blocked_: Bool? { get }
+    var purged_: Bool? { get }
+    var visibility_: ApiCommunityVisibility? { get }
+    
+    // From Community2Providing.
+    var subscribed_: Bool? { get }
+    var favorited_: Bool? { get }
+    var subscriberCount_: Int? { get }
+    var localSubscriberCount_: Int? { get }
+    var postCount_: Int? { get }
+    var commentCount_: Int? { get }
+    var activeUserCount_: ActiveUserCount? { get }
+    var subscriptionTier_: SubscriptionTier? { get }
+    
+    // From Community3Providing.
+    var instance_: Instance1? { get }
+    var moderators_: [Person1]? { get }
+    var discussionLanguages_: [Int]? { get }
+    var defaultPostLanguage_: Int? { get }
+    
+    func upgrade() async throws -> any Community
+}
+
+public extension CommunityStubProviding {
+    static var identifierPrefix: String { "!" }
+    
+    // From Community1Providing.
+    var actorId_: ActorIdentifier? { nil }
+    var id_: Int? { nil }
+    var created_: Date? { nil }
+    var instanceId_: Int? { nil }
+    var updated_: Date? { nil }
+    var name_: String? { nil }
+    var displayName_: String? { nil }
+    var description_: String? { nil }
+    var removed_: Bool? { nil }
+    var removedManager_: StateManager<Bool>? { nil }
+    var deleted_: Bool? { nil }
+    var nsfw_: Bool? { nil }
+    var avatar_: URL? { nil }
+    var banner_: URL? { nil }
+    var hidden_: Bool? { nil }
+    var onlyModeratorsCanPost_: Bool? { nil }
+    var blocked_: Bool? { nil }
+    var purged_: Bool? { nil }
+    var visibility_: ApiCommunityVisibility? { nil }
+    
+    // From Community2Providing.
+    var subscribed_: Bool? { nil }
+    var favorited_: Bool? { nil }
+    var subscriberCount_: Int? { nil }
+    var localSubscriberCount_: Int? { nil }
+    var postCount_: Int? { nil }
+    var commentCount_: Int? { nil }
+    var activeUserCount_: ActiveUserCount? { nil }
+    var subscriptionTier_: SubscriptionTier? { nil }
+    
+    // From Community3Providing.
+    var instance_: Instance1? { nil }
+    var moderators_: [Person1]? { nil }
+    var discussionLanguages_: [Int]? { nil }
+    var defaultPostLanguage_: Int? { nil }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/SubscriptionTier.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/SubscriptionTier.swift
@@ -1,0 +1,10 @@
+//
+//  SubscriptionTier.swift
+//  Mlem
+//
+//  Created by Sjmarf on 15/02/2024.
+//
+
+public enum SubscriptionTier {
+    case unsubscribed, subscribed, favorited
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityOrPersonStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityOrPersonStub.swift
@@ -1,0 +1,21 @@
+//
+//  CommunityOrAccount.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+import Observation
+
+public protocol CommunityOrPerson: ContentModel, ActorIdentifiable {
+    static var identifierPrefix: String { get }
+    
+    var name: String { get }
+}
+
+public extension CommunityOrPerson {
+    var fullName: String { "\(name)@\(host)" }
+    
+    var fullNameWithPrefix: String { "\(Self.identifierPrefix)\(name)@\(host)" }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ContentModel.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ContentModel.swift
@@ -1,0 +1,54 @@
+//
+//  ContentModel.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+
+public protocol ContentModel {
+    static var tierNumber: Int { get }
+    var api: ApiClient { get }
+}
+
+extension ContentModel {
+    @MainActor
+    func setIfChanged<T: Equatable>(_ keyPath: ReferenceWritableKeyPath<Self, T>, _ value: T) {
+        if self[keyPath: keyPath] != value {
+            self[keyPath: keyPath] = value
+        }
+    }
+}
+
+public extension ContentModel where Self: ActorIdentifiable {
+    var apiIsLocal: Bool {
+        api.host == "localhost" || api.host == host
+    }
+}
+
+public protocol ContentIdentifiable: AnyObject, ContentModel, Hashable, Identifiable where ID == Int {
+    static var modelTypeId: ContentType { get }
+}
+
+public extension ContentIdentifiable {
+    var uid: Int {
+        var hasher = Hasher()
+        hasher.combine(Self.modelTypeId)
+        hasher.combine(id)
+        return hasher.finalize()
+    }
+}
+
+public extension ContentIdentifiable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(api)
+        hasher.combine(id)
+        hasher.combine(Self.modelTypeId)
+        hasher.combine(Self.tierNumber)
+    }
+    
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs === rhs
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ContentModelUrlType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ContentModelUrlType.swift
@@ -1,0 +1,15 @@
+//
+//  ContentModelUrlType.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-26.
+//
+
+import Foundation
+
+public enum ContentModelUrlType: CaseIterable {
+    /// Refers to the instance that this entity originally came from.
+    case host
+    /// Refers to the instance that provided this entity (e.g. the `ApiClient` attached to the entity).
+    case provider
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ContentType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ContentType.swift
@@ -1,0 +1,12 @@
+//
+//  Content Type.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-08-26.
+//
+
+import Foundation
+
+public enum ContentType: Int, Codable {
+    case post, comment, community, person, message, mention, reply, instance, registrationApplication
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/DeletableProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/DeletableProviding.swift
@@ -1,0 +1,22 @@
+//
+//  DeletableProviding.swift
+//
+//
+//  Created by Sjmarf on 22/07/2024.
+//
+
+import Foundation
+
+public protocol DeletableProviding: ContentIdentifiable {
+    var deleted: Bool { get }
+    
+    @discardableResult
+    func updateDeleted(_ newValue: Bool) -> Task<StateUpdateResult, Never>
+}
+
+public extension DeletableProviding {
+    @discardableResult
+    func toggleDeleted() -> Task<StateUpdateResult, Never> {
+        updateDeleted(!deleted)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/DeletableProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/DeletableProviding.swift
@@ -1,6 +1,6 @@
 //
 //  DeletableProviding.swift
-//
+//  
 //
 //  Created by Sjmarf on 22/07/2024.
 //

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/DeletableProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/DeletableProviding.swift
@@ -1,6 +1,6 @@
 //
 //  DeletableProviding.swift
-//  
+//
 //
 //  Created by Sjmarf on 22/07/2024.
 //

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/FederationStatus.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/FederationStatus.swift
@@ -1,0 +1,20 @@
+//
+//  FederationStatus.swift
+//
+//
+//  Created by Sjmarf on 10/06/2024.
+//
+
+import Foundation
+
+public enum FederationStatus {
+    case explicitlyAllowed, explicitlyBlocked, implicitlyAllowed, implicitlyBlocked
+    
+    public var isExplicit: Bool {
+        self == .explicitlyAllowed || self == .explicitlyBlocked
+    }
+    
+    public var isAllowed: Bool {
+        self == .explicitlyAllowed || self == .implicitlyAllowed
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/GetContentFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/GetContentFilter.swift
@@ -1,0 +1,12 @@
+//
+//  GetContentFilter.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+
+public enum GetContentFilter {
+    case saved, upvoted, downvoted
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ImageUpload/ImageUpload1.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ImageUpload/ImageUpload1.swift
@@ -1,0 +1,35 @@
+//
+//  ImageUpload1.swift
+//
+//
+//  Created by Sjmarf on 26/08/2024.
+//
+
+import Foundation
+import Observation
+
+// There are no higher tiers of this model yet - in future `ImageUpload2` will be
+// created from `ApiLocalImage` and `ImageUpload3` will be created from `ApiLocalImageView`.
+
+@Observable
+public class ImageUpload1: ImageUpload1Providing {
+    public static let tierNumber: Int = 1
+    public var api: ApiClient
+    public var mediaUpload1: ImageUpload1 { self }
+    
+    // This includes the file extension
+    let alias: String
+    let deleteToken: String
+    
+    public internal(set) var deleted: Bool = false
+    
+    public var url: URL {
+        api.baseUrl.appending(path: "pictrs/image/\(alias)")
+    }
+    
+    init(api: ApiClient, alias: String, deleteToken: String) {
+        self.api = api
+        self.alias = alias
+        self.deleteToken = deleteToken
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ImageUpload/ImageUpload1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ImageUpload/ImageUpload1Providing.swift
@@ -1,0 +1,33 @@
+//
+//  ImageUpload1Providing.swift
+//
+//
+//  Created by Sjmarf on 26/08/2024.
+//
+
+import Foundation
+
+public protocol ImageUpload1Providing: ContentModel, Hashable {
+    var mediaUpload1: ImageUpload1 { get }
+    var url: URL { get }
+    var deleted: Bool { get }
+}
+
+public extension ImageUpload1Providing {
+    /// Delete the image. Doesn't state-fake. Can't be undone.
+    func delete() async throws {
+        try await api.deleteImage(alias: mediaUpload1.alias, deleteToken: mediaUpload1.deleteToken)
+        mediaUpload1.deleted = true
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(url)
+    }
+    
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+}
+
+public typealias ImageUpload = ImageUpload1Providing
+ 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/InboxItemProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/InboxItemProviding.swift
@@ -1,0 +1,23 @@
+//
+//  InboxItemProviding.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+public protocol InboxItemProviding: ContentIdentifiable, ContentModel, ReadableProviding {
+    var created: Date { get }
+    var read: Bool { get }
+    
+    @discardableResult
+    func updateRead(_ newValue: Bool) -> Task<StateUpdateResult, Never>
+}
+
+public extension InboxItemProviding {
+    @discardableResult
+    func toggleRead() -> Task<StateUpdateResult, Never> {
+        updateRead(!read)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance1.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance1.swift
@@ -1,0 +1,88 @@
+//
+//  InstanceTier1.swift
+//  Mlem
+//
+//  Created by Sjmarf on 09/02/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Instance1: Instance1Providing {
+    public static let tierNumber: Int = 1
+    public var api: ApiClient
+    public var instance1: Instance1 { self }
+    
+    public let actorId: ActorIdentifier
+    
+    // For some reason, instances have two different IDs.
+    // `instanceId` should be used when blocking the instance.
+    public let id: Int
+    public let instanceId: Int
+    
+    public let created: Date
+    public let updated: Date?
+    public let publicKey: String
+    
+    public var displayName: String = ""
+    public var description: String?
+    public var shortDescription: String?
+    public var avatar: URL?
+    public var banner: URL?
+    public var lastRefresh: Date = .distantPast
+    public var contentWarning: String?
+    
+    /// If this is `false`, The instance is *not* guaranteed to be non-local, particularly for locally running instances.
+    public var local: Bool = false
+    
+    // This is set externally when the instance is loaded
+    var blockedManager: StateManager<Bool>
+    public var blocked: Bool { blockedManager.wrappedValue }
+    
+    init(
+        api: ApiClient,
+        actorId: ActorIdentifier,
+        id: Int,
+        instanceId: Int,
+        created: Date,
+        updated: Date?,
+        publicKey: String,
+        displayName: String,
+        description: String?,
+        shortDescription: String?,
+        avatar: URL?,
+        banner: URL?,
+        lastRefresh: Date,
+        contentWarning: String?,
+        blocked: Bool?
+    ) {
+        self.api = api
+        self.actorId = actorId
+        self.id = id
+        self.instanceId = instanceId
+        self.created = created
+        self.updated = updated
+        self.publicKey = publicKey
+        self.displayName = displayName
+        self.description = description
+        self.shortDescription = shortDescription
+        self.avatar = avatar
+        self.banner = banner
+        self.lastRefresh = lastRefresh
+        self.contentWarning = contentWarning
+        self.local = actorId.url == api.baseUrl
+        self.blockedManager = .init(
+            wrappedValue: blocked ?? api.blocks?.instances.keys.contains(actorId) ?? false
+        )
+        blockedManager.onSet = { newValue, type, _ in
+            if type != .receive {
+                if newValue {
+                    api.blocks?.instances[actorId] = instanceId
+                } else {
+                    api.blocks?.instances.removeValue(forKey: actorId)
+                }
+            }
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance1Providing.swift
@@ -1,0 +1,92 @@
+//
+//  Instance1Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public protocol Instance1Providing:
+    Profile2Providing,
+    ActorIdentifiable,
+    ContentIdentifiable,
+    InstanceStubProviding,
+    ContentModel {
+    var instance1: Instance1 { get }
+    
+    var id: Int { get }
+    /// This ID is different from `id`, and should be used when blocking an instance.
+    var instanceId: Int { get }
+    var publicKey: String { get }
+    var lastRefresh: Date { get }
+    var local: Bool { get }
+    var shortDescription: String? { get }
+    var contentWarning: String? { get }
+    var blocked: Bool { get }
+}
+
+public typealias Instance = Instance1Providing
+
+public extension Instance1Providing {
+    static var modelTypeId: ContentType { .instance }
+    
+    var actorId: ActorIdentifier { instance1.actorId }
+    var id: Int { instance1.id }
+    var instanceId: Int { instance1.instanceId }
+    var displayName: String { instance1.displayName }
+    var description: String? { instance1.description }
+    var shortDescription: String? { instance1.shortDescription }
+    var avatar: URL? { instance1.avatar }
+    var banner: URL? { instance1.banner }
+    var created: Date { instance1.created }
+    var updated: Date? { instance1.updated }
+    var publicKey: String { instance1.publicKey }
+    var lastRefresh: Date { instance1.lastRefresh }
+    internal(set) var local: Bool { get { instance1.local } set {
+        instance1.local = newValue
+    }}
+    var contentWarning: String? { instance1.contentWarning }
+    var blocked: Bool { instance1.blocked }
+    
+    var id_: Int? { instance1.id }
+    var instanceId_: Int { instance1.instanceId }
+    var displayName_: String? { instance1.displayName }
+    var description_: String? { instance1.description }
+    var shortDescription_: String? { instance1.shortDescription }
+    var avatar_: URL? { instance1.avatar }
+    var banner_: URL? { instance1.banner }
+    var created_: Date? { instance1.created }
+    var updated_: Date? { instance1.updated }
+    var publicKey_: String? { instance1.publicKey }
+    var lastRefresh_: Date? { instance1.lastRefresh }
+    var contentWarning_: String? { instance1.contentWarning }
+    var blocked_: Bool? { instance1.blocked }
+}
+
+public extension Instance1Providing {
+    private var blockedManager: StateManager<Bool> { instance1.blockedManager }
+    
+    @inlinable
+    var name: String { host } // TODO: Remove this?
+    
+    var guestApi: ApiClient {
+        .getApiClient(url: local ? api.baseUrl : actorId.hostUrl, username: nil)
+    }
+    
+    @discardableResult
+    func updateBlocked(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        blockedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.blockInstance(
+                url: self.actorId.url,
+                instanceId: self.instanceId,
+                block: newValue, semaphore: semaphore
+            )
+        }
+    }
+    
+    @discardableResult
+    func toggleBlocked() -> Task<StateUpdateResult, Never> {
+        updateBlocked(!blocked)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance2.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance2.swift
@@ -1,0 +1,109 @@
+//
+//  Instance2.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Instance2: Instance2Providing {
+    public static let tierNumber: Int = 2
+    public var api: ApiClient
+    public var instance2: Instance2 { self }
+    
+    public let instance1: Instance1
+    
+    public var setup: Bool
+    public var downvotesEnabled: Bool
+    public var nsfwContentEnabled: Bool
+    public var communityCreationRestrictedToAdmins: Bool
+    public var emailVerificationRequired: Bool
+    public var applicationQuestion: String?
+    public var isPrivate: Bool
+    public var defaultTheme: String
+    public var defaultFeed: ApiListingType
+    public var legalInformation: String?
+    public var hideModlogNames: Bool
+    public var emailApplicationsToAdmins: Bool
+    public var emailReportsToAdmins: Bool
+    public var slurFilterRegex: String?
+    public var actorNameMaxLength: Int
+    public var federationEnabled: Bool
+    public var captchaEnabled: Bool
+    public var captchaDifficulty: CaptchaDifficulty?
+    public var registrationMode: ApiRegistrationMode
+    public var federationSignedFetch: Bool?
+    public var defaultPostListingMode: ApiPostListingMode?
+    public var defaultSortType: ApiSortType?
+    
+    public var userCount: Int
+    public var postCount: Int
+    public var commentCount: Int
+    public var communityCount: Int
+    public var activeUserCount: ActiveUserCount
+
+    init(
+        api: ApiClient,
+        instance1: Instance1,
+        setup: Bool,
+        downvotesEnabled: Bool,
+        nsfwContentEnabled: Bool,
+        communityCreationRestrictedToAdmins: Bool,
+        emailVerificationRequired: Bool,
+        applicationQuestion: String? = nil,
+        isPrivate: Bool,
+        defaultTheme: String,
+        defaultFeed: ApiListingType,
+        legalInformation: String? = nil,
+        hideModlogNames: Bool,
+        emailApplicationsToAdmins: Bool,
+        emailReportsToAdmins: Bool,
+        slurFilterRegex: String? = nil,
+        actorNameMaxLength: Int,
+        federationEnabled: Bool,
+        captchaEnabled: Bool,
+        captchaDifficulty: CaptchaDifficulty? = nil,
+        registrationMode: ApiRegistrationMode,
+        federationSignedFetch: Bool? = nil,
+        defaultPostListingMode: ApiPostListingMode? = nil,
+        defaultSortType: ApiSortType? = nil,
+        userCount: Int,
+        postCount: Int,
+        commentCount: Int,
+        communityCount: Int,
+        activeUserCount: ActiveUserCount
+    ) {
+        self.api = api
+        self.instance1 = instance1
+        self.setup = setup
+        self.downvotesEnabled = downvotesEnabled
+        self.nsfwContentEnabled = nsfwContentEnabled
+        self.communityCreationRestrictedToAdmins = communityCreationRestrictedToAdmins
+        self.emailVerificationRequired = emailVerificationRequired
+        self.applicationQuestion = applicationQuestion
+        self.isPrivate = isPrivate
+        self.defaultTheme = defaultTheme
+        self.defaultFeed = defaultFeed
+        self.legalInformation = legalInformation
+        self.hideModlogNames = hideModlogNames
+        self.emailApplicationsToAdmins = emailApplicationsToAdmins
+        self.emailReportsToAdmins = emailReportsToAdmins
+        self.slurFilterRegex = slurFilterRegex
+        self.actorNameMaxLength = actorNameMaxLength
+        self.federationEnabled = federationEnabled
+        self.captchaEnabled = captchaEnabled
+        self.captchaDifficulty = captchaDifficulty
+        self.registrationMode = registrationMode
+        self.federationSignedFetch = federationSignedFetch
+        self.defaultPostListingMode = defaultPostListingMode
+        self.defaultSortType = defaultSortType
+        self.userCount = userCount
+        self.postCount = postCount
+        self.commentCount = commentCount
+        self.communityCount = communityCount
+        self.activeUserCount = activeUserCount
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance2Providing.swift
@@ -1,0 +1,101 @@
+//
+//  Instance2Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public protocol Instance2Providing: Instance1Providing {
+    var instance2: Instance2 { get }
+    
+    var setup: Bool { get }
+    var downvotesEnabled: Bool { get }
+    var nsfwContentEnabled: Bool { get }
+    var communityCreationRestrictedToAdmins: Bool { get }
+    var emailVerificationRequired: Bool { get }
+    var applicationQuestion: String? { get }
+    var isPrivate: Bool { get }
+    var defaultTheme: String { get }
+    var defaultFeed: ApiListingType { get }
+    var legalInformation: String? { get }
+    var hideModlogNames: Bool { get }
+    var emailApplicationsToAdmins: Bool { get }
+    var emailReportsToAdmins: Bool { get }
+    var slurFilterRegex: String? { get }
+    var actorNameMaxLength: Int { get }
+    var federationEnabled: Bool { get }
+    var captchaEnabled: Bool { get }
+    var captchaDifficulty: CaptchaDifficulty? { get }
+    var registrationMode: ApiRegistrationMode { get }
+    var federationSignedFetch: Bool? { get }
+    var defaultPostListingMode: ApiPostListingMode? { get }
+    var defaultSortType: ApiSortType? { get }
+    
+    var userCount: Int { get }
+    var postCount: Int { get }
+    var commentCount: Int { get }
+    var communityCount: Int { get }
+    var activeUserCount: ActiveUserCount { get }
+}
+
+public extension Instance2Providing {
+    var instance1: Instance1 { instance2.instance1 }
+    
+    var setup: Bool { instance2.setup }
+    var downvotesEnabled: Bool { instance2.downvotesEnabled }
+    var nsfwContentEnabled: Bool { instance2.nsfwContentEnabled }
+    var communityCreationRestrictedToAdmins: Bool { instance2.communityCreationRestrictedToAdmins }
+    var emailVerificationRequired: Bool { instance2.emailVerificationRequired }
+    var applicationQuestion: String? { instance2.applicationQuestion }
+    var isPrivate: Bool { instance2.isPrivate }
+    var defaultTheme: String { instance2.defaultTheme }
+    var defaultFeed: ApiListingType { instance2.defaultFeed }
+    var legalInformation: String? { instance2.legalInformation }
+    var hideModlogNames: Bool { instance2.hideModlogNames }
+    var emailApplicationsToAdmins: Bool { instance2.emailApplicationsToAdmins }
+    var emailReportsToAdmins: Bool { instance2.emailReportsToAdmins }
+    var slurFilterRegex: String? { instance2.slurFilterRegex }
+    var actorNameMaxLength: Int { instance2.actorNameMaxLength }
+    var federationEnabled: Bool { instance2.federationEnabled }
+    var captchaEnabled: Bool { instance2.captchaEnabled }
+    var captchaDifficulty: CaptchaDifficulty? { instance2.captchaDifficulty }
+    var registrationMode: ApiRegistrationMode { instance2.registrationMode }
+    var federationSignedFetch: Bool? { instance2.federationSignedFetch }
+    var defaultPostListingMode: ApiPostListingMode? { instance2.defaultPostListingMode }
+    var defaultSortType: ApiSortType? { instance2.defaultSortType }
+    var userCount: Int { instance2.userCount }
+    var postCount: Int { instance2.postCount }
+    var commentCount: Int { instance2.commentCount }
+    var communityCount: Int { instance2.communityCount }
+    var activeUserCount: ActiveUserCount { instance2.activeUserCount }
+
+    var setup_: Bool? { instance2.setup }
+    var downvotesEnabled_: Bool? { instance2.downvotesEnabled }
+    var nsfwContentEnabled_: Bool? { instance2.nsfwContentEnabled }
+    var communityCreationRestrictedToAdmins_: Bool? { instance2.communityCreationRestrictedToAdmins }
+    var emailVerificationRequired_: Bool? { instance2.emailVerificationRequired }
+    var applicationQuestion_: String? { instance2.applicationQuestion }
+    var isPrivate_: Bool? { instance2.isPrivate }
+    var defaultTheme_: String? { instance2.defaultTheme }
+    var defaultFeed_: ApiListingType? { instance2.defaultFeed }
+    var legalInformation_: String? { instance2.legalInformation }
+    var hideModlogNames_: Bool? { instance2.hideModlogNames }
+    var emailApplicationsToAdmins_: Bool? { instance2.emailApplicationsToAdmins }
+    var emailReportsToAdmins_: Bool? { instance2.emailReportsToAdmins }
+    var slurFilterRegex_: String? { instance2.slurFilterRegex }
+    var actorNameMaxLength_: Int? { instance2.actorNameMaxLength }
+    var federationEnabled_: Bool? { instance2.federationEnabled }
+    var captchaEnabled_: Bool? { instance2.captchaEnabled }
+    var captchaDifficulty_: CaptchaDifficulty? { instance2.captchaDifficulty }
+    var registrationMode_: ApiRegistrationMode? { instance2.registrationMode }
+    var federationSignedFetch_: Bool? { instance2.federationSignedFetch }
+    var defaultPostListingMode_: ApiPostListingMode? { instance2.defaultPostListingMode }
+    var defaultSortType_: ApiSortType? { instance2.defaultSortType }
+    var userCount_: Int? { instance2.userCount }
+    var postCount_: Int? { instance2.postCount }
+    var commentCount_: Int? { instance2.commentCount }
+    var communityCount_: Int? { instance2.communityCount }
+    var activeUserCount_: ActiveUserCount? { instance2.activeUserCount }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance3.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance3.swift
@@ -1,0 +1,54 @@
+//
+//  Instance3.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Instance3: Instance3Providing {
+    public static let tierNumber: Int = 3
+    public var api: ApiClient
+    public var instance3: Instance3 { self }
+    
+    public let instance2: Instance2
+    
+    public var version: SiteVersion
+    
+    public let allLanguages: [Locale.Language]
+    
+    // This excludes the "undetermined" language identifier (which is 0),
+    // because its presence or absence doesn't actually affect whether you're
+    // able to create a post with "undetermined" as the language
+    public var allowedLanguageIds: Set<Int>
+    
+    public var taglines: [ApiTagline]
+    public var customEmojis: [ApiCustomEmojiView]
+    public var blockedUrls: [ApiLocalSiteUrlBlocklist]?
+    public var administrators: [Person2]
+  
+    init(
+        api: ApiClient,
+        instance2: Instance2,
+        version: SiteVersion,
+        allLanguages: [Locale.Language],
+        allowedLanguageIds: Set<Int>,
+        taglines: [ApiTagline],
+        customEmojis: [ApiCustomEmojiView],
+        blockedUrls: [ApiLocalSiteUrlBlocklist]?,
+        administrators: [Person2]
+    ) {
+        self.api = api
+        self.instance2 = instance2
+        self.version = version
+        self.allLanguages = allLanguages
+        self.allowedLanguageIds = allowedLanguageIds
+        self.taglines = taglines
+        self.customEmojis = customEmojis
+        self.blockedUrls = blockedUrls
+        self.administrators = administrators
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance3Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance3Providing.swift
@@ -1,0 +1,64 @@
+//
+//  Instance3Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public protocol Instance3Providing: Instance2Providing {
+    var instance3: Instance3 { get }
+    
+    var version: SiteVersion { get }
+    var allLanguages: [Locale.Language] { get }
+    var allowedLanguageIds: Set<Int> { get }
+    var taglines: [ApiTagline] { get }
+    var customEmojis: [ApiCustomEmojiView] { get }
+    var blockedUrls: [ApiLocalSiteUrlBlocklist]? { get }
+    var administrators: [Person2] { get }
+}
+
+public extension Instance3Providing {
+    var instance2: Instance2 { instance3.instance2 }
+    
+    var version: SiteVersion { instance3.version }
+    var allLanguages: [Locale.Language] { instance3.allLanguages }
+    var allowedLanguageIds: Set<Int> { instance3.allowedLanguageIds }
+    var taglines: [ApiTagline] { instance3.taglines }
+    var customEmojis: [ApiCustomEmojiView] { instance3.customEmojis }
+    var blockedUrls: [ApiLocalSiteUrlBlocklist]? { instance3.blockedUrls }
+    var administrators: [Person2] { instance3.administrators }
+    
+    var version_: SiteVersion? { instance3.version }
+    var allLanguages_: [Locale.Language]? { instance3.allLanguages }
+    var allowedLanguageIds_: Set<Int>? { instance3.allowedLanguageIds }
+    var taglines_: [ApiTagline]? { instance3.taglines }
+    var customEmojis_: [ApiCustomEmojiView]? { instance3.customEmojis }
+    var blockedUrls_: [ApiLocalSiteUrlBlocklist]? { instance3.blockedUrls }
+    var administrators_: [Person2]? { instance3.administrators }
+    
+    func addAdmin(personId: Int, added: Bool) async throws {
+        try await api.addAdmin(personId: personId, added: added)
+    }
+    
+    func addAdmin(_ person: any Person, added: Bool) async throws {
+        try await addAdmin(personId: person.id, added: added)
+    }
+    
+    func language(withId id: Int) -> Locale.Language? {
+        allLanguages[safeIndex: id - 1]
+    }
+    
+    func getLanguageId(for language: Locale.Language) -> Int? {
+        allLanguages.firstIndex(of: language)?.advanced(by: 1)
+    }
+    
+    func languages(withIds ids: Set<Int>) -> [Locale.Language] {
+        ids.lazy.sorted(by: <).compactMap { self.language(withId: $0) }
+    }
+    
+    var allowedLanguages: Set<Locale.Language> {
+        Set(allowedLanguageIds.lazy.compactMap { self.language(withId: $0) })
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/InstanceStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/InstanceStub.swift
@@ -1,0 +1,68 @@
+//
+//  File.swift
+//
+//
+//  Created by Sjmarf on 28/05/2024.
+//
+
+import Foundation
+
+public struct InstanceStub: InstanceStubProviding, Hashable {
+    public static var tierNumber: Int = 0
+    public var api: ApiClient
+    public let actorId: ActorIdentifier
+    
+    public var local: Bool { actorId.url == api.baseUrl }
+    
+    public init(api: ApiClient, actorId: ActorIdentifier) {
+        self.api = api
+        self.actorId = actorId
+    }
+    
+    public func asLocal() -> Self {
+        .init(api: .getApiClient(url: actorId.hostUrl, username: nil), actorId: actorId)
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(actorId)
+    }
+    
+    public static func == (lhs: InstanceStub, rhs: InstanceStub) -> Bool {
+        lhs.actorId == rhs.actorId
+    }
+}
+
+// These are defined here rather than in `InstanceStubProviding`
+// because `upgrade()` only goes up to `Instance1`, not `Instance3`.
+// The names of `upgrade` methods on higher-tier models would be
+// misleading because they would instead downgrade the model.
+public extension InstanceStub {
+    /// Upgrades to an ``Instance1`` -  the highest tier that can be upgraded to without using the local ``ApiClient`` instead.
+    /// Use ``upgradeLocal()`` if you need an ``Instance3``. This method does not work for locally running instances.
+    ///
+    /// Due to API limitations (see [here](https://github.com/mlemgroup/mlem/pull/1029#issuecomment-2067746011)),
+    /// it takes 4 API calls to perform this upgrade.
+    func upgrade() async throws -> Instance1 {
+        let externalApi: ApiClient = .getApiClient(url: actorId.url, username: nil)
+        
+        let response = try await externalApi.getPosts(
+            feed: .local,
+            sort: .new,
+            page: 1,
+            cursor: nil,
+            limit: 1
+        )
+        
+        guard let post = response.posts.first else {
+            throw InstanceUpgradeError.noPostReturned
+        }
+        
+        let comm: Community3 = try await api.getCommunity(url: post.community.actorId.url)
+        
+        guard let instance = comm.instance else {
+            throw InstanceUpgradeError.noSiteReturned
+        }
+        
+        return instance
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/InstanceStubProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/InstanceStubProviding.swift
@@ -1,0 +1,131 @@
+//
+//  InstanceStubProviding.swift
+//
+//
+//  Created by Sjmarf on 28/05/2024.
+//
+
+import Foundation
+
+public protocol InstanceStubProviding: ActorIdentifiable, ContentModel {
+    var local: Bool { get }
+    
+    // From Instance1Providing. These are defined as nil in the extension below
+    var id_: Int? { get }
+    var instanceId_: Int? { get }
+    var displayName_: String? { get }
+    var description_: String? { get }
+    var shortDescription_: String? { get }
+    var avatar_: URL? { get }
+    var banner_: URL? { get }
+    var created_: Date? { get }
+    var updated_: Date? { get }
+    var publicKey_: String? { get }
+    var lastRefresh_: Date? { get }
+    var contentWarning_: String? { get }
+    var blocked_: Bool? { get }
+    
+    // From Instance2Providing. These are defined as nil in the extension below
+    var setup_: Bool? { get }
+    var downvotesEnabled_: Bool? { get }
+    var nsfwContentEnabled_: Bool? { get }
+    var communityCreationRestrictedToAdmins_: Bool? { get }
+    var emailVerificationRequired_: Bool? { get }
+    var applicationQuestion_: String? { get }
+    var isPrivate_: Bool? { get }
+    var defaultTheme_: String? { get }
+    var defaultFeed_: ApiListingType? { get }
+    var legalInformation_: String? { get }
+    var hideModlogNames_: Bool? { get }
+    var emailApplicationsToAdmins_: Bool? { get }
+    var emailReportsToAdmins_: Bool? { get }
+    var slurFilterRegex_: String? { get }
+    var actorNameMaxLength_: Int? { get }
+    var federationEnabled_: Bool? { get }
+    var captchaEnabled_: Bool? { get }
+    var captchaDifficulty_: CaptchaDifficulty? { get }
+    var registrationMode_: ApiRegistrationMode? { get }
+    var federationSignedFetch_: Bool? { get }
+    var defaultPostListingMode_: ApiPostListingMode? { get }
+    var defaultSortType_: ApiSortType? { get }
+    var userCount_: Int? { get }
+    var postCount_: Int? { get }
+    var commentCount_: Int? { get }
+    var communityCount_: Int? { get }
+    var activeUserCount_: ActiveUserCount? { get }
+    
+    // From Instance3Providing. These are defined as get in the extension below
+    var version_: SiteVersion? { get }
+    var allLanguages_: [Locale.Language]? { get }
+    var allowedLanguageIds_: Set<Int>? { get }
+    var taglines_: [ApiTagline]? { get }
+    var customEmojis_: [ApiCustomEmojiView]? { get }
+    var blockedUrls_: [ApiLocalSiteUrlBlocklist]? { get }
+    var administrators_: [Person2]? { get }
+}
+
+public extension InstanceStubProviding {
+    var id_: Int? { nil }
+    var instanceId_: Int? { nil }
+    var displayName_: String? { nil }
+    var description_: String? { nil }
+    var shortDescription_: String? { nil }
+    var avatar_: URL? { nil }
+    var banner_: URL? { nil }
+    var created_: Date? { nil }
+    var updated_: Date? { nil }
+    var publicKey_: String? { nil }
+    var lastRefresh_: Date? { nil }
+    var local_: Bool? { nil }
+    var contentWarning_: String? { nil }
+    
+    var setup_: Bool? { nil }
+    var downvotesEnabled_: Bool? { nil }
+    var nsfwContentEnabled_: Bool? { nil }
+    var communityCreationRestrictedToAdmins_: Bool? { nil }
+    var emailVerificationRequired_: Bool? { nil }
+    var applicationQuestion_: String? { nil }
+    var isPrivate_: Bool? { nil }
+    var defaultTheme_: String? { nil }
+    var defaultFeed_: ApiListingType? { nil }
+    var legalInformation_: String? { nil }
+    var hideModlogNames_: Bool? { nil }
+    var emailApplicationsToAdmins_: Bool? { nil }
+    var emailReportsToAdmins_: Bool? { nil }
+    var slurFilterRegex_: String? { nil }
+    var actorNameMaxLength_: Int? { nil }
+    var federationEnabled_: Bool? { nil }
+    var captchaEnabled_: Bool? { nil }
+    var captchaDifficulty_: CaptchaDifficulty? { nil }
+    var registrationMode_: ApiRegistrationMode? { nil }
+    var federationSignedFetch_: Bool? { nil }
+    var defaultPostListingMode_: ApiPostListingMode? { nil }
+    var defaultSortType_: ApiSortType? { nil }
+    var userCount_: Int? { nil }
+    var postCount_: Int? { nil }
+    var commentCount_: Int? { nil }
+    var communityCount_: Int? { nil }
+    var activeUserCount_: ActiveUserCount? { nil }
+    var blocked_: Bool? { nil }
+    
+    var version_: SiteVersion? { nil }
+    var allLanguages_: [Locale.Language]? { nil }
+    var allowedLanguageIds_: Set<Int>? { nil }
+    var taglines_: [ApiTagline]? { nil }
+    var customEmojis_: [ApiCustomEmojiView]? { nil }
+    var blockedUrls_: [ApiLocalSiteUrlBlocklist]? { nil }
+    var administrators_: [Person2]? { nil }
+}
+
+public enum InstanceUpgradeError: Error {
+    case noPostReturned
+    case noSiteReturned
+}
+
+public extension InstanceStubProviding {
+    /// Upgrade to an ``Instance3``, using the instance's local ``ApiClient``. This will not work for locally running instances.
+    func upgradeLocal() async throws -> Instance3 {
+        let externalApi: ApiClient = apiIsLocal ? api : .getApiClient(url: actorId.url, username: nil)
+        return try await externalApi.getMyInstance()
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/InstanceBanType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/InstanceBanType.swift
@@ -1,0 +1,21 @@
+//
+//  BanType.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+
+public enum InstanceBanType: Equatable {
+    case notBanned
+    case permanentlyBanned
+    case temporarilyBanned(expires: Date)
+    
+    var expiryDate: Date? {
+        switch self {
+        case let .temporarilyBanned(expires): expires
+        default: nil
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Interactable/Interactable1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Interactable/Interactable1Providing.swift
@@ -1,0 +1,23 @@
+//
+//  Interactable1Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 30/03/2024.
+//
+
+import Foundation
+
+/// Represents a post/comment that you *should* be able to interact with, but you cannot actually interact with due to the model being too low-tier.
+public protocol Interactable1Providing: AnyObject, ContentModel, ReportableProviding, ContentIdentifiable {
+    var created: Date { get }
+    var updated: Date? { get }
+    
+    var creator_: (any Person)? { get }
+    var community_: (any Community)? { get }
+    var creatorIsModerator_: Bool? { get }
+    var creatorIsAdmin_: Bool? { get }
+    var bannedFromCommunity_: Bool? { get }
+    var commentCount_: Int? { get }
+    var votes_: VotesModel? { get }
+    var saved_: Bool? { get }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
@@ -1,0 +1,45 @@
+//
+//  Interactable2Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 17/02/2024.
+//
+
+import Foundation
+
+// Content that can be upvoted, downvoted, saved etc
+public protocol Interactable2Providing: Interactable1Providing, RemovableProviding, PurgableProviding {
+    var creator: any Person { get }
+    var community: any Community { get }
+    var creatorIsModerator: Bool? { get }
+    var creatorIsAdmin: Bool? { get }
+    var bannedFromCommunity: Bool { get }
+    var commentCount: Int { get }
+    var votes: VotesModel { get }
+    var saved: Bool { get }
+    
+    @discardableResult
+    func updateVote(_ newVote: ScoringOperation) -> Task<StateUpdateResult, Never>
+    
+    @discardableResult
+    func updateSaved(_ newValue: Bool) -> Task<StateUpdateResult, Never>
+    
+    func reply(content: String, languageId: Int?) async throws -> Comment2
+}
+
+public extension Interactable2Providing {
+    @discardableResult
+    func toggleUpvoted() -> Task<StateUpdateResult, Never> {
+        updateVote(votes.myVote == .upvote ? .none : .upvote)
+    }
+    
+    @discardableResult
+    func toggleDownvoted() -> Task<StateUpdateResult, Never> {
+        updateVote(votes.myVote == .downvote ? .none : .downvote)
+    }
+    
+    @discardableResult
+    func toggleSaved() -> Task<StateUpdateResult, Never> {
+        updateSaved(!saved)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/LemmyURL.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/LemmyURL.swift
@@ -1,0 +1,27 @@
+//
+//  LemmyURL.swift
+//  Mlem
+//
+//  Created by mormaer on 15/09/2023.
+//
+//
+
+import Foundation
+
+struct LemmyURL {
+    let url: URL
+    
+    init?(string: String?) {
+        guard let string else {
+            return nil
+        }
+        
+        if let url = URL(string: string) {
+            self.url = url
+        } else if let encoded = string.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed), let url = URL(string: encoded) {
+            self.url = url
+        } else {
+            return nil
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/ScoringOperation.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/ScoringOperation.swift
@@ -1,0 +1,45 @@
+//
+//  ScoringOperation.swift
+//  Mlem
+//
+//  Created by mormaer on 16/08/2023.
+//
+//
+
+import Foundation
+import SwiftUI
+
+public enum ScoringOperation: Int, Decodable, CustomStringConvertible {
+    case upvote = 1
+    case downvote = -1
+    case none = 0
+
+    public var upvoteValue: Int { self == .upvote ? 1 : 0 }
+    public var downvoteValue: Int { self == .downvote ? 1 : 0 }
+
+    public var description: String {
+        switch self {
+        case .upvote:
+            "Upvote"
+        case .downvote:
+            "Downvote"
+        case .none:
+            "No Vote"
+        }
+    }
+}
+
+public extension ScoringOperation {
+    /// Non-optional initializer; if int is nil or invalid, returns .none
+    static func guaranteedInit(from int: Int?) -> ScoringOperation {
+        guard let int else {
+            return .none
+        }
+        
+        if let value = ScoringOperation(rawValue: int) {
+            return value
+        } else {
+            return .none
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion+EndpointVersion.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion+EndpointVersion.swift
@@ -19,7 +19,17 @@ public extension SiteVersion {
         }
     }
     
-    var endpointVersion: EndpointVersion {
-        self >= .v1_0_0 ? .v4 : .v3
+    var supportedEndpointVersions: Set<EndpointVersion> {
+        switch self {
+        case .other: [.v3] // To be safe, don't allow v4
+        default: self >= .v1_0_0 ? [.v3, .v4] : [.v3]
+        }
+    }
+    
+    var highestSupportedEndpointVersion: EndpointVersion {
+        switch self {
+        case .other: .v3
+        default: self >= .v1_0_0 ? .v4 : .v3
+        }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion+EndpointVersion.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion+EndpointVersion.swift
@@ -1,0 +1,25 @@
+//
+//  SiteVersion+EndpointVersion.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-21.
+//
+
+import Foundation
+
+public extension SiteVersion {
+    enum EndpointVersion: Hashable, Sendable {
+        case v3, v4
+        
+        public var pathComponent: String {
+            switch self {
+            case .v3: "v3"
+            case .v4: "v4"
+            }
+        }
+    }
+    
+    var endpointVersion: EndpointVersion {
+        self >= .v1_0_0 ? .v4 : .v3
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion+Feature.swift
@@ -1,0 +1,29 @@
+//
+//  SiteVersion+Feature.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-21.
+//
+
+import Foundation
+
+public extension SiteVersion {
+    enum Feature {
+        case headerAuthentication, batchMarkRead
+        
+        var minimumVersion: SiteVersion {
+            switch self {
+            case .headerAuthentication: .v0_19_0
+            case .batchMarkRead: .v0_19_0
+            }
+        }
+    }
+    
+    /// Checks whether this SiteVersion supports the given feature. Always returns false if version unknown.
+    func suppports(_ feature: Feature) -> Bool {
+        switch self {
+        case .other: false
+        default: feature.minimumVersion <= self
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion.swift
@@ -1,0 +1,103 @@
+//
+//  ApiSiteVersionNumber.swift
+//  Mlem
+//
+//  Created by Sjmarf on 09/09/2023.
+//
+import Foundation
+
+public enum SiteVersion: Equatable, Hashable {
+    case release(major: Int, minor: Int, patch: Int)
+    case other(String)
+    case zero
+    case infinity
+    
+    public init(_ version: String) {
+        let parts = version.split(separator: "-")
+        if let firstPart = parts.first {
+            let components = firstPart.split(separator: ".").compactMap { Int($0) }
+            if components.count == 3 {
+                self = .release(major: components[0], minor: components[1], patch: components[2])
+            } else {
+                self = .other(version)
+            }
+        } else {
+            self = .other(version)
+        }
+    }
+    
+    // swiftlint: disable large_tuple
+    public var parts: (Int, Int, Int)? {
+        switch self {
+        case let .release(major, minor, patch):
+            return (major, minor, patch)
+        default:
+            return nil
+        }
+    }
+
+    // swiftlint: enable large_tuple
+    
+    public static let v0_18_0: Self = .init("0.18.0")
+    public static let v0_18_1: Self = .init("0.18.1")
+    public static let v0_18_2: Self = .init("0.18.2")
+    public static let v0_18_3: Self = .init("0.18.3")
+    public static let v0_18_4: Self = .init("0.18.4")
+    public static let v0_18_5: Self = .init("0.18.5")
+    public static let v0_19_0: Self = .init("0.19.0")
+    public static let v0_19_1: Self = .init("0.19.1")
+    public static let v0_19_2: Self = .init("0.19.2")
+    public static let v0_19_3: Self = .init("0.19.3")
+    public static let v0_19_4: Self = .init("0.19.4")
+    public static let v0_19_5: Self = .init("0.19.5")
+    public static let v0_19_6: Self = .init("0.19.6")
+    public static let v0_19_7: Self = .init("0.19.7")
+    public static let v0_19_8: Self = .init("0.19.8")
+    public static let v0_19_9: Self = .init("0.19.9")
+    public static let v1_0_0: Self = .init("1.0.0")
+}
+
+extension SiteVersion: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .zero:
+            return "zero"
+        case .infinity:
+            return "infinity"
+        case let .release(major, minor, patch):
+            return "\(major).\(minor).\(patch)"
+        case let .other(string):
+            return string
+        }
+    }
+}
+
+extension SiteVersion: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let versionString = try container.decode(String.self)
+        self.init(versionString)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(String(describing: self))
+    }
+}
+
+extension SiteVersion: Comparable {
+    public static func < (lhs: SiteVersion, rhs: SiteVersion) -> Bool {
+        switch (lhs, rhs) {
+        case (.release, .release):
+            return lhs.parts! < rhs.parts!
+            
+        case (.zero, _), (_, .infinity):
+            return true
+            
+        case (_, .zero), (.infinity, _):
+            return false
+        default:
+            return false
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1.swift
@@ -1,0 +1,66 @@
+//
+//  Message1.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Message1: Message1Providing {
+    public static let tierNumber: Int = 1
+    public var api: ApiClient
+    public var message1: Message1 { self }
+    
+    public let actorId: ActorIdentifier
+    public let id: Int
+    public let creatorId: Int
+    public let recipientId: Int
+    public var content: String
+    public let created: Date
+    public var updated: Date?
+    public let isOwnMessage: Bool
+    
+    let readManager: StateManager<Bool>
+    public var read: Bool { readManager.wrappedValue }
+    
+    var deletedManager: StateManager<Bool>
+    public var deleted: Bool { deletedManager.wrappedValue }
+    
+    init(
+        api: ApiClient,
+        
+        actorId: ActorIdentifier,
+        id: Int,
+        creatorId: Int,
+        recipientId: Int,
+        isOwnMessage: Bool,
+        content: String,
+        deleted: Bool,
+        created: Date,
+        updated: Date?,
+        read: Bool
+    ) {
+        self.api = api
+        self.actorId = actorId
+        self.id = id
+        self.creatorId = creatorId
+        self.recipientId = recipientId
+        self.isOwnMessage = isOwnMessage
+        self.content = content
+        self.deletedManager = .init(wrappedValue: deleted)
+        self.created = created
+        self.updated = updated
+        self.readManager = .init(wrappedValue: isOwnMessage ? true : read)
+        readManager.onSet = { newValue, type, _ in
+            if type == .begin || type == .rollback {
+                api.unreadCount?.updateUnverifiedItem(itemType: .message, isRead: newValue)
+            }
+        }
+        readManager.onVerify = { newValue, _ in
+            api.unreadCount?.verifyItem(itemType: .message, isRead: newValue)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1Providing.swift
@@ -1,0 +1,108 @@
+//
+//  Message1Providing.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+public protocol Message1Providing:
+    ContentModel,
+    ActorIdentifiable,
+    ContentIdentifiable,
+    InboxItemProviding,
+    DeletableProviding,
+    ReportableProviding,
+    SelectableContentProviding {
+    var message1: Message1 { get }
+    
+    var id: Int { get }
+    var creatorId: Int { get }
+    var recipientId: Int { get }
+    var content: String { get }
+    var deleted: Bool { get }
+    var created: Date { get }
+    var updated: Date? { get }
+    var read: Bool { get }
+    
+    var id_: Int? { get }
+    var creatorId_: Int? { get }
+    var recipientId_: Int? { get }
+    var content_: String? { get }
+    var deleted_: Bool? { get }
+    var created_: Date? { get }
+    var updated_: Date? { get }
+    var read_: Bool? { get }
+    
+    // From Message2Providing
+    var creator_: Person1? { get }
+    var recipient_: Person1? { get }
+}
+
+public typealias Message = Message1Providing
+
+// SelectableContentProviding conformance
+public extension Message1Providing {
+    var selectableContent: String? { content }
+}
+
+public extension Message1Providing {
+    static var modelTypeId: ContentType { .message }
+    
+    var actorId: ActorIdentifier { message1.actorId }
+    var id: Int { message1.id }
+    var creatorId: Int { message1.creatorId }
+    var recipientId: Int { message1.recipientId }
+    var content: String { message1.content }
+    var deleted: Bool { message1.deleted }
+    var created: Date { message1.created }
+    var updated: Date? { message1.updated }
+    var read: Bool { message1.read }
+    var isOwnMessage: Bool { message1.isOwnMessage }
+    
+    var id_: Int? { message1.id }
+    var creatorId_: Int? { message1.creatorId }
+    var recipientId_: Int? { message1.recipientId }
+    var content_: String? { message1.content }
+    var deleted_: Bool? { message1.deleted }
+    var created_: Date? { message1.created }
+    var updated_: Date? { message1.updated }
+    var read_: Bool? { message1.read }
+    var isOwnMessage_: Bool? { message1.isOwnMessage }
+    
+    var creator_: Person1? { nil }
+    var recipient_: Person1? { nil }
+}
+
+public extension Message1Providing {
+    private var readManager: StateManager<Bool> { message1.readManager }
+    private var deletedManager: StateManager<Bool> { message1.deletedManager }
+    
+    // `toggleRead` is defined in `InboxItemProviding`
+    @discardableResult
+    func updateRead(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        readManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.markMessageAsRead(id: self.id, read: newValue, semaphore: semaphore)
+        }
+    }
+    
+    func reply(content: String) async throws -> Message2 {
+        try await api.createMessage(personId: recipientId, content: content)
+    }
+    
+    func report(reason: String) async throws {
+        try await api.reportMessage(id: id, reason: reason)
+    }
+    
+    @discardableResult
+    func updateDeleted(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        deletedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.deleteMessage(id: self.id, delete: newValue, semaphore: semaphore)
+        }
+    }
+    
+    func edit(content: String) async throws {
+        try await api.editMessage(id: id, content: content)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message2.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message2.swift
@@ -1,0 +1,40 @@
+//
+//  Message2.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+@Observable
+public final class Message2: Message2Providing, FeedLoadable {
+    public typealias FilterType = InboxItemFilterType
+    
+    public func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        switch sortType {
+        case .new:
+            return .new(created)
+        }
+    }
+    
+    public static let tierNumber: Int = 2
+    public var api: ApiClient
+    public var message2: Message2 { self }
+    
+    public let message1: Message1
+    public let creator: Person1
+    public let recipient: Person1
+    
+    init(
+        api: ApiClient,
+        message1: Message1,
+        creator: Person1,
+        recipient: Person1
+    ) {
+        self.api = api
+        self.message1 = message1
+        self.creator = creator
+        self.recipient = recipient
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message2Providing.swift
@@ -1,0 +1,25 @@
+//
+//  Message2Providing.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+public protocol Message2Providing: Message1Providing, ActorIdentifiable {
+    var message2: Message2 { get }
+    
+    var creator: Person1 { get }
+    var recipient: Person1 { get }
+}
+
+public extension Message2Providing {
+    var message1: Message1 { message2.message1 }
+    
+    var creator: Person1 { message2.creator }
+    var recipient: Person1 { message2.recipient }
+    
+    var creator_: Person1? { message2.creator }
+    var recipient_: Person1? { message2.recipient }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntry.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntry.swift
@@ -1,0 +1,31 @@
+//
+//  ModlogEntry.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-23.
+//
+
+import Foundation
+
+public struct ModlogEntry {
+    public let api: ApiClient
+    public let created: Date
+    public let moderator: Person1?
+    public let moderatorId: Int
+    public let type: ModlogEntryType
+}
+
+extension ModlogEntry: FeedLoadable {
+    public typealias FilterType = ModlogEntryFilterType
+    
+    public func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        switch sortType {
+        case .new:
+            return .new(created)
+        }
+    }
+    
+    public static func == (lhs: ModlogEntry, rhs: ModlogEntry) -> Bool {
+        lhs.created == rhs.created && lhs.type == rhs.type
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryType.swift
@@ -1,0 +1,114 @@
+//
+//  ModlogEntryType.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-25.
+//
+
+import Foundation
+
+public enum ModlogEntryType: Equatable {
+    case removePost(
+        _ post: Post1,
+        community: Community1,
+        removed: Bool,
+        reason: String?
+    )
+    case lockPost(
+        _ post: Post1,
+        community: Community1,
+        locked: Bool
+    )
+    case pinPost(
+        _ post: Post1,
+        community: Community1,
+        pinned: Bool,
+        type: ApiPostFeatureType
+    )
+    case purgePost(reason: String?)
+    
+    case removeComment(
+        _ comment: Comment1,
+        creator: Person1,
+        post: Post1,
+        community: Community1,
+        removed: Bool,
+        reason: String?
+    )
+    case purgeComment(reason: String?)
+    
+    case removeCommunity(
+        _ community: Community1,
+        removed: Bool,
+        reason: String?
+    )
+    case purgeCommunity(reason: String?)
+    case hideCommunity(
+        _ community: Community1,
+        hidden: Bool,
+        reason: String?
+    )
+    case transferCommunityOwnership(
+        person: Person1,
+        community: Community1
+    )
+    
+    case updatePersonModeratorStatus(
+        person: Person1,
+        community: Community1,
+        appointed: Bool
+    )
+    case updatePersonAdminStatus(
+        person: Person1,
+        appointed: Bool
+    )
+    case banPersonFromCommunity(
+        person: Person1,
+        community: Community1,
+        banned: Bool,
+        reason: String?,
+        expires: Date?
+    )
+    case banPersonFromInstance(
+        person: Person1,
+        banned: Bool,
+        reason: String?,
+        expires: Date?
+    )
+    case purgePerson(reason: String?)
+    
+    public var community: Community1? {
+        switch self {
+        case let .removePost(_, community, _, _): community
+        case let .lockPost(_, community, _): community
+        case let .pinPost(_, community, _, _): community
+        case let .removeComment(_, _, _, community, _, _): community
+        case let .removeCommunity(community, _, _): community
+        case let .hideCommunity(community, _, _): community
+        case let .transferCommunityOwnership(_, community): community
+        case let .updatePersonModeratorStatus(_, community, _): community
+        case let .banPersonFromCommunity(_, community, _, _, _): community
+        default: nil
+        }
+    }
+    
+    public var type: ApiModlogActionType {
+        switch self {
+        case .removePost: .modRemovePost
+        case .lockPost: .modLockPost
+        case .pinPost: .modFeaturePost
+        case .purgePost: .adminPurgePost
+        case .removeComment: .modRemoveComment
+        case .purgeComment: .adminPurgeComment
+        case .removeCommunity: .modRemoveCommunity
+        case .purgeCommunity: .adminPurgeCommunity
+        case .hideCommunity: .modHideCommunity
+        case .transferCommunityOwnership: .modTransferCommunity
+        case .updatePersonModeratorStatus: .modAddCommunity
+        case .updatePersonAdminStatus: .modAdd
+        case .banPersonFromCommunity: .modBanFromCommunity
+        case .banPersonFromInstance: .modBan
+        case .purgePerson: .adminPurgePerson
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/AnyPerson.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/AnyPerson.swift
@@ -1,0 +1,79 @@
+//
+//  AnyPerson.swift
+//
+//
+//  Created by Sjmarf on 30/05/2024.
+//
+
+import Foundation
+
+@Observable
+public class AnyPerson: Hashable, Upgradable {
+    public typealias Base = PersonStubProviding
+    public typealias MinimumRenderable = Person1Providing
+    public typealias Upgraded = Person3Providing
+    
+    public var wrappedValue: any PersonStubProviding
+    
+    public required init(_ wrappedValue: any PersonStubProviding) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+/// Hashable, Equatable conformance
+public extension AnyPerson {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+    
+    static func == (lhs: AnyPerson, rhs: AnyPerson) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+}
+
+/// Upgradable conformance
+public extension AnyPerson {
+    internal func upgrade(
+        initialValue: (any Base)? = nil,
+        upgradeOperation: (any Base) async throws -> any Base
+    ) async throws {
+        var lastValue = initialValue ?? wrappedValue
+        while !(lastValue is any Upgraded) {
+            lastValue = try await upgradeOperation(lastValue)
+            if type(of: lastValue).tierNumber >= type(of: wrappedValue).tierNumber {
+                let task = Task { @MainActor [lastValue] in
+                    self.wrappedValue = lastValue
+                }
+                _ = await task.value
+            }
+        }
+    }
+    
+    func upgrade(
+        api: ApiClient?,
+        upgradeOperation: ((any Base) async throws -> any Base)?
+    ) async throws {
+        let initialValue: any Base
+        if let api {
+            initialValue = api === wrappedValue.api ? wrappedValue : PersonStub(
+                api: api,
+                url: wrappedValue.allResolvableUrls[0]
+            )
+        } else {
+            initialValue = wrappedValue
+        }
+        try await upgrade(
+            initialValue: initialValue,
+            upgradeOperation: upgradeOperation ?? { try await $0.upgrade() }
+        )
+    }
+    
+    func refresh(upgradeOperation: ((any Base) async throws -> any Base)?) async throws {
+        if let wrappedValue = wrappedValue as? any Upgraded {
+            try await upgrade(
+                initialValue: wrappedValue.person2,
+                upgradeOperation: upgradeOperation ?? { try await $0.upgrade() }
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person1+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person1+Codable.swift
@@ -1,0 +1,47 @@
+//
+//  Person1+Codable.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-03.
+//
+
+import Foundation
+
+public extension Person1 {
+    struct CodedData: Codable {
+        let apiUrl: URL
+        let apiMyPersonId: Int?
+        let apiPerson: ApiPerson
+    }
+    
+    internal var apiPerson: ApiPerson {
+        .init(
+            id: id,
+            name: name,
+            displayName: displayName == name ? nil : displayName,
+            avatar: avatar,
+            banned: bannedFromInstance,
+            published: created,
+            updated: updated,
+            actorId: actorId,
+            bio: description,
+            local: apiIsLocal,
+            banner: banner,
+            deleted: deleted,
+            matrixUserId: matrixId,
+            admin: nil,
+            botAccount: isBot,
+            banExpires: instanceBan.expiryDate,
+            instanceId: instanceId,
+            inboxUrl: nil
+        )
+    }
+    
+    func codedData() async throws -> CodedData {
+        try await .init(
+            apiUrl: api.baseUrl,
+            apiMyPersonId: api.myPersonId,
+            apiPerson: apiPerson
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person1+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person1+Mock.swift
@@ -1,0 +1,50 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-02.
+//
+
+import Foundation
+
+#if DEBUG
+    public extension Person1 {
+        static func mock(
+            api: MockApiClient = .mock,
+            actorId: ActorIdentifier?,
+            id: Int,
+            name: String,
+            created: Date,
+            instanceId: Int,
+            updated: Date?,
+            displayName: String,
+            description: String?,
+            matrixId: String?,
+            avatar: URL?,
+            banner: URL?,
+            deleted: Bool,
+            isBot: Bool,
+            instanceBan: InstanceBanType,
+            blocked: Bool
+        ) -> Person1 {
+            .init(
+                api: api,
+                actorId: actorId ?? .init(url: URL(string: "https://\(api.host)/u/\(name)")!)!,
+                id: id,
+                name: name,
+                created: created,
+                instanceId: instanceId,
+                updated: updated,
+                displayName: displayName,
+                description: description,
+                matrixId: matrixId,
+                avatar: avatar,
+                banner: banner,
+                deleted: deleted,
+                isBot: isBot,
+                instanceBan: instanceBan,
+                blocked: blocked
+            )
+        }
+    }
+#endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person1.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person1.swift
@@ -1,0 +1,107 @@
+//
+//  UserTier1.swift
+//  Mlem
+//
+//  Created by Sjmarf on 10/02/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Person1: Person1Providing {
+    public static let tierNumber: Int = 1
+    public var api: ApiClient
+    public var person1: Person1 { self }
+    
+    public let actorId: ActorIdentifier
+    public let id: Int
+    
+    public let name: String
+    public let created: Date
+    public let instanceId: Int
+    
+    public var updated: Date? = .distantPast
+    public var displayName: String
+    public var description: String?
+    public var matrixId: String?
+    public var avatar: URL?
+    public var banner: URL?
+    
+    public var deleted: Bool = false
+    public var isBot: Bool = false
+    
+    public var purged: Bool = false
+    
+    public var instanceBan: InstanceBanType = .notBanned
+    
+    // This isn't included in the ApiPerson, and so is set externally by Post2 instead
+    var blockedManager: StateManager<Bool>
+    public var blocked: Bool { blockedManager.wrappedValue }
+    
+    // Communities from which this person is *known* to be banned.
+    // If an ID is not in this set, its status is unknown.
+    //
+    // Don't make this public. Instead, use the `bannedFromCommunity` property of
+    // Post2/Comment2/Reply2. Accessing it from there guarantees that the ban
+    // status is known. Those properties access this set as a shared source-of-truth.
+    var knownCommunityBanStates: [Int: Bool] = .init()
+    
+    init(
+        api: ApiClient,
+        actorId: ActorIdentifier,
+        id: Int,
+        name: String,
+        created: Date,
+        instanceId: Int,
+        updated: Date?,
+        displayName: String,
+        description: String?,
+        matrixId: String?,
+        avatar: URL?,
+        banner: URL?,
+        deleted: Bool,
+        isBot: Bool,
+        instanceBan: InstanceBanType,
+        blocked: Bool?
+    ) {
+        self.api = api
+        self.actorId = actorId
+        self.id = id
+        self.name = name
+        self.created = created
+        self.instanceId = instanceId
+        self.updated = updated
+        self.displayName = displayName
+        self.description = description
+        self.matrixId = matrixId
+        self.avatar = avatar
+        self.banner = banner
+        self.deleted = deleted
+        self.isBot = isBot
+        self.instanceBan = instanceBan
+        self.blockedManager = .init(wrappedValue: blocked ?? api.blocks?.people.keys.contains(actorId) ?? false)
+        blockedManager.onSet = { newValue, type, _ in
+            if type != .receive {
+                if newValue {
+                    api.blocks?.people[actorId] = id
+                } else {
+                    api.blocks?.people.removeValue(forKey: actorId)
+                }
+            }
+        }
+    }
+    
+    func updateKnownCommunityBanState(id: Int, banned: Bool) {
+        if banned {
+            // This `if` statement avoids unneccessary state update
+            if !(knownCommunityBanStates[id] ?? false) {
+                knownCommunityBanStates[id] = true
+            }
+        } else {
+            if knownCommunityBanStates[id] ?? true {
+                knownCommunityBanStates[id] = false
+            }
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person1Providing.swift
@@ -1,0 +1,204 @@
+//
+//  User1Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public protocol Person1Providing:
+    PersonStubProviding,
+    Profile2Providing,
+    CommunityOrPerson,
+    ContentIdentifiable,
+    SelectableContentProviding,
+    PurgableProviding,
+    Sharable,
+    FeedLoadable where FilterType == PersonFilterType {
+    var api: ApiClient { get }
+    
+    var person1: Person1 { get }
+    
+    var matrixId: String? { get }
+    var deleted: Bool { get }
+    var isBot: Bool { get }
+    var instanceBan: InstanceBanType { get }
+    
+    var blocked: Bool { get }
+}
+
+public typealias Person = Person1Providing
+
+public extension Person1Providing {
+    static var modelTypeId: ContentType { .person }
+    
+    var actorId: ActorIdentifier { person1.actorId }
+    var id: Int { person1.id }
+    var name: String { person1.name }
+    
+    var created: Date { person1.created }
+    var instanceId: Int { person1.instanceId }
+    var updated: Date? { person1.updated }
+    var displayName: String { person1.displayName }
+    var description: String? { person1.description }
+    var matrixId: String? { person1.matrixId }
+    var avatar: URL? { person1.avatar }
+    var banner: URL? { person1.banner }
+    var deleted: Bool { person1.deleted }
+    var isBot: Bool { person1.isBot }
+    var instanceBan: InstanceBanType { person1.instanceBan }
+    var blocked: Bool { person1.blocked }
+    var purged: Bool { person1.purged }
+    
+    var actorId_: ActorIdentifier? { person1.actorId }
+    var id_: Int? { person1.id }
+    var created_: Date? { person1.created }
+    var instanceId_: Int? { person1.instanceId }
+    var updated_: Date? { person1.updated }
+    var displayName_: String? { person1.displayName }
+    var description_: String? { person1.description }
+    var matrixId_: String? { person1.matrixId }
+    var avatar_: URL? { person1.avatar }
+    var banner_: URL? { person1.banner }
+    var deleted_: Bool? { person1.deleted }
+    var isBot_: Bool? { person1.isBot }
+    var instanceBan_: InstanceBanType? { person1.instanceBan }
+    var blocked_: Bool? { person1.blocked }
+}
+
+// Resolvable conformance
+public extension Person1Providing {
+    @inlinable
+    var allResolvableUrls: [URL] {
+        ContentModelUrlType.allCases.map { resolvableUrl(from: $0) }
+    }
+}
+
+// Sharable conformance
+public extension Person1Providing {
+    func url() -> URL {
+        if apiIsLocal {
+            api.baseUrl.appending(path: "u/\(name)")
+        } else {
+            api.baseUrl.appending(path: "u/\(name)@\(host)")
+        }
+    }
+}
+
+// FeedLoadable conformance
+public extension Person1Providing {
+    func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        switch sortType {
+        case .new:
+            return .new(created)
+        }
+    }
+}
+
+// SelectableContentProviding conformance
+public extension Person1Providing {
+    var selectableContent: String? { description }
+}
+
+public extension Person1Providing {
+    private var blockedManager: StateManager<Bool> { person1.blockedManager }
+
+    var isMlemDeveloper: Bool { developerNames.contains(actorId.description) }
+    
+    /// Returns a `URL` that can be resolved by another `ApiClient`.
+    func resolvableUrl(from instance: ContentModelUrlType) -> URL {
+        switch instance {
+        case .host: actorId.url
+        case .provider: .person(host: api.host, name: name)
+        }
+    }
+    
+    var bannedFromInstance: Bool { instanceBan != .notBanned }
+
+    func upgrade() async throws -> any Person {
+        try await api.getPerson(id: id)
+    }
+    
+    func getContent(
+        community: (any Community)? = nil,
+        sort: ApiSortType = .new,
+        page: Int,
+        limit: Int,
+        savedOnly: Bool = false
+    ) async throws -> (person: Person3, posts: [Post2], comments: [Comment2]) {
+        try await api.getContent(
+            authorId: id,
+            sort: sort,
+            page: page,
+            limit: limit,
+            savedOnly: savedOnly,
+            communityId: community?.id
+        )
+    }
+    
+    @discardableResult
+    func updateBlocked(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        blockedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.blockPerson(id: self.id, block: newValue, semaphore: semaphore)
+        }
+    }
+    
+    @discardableResult
+    func toggleBlocked() -> Task<StateUpdateResult, Never> {
+        updateBlocked(!blocked)
+    }
+    
+    func ban(from community: any Community, removeContent: Bool, reason: String?, expires: Date?) async throws {
+        try await api.banPersonFromCommunity(
+            personId: id,
+            communityId: community.id,
+            ban: true,
+            removeContent: removeContent,
+            reason: reason,
+            expires: expires
+        )
+    }
+    
+    func unban(from community: any Community, reason: String?) async throws {
+        try await api.banPersonFromCommunity(
+            personId: id,
+            communityId: community.id,
+            ban: false,
+            removeContent: false,
+            reason: reason
+        )
+    }
+    
+    func purge(reason: String?) async throws {
+        try await api.purgePerson(id: id, reason: reason)
+    }
+    
+    func banFromInstance(removeContent: Bool, reason: String?, expires: Date?) async throws {
+        try await api.banPersonFromInstance(
+            personId: id,
+            ban: true,
+            removeContent: removeContent,
+            reason: reason,
+            expires: expires
+        )
+    }
+    
+    func unbanFromInstance(reason: String?) async throws {
+        try await api.banPersonFromInstance(
+            personId: id,
+            ban: false,
+            removeContent: false,
+            reason: reason,
+            expires: nil
+        )
+    }
+    
+    func isBannedFromCommunity(id: Int) -> Bool? {
+        person1.knownCommunityBanStates[id]
+    }
+    
+    func isBannedFromCommunity(_ community: any Community) -> Bool? {
+        isBannedFromCommunity(id: community.id)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person2+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person2+Codable.swift
@@ -1,0 +1,39 @@
+//
+//  Person2+Codable.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-03.
+//
+
+import Foundation
+
+public extension Person2 {
+    struct CodedData: Codable {
+        let apiUrl: URL
+        let apiMyPersonId: Int?
+        let apiPersonView: ApiPersonView
+    }
+    
+    internal var apiPersonView: ApiPersonView {
+        .init(
+            person: person1.apiPerson,
+            counts: .init(
+                id: nil,
+                personId: id,
+                postCount: postCount,
+                postScore: nil,
+                commentCount: commentCount,
+                commentScore: nil
+            ),
+            isAdmin: isAdmin
+        )
+    }
+    
+    func codedData() async throws -> CodedData {
+        try await .init(
+            apiUrl: api.baseUrl,
+            apiMyPersonId: api.myPersonId,
+            apiPersonView: apiPersonView
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person2+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person2+Mock.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-02.
+//
+
+import Foundation
+
+#if DEBUG
+    public extension Person2 {
+        static func mock(
+            person1: Person1,
+            postCount: Int,
+            commentCount: Int,
+            isAdmin: Bool
+        ) -> Person2 {
+            Person2(
+                api: person1.api,
+                person1: person1,
+                postCount: postCount,
+                commentCount: commentCount,
+                isAdmin: isAdmin
+            )
+        }
+    }
+#endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person2.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person2.swift
@@ -1,0 +1,36 @@
+//
+//  UserCore2.swift
+//  Mlem
+//
+//  Created by Sjmarf on 10/02/2024.
+//
+
+import Observation
+
+@Observable
+public final class Person2: Person2Providing {
+    public static let tierNumber: Int = 2
+    public var api: ApiClient
+    public var person2: Person2 { self }
+    
+    public let person1: Person1
+    
+    public var postCount: Int
+    public var commentCount: Int
+    
+    public var isAdmin: Bool
+    
+    init(
+        api: ApiClient,
+        person1: Person1,
+        postCount: Int,
+        commentCount: Int,
+        isAdmin: Bool
+    ) {
+        self.api = api
+        self.person1 = person1
+        self.postCount = postCount
+        self.commentCount = commentCount
+        self.isAdmin = isAdmin
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person2Providing.swift
@@ -1,0 +1,28 @@
+//
+//  User2Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public protocol Person2Providing: Person1Providing {
+    var person2: Person2 { get }
+    
+    var postCount: Int { get }
+    var commentCount: Int { get }
+    var isAdmin: Bool { get }
+}
+
+public extension Person2Providing {
+    var person1: Person1 { person2.person1 }
+    
+    var postCount: Int { person2.postCount }
+    var commentCount: Int { person2.commentCount }
+    var isAdmin: Bool { person2.isAdmin }
+
+    var postCount_: Int? { person2.postCount }
+    var commentCount_: Int? { person2.commentCount }
+    var isAdmin_: Bool? { person2.isAdmin }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person3.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person3.swift
@@ -1,0 +1,34 @@
+//
+//  UserCore3.swift
+//  Mlem
+//
+//  Created by Sjmarf on 10/02/2024.
+//
+
+import Observation
+
+@Observable
+public final class Person3: Person3Providing {
+    public static let tierNumber: Int = 3
+    public var api: ApiClient
+    public var person3: Person3 { self }
+
+    public let person2: Person2
+
+    public var instance: Instance1?
+    public var moderatedCommunities: [Community1] = .init()
+    
+    init(
+        api: ApiClient,
+        person2: Person2,
+        instance: Instance1? = nil,
+        moderatedCommunities: [Community1] = .init()
+    ) {
+        self.api = api
+        self.person2 = person2
+        self.instance = instance
+        self.moderatedCommunities = moderatedCommunities
+    }
+    
+    public func upgrade() async throws -> any Person { self }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person3Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person3Providing.swift
@@ -1,0 +1,66 @@
+//
+//  User3Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 12/02/2024.
+//
+
+import Foundation
+
+public protocol Person3Providing: Person2Providing {
+    var person3: Person3 { get }
+    
+    var instance: Instance1? { get }
+    var moderatedCommunities: [Community1] { get }
+}
+
+public extension Person3Providing {
+    var person2: Person2 { person3.person2 }
+    
+    /// Is always `nil` pre-0.19.2, and can be `nil` on 0.19.3 and above, but I'm not sure under what circumstances.
+    var instance: Instance1? { person3.instance }
+    var moderatedCommunities: [Community1] { person3.moderatedCommunities }
+    
+    var instance_: Instance1? { person3.instance }
+    var moderatedCommunities_: [Community1]? { person3.moderatedCommunities }
+}
+
+public extension Person3Providing {
+    func upgrade() async throws -> any Person { self }
+    
+    func moderates(communityId: Int) -> Bool {
+        moderatedCommunities.contains { $0.id == communityId }
+    }
+    
+    func moderates(communityActorId: ActorIdentifier) -> Bool {
+        moderatedCommunities.contains { $0.actorId == communityActorId }
+    }
+    
+    func moderates(community: any Community) -> Bool {
+        moderates(communityActorId: community.actorId)
+    }
+    
+    /// Returns true if this person can perform moderator actions on the target person
+    func canModerate(_ person: any Person, in community: any Community3Providing) -> Bool {
+        // admins can moderate anybody but a higher-ranking admin
+        if isAdmin {
+            if person.isAdmin_ ?? false {
+                return api.isHigherAdmin(than: person)
+            }
+            return true
+        }
+        
+        // if this person is not a mod, can't moderate
+        guard let myModIndex = community.moderators.firstIndex(where: { $0.id == id }) else {
+            return false
+        }
+        
+        // if target is a mod, check that this person outranks them
+        if let targetModIndex = community.moderators.firstIndex(where: { $0.id == person.id }) {
+            return myModIndex < targetModIndex
+        }
+        
+        // if target not a mod, can moderate
+        return true
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person4.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person4.swift
@@ -1,0 +1,201 @@
+//
+//  Person4.swift
+//
+//
+//  Created by Sjmarf on 20/05/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Person4: Person4Providing {
+    public static let tierNumber: Int = 4
+    public var api: ApiClient
+    public var person4: Person4 { self }
+
+    public let person3: Person3
+    
+    public internal(set) var voteDisplayMode: ApiLocalUserVoteDisplayMode?
+    public internal(set) var email: String?
+    public internal(set) var showNsfw: Bool
+    public internal(set) var theme: String
+    public internal(set) var defaultSortType: ApiSortType
+    public internal(set) var defaultListingType: ApiListingType
+    public internal(set) var interfaceLanguage: String
+    public internal(set) var showAvatars: Bool
+    public internal(set) var sendNotificationsToEmail: Bool
+    public internal(set) var showScores: Bool
+    public internal(set) var showBotAccounts: Bool
+    public internal(set) var showReadPosts: Bool
+    public internal(set) var discussionLanguageIds: Set<Int>
+    public internal(set) var showNewPostNotifs: Bool?
+    public internal(set) var emailVerified: Bool
+    public internal(set) var acceptedApplication: Bool
+    public internal(set) var openLinksInNewTab: Bool?
+    public internal(set) var blurNsfw: Bool?
+    public internal(set) var autoExpandImages: Bool?
+    public internal(set) var infiniteScrollEnabled: Bool?
+    public internal(set) var postListingMode: ApiPostListingMode?
+    public internal(set) var totp2faEnabled: Bool?
+    public internal(set) var enableKeyboardNavigation: Bool?
+    public internal(set) var enableAnimatedImages: Bool?
+    public internal(set) var collapseBotComments: Bool?
+    
+    init(
+        api: ApiClient,
+        person3: Person3,
+        voteDisplayMode: ApiLocalUserVoteDisplayMode?,
+        email: String?,
+        showNsfw: Bool,
+        theme: String,
+        defaultSortType: ApiSortType,
+        defaultListingType: ApiListingType,
+        interfaceLanguage: String,
+        showAvatars: Bool,
+        sendNotificationsToEmail: Bool,
+        showScores: Bool,
+        showBotAccounts: Bool,
+        showReadPosts: Bool,
+        discussionLanguageIds: Set<Int>,
+        showNewPostNotifs: Bool?,
+        emailVerified: Bool,
+        acceptedApplication: Bool,
+        openLinksInNewTab: Bool?,
+        blurNsfw: Bool?,
+        autoExpandImages: Bool?,
+        infiniteScrollEnabled: Bool?,
+        postListingMode: ApiPostListingMode?,
+        totp2faEnabled: Bool?,
+        enableKeyboardNavigation: Bool?,
+        enableAnimatedImages: Bool?,
+        collapseBotComments: Bool?
+    ) {
+        self.api = api
+        self.person3 = person3
+        self.voteDisplayMode = voteDisplayMode
+        self.email = email
+        self.showNsfw = showNsfw
+        self.theme = theme
+        self.defaultSortType = defaultSortType
+        self.defaultListingType = defaultListingType
+        self.interfaceLanguage = interfaceLanguage
+        self.showAvatars = showAvatars
+        self.sendNotificationsToEmail = sendNotificationsToEmail
+        self.showScores = showScores
+        self.showBotAccounts = showBotAccounts
+        self.showReadPosts = showReadPosts
+        self.discussionLanguageIds = discussionLanguageIds
+        self.showNewPostNotifs = showNewPostNotifs
+        self.emailVerified = emailVerified
+        self.acceptedApplication = acceptedApplication
+        self.openLinksInNewTab = openLinksInNewTab
+        self.blurNsfw = blurNsfw
+        self.autoExpandImages = autoExpandImages
+        self.infiniteScrollEnabled = infiniteScrollEnabled
+        self.postListingMode = postListingMode
+        self.totp2faEnabled = totp2faEnabled
+        self.enableKeyboardNavigation = enableKeyboardNavigation
+        self.enableAnimatedImages = enableAnimatedImages
+        self.collapseBotComments = collapseBotComments
+    }
+    
+    public func upgrade() async throws -> any Person { self }
+    
+    public func updateSettings(
+        email: String? = nil,
+        matrixId: String? = nil,
+        showNsfw: Bool? = nil,
+        blurNsfw: Bool? = nil,
+        showBotAccounts: Bool? = nil,
+        discussionLanguageIds: Set<Int>? = nil,
+        sendNotificationsToEmail: Bool? = nil,
+        isBot: Bool? = nil
+    ) async throws {
+        // iirc previous lemmy versions had issues with supplying `nil` for certain setting values.
+        // I don't remember which versions this happened on or which parameters couldn't be `nil`.
+        // Supplying them all to be safe.
+        try await api.editAccountSettings(
+            showNsfw: showNsfw ?? self.showNsfw,
+            showScores: showScores,
+            theme: theme,
+            defaultSortType: defaultSortType,
+            defaultListingType: defaultListingType,
+            interfaceLanguage: interfaceLanguage,
+            avatar: avatar?.absoluteString ?? "",
+            banner: banner?.absoluteString ?? "",
+            displayName: displayName,
+            email: email ?? self.email,
+            bio: description,
+            matrixUserId: matrixId ?? self.matrixId,
+            showAvatars: showAvatars,
+            sendNotificationsToEmail: sendNotificationsToEmail ?? self.sendNotificationsToEmail,
+            botAccount: isBot ?? self.isBot,
+            showBotAccounts: showBotAccounts ?? self.showBotAccounts,
+            showReadPosts: showReadPosts,
+            discussionLanguages: discussionLanguageIds?.sorted(),
+            openLinksInNewTab: openLinksInNewTab,
+            blurNsfw: blurNsfw ?? self.blurNsfw,
+            autoExpand: autoExpandImages,
+            infiniteScrollEnabled: infiniteScrollEnabled,
+            postListingMode: postListingMode,
+            enableKeyboardNavigation: enableKeyboardNavigation,
+            enableAnimatedImages: enableAnimatedImages,
+            collapseBotComments: collapseBotComments,
+            showUpvotes: voteDisplayMode?.upvotes,
+            showDownvotes: voteDisplayMode?.downvotes,
+            showUpvotePercentage: voteDisplayMode?.upvotePercentage
+        )
+        self.email = email ?? self.email
+        person1.matrixId = matrixId ?? self.matrixId
+        self.showNsfw = showNsfw ?? self.showNsfw
+        self.blurNsfw = blurNsfw ?? self.blurNsfw
+        self.showBotAccounts = showBotAccounts ?? self.showBotAccounts
+        self.discussionLanguageIds = discussionLanguageIds ?? self.discussionLanguageIds
+        self.sendNotificationsToEmail = sendNotificationsToEmail ?? self.sendNotificationsToEmail
+        person1.isBot = isBot ?? self.isBot
+    }
+    
+    public func updateProfile(
+        displayName: String?,
+        description: String?,
+        avatar: URL?,
+        banner: URL?
+    ) async throws {
+        try await api.editAccountSettings(
+            showNsfw: showNsfw,
+            showScores: showScores,
+            theme: theme,
+            defaultSortType: defaultSortType,
+            defaultListingType: defaultListingType,
+            interfaceLanguage: interfaceLanguage,
+            avatar: avatar?.absoluteString ?? "",
+            banner: banner?.absoluteString ?? "",
+            displayName: displayName ?? "",
+            email: email,
+            bio: description ?? "",
+            matrixUserId: matrixId,
+            showAvatars: showAvatars,
+            sendNotificationsToEmail: sendNotificationsToEmail,
+            botAccount: isBot,
+            showBotAccounts: showBotAccounts,
+            showReadPosts: showReadPosts,
+            discussionLanguages: nil,
+            openLinksInNewTab: openLinksInNewTab,
+            blurNsfw: blurNsfw,
+            autoExpand: autoExpandImages,
+            infiniteScrollEnabled: infiniteScrollEnabled,
+            postListingMode: postListingMode,
+            enableKeyboardNavigation: enableKeyboardNavigation,
+            enableAnimatedImages: enableAnimatedImages,
+            collapseBotComments: collapseBotComments,
+            showUpvotes: voteDisplayMode?.upvotes,
+            showDownvotes: voteDisplayMode?.downvotes,
+            showUpvotePercentage: voteDisplayMode?.upvotePercentage
+        )
+        person1.displayName = displayName ?? name
+        person1.description = description
+        person1.avatar = avatar
+        person1.banner = banner
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person4Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person4Providing.swift
@@ -1,0 +1,98 @@
+//
+//  Person4Providing.swift
+//
+//
+//  Created by Sjmarf on 20/05/2024.
+//
+
+import Foundation
+
+public protocol Person4Providing: Person3Providing {
+    var person4: Person4 { get }
+    
+    var voteDisplayMode: ApiLocalUserVoteDisplayMode? { get }
+    var email: String? { get }
+    var showNsfw: Bool { get }
+    var theme: String { get }
+    var defaultSortType: ApiSortType { get }
+    var defaultListingType: ApiListingType { get }
+    var interfaceLanguage: String { get }
+    var showAvatars: Bool { get }
+    var sendNotificationsToEmail: Bool { get }
+    var showScores: Bool { get }
+    var showBotAccounts: Bool { get }
+    var showReadPosts: Bool { get }
+    var discussionLanguageIds: Set<Int> { get }
+    var showNewPostNotifs: Bool? { get }
+    var emailVerified: Bool { get }
+    var acceptedApplication: Bool { get }
+    var openLinksInNewTab: Bool? { get }
+    var blurNsfw: Bool? { get }
+    var autoExpandImages: Bool? { get }
+    var infiniteScrollEnabled: Bool? { get }
+    var postListingMode: ApiPostListingMode? { get }
+    var totp2faEnabled: Bool? { get }
+    var enableKeyboardNavigation: Bool? { get }
+    var enableAnimatedImages: Bool? { get }
+    var collapseBotComments: Bool? { get }
+}
+
+public extension Person4Providing {
+    var person3: Person3 { person4.person3 }
+    
+    var voteDisplayMode: ApiLocalUserVoteDisplayMode? { person4.voteDisplayMode }
+    var email: String? { person4.email }
+    var showNsfw: Bool { person4.showNsfw }
+    var theme: String { person4.theme }
+    var defaultSortType: ApiSortType { person4.defaultSortType }
+    var defaultListingType: ApiListingType { person4.defaultListingType }
+    var interfaceLanguage: String { person4.interfaceLanguage }
+    var showAvatars: Bool { person4.showAvatars }
+    var sendNotificationsToEmail: Bool { person4.sendNotificationsToEmail }
+    var showScores: Bool { person4.showScores }
+    var showBotAccounts: Bool { person4.showBotAccounts }
+    var showReadPosts: Bool { person4.showReadPosts }
+    var discussionLanguageIds: Set<Int> { person4.discussionLanguageIds }
+    var showNewPostNotifs: Bool? { person4.showNewPostNotifs }
+    var emailVerified: Bool { person4.emailVerified }
+    var acceptedApplication: Bool { person4.acceptedApplication }
+    var openLinksInNewTab: Bool? { person4.openLinksInNewTab }
+    var blurNsfw: Bool? { person4.blurNsfw }
+    var autoExpandImages: Bool? { person4.autoExpandImages }
+    var infiniteScrollEnabled: Bool? { person4.infiniteScrollEnabled }
+    var postListingMode: ApiPostListingMode? { person4.postListingMode }
+    var totp2faEnabled: Bool? { person4.totp2faEnabled }
+    var enableKeyboardNavigation: Bool? { person4.enableKeyboardNavigation }
+    var enableAnimatedImages: Bool? { person4.enableAnimatedImages }
+    var collapseBotComments: Bool? { person4.collapseBotComments }
+    
+    var voteDisplayMode_: ApiLocalUserVoteDisplayMode? { person4.voteDisplayMode }
+    var email_: String? { person4.email }
+    var showNsfw_: Bool? { person4.showNsfw }
+    var theme_: String? { person4.theme }
+    var defaultSortType_: ApiSortType? { person4.defaultSortType }
+    var defaultListingType_: ApiListingType? { person4.defaultListingType }
+    var interfaceLanguage_: String? { person4.interfaceLanguage }
+    var showAvatars_: Bool? { person4.showAvatars }
+    var sendNotificationsToEmail_: Bool? { person4.sendNotificationsToEmail }
+    var showScores_: Bool? { person4.showScores }
+    var showBotAccounts_: Bool? { person4.showBotAccounts }
+    var showReadPosts_: Bool? { person4.showReadPosts }
+    var discussionLanguageIds_: Set<Int>? { person4.discussionLanguageIds }
+    var showNewPostNotifs_: Bool? { person4.showNewPostNotifs }
+    var emailVerified_: Bool? { person4.emailVerified }
+    var acceptedApplication_: Bool? { person4.acceptedApplication }
+    var openLinksInNewTab_: Bool? { person4.openLinksInNewTab }
+    var blurNsfw_: Bool? { person4.blurNsfw }
+    var autoExpandImages_: Bool? { person4.autoExpandImages }
+    var infiniteScrollEnabled_: Bool? { person4.infiniteScrollEnabled }
+    var postListingMode_: ApiPostListingMode? { person4.postListingMode }
+    var totp2faEnabled_: Bool? { person4.totp2faEnabled }
+    var enableKeyboardNavigation_: Bool? { person4.enableKeyboardNavigation }
+    var enableAnimatedImages_: Bool? { person4.enableAnimatedImages }
+    var collapseBotComments_: Bool? { person4.collapseBotComments }
+}
+
+public extension Person4Providing {
+    var moderatedCommunityActorIds: Set<ActorIdentifier> { .init(moderatedCommunities.map(\.actorId)) }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/PersonStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/PersonStub.swift
@@ -1,0 +1,44 @@
+//
+//  Account.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+import Observation
+
+public struct PersonStub: PersonStubProviding, Hashable {
+    public static let tierNumber: Int = 0
+    public var api: ApiClient
+    public let url: URL
+    
+    public init(api: ApiClient, url: URL) {
+        self.api = api
+        self.url = url
+    }
+    
+    public func asLocal() -> Self {
+        .init(api: .getApiClient(url: url, username: nil), url: url)
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(url)
+    }
+    
+    public static func == (lhs: PersonStub, rhs: PersonStub) -> Bool {
+        lhs.url == rhs.url
+    }
+    
+    public func upgrade() async throws -> any Person {
+        try await api.getPerson(url: url) as Person2
+    }
+}
+
+// Resolvable conformance
+public extension PersonStub {
+    var resolvableUrl: URL { url }
+    
+    @inlinable
+    var allResolvableUrls: [URL] { [resolvableUrl] }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/PersonStubProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/PersonStubProviding.swift
@@ -1,0 +1,125 @@
+//
+//  AccountProviding.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+
+let developerNames = [
+    "https://lemmy.tespia.org/u/navi",
+    "https://beehaw.org/u/jojo",
+    "https://beehaw.org/u/kronusdark",
+    "https://lemmy.ml/u/ericbandrews",
+    "https://programming.dev/u/tht7",
+    "https://lemmy.ml/u/sjmarf"
+]
+
+public protocol PersonStubProviding: ContentModel, Resolvable {
+    // From Person1Providing.
+    var actorId_: ActorIdentifier? { get }
+    var id_: Int? { get }
+    var created_: Date? { get }
+    var instanceId_: Int? { get }
+    var updated_: Date? { get }
+    var displayName_: String? { get }
+    var description_: String? { get }
+    var matrixId_: String? { get }
+    var avatar_: URL? { get }
+    var banner_: URL? { get }
+    var deleted_: Bool? { get }
+    var isBot_: Bool? { get }
+    var instanceBan_: InstanceBanType? { get }
+    var blocked_: Bool? { get }
+    
+    // From Person2Providing.
+    var postCount_: Int? { get }
+    var commentCount_: Int? { get }
+    
+    // From Person3Providing.
+    var instance_: Instance1? { get }
+    var moderatedCommunities_: [Community1]? { get }
+    
+    // From Person4Providing.
+    var isAdmin_: Bool? { get }
+    var voteDisplayMode_: ApiLocalUserVoteDisplayMode? { get }
+    var email_: String? { get }
+    var showNsfw_: Bool? { get }
+    var theme_: String? { get }
+    var defaultSortType_: ApiSortType? { get }
+    var defaultListingType_: ApiListingType? { get }
+    var interfaceLanguage_: String? { get }
+    var showAvatars_: Bool? { get }
+    var sendNotificationsToEmail_: Bool? { get }
+    var showScores_: Bool? { get }
+    var showBotAccounts_: Bool? { get }
+    var showReadPosts_: Bool? { get }
+    var discussionLanguageIds_: Set<Int>? { get }
+    var showNewPostNotifs_: Bool? { get }
+    var emailVerified_: Bool? { get }
+    var acceptedApplication_: Bool? { get }
+    var openLinksInNewTab_: Bool? { get }
+    var blurNsfw_: Bool? { get }
+    var autoExpandImages_: Bool? { get }
+    var infiniteScrollEnabled_: Bool? { get }
+    var postListingMode_: ApiPostListingMode? { get }
+    var totp2faEnabled_: Bool? { get }
+    var enableKeyboardNavigation_: Bool? { get }
+    var enableAnimatedImages_: Bool? { get }
+    var collapseBotComments_: Bool? { get }
+    
+    func upgrade() async throws -> any Person
+}
+
+public extension PersonStubProviding {
+    static var identifierPrefix: String { "@" }
+    
+    var actorId_: ActorIdentifier? { nil }
+    var id_: Int? { nil }
+    var created_: Date? { nil }
+    var instanceId_: Int? { nil }
+    var updated_: Date? { nil }
+    var displayName_: String? { nil }
+    var description_: String? { nil }
+    var matrixId_: String? { nil }
+    var avatar_: URL? { nil }
+    var banner_: URL? { nil }
+    var deleted_: Bool? { nil }
+    var isBot_: Bool? { nil }
+    var instanceBan_: InstanceBanType? { nil }
+    var blocked_: Bool? { nil }
+    
+    var postCount_: Int? { nil }
+    var commentCount_: Int? { nil }
+    
+    var instance_: Instance1? { nil }
+    var moderatedCommunities_: [Community1]? { nil }
+    
+    var isAdmin_: Bool? { nil }
+    var voteDisplayMode_: ApiLocalUserVoteDisplayMode? { nil }
+    var email_: String? { nil }
+    var showNsfw_: Bool? { nil }
+    var theme_: String? { nil }
+    var defaultSortType_: ApiSortType? { nil }
+    var defaultListingType_: ApiListingType? { nil }
+    var interfaceLanguage_: String? { nil }
+    var showAvatars_: Bool? { nil }
+    var sendNotificationsToEmail_: Bool? { nil }
+    var showScores_: Bool? { nil }
+    var showBotAccounts_: Bool? { nil }
+    var showReadPosts_: Bool? { nil }
+    var discussionLanguageIds_: Set<Int>? { nil }
+    var showNewPostNotifs_: Bool? { nil }
+    var emailVerified_: Bool? { nil }
+    var acceptedApplication_: Bool? { nil }
+    var openLinksInNewTab_: Bool? { nil }
+    var blurNsfw_: Bool? { nil }
+    var autoExpandImages_: Bool? { nil }
+    var infiniteScrollEnabled_: Bool? { nil }
+    var postListingMode_: ApiPostListingMode? { nil }
+    var totp2faEnabled_: Bool? { nil }
+    var enableKeyboardNavigation_: Bool? { nil }
+    var enableAnimatedImages_: Bool? { nil }
+    var collapseBotComments_: Bool? { nil }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonVote/PersonVote+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonVote/PersonVote+CacheExtensions.swift
@@ -1,0 +1,26 @@
+//
+//  PersonVote+CacheExtensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-18.
+//
+
+import Foundation
+
+extension PersonVote: CacheIdentifiable {
+    public var cacheId: Int {
+        var hasher = Hasher()
+        hasher.combine(target)
+        hasher.combine(creator.id)
+        return hasher.finalize()
+    }
+    
+    @MainActor
+    func update(with voteView: ApiVoteView, semaphore: UInt? = nil) {
+        setIfChanged(\.vote, ScoringOperation(rawValue: voteView.score) ?? .none)
+        creator.update(with: voteView.creator, semaphore: semaphore)
+        if let creatorBannedFromCommunity = voteView.creatorBannedFromCommunity {
+            creator.updateKnownCommunityBanState(id: communityId, banned: creatorBannedFromCommunity)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonVote/PersonVote.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonVote/PersonVote.swift
@@ -1,0 +1,53 @@
+//
+//  PersonVote.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-18.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public class PersonVote: ContentModel {
+    public static var tierNumber: Int = 1
+    
+    public enum Target: Hashable {
+        case post(id: Int)
+        case comment(id: Int)
+    }
+    
+    public let api: ApiClient
+
+    public let target: Target
+    public let communityId: Int
+    
+    public let creator: Person1
+    public var vote: ScoringOperation
+    
+    public var bannedFromCommunity: Bool {
+        guard let state = creator.isBannedFromCommunity(id: communityId) else {
+            assertionFailure("Ban status should be present at this point")
+            return false
+        }
+        return state
+    }
+
+    init(
+        api: ApiClient,
+        target: Target,
+        communityId: Int,
+        creator: Person1,
+        vote: ScoringOperation,
+        creatorBannedFromCommunity: Bool?
+    ) {
+        self.api = api
+        self.target = target
+        self.communityId = communityId
+        self.creator = creator
+        self.vote = vote
+        if let creatorBannedFromCommunity {
+            creator.updateKnownCommunityBanState(id: communityId, banned: creatorBannedFromCommunity)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonVote/PersonVote.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonVote/PersonVote.swift
@@ -32,7 +32,6 @@ public class PersonVote: ContentModel {
         }
         return state
     }
-
     init(
         api: ApiClient,
         target: Target,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonVote/PersonVote.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonVote/PersonVote.swift
@@ -32,6 +32,7 @@ public class PersonVote: ContentModel {
         }
         return state
     }
+
     init(
         api: ApiClient,
         target: Target,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/AnyPost.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/AnyPost.swift
@@ -1,0 +1,79 @@
+//
+//  AnyPost.swift
+//
+//
+//  Created by Eric Andrews on 2024-05-13.
+//
+
+import Foundation
+
+@Observable
+public class AnyPost: Hashable, Upgradable {
+    public typealias Base = PostStubProviding
+    public typealias MinimumRenderable = Post1Providing
+    public typealias Upgraded = Post3Providing
+    
+    public var wrappedValue: any PostStubProviding
+    
+    public required init(_ wrappedValue: any PostStubProviding) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+/// Hashable, Equatable conformance
+public extension AnyPost {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+    
+    static func == (lhs: AnyPost, rhs: AnyPost) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+}
+
+/// Upgradable conformance
+public extension AnyPost {
+    internal func upgrade(
+        initialValue: (any Base)? = nil,
+        upgradeOperation: (any Base) async throws -> any Base
+    ) async throws {
+        var lastValue = initialValue ?? wrappedValue
+        while !(lastValue is any Upgraded) {
+            lastValue = try await upgradeOperation(lastValue)
+            if type(of: lastValue).tierNumber >= type(of: wrappedValue).tierNumber {
+                let task = Task { @MainActor [lastValue] in
+                    self.wrappedValue = lastValue
+                }
+                _ = await task.value
+            }
+        }
+    }
+    
+    func upgrade(
+        api: ApiClient?,
+        upgradeOperation: ((any Base) async throws -> any Base)?
+    ) async throws {
+        let initialValue: any Base
+        if let api {
+            initialValue = api === wrappedValue.api ? wrappedValue : PostStub(
+                api: api,
+                url: wrappedValue.allResolvableUrls[0]
+            )
+        } else {
+            initialValue = wrappedValue
+        }
+        try await upgrade(
+            initialValue: initialValue,
+            upgradeOperation: upgradeOperation ?? { try await $0.upgrade() }
+        )
+    }
+    
+    func refresh(upgradeOperation: ((any Base) async throws -> any Base)?) async throws {
+        if let wrappedValue = wrappedValue as? any Upgraded {
+            try await upgrade(
+                initialValue: wrappedValue.post1,
+                upgradeOperation: upgradeOperation ?? { try await $0.upgrade() }
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1+Codable.swift
@@ -1,0 +1,39 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-23.
+//
+
+import Foundation
+
+extension Post1 {
+    var apiPost: ApiPost {
+        ApiPost(
+            id: id,
+            name: title,
+            url: linkUrl?.absoluteString,
+            body: content,
+            creatorId: creatorId,
+            communityId: communityId,
+            removed: removed,
+            locked: locked,
+            published: created,
+            updated: updated,
+            deleted: deleted,
+            nsfw: nsfw,
+            embedTitle: embed?.title,
+            embedDescription: embed?.description,
+            thumbnailUrl: thumbnailUrl,
+            actorId: actorId,
+            local: actorId.host == api.actorId.host,
+            embedVideoUrl: embed?.videoUrl,
+            languageId: languageId,
+            featuredCommunity: pinnedCommunity,
+            featuredLocal: pinnedInstance,
+            urlContentType: nil,
+            altText: altText,
+            scheduledPublishTime: nil
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1+ImagePrefetchProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1+ImagePrefetchProviding.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-02-25.
-//
+//  
 
 import Foundation
 import Nuke

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1+ImagePrefetchProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1+ImagePrefetchProviding.swift
@@ -1,0 +1,52 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-25.
+//
+
+import Foundation
+import Nuke
+
+extension Post1: ImagePrefetchProviding {
+    public func imageRequests(configuration config: PrefetchingConfiguration) async -> [ImageRequest] {
+        var ret: [ImageRequest] = .init()
+        
+        // handle loops.video embedding
+        if config.embedLoops {
+            await parseLoopEmbeds()
+        }
+        
+        switch type {
+        case let .media(url), let .embedded(url, _):
+            // media/embedded media: only load the media
+            var urlRequest: URLRequest
+            switch config.imageSize {
+            case .unlimited:
+                urlRequest = mlemUrlRequest(url: url)
+            case let .limited(size):
+                urlRequest = mlemUrlRequest(url: url.withIconSize(size))
+            }
+            ret.append(ImageRequest(urlRequest: urlRequest, priority: .high))
+        case let .link(link):
+            // websites: load image and favicon
+            if config.fetchFavicons, let url = link.favicon {
+                let urlRequest = mlemUrlRequest(url: url)
+                ret.append(ImageRequest(urlRequest: urlRequest))
+            }
+            if let url = link.thumbnail {
+                var urlRequest: URLRequest
+                switch config.imageSize {
+                case .unlimited:
+                    urlRequest = mlemUrlRequest(url: url)
+                case let .limited(size):
+                    urlRequest = mlemUrlRequest(url: url.withIconSize(size))
+                }
+                ret.append(ImageRequest(urlRequest: urlRequest, priority: .high))
+            }
+        default:
+            break
+        }
+        return ret
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1+ImagePrefetchProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1+ImagePrefetchProviding.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-02-25.
-//  
+//
 
 import Foundation
 import Nuke

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1+Mock.swift
@@ -1,0 +1,58 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-02.
+//
+
+import Foundation
+
+#if DEBUG
+    public extension Post1 {
+        static func mock(
+            api: MockApiClient = .mock,
+            actorId: ActorIdentifier? = nil,
+            id: Int,
+            creatorId: Int,
+            communityId: Int,
+            created: Date,
+            title: String,
+            content: String?,
+            linkUrl: URL?,
+            deleted: Bool,
+            embed: PostEmbed?,
+            pinnedCommunity: Bool,
+            pinnedInstance: Bool,
+            locked: Bool,
+            nsfw: Bool,
+            removed: Bool,
+            thumbnailUrl: URL?,
+            updated: Date?,
+            languageId: Int,
+            altText: String?
+        ) -> Post1 {
+            .init(
+                api: api,
+                actorId: actorId ?? .init(url: URL(string: "https://\(api.host)/post/\(id)")!)!,
+                id: id,
+                creatorId: creatorId,
+                communityId: communityId,
+                created: created,
+                title: title,
+                content: content,
+                linkUrl: linkUrl,
+                deleted: deleted,
+                embed: embed,
+                pinnedCommunity: pinnedCommunity,
+                pinnedInstance: pinnedInstance,
+                locked: locked,
+                nsfw: nsfw,
+                removed: removed,
+                thumbnailUrl: thumbnailUrl,
+                updated: updated,
+                languageId: languageId,
+                altText: altText
+            )
+        }
+    }
+#endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1.swift
@@ -1,0 +1,103 @@
+//
+//  Post1.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+import Observation
+
+public struct PostEmbed: Equatable {
+    public let title: String?
+    public let description: String?
+    public let videoUrl: URL?
+}
+
+@Observable
+public final class Post1: Post1Providing {
+    public static let tierNumber: Int = 1
+    public var api: ApiClient
+    public var post1: Post1 { self }
+    
+    public let actorId: ActorIdentifier
+    public let id: Int
+    public let creatorId: Int
+    public let communityId: Int
+    
+    public var title: String
+    
+    // We can't name this 'body' because @Observable uses that property name already
+    public var content: String?
+    public var linkUrl: URL?
+    public var embeddedMediaUrl: URL?
+    public var embed: PostEmbed?
+    public var nsfw: Bool
+    public var thumbnailUrl: URL?
+    public let created: Date
+    public var updated: Date?
+    public var languageId: Int
+    public var altText: String?
+    
+    public var purged: Bool = false
+    
+    public var lockedManager: StateManager<Bool>
+    public var locked: Bool { lockedManager.wrappedValue }
+    public var verifiedLocked: Bool { lockedManager.verifiedValue }
+    
+    public var pinnedCommunityManager: StateManager<Bool>
+    public var pinnedCommunity: Bool { pinnedCommunityManager.wrappedValue }
+    
+    public var pinnedInstanceManager: StateManager<Bool>
+    public var pinnedInstance: Bool { pinnedInstanceManager.wrappedValue }
+    
+    var deletedManager: StateManager<Bool>
+    public var deleted: Bool { deletedManager.wrappedValue }
+    
+    public var removedManager: StateManager<Bool>
+    public var removed: Bool { removedManager.wrappedValue }
+    
+    init(
+        api: ApiClient,
+        actorId: ActorIdentifier,
+        id: Int,
+        creatorId: Int,
+        communityId: Int,
+        created: Date,
+        title: String,
+        content: String?,
+        linkUrl: URL?,
+        deleted: Bool,
+        embed: PostEmbed?,
+        pinnedCommunity: Bool,
+        pinnedInstance: Bool,
+        locked: Bool,
+        nsfw: Bool,
+        removed: Bool,
+        thumbnailUrl: URL?,
+        updated: Date?,
+        languageId: Int,
+        altText: String?
+    ) {
+        self.api = api
+        self.actorId = actorId
+        self.id = id
+        self.creatorId = creatorId
+        self.communityId = communityId
+        self.created = created
+        self.title = title
+        self.content = content
+        self.linkUrl = linkUrl
+        self.deletedManager = .init(wrappedValue: deleted)
+        self.embed = embed
+        self.pinnedCommunityManager = .init(wrappedValue: pinnedCommunity)
+        self.pinnedInstanceManager = .init(wrappedValue: pinnedInstance)
+        self.lockedManager = .init(wrappedValue: locked)
+        self.nsfw = nsfw
+        self.removedManager = .init(wrappedValue: removed)
+        self.thumbnailUrl = thumbnailUrl
+        self.updated = updated
+        self.languageId = languageId
+        self.altText = altText
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
@@ -1,0 +1,287 @@
+//
+//  Post1Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+
+public protocol Post1Providing:
+    PostStubProviding,
+    ActorIdentifiable,
+    ContentIdentifiable,
+    Interactable1Providing,
+    SelectableContentProviding,
+    DeletableProviding,
+    RemovableProviding,
+    PurgableProviding,
+    ImagePrefetchProviding,
+    Sharable,
+    FeedLoadable where FilterType == PostFilterType {
+    var post1: Post1 { get }
+    
+    var id: Int { get }
+    var creatorId: Int { get }
+    var communityId: Int { get }
+    var title: String { get }
+    var content: String? { get }
+    var linkUrl: URL? { get }
+    var embeddedMediaUrl: URL? { get }
+    var deleted: Bool { get }
+    var embed: PostEmbed? { get }
+    var pinnedCommunity: Bool { get }
+    var pinnedInstance: Bool { get }
+    var locked: Bool { get }
+    var pinnedCommunityManager: StateManager<Bool> { get }
+    var pinnedInstanceManager: StateManager<Bool> { get }
+    var lockedManager: StateManager<Bool> { get }
+    var nsfw: Bool { get }
+    var created: Date { get }
+    var thumbnailUrl: URL? { get }
+    var updated: Date? { get }
+    var languageId: Int { get }
+    var altText: String? { get }
+}
+
+public typealias Post = Post1Providing
+
+public extension Post1Providing {
+    static var modelTypeId: ContentType { .post }
+    
+    var actorId: ActorIdentifier { post1.actorId }
+    var id: Int { post1.id }
+    var creatorId: Int { post1.creatorId }
+    var communityId: Int { post1.communityId }
+    var title: String { post1.title }
+    var content: String? { post1.content }
+    var linkUrl: URL? { post1.linkUrl }
+    var embeddedMediaUrl: URL? { post1.embeddedMediaUrl }
+    var deleted: Bool { post1.deleted }
+    var embed: PostEmbed? { post1.embed }
+    var pinnedCommunity: Bool { post1.pinnedCommunity }
+    var pinnedInstance: Bool { post1.pinnedInstance }
+    var locked: Bool { post1.locked }
+    var pinnedCommunityManager: StateManager<Bool> { post1.pinnedCommunityManager }
+    var pinnedInstanceManager: StateManager<Bool> { post1.pinnedInstanceManager }
+    var lockedManager: StateManager<Bool> { post1.lockedManager }
+    var nsfw: Bool { post1.nsfw }
+    var created: Date { post1.created }
+    var removed: Bool { post1.removed }
+    var removedManager: StateManager<Bool> { post1.removedManager }
+    var thumbnailUrl: URL? { post1.thumbnailUrl }
+    var updated: Date? { post1.updated }
+    var languageId: Int { post1.languageId }
+    var altText: String? { post1.altText }
+    var purged: Bool { post1.purged }
+    
+    var actorId_: ActorIdentifier? { actorId }
+    var creatorId_: Int? { post1.creatorId }
+    var communityId_: Int? { post1.communityId }
+    var title_: String? { post1.title }
+    var content_: String? { post1.content }
+    var linkUrl_: URL? { post1.linkUrl }
+    var deleted_: Bool? { post1.deleted }
+    var embed_: PostEmbed? { post1.embed }
+    var pinnedCommunity_: Bool? { post1.pinnedCommunity }
+    var pinnedInstance_: Bool? { post1.pinnedInstance }
+    var locked_: Bool? { post1.locked }
+    var pinnedCommunityManager_: StateManager<Bool>? { post1.pinnedCommunityManager }
+    var pinnedInstanceManager_: StateManager<Bool>? { post1.pinnedInstanceManager }
+    var lockedManager_: StateManager<Bool>? { post1.lockedManager }
+    var nsfw_: Bool? { post1.nsfw }
+    var created_: Date? { post1.created }
+    var removed_: Bool? { post1.removed }
+    var removedManager_: StateManager<Bool>? { post1.removedManager }
+    var thumbnailUrl_: URL? { post1.thumbnailUrl }
+    var updated_: Date? { post1.updated }
+    var languageId_: Int? { post1.languageId }
+    var altText_: String? { post1.altText }
+}
+
+// Resolvable conformance
+public extension Post1Providing {
+    @inlinable
+    var allResolvableUrls: [URL] {
+        ContentModelUrlType.allCases.map { resolvableUrl(from: $0) }
+    }
+}
+
+// Sharable conformance
+public extension Post1Providing {
+    func url() -> URL { api.baseUrl.appending(path: "post/\(id)") }
+}
+
+// FeedLoadable conformance
+public extension Post1Providing {
+    func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        switch sortType {
+        case .new:
+            return .new(created)
+        }
+    }
+}
+
+// SelectableContentProviding conformance
+public extension Post1Providing {
+    var selectableContent: String? {
+        if let content {
+            "\(title)\n\n\(content)"
+        } else {
+            title
+        }
+    }
+}
+
+public extension Post1Providing {
+    /// Returns a `URL` that can be resolved by another `ApiClient`.
+    func resolvableUrl(from instance: ContentModelUrlType) -> URL {
+        switch instance {
+        case .host: actorId.url
+        case .provider: .post(host: api.host, id: id)
+        }
+    }
+    
+    /// If this post links to loops.video, attempts to parse the underlying media url and set embeddedMediaUrl
+    func parseLoopEmbeds() async {
+        if let loopsUrl = await linkUrl?.parseEmbeddedLoops() {
+            _ = await Task { @MainActor in
+                post1.embeddedMediaUrl = loopsUrl
+            }.result
+        }
+    }
+    
+    var type: PostType {
+        // post with URL: image, embedded, or link
+        if let linkUrl {
+            if let embeddedMediaUrl {
+                return .embedded(embeddedMediaUrl, originalLink: linkUrl)
+            }
+            
+            // if image, return image link, otherwise return thumbnail
+            if linkUrl.isMedia {
+                return .media(linkUrl)
+            }
+            return .link(.init(content: linkUrl, thumbnail: thumbnailUrl, label: embed?.title ?? title))
+        }
+
+        // otherwise text, but post.body needs to be present, even if it's an empty string
+        if let postBody = content {
+            return .text(postBody)
+        }
+
+        return .titleOnly
+    }
+}
+
+public extension Post1Providing {
+    private var deletedManager: StateManager<Bool> { post1.deletedManager }
+
+    func upgrade() async throws -> any Post {
+        try await api.getPost(id: id)
+    }
+    
+    func getComments(
+        sort: CommentSortType = .hot,
+        page: Int,
+        maxDepth: Int? = nil,
+        limit: Int,
+        filter: GetContentFilter? = nil
+    ) async throws -> [Comment2] {
+        try await api.getComments(
+            postId: id,
+            sort: sort.apiSortType,
+            page: page,
+            maxDepth: maxDepth,
+            limit: limit,
+            filter: filter
+        )
+    }
+    
+    func reply(content: String, languageId: Int? = nil) async throws -> Comment2 {
+        try await api.replyToPost(id: id, content: content, languageId: languageId)
+    }
+    
+    func report(reason: String) async throws {
+        try await api.reportPost(id: id, reason: reason)
+    }
+    
+    func purge(reason: String?) async throws {
+        try await api.purgePost(id: id, reason: reason)
+    }
+    
+    @discardableResult
+    func updateDeleted(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        deletedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.deletePost(id: self.id, delete: newValue, semaphore: semaphore)
+        }
+    }
+    
+    func edit(
+        title: String,
+        content: String?,
+        linkUrl: URL?,
+        altText: String?,
+        thumbnail: URL?,
+        nsfw: Bool,
+        languageId: Int?
+    ) async throws {
+        try await api.editPost(
+            id: id,
+            title: title,
+            content: content,
+            linkUrl: linkUrl,
+            altText: altText,
+            thumbnail: thumbnail,
+            nsfw: nsfw,
+            languageId: languageId
+        )
+    }
+    
+    @discardableResult
+    func updateLocked(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        lockedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.lockPost(id: self.id, lock: newValue, semaphore: semaphore)
+        }
+    }
+    
+    @discardableResult
+    func toggleLocked() -> Task<StateUpdateResult, Never> {
+        updateLocked(!locked)
+    }
+    
+    @discardableResult
+    func updatePinnedCommunity(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        pinnedCommunityManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.pinPost(id: self.id, pin: newValue, to: .community, semaphore: semaphore)
+        }
+    }
+    
+    @discardableResult
+    func togglePinnedCommunity() -> Task<StateUpdateResult, Never> {
+        updatePinnedCommunity(!pinnedCommunity)
+    }
+    
+    @discardableResult
+    func updatePinnedInstance(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        pinnedInstanceManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.pinPost(id: self.id, pin: newValue, to: .local, semaphore: semaphore)
+        }
+    }
+    
+    @discardableResult
+    func togglePinnedInstance() -> Task<StateUpdateResult, Never> {
+        updatePinnedInstance(!pinnedInstance)
+    }
+    
+    @discardableResult
+    func updateRemoved(_ newValue: Bool, reason: String?) -> Task<StateUpdateResult, Never> {
+        removedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.removePost(id: self.id, remove: newValue, reason: reason, semaphore: semaphore)
+        }
+    }
+    
+    func getVotes(page: Int, limit: Int) async throws -> [PersonVote] {
+        try await api.getPostVotes(id: id, communityId: communityId, page: page, limit: limit)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+Codable.swift
@@ -1,0 +1,49 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-23.
+//
+
+import Foundation
+
+extension Post2 {
+    var apiPostView: ApiPostView {
+        ApiPostView(
+            post: post1.apiPost,
+            creator: creator.apiPerson,
+            community: community.apiCommunity,
+            creatorBannedFromCommunity: creator.isBannedFromCommunity(id: communityId) ?? false,
+            counts: .init(
+                id: nil,
+                postId: post1.id,
+                comments: commentCount,
+                score: votes.total,
+                upvotes: votes.upvotes,
+                downvotes: votes.downvotes,
+                published: created,
+                newestCommentTimeNecro: nil,
+                newestCommentTime: nil,
+                featuredCommunity: pinnedCommunity,
+                featuredLocal: pinnedInstance,
+                hotRank: nil,
+                hotRankActive: nil,
+                reportCount: nil,
+                unresolvedReportCount: nil
+            ),
+            subscribed: .notSubscribed,
+            saved: saved,
+            read: read,
+            creatorBlocked: creator.blocked,
+            myVote: votes.myVote.rawValue,
+            unreadComments: unreadCommentCount,
+            creatorIsModerator: creatorIsModerator,
+            creatorIsAdmin: creatorIsAdmin,
+            bannedFromCommunity: bannedFromCommunity,
+            hidden: hidden,
+            imageDetails: nil,
+            tags: nil,
+            canMod: nil
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+ImagePrefetchProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+ImagePrefetchProviding.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-02-25.
-//
+//  
 
 import Foundation
 import Nuke

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+ImagePrefetchProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+ImagePrefetchProviding.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-02-25.
-//  
+//
 
 import Foundation
 import Nuke

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+ImagePrefetchProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+ImagePrefetchProviding.swift
@@ -1,0 +1,29 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-25.
+//
+
+import Foundation
+import Nuke
+
+extension Post2: ImagePrefetchProviding {
+    public func imageRequests(configuration config: PrefetchingConfiguration) async -> [ImageRequest] {
+        var ret: [ImageRequest] = await post1.imageRequests(configuration: config)
+        
+        // preload user and community avatars--fetching both because we don't know which we'll need, but these are super tiny
+        // so it's probably not an API crime, right?
+        if let avatarSize = config.avatarSize {
+            if let communityAvatarLink = community.avatar {
+                ret.append(ImageRequest(urlRequest: mlemUrlRequest(url: communityAvatarLink.withIconSize(avatarSize))))
+            }
+            
+            if let userAvatarLink = creator.avatar {
+                ret.append(ImageRequest(urlRequest: mlemUrlRequest(url: userAvatarLink.withIconSize(avatarSize))))
+            }
+        }
+        
+        return ret
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+Mock.swift
@@ -1,0 +1,47 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-04.
+//
+
+import Foundation
+
+#if DEBUG
+    public extension Post2 {
+        static func mock(
+            api: ApiClient = .mock,
+            post1: Post1,
+            creator: Person1,
+            community: Community1,
+            votes: VotesModel,
+            creatorIsModerator: Bool?,
+            creatorIsAdmin: Bool?,
+            bannedFromCommunity: Bool,
+            commentCount: Int,
+            unreadCommentCount: Int,
+            saved: Bool,
+            read: Bool,
+            hidden: Bool
+        ) -> Post2 {
+            assert(api === post1.api)
+            assert(api === creator.api)
+            assert(api === community.api)
+            return .init(
+                api: api,
+                post1: post1,
+                creator: creator,
+                community: community,
+                votes: votes,
+                creatorIsModerator: creatorIsModerator,
+                creatorIsAdmin: creatorIsAdmin,
+                bannedFromCommunity: bannedFromCommunity,
+                commentCount: commentCount,
+                unreadCommentCount: unreadCommentCount,
+                saved: saved,
+                read: read,
+                hidden: hidden
+            )
+        }
+    }
+#endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2.swift
@@ -1,0 +1,82 @@
+//
+//  Post2.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Post2: Post2Providing {
+    public static let tierNumber: Int = 2
+    public var api: ApiClient
+    public var post2: Post2 { self }
+    
+    public let post1: Post1
+    
+    public let creator: Person1
+    public let community: Community1
+    
+    public var creatorIsModerator: Bool?
+    public var creatorIsAdmin: Bool?
+    public var commentCount: Int
+    public var unreadCommentCount: Int
+    
+    var votesManager: StateManager<VotesModel>
+    public var votes: VotesModel { votesManager.wrappedValue }
+    
+    var readManager: StateManager<Bool>
+    public var read: Bool { readManager.wrappedValue || readQueued }
+    private var readQueued: Bool = false
+    
+    var savedManager: StateManager<Bool>
+    public var saved: Bool { savedManager.wrappedValue }
+    
+    var hiddenManager: StateManager<Bool>
+    public var hidden: Bool { hiddenManager.wrappedValue }
+    
+    public var bannedFromCommunity: Bool {
+        guard let state = creator.isBannedFromCommunity(community) else {
+            assertionFailure("Ban status should be present at this point")
+            return false
+        }
+        return state
+    }
+    
+    init(
+        api: ApiClient,
+        post1: Post1,
+        creator: Person1,
+        community: Community1,
+        votes: VotesModel,
+        creatorIsModerator: Bool?,
+        creatorIsAdmin: Bool?,
+        bannedFromCommunity: Bool,
+        commentCount: Int,
+        unreadCommentCount: Int,
+        saved: Bool,
+        read: Bool,
+        hidden: Bool
+    ) {
+        self.api = api
+        self.post1 = post1
+        self.creator = creator
+        self.community = community
+        self.votesManager = .init(wrappedValue: votes)
+        self.creatorIsModerator = creatorIsModerator
+        self.creatorIsAdmin = creatorIsAdmin
+        self.commentCount = commentCount
+        self.unreadCommentCount = unreadCommentCount
+        self.savedManager = .init(wrappedValue: saved)
+        self.readManager = .init(wrappedValue: read)
+        self.hiddenManager = .init(wrappedValue: hidden)
+        creator.updateKnownCommunityBanState(id: community.id, banned: bannedFromCommunity)
+    }
+    
+    @MainActor
+    func updateReadQueued(_ newValue: Bool) {
+        readQueued = newValue
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
@@ -1,0 +1,121 @@
+//
+//  Post2Providing.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+import Nuke
+
+public protocol Post2Providing: Post1Providing, Interactable2Providing, PersonContentProviding, ReadableProviding {
+    var post2: Post2 { get }
+    
+    var creator: any Person { get }
+    var community: any Community { get }
+    var unreadCommentCount: Int { get }
+    var read: Bool { get }
+    var hidden: Bool { get }
+}
+
+public extension Post2Providing {
+    var post1: Post1 { post2.post1 }
+    
+    var creator: any Person { post2.creator }
+    var community: any Community { post2.community }
+    var creatorIsModerator: Bool? { post2.creatorIsModerator }
+    var creatorIsAdmin: Bool? { post2.creatorIsAdmin }
+    var bannedFromCommunity: Bool { post2.bannedFromCommunity }
+    var commentCount: Int { post2.commentCount }
+    var unreadCommentCount: Int { post2.unreadCommentCount }
+    var votes: VotesModel { post2.votes }
+    var saved: Bool { post2.saved }
+    var read: Bool { post2.read }
+    var hidden: Bool { post2.hidden }
+    
+    var creator_: (any Person)? { post2.creator }
+    var community_: (any Community)? { post2.community }
+    var creatorIsModerator_: Bool? { post2.creatorIsModerator }
+    var creatorIsAdmin_: Bool? { post2.creatorIsAdmin }
+    var bannedFromCommunity_: Bool? { post2.bannedFromCommunity }
+    var commentCount_: Int? { post2.commentCount }
+    var unreadCommentCount_: Int? { post2.unreadCommentCount }
+    var votes_: VotesModel? { post2.votes }
+    var saved_: Bool? { post2.saved }
+    var read_: Bool? { post2.read }
+    var hidden_: Bool? { post2.hidden }
+}
+
+public extension Post2Providing {
+    private var votesManager: StateManager<VotesModel> { post2.votesManager }
+    private var readManager: StateManager<Bool> { post2.readManager }
+    private var savedManager: StateManager<Bool> { post2.savedManager }
+    private var hiddenManager: StateManager<Bool> { post2.hiddenManager }
+        
+    @discardableResult
+    func updateRead(_ newValue: Bool, shouldQueue: Bool = false) -> Task<StateUpdateResult, Never> {
+        if shouldQueue {
+            return Task { @MainActor in
+                if newValue {
+                    await api.markReadQueue.add(self.id)
+                    post2.updateReadQueued(true)
+                } else {
+                    await api.markReadQueue.remove(self.id)
+                    post2.updateReadQueued(false)
+                }
+                return .deferred
+            }
+        } else {
+            return readManager.performRequest(expectedResult: newValue) { semaphore in
+                try await self.api.markPostAsRead(id: self.id, read: newValue, includeQueuedPosts: true, semaphore: semaphore)
+            }
+        }
+    }
+    
+    @discardableResult
+    func toggleRead(shouldQueue: Bool = false) -> Task<StateUpdateResult, Never> {
+        updateRead(!read, shouldQueue: shouldQueue)
+    }
+
+    @discardableResult
+    func updateVote(_ newValue: ScoringOperation) -> Task<StateUpdateResult, Never> {
+        groupStateRequest(
+            votesManager.ticket(votes.applyScoringOperation(operation: newValue)),
+            readManager.ticket(true)
+        ) { semaphore in
+            try await self.api.voteOnPost(id: self.id, score: newValue, semaphore: semaphore)
+        }
+    }
+    
+    @discardableResult
+    func updateSaved(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        groupStateRequest(
+            savedManager.ticket(newValue),
+            readManager.ticket(true)
+        ) { semaphore in
+            try await self.api.savePost(id: self.id, save: newValue, semaphore: semaphore)
+        }
+    }
+    
+    var queuedForMarkAsRead: Bool {
+        get async { await api.markReadQueue.ids.contains(id) }
+    }
+    
+    @discardableResult
+    func toggleHidden() -> Task<StateUpdateResult, Never> {
+        updateHidden(!hidden)
+    }
+    
+    @discardableResult
+    func updateHidden(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        // Unlike other post operations, this one does not mark the post as read
+        hiddenManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.hidePost(id: self.id, hide: newValue, semaphore: semaphore)
+        }
+    }
+}
+
+// PersonContentProviding conformance
+public extension Post2Providing {
+    var userContent: PersonContent { .init(wrappedValue: .post(post2)) }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post3.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post3.swift
@@ -19,7 +19,7 @@ public final class Post3: Post3Providing {
     public var communityModerators: [Person1]
     public var crossPosts: [Post2]
     
-    internal init(
+    init(
         api: ApiClient,
         post2: Post2,
         community: Community2,
@@ -33,4 +33,3 @@ public final class Post3: Post3Providing {
         self.crossPosts = crossPosts
     }
 }
-

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post3.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post3.swift
@@ -19,7 +19,7 @@ public final class Post3: Post3Providing {
     public var communityModerators: [Person1]
     public var crossPosts: [Post2]
     
-    init(
+    internal init(
         api: ApiClient,
         post2: Post2,
         community: Community2,
@@ -33,3 +33,4 @@ public final class Post3: Post3Providing {
         self.crossPosts = crossPosts
     }
 }
+

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post3.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post3.swift
@@ -1,0 +1,35 @@
+//
+//  Post3.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 25/09/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Post3: Post3Providing {
+    public static let tierNumber: Int = 3
+    public var api: ApiClient
+    public var post3: Post3 { self }
+    
+    public let post2: Post2
+    public let community: Community2
+    public var communityModerators: [Person1]
+    public var crossPosts: [Post2]
+    
+    init(
+        api: ApiClient,
+        post2: Post2,
+        community: Community2,
+        communityModerators: [Person1],
+        crossPosts: [Post2]
+    ) {
+        self.api = api
+        self.post2 = post2
+        self.community = community
+        self.communityModerators = communityModerators
+        self.crossPosts = crossPosts
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post3Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post3Providing.swift
@@ -1,0 +1,37 @@
+//
+//  Post3Providing.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 25/09/2024.
+//
+
+import Foundation
+import Nuke
+
+public protocol Post3Providing: Post2Providing {
+    var post3: Post3 { get }
+    
+    var communityModerators: [Person1] { get }
+    var crossPosts: [Post2] { get }
+}
+
+public extension Post3Providing {
+    func upgrade() async throws -> any Post { self }
+
+    // Override `Post2Providing` definition
+    var community: any Community { post3.community }
+    var community_: (any Community)? { post3.community }
+    
+    var communityModerators: [Person1] { post3.communityModerators }
+    var crossPosts: [Post2] { post3.crossPosts }
+    
+    var communityModerators_: [Person1]? { post3.communityModerators }
+    var crossPosts_: [Post2]? { post3.crossPosts }
+}
+
+// ImagePrefetchProviding conformance
+public extension Post3Providing {
+    func imageRequests(configuration config: PrefetchingConfiguration) async -> [ImageRequest] {
+        await post2.imageRequests(configuration: config)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/PostStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/PostStub.swift
@@ -1,0 +1,43 @@
+//
+//  PostStub.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+
+public struct PostStub: PostStubProviding, Hashable {
+    public static let tierNumber: Int = 0
+    public var api: ApiClient
+    public var url: URL
+    
+    public init(api: ApiClient, url: URL) {
+        self.api = api
+        self.url = url
+    }
+    
+    public func asLocal() -> Self {
+        .init(api: .getApiClient(url: url.removingPathComponents(), username: nil), url: url)
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(url)
+    }
+    
+    public static func == (lhs: PostStub, rhs: PostStub) -> Bool {
+        lhs.url == rhs.url
+    }
+    
+    public func upgrade() async throws -> any Post {
+        try await api.getPost(url: resolvableUrl)
+    }
+}
+
+// Resolvable conformance
+public extension PostStub {
+    var resolvableUrl: URL { url }
+    
+    @inlinable
+    var allResolvableUrls: [URL] { [resolvableUrl] }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/PostStubProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/PostStubProviding.swift
@@ -1,0 +1,93 @@
+//
+//  PostStubProviding.swift
+//  Mlem
+//
+//  Created by Sjmarf on 16/02/2024.
+//
+
+import Foundation
+
+public protocol PostStubProviding: ContentModel, Resolvable {
+    // From Post1Providing. These are defined as nil in the extension below
+    var actorId_: ActorIdentifier? { get }
+    var creatorId_: Int? { get }
+    var communityId_: Int? { get }
+    var title_: String? { get }
+    var content_: String? { get }
+    var linkUrl_: URL? { get }
+    var deleted_: Bool? { get }
+    var embed_: PostEmbed? { get }
+    var pinnedCommunity_: Bool? { get }
+    var pinnedInstance_: Bool? { get }
+    var locked_: Bool? { get }
+    var pinnedCommunityManager_: StateManager<Bool>? { get }
+    var pinnedInstanceManager_: StateManager<Bool>? { get }
+    var lockedManager_: StateManager<Bool>? { get }
+    var nsfw_: Bool? { get }
+    var created_: Date? { get }
+    var removed_: Bool? { get }
+    var removedManager_: StateManager<Bool>? { get }
+    var thumbnailUrl_: URL? { get }
+    var updated_: Date? { get }
+    var languageId_: Int? { get }
+    var altText_: String? { get }
+    
+    // From Post2Providing. These are defined as nil in the extension below
+    var creator_: (any Person)? { get }
+    var community_: (any Community)? { get }
+    var creatorIsModerator_: Bool? { get }
+    var creatorIsAdmin_: Bool? { get }
+    var bannedFromCommunity_: Bool? { get }
+    var commentCount_: Int? { get }
+    var unreadCommentCount_: Int? { get }
+    var votes_: VotesModel? { get }
+    var saved_: Bool? { get }
+    var read_: Bool? { get }
+    var hidden_: Bool? { get }
+    
+    // From Post3Providing. These are defined as nil in the extension below
+    var communityModerators_: [Person1]? { get }
+    var crossPosts_: [Post2]? { get }
+    
+    func upgrade() async throws -> any Post
+}
+
+public extension PostStubProviding {
+    var actorId_: ActorIdentifier? { nil }
+    var creatorId_: Int? { nil }
+    var communityId_: Int? { nil }
+    var title_: String? { nil }
+    var content_: String? { nil }
+    var linkUrl_: URL? { nil }
+    var deleted_: Bool? { nil }
+    var embed_: PostEmbed? { nil }
+    var pinnedCommunity_: Bool? { nil }
+    var pinnedInstance_: Bool? { nil }
+    var locked_: Bool? { nil }
+    var pinnedCommunityManager_: StateManager<Bool>? { nil }
+    var pinnedInstanceManager_: StateManager<Bool>? { nil }
+    var lockedManager_: StateManager<Bool>? { nil }
+    var nsfw_: Bool? { nil }
+    var created_: Date? { nil }
+    var removed_: Bool? { nil }
+    var removedManager_: StateManager<Bool>? { nil }
+    var thumbnailUrl_: URL? { nil }
+    var updated_: Date? { nil }
+    var languageId_: Int? { nil }
+    var altText_: String? { nil }
+    
+    var creator_: (any Person)? { nil }
+    var community_: (any Community)? { nil }
+    var creatorIsModerator_: Bool? { nil }
+    var creatorIsAdmin_: Bool? { nil }
+    var bannedFromCommunity_: Bool? { nil }
+    var commentCount_: Int? { nil }
+    var votes_: VotesModel? { nil }
+    var unreadCommentCount_: Int? { nil }
+    var saved_: Bool? { nil }
+    var read_: Bool? { nil }
+    var hidden_: Bool? { nil }
+    
+    var communityModerators_: [Person1]? { nil }
+    var crossPosts_: [Post2]? { nil }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostLink.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostLink.swift
@@ -1,0 +1,35 @@
+//
+//  PostLink.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-30.
+//
+
+import Foundation
+
+public struct PostLink: Equatable {
+    public let content: URL
+    public let thumbnail: URL?
+    public let label: String
+    
+    public var favicon: URL? {
+        if let baseUrl = content.host {
+            return URL(string: "https://www.google.com/s2/favicons?sz=64&domain=\(baseUrl)")
+        }
+        return nil
+    }
+
+    public var host: String {
+        if var host = content.host() {
+            host.trimPrefix("www.")
+            return host
+        }
+        return "website"
+    }
+    
+    public init(content: URL, thumbnail: URL?, label: String) {
+        self.content = content
+        self.thumbnail = thumbnail
+        self.label = label
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostType.swift
@@ -1,0 +1,42 @@
+//
+//  PostType.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-06-14.
+//
+
+import Foundation
+
+public enum PostType: Equatable {
+    /// Post containing both a title and text
+    case text(String)
+    /// Post containing only media
+    case media(URL)
+    /// Link post with embedded media content
+    case embedded(URL, originalLink: URL)
+    /// Link post
+    case link(PostLink)
+    /// Post containing only a title
+    case titleOnly
+    
+    public var isText: Bool {
+        if case .text = self {
+            return true
+        }
+        return false
+    }
+    
+    public var isMedia: Bool {
+        switch self {
+        case .media, .embedded: return true
+        default: return false
+        }
+    }
+    
+    public var isLink: Bool {
+        if case .link = self {
+            return true
+        }
+        return false
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Profile/Profile1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Profile/Profile1Providing.swift
@@ -1,0 +1,28 @@
+//
+//  Profile1Providing.swift
+//
+//
+//  Created by Sjmarf on 20/05/2024.
+//
+
+import Foundation
+
+public protocol Profile1Providing: ActorIdentifiable {
+    var name: String { get }
+    var avatar: URL? { get }
+    var blocked: Bool { get }
+    
+    var displayName_: String? { get }
+    var description_: String? { get }
+    var banner_: URL? { get }
+    var created_: Date? { get }
+    var updated_: Date? { get }
+}
+
+public extension Profile1Providing {
+    var displayName_: String? { nil }
+    var description_: String? { nil }
+    var banner_: URL? { nil }
+    var created_: Date? { nil }
+    var updated_: Date? { nil }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Profile/Profile2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Profile/Profile2Providing.swift
@@ -1,0 +1,16 @@
+//
+//  ProfileProviding.swift
+//
+//
+//  Created by Sjmarf on 08/05/2024.
+//
+
+import Foundation
+
+public protocol Profile2Providing: Profile1Providing {
+    var displayName: String { get }
+    var description: String? { get }
+    var banner: URL? { get }
+    var created: Date { get }
+    var updated: Date? { get }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PurgableProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PurgableProviding.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-10-27.
+//
+
+import Foundation
+
+public protocol PurgableProviding: ContentIdentifiable {
+    var purged: Bool { get }
+    func purge(reason: String?) async throws
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ReadableProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ReadableProviding.swift
@@ -1,0 +1,10 @@
+//
+//  ReadableProviding.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-12-04.
+//
+
+public protocol ReadableProviding {
+    var read: Bool { get }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/RegistrationApplication/RegistrationApplication.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/RegistrationApplication/RegistrationApplication.swift
@@ -1,0 +1,113 @@
+//
+//  RegistrationApplication1.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-12.
+//
+
+import Foundation
+
+// This could be two-tiered but doing so is tricky because whether the application has
+// been approved or denied is unknown at tier 1, which would make the tier 1 model pretty
+// useless. At this time, only tier 2 applications are returned anyways.
+
+@Observable
+public final class RegistrationApplication: ContentIdentifiable, FeedLoadable {
+    public typealias FilterType = ModMailItemFilterType
+    
+    public static let modelTypeId: ContentType = .registrationApplication
+    public static let tierNumber: Int = 1
+    public let api: ApiClient
+    
+    public let id: Int
+    public internal(set) var questionResponse: String
+    public let creator: Person1
+    public internal(set) var resolver: Person1?
+    public internal(set) var email: String?
+    public internal(set) var emailVerified: Bool
+    public internal(set) var showNsfw: Bool
+    public let created: Date
+    
+    var resolutionManager: StateManager<ResolutionState>
+    public var resolution: ResolutionState { resolutionManager.wrappedValue }
+    
+    init(
+        api: ApiClient,
+        id: Int,
+        questionResponse: String,
+        creator: Person1,
+        resolver: Person1?,
+        email: String?,
+        emailVerified: Bool,
+        showNsfw: Bool,
+        created: Date,
+        resolution: ResolutionState
+    ) {
+        self.api = api
+        self.id = id
+        self.questionResponse = questionResponse
+        self.creator = creator
+        self.resolver = resolver
+        self.email = email
+        self.emailVerified = emailVerified
+        self.showNsfw = showNsfw
+        self.created = created
+        self.resolutionManager = .init(wrappedValue: resolution)
+        resolutionManager.onSet = { newValue, type, _ in
+            if type == .begin || type == .rollback {
+                api.unreadCount?.updateUnverifiedItem(itemType: .registrationApplication, isRead: newValue != .unresolved)
+            }
+        }
+        resolutionManager.onVerify = { newValue, _ in
+            api.unreadCount?.verifyItem(itemType: .registrationApplication, isRead: newValue != .unresolved)
+        }
+    }
+    
+    var modMailId: Int {
+        var hasher: Hasher = .init()
+        hasher.combine("application")
+        hasher.combine(id)
+        return hasher.finalize()
+    }
+    
+    public func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        switch sortType {
+        case .new: .new(created)
+        }
+    }
+    
+    @discardableResult
+    public func approve() -> Task<StateUpdateResult, Never> {
+        resolutionManager.performRequest(expectedResult: .approved) { semaphore in
+            try await self.api.approveRegistrationApplication(id: self.id, semaphore: semaphore)
+        }
+    }
+    
+    @discardableResult
+    public func deny(reason: String?) -> Task<StateUpdateResult, Never> {
+        resolutionManager.performRequest(expectedResult: .denied(reason: reason)) { semaphore in
+            try await self.api.denyRegistrationApplication(id: self.id, reason: reason, semaphore: semaphore)
+        }
+    }
+}
+
+public extension RegistrationApplication {
+    enum ResolutionState: Equatable {
+        case unresolved, approved, denied(reason: String?)
+        
+        public var reason: String? {
+            switch self {
+            case .unresolved: nil
+            case .approved: nil
+            case let .denied(reason): reason
+            }
+        }
+        
+        public var isDenied: Bool {
+            switch self {
+            case .denied: true
+            default: false
+            }
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/RemovableProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/RemovableProviding.swift
@@ -1,0 +1,23 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-15.
+//
+
+import Foundation
+
+public protocol RemovableProviding: ContentIdentifiable {
+    var removedManager: StateManager<Bool> { get }
+    var removed: Bool { get }
+    
+    @discardableResult
+    func updateRemoved(_ newValue: Bool, reason: String?) -> Task<StateUpdateResult, Never>
+}
+
+public extension RemovableProviding {
+    @discardableResult
+    func toggleRemoved(reason: String?) -> Task<StateUpdateResult, Never> {
+        updateRemoved(!removed, reason: reason)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply1.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply1.swift
@@ -1,0 +1,59 @@
+//
+//  Reply1.swift
+//
+//
+//  Created by Sjmarf on 04/07/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Reply1: Reply1Providing {
+    public static let tierNumber: Int = 1
+    public var api: ApiClient
+    public var reply1: Reply1 { self }
+    
+    public let id: Int
+    public let recipientId: Int
+    public let commentId: Int
+    public let created: Date
+    public let isMention: Bool
+    
+    public var purged: Bool = false
+    
+    let readManager: StateManager<Bool>
+    public var read: Bool { readManager.wrappedValue }
+    
+    init(
+        api: ApiClient,
+        id: Int,
+        recipientId: Int,
+        commentId: Int,
+        created: Date,
+        read: Bool,
+        isMention: Bool
+    ) {
+        self.api = api
+        self.id = id
+        self.recipientId = recipientId
+        self.commentId = commentId
+        self.created = created
+        self.isMention = isMention
+        self.readManager = .init(wrappedValue: read)
+        readManager.onSet = { newValue, type, _ in
+            if type == .begin || type == .rollback {
+                api.unreadCount?.updateUnverifiedItem(
+                    itemType: isMention ? .mention : .reply,
+                    isRead: newValue
+                )
+            }
+        }
+        readManager.onVerify = { newValue, _ in
+            api.unreadCount?.verifyItem(
+                itemType: isMention ? .mention : .reply,
+                isRead: newValue
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
@@ -1,0 +1,146 @@
+//
+//  Reply1Providing.swift
+//
+//
+//  Created by Sjmarf on 04/07/2024.
+//
+
+import Foundation
+
+public protocol Reply1Providing:
+    ContentModel,
+    ContentIdentifiable,
+    Interactable1Providing,
+    InboxItemProviding,
+    PurgableProviding {
+    var reply1: Reply1 { get }
+    
+    var id: Int { get }
+    var recipientId: Int { get }
+    var commentId: Int { get }
+    var read: Bool { get }
+    var created: Date { get }
+    var isMention: Bool { get }
+
+    var id_: Int? { get }
+    var recipientId_: Int? { get }
+    var commentId_: Int? { get }
+    var read_: Bool? { get }
+    var created_: Date? { get }
+    var isMention_: Bool? { get }
+    
+    // From Reply2Providing
+    var comment_: Comment1? { get }
+    var creator_: (any Person)? { get }
+    var post_: Post1? { get }
+    var community_: (any Community)? { get }
+    var recipient_: Person1? { get }
+    var subscribed_: Bool? { get }
+    var commentCount_: Int? { get }
+    var creatorIsModerator_: Bool? { get }
+    var creatorIsAdmin_: Bool? { get }
+    var bannedFromCommunity_: Bool? { get }
+    var removed_: Bool? { get }
+    var removedManager_: StateManager<Bool>? { get }
+    var votes_: VotesModel? { get }
+    var saved_: Bool? { get }
+}
+
+public typealias Reply = Reply1Providing
+
+// Interactable1Providing conformance
+public extension Reply1Providing {
+    var updated: Date? { nil }
+}
+
+public extension Reply1Providing {
+    static var modelTypeId: ContentType { .reply }
+    
+    var id: Int { reply1.id }
+    var recipientId: Int { reply1.recipientId }
+    var commentId: Int { reply1.commentId }
+    var read: Bool { reply1.read }
+    var created: Date { reply1.created }
+    var isMention: Bool { reply1.isMention }
+    
+    var purged: Bool { reply1.purged }
+    
+    var id_: Int? { id }
+    var recipientId_: Int? { recipientId }
+    var commentId_: Int? { commentId }
+    var read_: Bool? { read }
+    var created_: Date? { created }
+    var isMention_: Bool? { isMention }
+    
+    // From Reply2Providing
+    var comment_: Comment1? { nil }
+    var creator_: (any Person)? { nil }
+    var post_: Post1? { nil }
+    var community_: (any Community)? { nil }
+    var recipient_: Person1? { nil }
+    var subscribed_: Bool? { nil }
+    var commentCount_: Int? { nil }
+    var creatorIsModerator_: Bool? { nil }
+    var creatorIsAdmin_: Bool? { nil }
+    var bannedFromCommunity_: Bool? { nil }
+    var votes_: VotesModel? { nil }
+    var saved_: Bool? { nil }
+    var removed_: Bool? { nil }
+    var removedManager_: StateManager<Bool>? { nil }
+}
+
+public extension Reply1Providing {
+    private var readManager: StateManager<Bool> { reply1.readManager }
+    
+    // `toggleRead` is defined in `InboxItemProviding`
+    @discardableResult
+    func updateRead(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        readManager.performRequest(expectedResult: newValue) { semaphore in
+            if self.isMention {
+                try await self.api.markMentionAsRead(id: self.id, read: newValue, semaphore: semaphore)
+            } else {
+                try await self.api.markReplyAsRead(id: self.id, read: newValue, semaphore: semaphore)
+            }
+        }
+    }
+    
+    func report(reason: String) async throws {
+        try await api.reportComment(id: commentId, reason: reason)
+    }
+    
+    func purge(reason: String?) async throws {
+        try await api.purgeComment(id: commentId, reason: reason)
+    }
+    
+    // This is called by `ApiClient` when the associated comment is replied to.
+    // This needs to happen because the Lemmy backend automatically marks the reply
+    // as read in this case.
+    internal func setKnownReadState(newValue: Bool) {
+        readManager.updateWithReceivedValue(newValue, semaphore: nil)
+        if isMention {
+            api.unreadCount?.verifiedCount[.mention, default: 0] += newValue ? -1 : 1
+        } else {
+            api.unreadCount?.verifiedCount[.reply, default: 0] += newValue ? -1 : 1
+        }
+    }
+}
+
+// Override the `ContentIdentifiable` implementation to include `isMention`, because a reply
+// and a mention can have the same ID
+public extension Reply1Providing {
+    var uid: Int {
+        var hasher = Hasher()
+        hasher.combine(Self.modelTypeId)
+        hasher.combine(id)
+        hasher.combine(isMention)
+        return hasher.finalize()
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(api.actorId)
+        hasher.combine(id)
+        hasher.combine(isMention)
+        hasher.combine(Self.modelTypeId)
+        hasher.combine(Self.tierNumber)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply2.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply2.swift
@@ -1,0 +1,82 @@
+//
+//  Reply2.swift
+//
+//
+//  Created by Sjmarf on 04/07/2024.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public final class Reply2: Reply2Providing, FeedLoadable {
+    public typealias FilterType = InboxItemFilterType
+    
+    public func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        switch sortType {
+        case .new:
+            return .new(created)
+        }
+    }
+    
+    public static let tierNumber: Int = 2
+    public var api: ApiClient
+    public var reply2: Reply2 { self }
+    
+    public let reply1: Reply1
+    public let comment: Comment1
+    public let creator: Person1
+    public let post: Post1
+    public let community: Community1
+    public let recipient: Person1
+    public var subscribed: Bool
+    public var commentCount: Int
+    public var creatorIsModerator: Bool?
+    public var creatorIsAdmin: Bool?
+    
+    public var bannedFromCommunity: Bool {
+        guard let state = creator.isBannedFromCommunity(community) else {
+            assertionFailure("Ban status should be present at this point")
+            return false
+        }
+        return state
+    }
+    
+    var votesManager: StateManager<VotesModel>
+    public var votes: VotesModel { votesManager.wrappedValue }
+    
+    var savedManager: StateManager<Bool>
+    public var saved: Bool { savedManager.wrappedValue }
+    
+    init(
+        api: ApiClient,
+        reply1: Reply1,
+        comment: Comment1,
+        creator: Person1,
+        post: Post1,
+        community: Community1,
+        recipient: Person1,
+        subscribed: Bool,
+        commentCount: Int,
+        creatorIsModerator: Bool?,
+        creatorIsAdmin: Bool?,
+        bannedFromCommunity: Bool,
+        votesManager: StateManager<VotesModel>,
+        savedManager: StateManager<Bool>
+    ) {
+        self.api = api
+        self.reply1 = reply1
+        self.comment = comment
+        self.creator = creator
+        self.post = post
+        self.community = community
+        self.recipient = recipient
+        self.subscribed = subscribed
+        self.commentCount = commentCount
+        self.creatorIsModerator = creatorIsModerator
+        self.creatorIsAdmin = creatorIsAdmin
+        self.votesManager = votesManager
+        self.savedManager = savedManager
+        creator.updateKnownCommunityBanState(id: community.id, banned: bannedFromCommunity)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply2Providing.swift
@@ -1,0 +1,84 @@
+//
+//  Reply2Providing.swift
+//
+//
+//  Created by Sjmarf on 04/07/2024.
+//
+
+import Foundation
+
+public protocol Reply2Providing: Reply1Providing, Interactable2Providing, ActorIdentifiable {
+    var reply2: Reply2 { get }
+    
+    var actorId: ActorIdentifier { get }
+    var reply1: Reply1 { get }
+    var comment: Comment1 { get }
+    var creator: any Person { get }
+    var post: Post1 { get }
+    var community: any Community { get }
+    var recipient: Person1 { get }
+    var subscribed: Bool { get }
+    var commentCount: Int { get }
+    var creatorIsModerator: Bool? { get }
+    var creatorIsAdmin: Bool? { get }
+    var bannedFromCommunity: Bool { get }
+    var removed: Bool { get }
+    var removedManager: StateManager<Bool> { get }
+}
+
+public extension Reply2Providing {
+    var reply1: Reply1 { reply2.reply1 }
+    var actorId: ActorIdentifier { reply2.comment.actorId }
+    var comment: Comment1 { reply2.comment }
+    var creator: any Person { reply2.creator }
+    var post: Post1 { reply2.post }
+    var community: any Community { reply2.community }
+    var recipient: Person1 { reply2.recipient }
+    var subscribed: Bool { reply2.subscribed }
+    var commentCount: Int { reply2.commentCount }
+    var creatorIsModerator: Bool? { reply2.creatorIsModerator }
+    var creatorIsAdmin: Bool? { reply2.creatorIsAdmin }
+    var bannedFromCommunity: Bool { reply2.bannedFromCommunity }
+    var removed: Bool { reply2.comment.removed }
+    var removedManager: StateManager<Bool> { reply2.comment.removedManager }
+    
+    var reply1_: Reply1? { reply2.reply1 }
+    var comment_: Comment1? { reply2.comment }
+    var creator_: (any Person)? { reply2.creator }
+    var post_: Post1? { reply2.post }
+    var community_: (any Community)? { reply2.community }
+    var recipient_: Person1? { reply2.recipient }
+    var subscribed_: Bool? { reply2.subscribed }
+    var commentCount_: Int? { reply2.commentCount }
+    var creatorIsModerator_: Bool? { reply2.creatorIsModerator }
+    var creatorIsAdmin_: Bool? { reply2.creatorIsAdmin }
+    var bannedFromCommunity_: Bool? { reply2.bannedFromCommunity }
+}
+
+public extension Reply2Providing {
+    private var votesManager: StateManager<VotesModel> { reply2.votesManager }
+    private var savedManager: StateManager<Bool> { reply2.savedManager }
+    
+    @discardableResult
+    func updateVote(_ newValue: ScoringOperation) -> Task<StateUpdateResult, Never> {
+        votesManager.performRequest(expectedResult: votes.applyScoringOperation(operation: newValue)) { semaphore in
+            try await self.api.voteOnComment(id: self.commentId, score: newValue, semaphore: semaphore)
+        }
+    }
+    
+    @discardableResult
+    func updateSaved(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        savedManager.performRequest(expectedResult: newValue) { semaphore in
+            try await self.api.saveComment(id: self.commentId, save: newValue, semaphore: semaphore)
+        }
+    }
+    
+    func reply(content: String, languageId: Int? = nil) async throws -> Comment2 {
+        try await api.replyToComment(postId: post.id, parentId: commentId, content: content, languageId: languageId)
+    }
+    
+    @discardableResult
+    func updateRemoved(_ newValue: Bool, reason: String?) -> Task<StateUpdateResult, Never> {
+        comment.updateRemoved(newValue, reason: reason)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Report/Report.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Report/Report.swift
@@ -1,0 +1,98 @@
+//
+//  Report.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-15.
+//
+
+import Foundation
+import Observation
+
+@Observable
+public class Report: CacheIdentifiable, ContentModel, FeedLoadable {
+    public typealias FilterType = ModMailItemFilterType
+    
+    public static let tierNumber: Int = 1
+    public var api: ApiClient
+    
+    // Keep this internal - a post report and a comment report can have the same ID, so it's not a true identifier.
+    var id: Int
+    
+    public let created: Date
+    public internal(set) var updated: Date?
+    public let creator: Person1
+    public let target: ReportTarget
+    public internal(set) var resolver: Person1?
+    public internal(set) var reason: String
+    
+    var resolvedManager: StateManager<Bool>
+    public var resolved: Bool { resolvedManager.wrappedValue }
+    
+    init(
+        api: ApiClient,
+        id: Int,
+        creator: Person1,
+        resolver: Person1?,
+        target: ReportTarget,
+        resolved: Bool,
+        reason: String,
+        created: Date,
+        updated: Date?
+    ) {
+        self.api = api
+        self.id = id
+        self.creator = creator
+        self.resolver = resolver
+        self.target = target
+        self.reason = reason
+        self.created = created
+        self.updated = updated
+        
+        self.resolvedManager = .init(wrappedValue: resolved)
+        resolvedManager.onSet = { newValue, type, _ in
+            if type == .begin || type == .rollback {
+                api.unreadCount?.updateUnverifiedItem(itemType: target.type.inboxItemType, isRead: newValue)
+            }
+        }
+        resolvedManager.onVerify = { newValue, _ in
+            api.unreadCount?.verifyItem(itemType: target.type.inboxItemType, isRead: newValue)
+        }
+    }
+    
+    public var modMailId: Int {
+        var hasher: Hasher = .init()
+        hasher.combine("report")
+        hasher.combine(target.case)
+        hasher.combine(id)
+        return hasher.finalize()
+    }
+    
+    @discardableResult
+    public func updateResolved(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
+        resolvedManager.performRequest(expectedResult: newValue) { semaphore in
+            switch self.target.type {
+            case .post:
+                try await self.api.resolvePostReport(id: self.id, resolved: newValue, semaphore: semaphore)
+            case .comment:
+                try await self.api.resolveCommentReport(id: self.id, resolved: newValue, semaphore: semaphore)
+            case .message:
+                try await self.api.resolveMessageReport(id: self.id, resolved: newValue, semaphore: semaphore)
+            }
+        }
+    }
+    
+    @discardableResult
+    public func toggleResolved() -> Task<StateUpdateResult, Never> {
+        updateResolved(!resolved)
+    }
+    
+    public func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        switch sortType {
+        case .new: .new(created)
+        }
+    }
+    
+    public static func == (lhs: Report, rhs: Report) -> Bool {
+        lhs.target.case == rhs.target.case && lhs.id == rhs.id
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Report/ReportTarget.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Report/ReportTarget.swift
@@ -1,0 +1,87 @@
+//
+//  ReportTarget.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-16.
+//
+
+import Foundation
+
+public enum ReportTarget {
+    enum Case {
+        case post, comment, message, legacyPost, legacyComment
+    }
+    
+    var `case`: Case {
+        switch self {
+        case .post: .post
+        case .comment: .comment
+        case .message: .message
+        case .legacyPost: .legacyPost
+        case .legacyComment: .legacyComment
+        }
+    }
+    
+    /// All post reports use this case on 0.19.4 and above.
+    case post(Post2)
+    /// All comment reports use this case on 0.19.4 and above.
+    case comment(Comment2)
+    /// All messages reports use this case regardless of version.
+    case message(Message2)
+    
+    // TODO: 0.19.3 deprecation - remove the below two cases and associated code.
+    
+    // `ApiPostReportView` is a superset of `ApiPostView` from 0.19.4 onwards, allowing
+    // us to create a `Post2` (as seen above). However, prior to 0.19.4 this was not the
+    // case - only *some* of the necessary properties are included.
+    
+    // For simplicity I've opted to only store `Post1` on those older versions rather than creating
+    // a new intermediate `Post` tier. This solution means losing access to certain information
+    // (e.g. vote and save status) but saves significant headache so I think it's easier to just
+    // not display vote status on pre-0.19.4 versions.
+    
+    /// All post reports use this case on 0.19.3 and below.
+    case legacyPost(Post1, community: Community1, creator: Person1)
+    /// All comment reports use this case on 0.19.3 and below.
+    case legacyComment(Comment1, community: Community1, creator: Person1)
+    
+    var type: ReportType {
+        switch self {
+        case .post, .legacyPost: .post
+        case .comment, .legacyComment: .comment
+        case .message: .message
+        }
+    }
+    
+    public var community: Community1? {
+        switch self {
+        case let .legacyPost(_, community, _): community
+        case let .post(post): post.community
+        case let .legacyComment(_, community, _): community
+        case let .comment(comment): comment.community
+        case .message: nil
+        }
+    }
+    
+    public var creator: Person1 {
+        switch self {
+        case let .legacyPost(_, _, creator): creator
+        case let .post(post): post.creator
+        case let .legacyComment(_, _, creator): creator
+        case let .comment(comment): comment.creator
+        case let .message(message): message.creator
+        }
+    }
+}
+
+public enum ReportType: Hashable {
+    case post, comment, message
+    
+    var inboxItemType: InboxItemType {
+        switch self {
+        case .post: .postReport
+        case .comment: .commentReport
+        case .message: .messageReport
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ReportableProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ReportableProviding.swift
@@ -1,0 +1,12 @@
+//
+//  ReportableProviding.swift
+//
+//
+//  Created by Sjmarf on 23/07/2024.
+//
+
+import Foundation
+
+public protocol ReportableProviding: ContentIdentifiable {
+    func report(reason: String) async throws
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Resolvable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Resolvable.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-26.
+//
+
+import Foundation
+
+public protocol Resolvable {
+    /// An array of available URLs for this entity that can be resolved by another `ApiClient`.
+    var allResolvableUrls: [URL] { get }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SearchSortTypeBridge.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SearchSortTypeBridge.swift
@@ -1,0 +1,43 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-22.
+//
+
+import Foundation
+
+// The `ApiSearch.sort` property uses `ApiSortType` pre-0.20 and
+// uses `ApiSearchSortType` post-0.20, even when interacting using the v3 api.
+// The type of that property is manually overriden with this type, which
+// can then be converted into either of those two types.
+
+public struct SearchSortTypeBridge: Codable, Hashable, Sendable, URLQueryItemEncodable {
+    public typealias RawValue = String
+    
+    let oldSortType: ApiSortType?
+    let newSortType: ApiSearchSortType?
+}
+
+public extension SearchSortTypeBridge {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.oldSortType = try? container.decode(ApiSortType.self)
+        self.newSortType = try? container.decode(ApiSearchSortType.self)
+    }
+    
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(encodeInQueryItemFormat())
+    }
+    
+    internal func encodeInQueryItemFormat() -> String? {
+        if let oldSortType {
+            return oldSortType.rawValue
+        } else if let newSortType {
+            return newSortType.rawValue
+        } else {
+            return nil
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SelectableContentProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SelectableContentProviding.swift
@@ -1,0 +1,12 @@
+//
+//  SelectableContentProviding.swift
+//
+//
+//  Created by Sjmarf on 02/07/2024.
+//
+
+import Foundation
+
+public protocol SelectableContentProviding: ActorIdentifiable {
+    var selectableContent: String? { get }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sharable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sharable.swift
@@ -1,0 +1,12 @@
+//
+//  Sharable.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-03-09.
+//
+
+import Foundation
+
+public protocol Sharable: ContentIdentifiable, ActorIdentifiable, Resolvable {
+    func url() -> URL
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sort Types/CommentSortType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sort Types/CommentSortType.swift
@@ -1,0 +1,95 @@
+//
+//  CommentSortType.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-03-04.
+//
+
+import SwiftUI
+
+public enum CommentSortType: Hashable, Sendable {
+    case new
+    case old
+    case hot
+    
+    /// Added in 0.19.0
+    case controversial
+    
+    /// From 1.0.0 onwards, any time interval is supported.
+    /// Before 1.0.0, only `.allTime` is supported.
+    case top(SortTimeRange)
+    
+    public var isTop: Bool {
+        switch self {
+        case .top: true
+        default: false
+        }
+    }
+    
+    public static var nonTopCases: [Self] = [
+        .hot,
+        .new,
+        .old,
+        .controversial
+    ]
+    
+    public static var legacyCases: [Self] = nonTopCases + [.top(.allTime)]
+    
+    public init(_ apiSortType: ApiCommentSortType) {
+        self = switch apiSortType {
+        case .hot: .hot
+        case .top: .top(.allTime)
+        case .new: .new
+        case .old: .old
+        case .controversial: .controversial
+        }
+    }
+    
+    public var apiSortType: ApiCommentSortType {
+        switch self {
+        case .new: .new
+        case .old: .old
+        case .hot: .hot
+        case .controversial: .controversial
+        case .top: .top
+        }
+    }
+    
+    public var legacyApiSortType: ApiSortType {
+        switch self {
+        case .new: .new
+        case .old: .old
+        case .hot: .hot
+        case .controversial: .controversial
+        case .top: .topAll
+        }
+    }
+    
+    /// Returns `nil` if the `CommentSortType` is a value that cannot be converted to an `ApiSearchSortType`.
+    public var apiSearchSortType: ApiSearchSortType? {
+        switch self {
+        case .new: .new
+        case .old: .old
+        case .top: .top
+        default: nil
+        }
+    }
+    
+    public var timeRange: SortTimeRange? {
+        switch self {
+        case let .top(timeRange): timeRange
+        default: nil
+        }
+    }
+    
+    // This should only be used internally within ApiClient
+    var timeRangeSeconds: Int? { timeRange?.timeRangeSeconds }
+    
+    public var minimumVersion: SiteVersion {
+        switch self {
+        case .controversial: .v0_19_0
+        case let .top(timeRange): timeRange == .allTime ? .zero : .v1_0_0
+        default: .zero
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sort Types/LegacySortTimeRange.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sort Types/LegacySortTimeRange.swift
@@ -1,0 +1,97 @@
+//
+//  LegacySortTimeRange.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-25.
+//  
+
+import Foundation
+
+/// Represents the available "top" sort time ranges available before Lemmy 1.0.0.
+/// After 1.0.0, the top sort time range can be any number of seconds.
+public enum LegacySortTimeRangeLimit: CaseIterable {
+    case hour
+    case sixHour
+    case twelveHour
+    case day
+    case week
+    case month
+    /// Added in 0.18.1
+    case threeMonth
+    /// Added in 0.18.1
+    case sixMonth
+    /// Added in 0.18.1
+    case nineMonth
+    case year
+}
+
+public extension LegacySortTimeRangeLimit {
+    init?(_ timeInterval: TimeInterval?) {
+        if let match = Self.allCases.first(where: { $0.timeInterval == timeInterval }) {
+            self = match
+        } else {
+            return nil
+        }
+    }
+    
+    internal init?(_ legacyApiSortType: ApiSortType) {
+        if let value: Self = switch legacyApiSortType {
+        case .topHour: .hour
+        case .topSixHour: .sixHour
+        case .topTwelveHour: .twelveHour
+        case .topDay: .day
+        case .topWeek: .week
+        case .topMonth: .month
+        case .topThreeMonths: .threeMonth
+        case .topSixMonths: .sixMonth
+        case .topNineMonths: .nineMonth
+        case .topYear: .year
+        default: nil
+        } {
+            self = value
+        } else {
+            return nil
+        }
+    }
+    
+    var timeInterval: TimeInterval {
+        let hour = 3600.0
+        let day = hour * 24
+        let month = day * 30
+        
+        return switch self {
+        case .hour: hour
+        case .sixHour: hour * 6
+        case .twelveHour: hour * 12
+        case .day: day
+        case .week: day * 7
+        case .month: month
+        case .threeMonth: month * 3
+        case .sixMonth: month * 6
+        case .nineMonth: month * 9
+        case .year: day * 365
+        }
+    }
+    
+    var legacyApiSortType: ApiSortType {
+        switch self {
+        case .hour: .topHour
+        case .sixHour: .topSixHour
+        case .twelveHour: .topTwelveHour
+        case .day: .topDay
+        case .week: .topWeek
+        case .month: .topMonth
+        case .threeMonth: .topThreeMonths
+        case .sixMonth: .topSixMonths
+        case .nineMonth: .topNineMonths
+        case .year: .topYear
+        }
+    }
+    
+    var minimumVersion: SiteVersion {
+        switch self {
+        case .threeMonth, .sixMonth, .nineMonth: .v0_18_1
+        default: .zero
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sort Types/PostSortType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sort Types/PostSortType.swift
@@ -1,0 +1,125 @@
+//
+//  PostSortTimeRange.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-25.
+//
+
+import Foundation
+
+public enum PostSortType: Hashable, Sendable {
+    case active
+    case hot
+    case new
+    case old
+    case mostComments
+    case newComments
+    /// Added in 0.19.0
+    case controversial
+    /// Added in 0.19.0
+    case scaled
+    
+    /// From 1.0.0 onwards, any time interval is supported.
+    /// Before 1.0.0, there is a discrete list of supported time intervals,
+    /// represented by the ``LegacySortTimeRange`` type.
+    case top(SortTimeRange)
+    
+    public var isTop: Bool {
+        switch self {
+        case .top: true
+        default: false
+        }
+    }
+    
+    public static var nonTopCases: [Self] = [
+        .hot,
+        .scaled,
+        .active,
+        .new,
+        .old,
+        .controversial,
+        .newComments,
+        .mostComments
+    ]
+    
+    public static var legacyTopCases: [Self] = SortTimeRange.legacyCases.map { .top($0) }
+    
+    public static var legacyCases: [Self] = nonTopCases + legacyTopCases
+    
+    public init(_ legacyApiSortType: ApiSortType) {
+        switch legacyApiSortType {
+        case .active: self = .active
+        case .hot: self = .hot
+        case .new: self = .new
+        case .old: self = .old
+        case .mostComments: self = .mostComments
+        case .newComments: self = .newComments
+        case .controversial: self = .controversial
+        case .scaled: self = .scaled
+        default:
+            if let timeRange = SortTimeRange(legacyApiSortType) {
+                self = .top(timeRange)
+            } else {
+                assertionFailure()
+                self = .top(.allTime)
+            }
+        }
+    }
+    
+    /// Returns `nil` if the `PostSortType` is a value that cannot be converted to an `ApiSortType`.
+    public var legacyApiSortType: ApiSortType? {
+        switch self {
+        case .active: .active
+        case .hot: .hot
+        case .new: .new
+        case .old: .old
+        case .mostComments: .mostComments
+        case .newComments: .newComments
+        case .controversial: .controversial
+        case .scaled: .scaled
+        case let .top(timeRange): timeRange.legacyApiSortType
+        }
+    }
+    
+    public var apiSortType: ApiPostSortType {
+        switch self {
+        case .active: .active
+        case .hot: .hot
+        case .new: .new
+        case .old: .old
+        case .mostComments: .mostComments
+        case .newComments: .newComments
+        case .controversial: .controversial
+        case .scaled: .scaled
+        case .top: .top
+        }
+    }
+    
+    /// Returns `nil` if the `PostSortType` is a value that cannot be converted to an `ApiSearchSortType`.
+    public var apiSearchSortType: ApiSearchSortType? {
+        switch self {
+        case .new: .new
+        case .old: .old
+        case .top: .top
+        default: nil
+        }
+    }
+    
+    public var timeRange: SortTimeRange? {
+        switch self {
+        case let .top(timeRange): timeRange
+        default: nil
+        }
+    }
+    
+    // This should only be used internally within ApiClient
+    var timeRangeSeconds: Int? { timeRange?.timeRangeSeconds }
+    
+    public var minimumVersion: SiteVersion {
+        switch self {
+        case .controversial, .scaled: .v0_19_0
+        case let .top(timeRange): timeRange.minimumVersion
+        default: .zero
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sort Types/SearchSortType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sort Types/SearchSortType.swift
@@ -1,0 +1,85 @@
+//
+//  SearchSortTimeRange.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-28.
+//
+
+import Foundation
+
+// In the v3 API, it was possible to search for posts using any
+// of the regular post sorts ("Hot", "Active" etc). This was
+// intentionally removed in v4.
+// https://github.com/LemmyNet/lemmy/issues/5401
+
+public enum SearchSortType: Hashable, Sendable {
+    case new
+    case old
+    
+    /// From 1.0.0 onwards, any time interval is supported.
+    /// Before 1.0.0, there is a discrete list of supported time intervals,
+    /// represented by the ``LegacySortTimeRange`` type.
+    case top(SortTimeRange)
+    
+    public var isTop: Bool {
+        switch self {
+        case .top: true
+        default: false
+        }
+    }
+    
+    public static var nonTopCases: [Self] = [.new, .old]
+    public static var legacyTopCases: [Self] = SortTimeRange.legacyCases.map { .top($0) }
+    public static var legacyCases: [Self] = nonTopCases + legacyTopCases
+    public static var legacyPersonCases: [Self] = nonTopCases + [.top(.allTime)]
+    
+    public init?(_ legacyApiSortType: ApiSortType) {
+        switch legacyApiSortType {
+        case .new:
+            self = .new
+        case .old:
+            self = .old
+        default:
+            if let timeRange = SortTimeRange(legacyApiSortType) {
+                self = .top(timeRange)
+            } else {
+                return nil
+            }
+        }
+    }
+    
+    /// Returns `nil` if the `SearchSortType` is a value that cannot be converted to an `ApiSortType`.
+    public var legacyApiSortType: ApiSortType? {
+        switch self {
+        case .new: .new
+        case .old: .old
+        case let .top(timeRange): timeRange.legacyApiSortType
+        }
+    }
+    
+    /// Returns `nil` if the `SearchSortType` is a value that cannot be converted to an `ApiSearchSortType`.
+    public var apiSortType: ApiSearchSortType? {
+        switch self {
+        case .new: .new
+        case .old: .old
+        case .top: .top
+        }
+    }
+    
+    public var timeRange: SortTimeRange? {
+        switch self {
+        case let .top(timeRange): timeRange
+        default: nil
+        }
+    }
+
+    // This should only be used internally within ApiClient
+    var timeRangeSeconds: Int? { timeRange?.timeRangeSeconds }
+
+    public var minimumVersion: SiteVersion {
+        switch self {
+        case let .top(timeRange): timeRange.minimumVersion
+        default: .zero
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sort Types/SortTimeRange.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Sort Types/SortTimeRange.swift
@@ -1,0 +1,51 @@
+//
+//  SortTimeRange.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-03-01.
+//
+
+import Foundation
+
+public enum SortTimeRange: Hashable, Sendable {
+    case allTime
+    case limited(TimeInterval)
+    
+    public static func limited(_ timeRangeLimit: LegacySortTimeRangeLimit) -> Self {
+        .limited(timeRangeLimit.timeInterval)
+    }
+    
+    init?(_ apiSortType: ApiSortType) {
+        if apiSortType == .topAll {
+            self = .allTime
+        } else if let legacyTimeRange = LegacySortTimeRangeLimit(apiSortType) {
+            self = .limited(legacyTimeRange)
+        } else {
+            return nil
+        }
+    }
+    
+    public static var legacyCases: [Self] = LegacySortTimeRangeLimit.allCases.map { .limited($0) } + [.allTime]
+ 
+    // This should only be used internally within ApiClient
+    var timeRangeSeconds: Int {
+        switch self {
+        case .allTime: .max
+        case let .limited(value): Int(value)
+        }
+    }
+    
+    public var legacyApiSortType: ApiSortType? {
+        switch self {
+        case .allTime: .topAll
+        case let .limited(timeInterval): LegacySortTimeRangeLimit(timeInterval)?.legacyApiSortType
+        }
+    }
+    
+    public var minimumVersion: SiteVersion {
+        switch self {
+        case .allTime: .zero
+        case let .limited(timeInterval): LegacySortTimeRangeLimit(timeInterval)?.minimumVersion ?? .v1_0_0
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/StateManager.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/StateManager.swift
@@ -1,0 +1,218 @@
+//
+//  StateManager.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-03.
+//
+
+import Foundation
+
+// These can't go inside of StateManager because generic classes cannot store static properties
+class SemaphoreServer {
+    static var value: UInt = 0
+    
+    static func next() -> UInt {
+        value += 1
+        return value
+    }
+}
+
+enum StateManagerUpdateType: Equatable {
+    case begin
+    case rollback
+    case receive
+}
+
+protocol StateManagerTickerProtocol {
+    var valid: Bool { get }
+    func begin(semaphore: UInt)
+    func rollback(semaphore: UInt)
+}
+
+struct StateManagerTicket<Value: Equatable>: StateManagerTickerProtocol {
+    let manager: StateManager<Value>
+    let expectedResult: Value
+    
+    func begin(semaphore: UInt) {
+        manager.beginOperation(expectedResult: expectedResult, semaphore: semaphore)
+    }
+    
+    func rollback(semaphore: UInt) {
+        manager.rollback(semaphore: semaphore)
+    }
+    
+    var valid: Bool {
+        manager.wrappedValue != expectedResult
+    }
+}
+
+/// This class provides logic to ensure proper handling of returned API responses so as to avoid flickering or the client falling out of sync.
+/// When you begin a task, call `.beginVotingOperation` with the result you expect to get. If no other operations are ongoing,
+/// `lastVerifiedValue` is updated to match; otherwise `lastVerifiedValue` is left untouched. The semaphore is incremented
+/// and its value returned. When a vote finishes successfully, call `finishVotingOperation` with the new state returned from the server.
+/// If the caller is the most recent one, then clean state is wiped and a `true` value is returned; this indicates that the caller is clear to
+/// update the post with the returned value. If the caller is not the most recent one (i.e., another vote is underway), then the clean state is
+/// updated but a `false` value is returned; this indicates that the caller should not update the post with the returned value. When a vote
+/// finishes unsuccessfully, call `rollback`. If the caller is the most recent one, then the  `wrappedValue` will be reset to the
+/// `lastVerifiedValue`.
+@Observable
+public class StateManager<Value: Equatable> {
+    /// The state-faked value that should be shown to the user.
+    public private(set) var wrappedValue: Value
+    
+    /// Called when `wrappedValue` is changed.
+    var onSet: (Value, _ type: StateManagerUpdateType, _ semaphore: UInt?) -> Void
+    
+    /// Called whenever `wrappedValue` is verified.
+    var onVerify: (Value, _ semaphore: UInt?) -> Void
+    
+    /// Responsible for tracking who the most recent caller is. Every time the state is changed, `lastSemaphore` is incremented by one.
+    private var lastSemaphore: UInt = 0
+    
+    /// Responsible for tracking the last verified value. If the current value is in sync with the server, this will be nil.
+    private var lastVerifiedValue: Value?
+    
+    public var isInSync: Bool { lastVerifiedValue == nil }
+    public var verifiedValue: Value { lastVerifiedValue ?? wrappedValue }
+    
+    init(
+        wrappedValue: Value,
+        onSet: @escaping (Value, _ type: StateManagerUpdateType, _ semaphore: UInt?) -> Void = { _, _, _ in },
+        onVerify: @escaping (Value, _ semaphore: UInt?) -> Void = { _, _ in }
+    ) {
+        self.wrappedValue = wrappedValue
+        self.onSet = onSet
+        self.onVerify = onVerify
+    }
+        
+    /// Call at the start of a voting operation, BEFORE state faking is performed. Updates the clean state if nil and increments semaphore.
+    /// - Returns: new sempaphore value
+    @discardableResult
+    func beginOperation(expectedResult: Value, semaphore: UInt? = nil) -> UInt {
+        let semaphore = semaphore ?? SemaphoreServer.next()
+        lastSemaphore = semaphore
+        print("DEBUG [\(semaphore)] began operation.")
+        if lastVerifiedValue == nil {
+            print("DEBUG [\(semaphore)] Set lastVerifiedValue to \(wrappedValue).")
+            lastVerifiedValue = wrappedValue
+        }
+        if wrappedValue != expectedResult {
+            wrappedValue = expectedResult
+            print("DEBUG [\(semaphore)] Set wrappedValue to \(expectedResult).")
+            onSet(expectedResult, .begin, semaphore)
+        }
+        return lastSemaphore
+    }
+    
+    /// Call when we receive a value from the ApiClient that we *know* to be up-to-date. Optionally pass a `sempahore` value. If the StateManager is awaiting the result of an operation, the `wrappedValue` will *only* be set if the passed semaphore matches the one that the `StateManager` is waiting for. Otherwise, the value is saved as the `lastVerifiedValue` such that the `StateManager` will rollback to it if the in-progress operation fails.
+    @discardableResult
+    func updateWithReceivedValue(_ newState: Value, semaphore: UInt?) -> Bool {
+        if lastVerifiedValue == nil {
+            if wrappedValue != newState {
+                Task { @MainActor in
+                    self.wrappedValue = newState
+                    self.onSet(newState, .receive, semaphore)
+                }
+            }
+            return false
+        }
+        
+        if lastSemaphore == semaphore {
+            print("DEBUG [\(semaphore?.description ?? "nil")] is the last caller! Resetting lastVerifiedValue.")
+            onVerify(newState, semaphore)
+            lastVerifiedValue = nil
+            return true
+        }
+        
+        if lastVerifiedValue != newState {
+            lastVerifiedValue = newState
+            if semaphore != nil {
+                print("DEBUG [\(semaphore?.description ?? "nil")] is not the last caller! Updating lastVerifiedValue to \(wrappedValue).")
+            }
+        }
+        return false
+    }
+    
+    /// If the given semaphore is still the most recent operation, rollback `wrappedValue` to `lastVerifiedValue`.
+    @discardableResult
+    func rollback(semaphore: UInt) -> Value? {
+        if lastSemaphore == semaphore, let lastVerifiedValue {
+            print("DEBUG [\(semaphore)] is the most recent caller! Resetting wrappedValue to lastVerifiedValue \(lastVerifiedValue) \(wrappedValue != lastVerifiedValue).")
+            if wrappedValue != lastVerifiedValue {
+                wrappedValue = lastVerifiedValue
+                onSet(lastVerifiedValue, .rollback, semaphore)
+            }
+            defer { self.lastVerifiedValue = nil }
+            return lastVerifiedValue
+        } else {
+            print("DEBUG [\(semaphore)] is not the most recent caller or vote state nil.")
+            return nil
+        }
+    }
+    
+    func performRequest(
+        expectedResult: Value,
+        operation: @escaping (_ semaphore: UInt) async throws -> Void,
+        onRollback: @escaping (_ value: Value) -> Void = { _ in }
+    ) -> Task<StateUpdateResult, Never> {
+        Task(priority: .userInitiated) { @MainActor in
+            guard wrappedValue != expectedResult else { return .ignored }
+            
+            let semaphore = beginOperation(expectedResult: expectedResult)
+            do {
+                try await operation(semaphore)
+                return .succeeded
+            } catch {
+                print("DEBUG [\(semaphore)] failed!")
+                print(error)
+                if let newValue = self.rollback(semaphore: semaphore) {
+                    onRollback(newValue)
+                }
+                return .failed
+            }
+        }
+    }
+    
+    func ticket(_ expectedResult: Value) -> StateManagerTicket<Value> {
+        StateManagerTicket(manager: self, expectedResult: expectedResult)
+    }
+}
+
+func groupStateRequest(
+    _ tickets: [any StateManagerTickerProtocol],
+    operation: @escaping (_ semaphore: UInt) async throws -> Void
+) -> Task<StateUpdateResult, Never> {
+    let semaphore = SemaphoreServer.next()
+    
+    let tickets = tickets.filter(\.valid)
+    
+    for ticket in tickets {
+        ticket.begin(semaphore: semaphore)
+    }
+    return Task(priority: .userInitiated) { @MainActor in
+        do {
+            try await operation(semaphore)
+            return .succeeded
+        } catch {
+            for ticket in tickets {
+                ticket.rollback(semaphore: semaphore)
+            }
+            return .failed
+        }
+    }
+}
+
+func groupStateRequest(
+    _ tickets: (any StateManagerTickerProtocol)...,
+    operation: @escaping (_ semaphore: UInt) async throws -> Void
+) -> Task<StateUpdateResult, Never> {
+    groupStateRequest(tickets, operation: operation)
+}
+
+public enum StateUpdateResult {
+    case succeeded
+    case failed
+    /// Returned when the action is queued for later, e.g. when a post is marked as read.
+    case deferred
+    case ignored
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/StateManager.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/StateManager.swift
@@ -133,11 +133,11 @@ public class StateManager<Value: Equatable> {
         return false
     }
     
-    /// If the given semaphore is still the most recent operation, rollback `wrappedValue` to `lastVerifiedValue`.
+    /// If the given semaphore is still the most recent operation, rollback `wrappedValue` to `cleanValue`.
     @discardableResult
     func rollback(semaphore: UInt) -> Value? {
         if lastSemaphore == semaphore, let lastVerifiedValue {
-            print("DEBUG [\(semaphore)] is the most recent caller! Resetting wrappedValue to lastVerifiedValue \(lastVerifiedValue) \(wrappedValue != lastVerifiedValue).")
+            print("DEBUG [\(semaphore)] is the most recent caller! Resetting lastVerifiedValue.")
             if wrappedValue != lastVerifiedValue {
                 wrappedValue = lastVerifiedValue
                 onSet(lastVerifiedValue, .rollback, semaphore)
@@ -189,7 +189,7 @@ func groupStateRequest(
     for ticket in tickets {
         ticket.begin(semaphore: semaphore)
     }
-    return Task(priority: .userInitiated) { @MainActor in
+    return Task(priority: .userInitiated) {
         do {
             try await operation(semaphore)
             return .succeeded

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SubscriptionList.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SubscriptionList.swift
@@ -1,0 +1,172 @@
+//
+//  SubscriptionList.swift
+//
+//
+//  Created by Sjmarf on 05/05/2024.
+//
+
+import Observation
+
+@Observable
+public class SubscriptionList {
+    /// All subscribed-to communities, including favorited communities.
+    public private(set) var communities: Set<Community2> = .init() {
+        didSet {
+            communityIds = .init(communities.map(\.id))
+        }
+    }
+
+    public private(set) var communityIds: Set<Int> = .init()
+    public private(set) var favorites: [Community2] = .init()
+    public private(set) var alphabeticSections: [String?: [Community2]] = .init()
+    public private(set) var instanceSections: [String?: [Community2]] = .init()
+    
+    public internal(set) var hasLoaded: Bool = false
+    
+    var favoriteIDs: Set<Int> {
+        get { getFavorites() }
+        set { setFavorites(newValue) }
+    }
+    
+    private var getFavorites: () -> Set<Int>
+    private var setFavorites: (Set<Int>) -> Void
+    
+    private var api: ApiClient
+    
+    init(
+        apiClient: ApiClient,
+        getFavorites: @escaping () -> Set<Int>,
+        setFavorites: @escaping (Set<Int>) -> Void
+    ) {
+        self.api = apiClient
+        self.getFavorites = getFavorites
+        self.setFavorites = setFavorites
+    }
+    
+    public func refresh() async throws {
+        _ = try await api.getSubscriptionList()
+    }
+    
+    public func isFavorited(_ community: any Community) -> Bool {
+        favoriteIDs.contains(community.id)
+    }
+    
+    private func alphabeticCategoryForCommunity(_ community: Community2) -> String? {
+        let first = String(community.name.first ?? "#").folding(options: .diacriticInsensitive, locale: .current)
+        guard first.first?.isLetter ?? false else { return nil }
+        return first.uppercased()
+    }
+    
+    @MainActor
+    func updateCommunities(with communities: Set<Community2>) {
+        self.communities = communities
+        
+        // Alphabetical
+        
+        var alphabeticSections: [String?: [Community2]] = .init()
+        
+        let alphabeticSectionsGrouping: [String?: [Community2]] = .init(
+            grouping: communities,
+            by: { alphabeticCategoryForCommunity($0) }
+        )
+        for section in alphabeticSectionsGrouping {
+            alphabeticSections[section.key] = section.value.sorted(by: { $0.name < $1.name })
+        }
+        
+        self.alphabeticSections = alphabeticSections
+        
+        // Instance
+        
+        var otherSection = [Community2]()
+        let instanceSectionsGrouping: [String?: [Community2]] = .init(grouping: communities, by: \.host)
+        var instanceSections: [String?: [Community2]] = .init()
+        
+        for section in instanceSectionsGrouping {
+            if section.value.count == 1, let community = section.value.first {
+                otherSection.append(community)
+            } else {
+                instanceSections[section.key] = section.value.sorted(by: { $0.name < $1.name })
+            }
+        }
+        if !otherSection.isEmpty {
+            instanceSections[nil] = otherSection.sorted(by: { $0.name < $1.name })
+        }
+        self.instanceSections = instanceSections
+        
+        favorites = communities.filter { favoriteIDs.contains($0.id) }
+    }
+    
+    func updateCommunitySubscription(community: Community2) {
+        guard hasLoaded else { return }
+        if community.subscribed {
+            if !communities.contains(community) {
+                addCommunity(community: community)
+            }
+            if isFavorited(community) != community.shouldBeFavorited {
+                if community.shouldBeFavorited {
+                    favoriteIDs.insert(community.id)
+                    favorites.sortedInsert(community) { $0.name < community.name }
+                } else {
+                    favoriteIDs.remove(community.id)
+                    favorites.removeFirst { $0 === community }
+                }
+            }
+        } else if communities.contains(community) {
+            removeCommunity(community: community)
+        }
+    }
+        
+    private func addCommunity(community: Community2) {
+        communities.insert(community)
+        
+        let alphabeticCategory = alphabeticCategoryForCommunity(community)
+        if alphabeticSections.keys.contains(alphabeticCategory) {
+            alphabeticSections[alphabeticCategory]?.sortedInsert(community) { $0.name < community.name }
+        } else {
+            alphabeticSections[alphabeticCategory] = [community]
+        }
+        
+        let hostCategoryExists = instanceSections.keys.contains(community.host)
+        let hostExists: Bool = (
+            hostCategoryExists || instanceSections[nil, default: []].contains(where: { $0.host == community.host })
+        )
+        
+        if hostExists {
+            if hostCategoryExists {
+                instanceSections[community.host]?.sortedInsert(community) { $0.name < community.name }
+            } else {
+                if let otherCommunity = instanceSections[nil]?.removeFirst(where: { $0.host == community.host }) {
+                    instanceSections[community.host] = [community, otherCommunity].sorted { $0.name < $1.name }
+                } else {
+                    instanceSections[nil, default: []].append(community)
+                }
+            }
+        }
+    }
+    
+    private func removeCommunity(community: Community2) {
+        communities.remove(community)
+        favoriteIDs.remove(community.id)
+        favorites.removeFirst { $0 === community }
+        let category = alphabeticCategoryForCommunity(community)
+        alphabeticSections[category]?.removeFirst { $0 === community }
+        if alphabeticSections[category]?.isEmpty ?? false {
+            alphabeticSections.removeValue(forKey: category)
+        }
+        
+        if var items = instanceSections[community.host] {
+            switch items.count {
+            case 1:
+                instanceSections.removeValue(forKey: community.host)
+            case 2:
+                items.removeFirst { $0 === community }
+                instanceSections[nil, default: []].sortedInsert(items[0], for: { $0.name < community.name })
+                instanceSections.removeValue(forKey: community.host)
+            default:
+                instanceSections[community.host]?.removeFirst { $0 === community }
+            }
+        } else {
+            alphabeticSections[nil]?.removeFirst { $0 === community }
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SubscriptionModel.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SubscriptionModel.swift
@@ -1,0 +1,109 @@
+//
+//  SubscriptionModel.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 08/08/2024.
+//
+
+import Foundation
+
+struct SubscriptionModel: Hashable, Equatable {
+    // These are the values actually provided by the API.
+    var actualTotal: Int
+    var actualLocal: Int?
+    
+    var subscribed: Bool
+    
+    // When you subscribe, your instance asks the community host to confirm the subscription.
+    // Until a confirmation is received from the host, the subscription state is
+    // `ApiSubscribedType.pending`. The subscription count of the community doesn't change
+    // until the subscription status is confirmed by the community host. There also appears
+    // to exist a "pending" state for unsubscribing, but the API doesn't tell us when it's
+    // in this state.
+    //
+    // This property is "true" when the subscription is thought to be pending in **either**
+    // direction. Because we don't actually know whether an unsubscription is pending, this
+    // may not always be accurate.
+    var pending: Bool
+    
+    // This accounts for the `actualTotal` not taking your own pending subscription into account.
+    var total: Int { actualTotal + pendingSubscriptionValue }
+    
+    // This accounts for the `actualLocal` not taking your own pending subscription into account.
+    /// Added in 0.19.4.
+    var local: Int? {
+        guard let actualLocal else { return nil }
+        return actualLocal + pendingSubscriptionValue
+    }
+    
+    private var pendingSubscriptionValue: Int {
+        switch (subscribed, pending) {
+        case (true, true):
+            return 1
+        case (false, true):
+            return -1
+        case (_, false):
+            return 0
+        }
+    }
+    
+    init(from aggregates: ApiCommunityAggregates, subscribedType: ApiSubscribedType) {
+        self.actualTotal = aggregates.subscribers
+        self.actualLocal = aggregates.subscribersLocal
+        self.subscribed = subscribedType.isSubscribed
+        self.pending = subscribedType == .pending
+    }
+    
+    init(total: Int, local: Int? = nil, subscribed: Bool, pending: Bool) {
+        self.actualTotal = total
+        self.actualLocal = local
+        self.subscribed = subscribed
+        self.pending = pending
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(actualTotal)
+        hasher.combine(actualLocal)
+        hasher.combine(subscribed)
+        hasher.combine(pending)
+    }
+    
+    static func == (lhs: SubscriptionModel, rhs: SubscriptionModel) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+}
+
+extension SubscriptionModel {
+    var subscribedType: ApiSubscribedType {
+        if subscribed {
+            pending ? .pending : .subscribed
+        } else {
+            .notSubscribed
+        }
+    }
+    
+    func withSubscriptionStatus(subscribed shouldSubscribe: Bool, isLocal: Bool) -> SubscriptionModel {
+        guard shouldSubscribe != subscribed else { return self }
+        
+        let diff: Int
+        if isLocal {
+            diff = shouldSubscribe ? 1 : -1
+        } else {
+            diff = 0
+        }
+        
+        let newLocal: Int?
+        if let actualLocal {
+            newLocal = actualLocal + diff
+        } else {
+            newLocal = nil
+        }
+        
+        return SubscriptionModel(
+            total: actualTotal + diff,
+            local: newLocal,
+            subscribed: shouldSubscribe,
+            pending: !(pending || isLocal)
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -1,0 +1,155 @@
+//
+//  UnreadCount.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+@Observable
+public final class UnreadCount {
+    public let api: ApiClient
+    
+    var verifiedCount: [InboxItemType: Int] = .init()
+    var unverifiedCount: [InboxItemType: Int] = .init()
+    
+    public var replies: Int { self[.reply] }
+    public var mentions: Int { self[.mention] }
+    public var messages: Int { self[.message] }
+    public var postReports: Int { self[.postReport] }
+    public var commentReports: Int { self[.commentReport] }
+    public var messageReports: Int { self[.messageReport] }
+    public var registrationApplications: Int { self[.registrationApplication] }
+    
+    /// This value is incremented whenever the inbox count changes due to an
+    /// updated unread count being fetched from the API. It is not incremented when
+    /// state-faking is performed. This can be used as a trigger to decide when to
+    /// refresh the inbox.
+    public private(set) var refreshNumber: UInt = 0
+    
+    public var personalTotal: Int { replies + mentions + messages }
+    public var reportTotal: Int { postReports + commentReports + messageReports }
+    public var moderationTotal: Int { reportTotal + registrationApplications }
+    public var total: Int { personalTotal + moderationTotal }
+    
+    init(api: ApiClient) {
+        self.api = api
+    }
+    
+    @MainActor
+    func update(with newValues: [InboxItemType: Int]) {
+        var shouldUpdate = false
+        for (type, value) in newValues {
+            if verifiedCount[type] != value {
+                verifiedCount[type] = value
+                shouldUpdate = true
+            }
+        }
+        if shouldUpdate {
+            refreshNumber += 1
+        }
+    }
+    
+    @MainActor
+    func update(with sources: [any DictionaryConvertible]) {
+        update(
+            with: sources.reduce(into: [InboxItemType: Int]()) {
+                $0.merge($1.unreadCountDictionary) { $1 }
+            }
+        )
+    }
+    
+    func clear() {
+        verifiedCount = .init()
+        unverifiedCount = .init()
+    }
+    
+    func clear(_ types: Set<InboxItemType>) {
+        for type in types {
+            verifiedCount[type] = 0
+            unverifiedCount[type] = 0
+        }
+    }
+    
+    func updateUnverifiedItem(itemType: InboxItemType, isRead: Bool) {
+        let diff = isRead ? -1 : 1
+        unverifiedCount[itemType, default: 0] += diff
+    }
+    
+    func verifyItem(itemType: InboxItemType, isRead: Bool) {
+        let diff = isRead ? -1 : 1
+        verifiedCount[itemType, default: 0] += diff
+        unverifiedCount[itemType, default: 0] -= diff
+    }
+    
+    public subscript(_ type: InboxItemType) -> Int {
+        (verifiedCount[type] ?? 0) + (unverifiedCount[type] ?? 0)
+    }
+    
+    public func refresh() async throws {
+        let values: [InboxItemType: Int] = try await withThrowingTaskGroup(
+            of: [InboxItemType: Int].self,
+            returning: [InboxItemType: Int].self
+        ) { taskGroup in
+            taskGroup.addTask {
+                try await self.api.getPersonalUnreadCount().unreadCountDictionary
+            }
+            if self.api.myPerson == nil || self.api.myInstance == nil {
+                // The theoretical solution to this is to store the moderated
+                // community IDs in `ApiClient.Context` and `await` them here.
+                print("Warning: ApiClient.myPerson or ApiClient.myInstance is nil at UnreadCount refresh - this may lead to unneeded API calls")
+            }
+            if !(self.api.myPerson?.moderatedCommunities.isEmpty ?? false) || self.api.isAdmin {
+                taskGroup.addTask {
+                    do {
+                        return try await self.api.getReportCount(communityId: nil).unreadCountDictionary
+                    } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
+                        return [:]
+                    }
+                }
+            }
+            // Don't use `api.isAdmin` here; it falls back to `false` and we need to fallback to `true`
+            if api.myInstance?.administrators.contains(where: { $0.id == api.myPerson?.id }) ?? true {
+                taskGroup.addTask {
+                    do {
+                        return try await self.api.getRegistrationApplicationCount().unreadCountDictionary
+                    } catch let ApiClientError.response(response, _) where response.notAdmin {
+                        return [:]
+                    }
+                }
+            }
+            return try await taskGroup.reduce(into: [:]) { $0.merge($1) { $1 } }
+        }
+        await update(with: values)
+    }
+}
+
+public enum InboxItemType: Codable {
+    case reply, mention, message
+    case postReport, commentReport, messageReport, registrationApplication
+}
+
+public extension Set<InboxItemType> {
+    static var all: Set<InboxItemType> {
+        [.reply, .mention, .message, .postReport, .commentReport, .messageReport, .registrationApplication]
+    }
+    
+    static var personal: Set<InboxItemType> {
+        [.reply, .mention, .message]
+    }
+    
+    static var reports: Set<InboxItemType> {
+        [.postReport, .commentReport, .messageReport]
+    }
+    
+    static var moderatorAndAdmin: Set<InboxItemType> {
+        reports.union([.registrationApplication])
+    }
+}
+
+extension UnreadCount {
+    protocol DictionaryConvertible {
+        var unreadCountDictionary: [InboxItemType: Int] { get }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/VotesModel.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/VotesModel.swift
@@ -1,0 +1,73 @@
+//
+//  VotesModel.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-08-26.
+//
+
+import Foundation
+
+public struct VotesModel: Hashable, Equatable {
+    public var total: Int { upvotes - downvotes }
+    public var upvotes: Int
+    public var downvotes: Int
+    public var myVote: ScoringOperation
+
+    // init from API type
+    public init(from voteCount: any ApiContentAggregatesProtocol, myVote: ScoringOperation?) {
+        self.upvotes = voteCount.upvotes
+        self.downvotes = voteCount.downvotes
+        self.myVote = myVote ?? .none
+    }
+
+    // raw init
+    public init(upvotes: Int, downvotes: Int, myVote: ScoringOperation) {
+        self.upvotes = upvotes
+        self.downvotes = downvotes
+        self.myVote = myVote
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(upvotes)
+        hasher.combine(downvotes)
+        hasher.combine(myVote)
+    }
+    
+    public static func == (lhs: VotesModel, rhs: VotesModel) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+}
+
+extension VotesModel {
+    /// Returns the result of applying the given scoring operation. Assumes that it is a valid operation (i.e., not upvoting an upvoted post or downvoting a downvoted one)
+    /// - Parameter operation: operation to apply
+    /// - Returns: VotesModel representing the result of applying the given operation
+    func applyScoringOperation(operation: ScoringOperation) -> VotesModel {
+        assert(!(operation == .upvote && myVote == .upvote), "Cannot apply upvote to upvoted score")
+        assert(!(operation == .downvote && myVote == .downvote), "Cannot apply downvote to downvoted score")
+
+        var upvoteDelta: Int
+        var downvoteDelta: Int
+
+        switch myVote {
+        case .upvote:
+            // no matter what, removing 1 upvote; if downvoting, adding 1 downvote
+            upvoteDelta = -1
+            downvoteDelta = operation == .downvote ? 1 : 0
+        case .none:
+            // adding 1 to whichever operation we get as long as it's not resetVote
+            upvoteDelta = operation == .upvote ? 1 : 0
+            downvoteDelta = operation == .downvote ? 1 : 0
+        case .downvote:
+            // no matter what, removing 1 downvote; if upvoting, adding 1 upvote
+            upvoteDelta = operation == .upvote ? 1 : 0
+            downvoteDelta = -1
+        }
+
+        return VotesModel(
+            upvotes: upvotes + upvoteDelta,
+            downvotes: downvotes + downvoteDelta,
+            myVote: operation
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/ApiPictrsFile.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/ApiPictrsFile.swift
@@ -1,0 +1,24 @@
+//
+//  ApiPictrsFile.swift
+//
+//
+//  Created by Sjmarf on 26/08/2024.
+//
+
+import Foundation
+
+public struct ApiPictrsFile: Codable, Equatable, ImageUpload1Backer {
+    public let file: String
+    public let deleteToken: String
+    
+    public var alias: String { file }
+    
+    public var cacheId: Int { alias.hashValue }
+}
+
+public extension ApiPictrsFile {
+    enum CodingKeys: String, CodingKey {
+        case file
+        case deleteToken = "delete_token"
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/ApiPictrsUploadResponse.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/ApiPictrsUploadResponse.swift
@@ -1,0 +1,13 @@
+//
+//  ApiPictrsUploadResponse.swift
+//
+//
+//  Created by Sjmarf on 26/08/2024.
+//
+
+import Foundation
+
+public struct ApiPictrsUploadResponse: Codable {
+    public let msg: String?
+    public let files: [ApiPictrsFile]?
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIComment+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIComment+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  ApiComment+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiComment: ActorIdentifiable, CacheIdentifiable {
+    public var cacheId: Int { id }
+}
+
+public extension ApiComment {
+    var parentId: Int? {
+        let components = path.components(separatedBy: ".")
+
+        guard path != "0", components.count != 2 else {
+            return nil
+        }
+
+        guard let id = components.dropLast(1).last else {
+            return nil
+        }
+
+        return Int(id)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APICommentView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APICommentView+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ApiCommentView+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiCommentView: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+
+    public var actorId: ActorIdentifier { post.actorId }
+    public var id: Int { comment.id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APICommunity+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APICommunity+Extensions.swift
@@ -1,0 +1,24 @@
+//
+//  ApiCommunity+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiCommunity: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+}
+
+extension ApiCommunity: Comparable {
+    public static func == (lhs: ApiCommunity, rhs: ApiCommunity) -> Bool {
+        lhs.actorId == rhs.actorId
+    }
+    
+    public static func < (lhs: ApiCommunity, rhs: ApiCommunity) -> Bool {
+        let lhsFullCommunity = lhs.name + lhs.actorId.host
+        let rhsFullCommunity = rhs.name + rhs.actorId.host
+        return lhsFullCommunity < rhsFullCommunity
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APICommunityView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APICommunityView+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ApiCommunityView+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiCommunityView: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+
+    public var actorId: ActorIdentifier { community.actorId }
+    public var id: Int { community.id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIGetCommunityResponse+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIGetCommunityResponse+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ApiGetCommunityResponse+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiGetCommunityResponse: CacheIdentifiable, ActorIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+    
+    public var actorId: ActorIdentifier { communityView.community.actorId }
+    public var id: Int { communityView.community.id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIGetPersonDetailsResponse+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIGetPersonDetailsResponse+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  ApiGetPersonDetailsResponse+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiGetPersonDetailsResponse: Person3ApiBacker {
+    public var person2ApiBacker: any Person2ApiBacker { personView }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIGetSiteResponse+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIGetSiteResponse+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ApiGetSiteResponse+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiGetSiteResponse: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+
+    public var actorId: ActorIdentifier { siteView.site.actorId }
+    public var id: Int { siteView.site.id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APILocalUserView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APILocalUserView+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  ApiLocalUserView+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiLocalUserView: Person2ApiBacker {
+    public var admin: Bool {
+        if let admin = localUser.admin ?? person.admin {
+            return admin
+        }
+        assertionFailure()
+        return false
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPerson+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPerson+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  ApiPerson+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiPerson: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPersonView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPersonView+Extensions.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension ApiPersonView: Person2ApiBacker {
     public var admin: Bool {
-        guard let admin = isAdmin ?? person.admin else {
+        guard let admin = self.isAdmin ?? self.person.admin else {
             assertionFailure("Could not determine admin status")
             return false
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPersonView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPersonView+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  ApiPersonView+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiPersonView: Person2ApiBacker {
+    public var admin: Bool {
+        guard let admin = isAdmin ?? person.admin else {
+            assertionFailure("Could not determine admin status")
+            return false
+        }
+        return admin
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPersonView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPersonView+Extensions.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension ApiPersonView: Person2ApiBacker {
     public var admin: Bool {
-        guard let admin = self.isAdmin ?? self.person.admin else {
+        guard let admin = isAdmin ?? person.admin else {
             assertionFailure("Could not determine admin status")
             return false
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPost+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPost+Extensions.swift
@@ -1,0 +1,29 @@
+//
+//  ApiPost+ActorIdentifiable.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiPost: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+}
+
+extension ApiPost {
+    var linkUrl: URL? { LemmyURL(string: url)?.url }
+    // var thumbnailImageUrl: URL? { LemmyURL(string: thumbnail_url)?.url }
+    var thumbnailImageUrl: URL? { thumbnailUrl }
+    
+    var embed: PostEmbed? {
+        if embedTitle != nil || embedDescription != nil || embedVideoUrl != nil {
+            return .init(
+                title: embedTitle,
+                description: embedDescription,
+                videoUrl: embedVideoUrl
+            )
+        }
+        return nil
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPostView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APIPostView+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ApiPostView+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiPostView: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+
+    public var actorId: ActorIdentifier { post.actorId }
+    public var id: Int { post.id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APISite+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APISite+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  ApiSite+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiSite: CacheIdentifiable, ActorIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APISiteView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APISiteView+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ApiSiteView+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+extension ApiSiteView: CacheIdentifiable, ActorIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+    
+    public var actorId: ActorIdentifier { site.actorId }
+    public var id: Int { site.id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APISubscribedType+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/APISubscribedType+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  ApiSubscribedType+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+public extension ApiSubscribedType {
+    var isSubscribed: Bool { self != .notSubscribed }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiAdminPurgeCommentView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiAdminPurgeCommentView+Extensions.swift
@@ -1,0 +1,19 @@
+//
+//  ApiAdminPurgeCommentView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-26.
+//
+
+import Foundation
+
+extension ApiAdminPurgeCommentView: ModlogEntryApiBacker {
+    var published: Date { adminPurgeComment.published }
+    var moderator: ApiPerson? { admin }
+    var moderatorId: Int { adminPurgeComment.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .purgeComment(reason: adminPurgeComment.reason)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiAdminPurgeCommunityView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiAdminPurgeCommunityView+Extensions.swift
@@ -1,0 +1,19 @@
+//
+//  ApiAdminPurgeCommunityView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-26.
+//
+
+import Foundation
+
+extension ApiAdminPurgeCommunityView: ModlogEntryApiBacker {
+    var published: Date { adminPurgeCommunity.published }
+    var moderator: ApiPerson? { admin }
+    var moderatorId: Int { adminPurgeCommunity.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .purgeCommunity(reason: adminPurgeCommunity.reason)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiAdminPurgePersonView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiAdminPurgePersonView+Extensions.swift
@@ -1,0 +1,19 @@
+//
+//  ApiAdminPurgePersonView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-28.
+//
+
+import Foundation
+
+extension ApiAdminPurgePersonView: ModlogEntryApiBacker {
+    var published: Date { adminPurgePerson.published }
+    var moderator: ApiPerson? { admin }
+    var moderatorId: Int { adminPurgePerson.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .purgePerson(reason: adminPurgePerson.reason)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiAdminPurgePostView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiAdminPurgePostView+Extensions.swift
@@ -1,0 +1,19 @@
+//
+//  ApiAdminPurgePostView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-26.
+//
+
+import Foundation
+
+extension ApiAdminPurgePostView: ModlogEntryApiBacker {
+    var published: Date { adminPurgePost.published }
+    var moderator: ApiPerson? { admin }
+    var moderatorId: Int { adminPurgePost.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .purgePost(reason: adminPurgePost.reason)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommentAggregates+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommentAggregates+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  ApiCommentAggregates.swift
+//
+//
+//  Created by Sjmarf on 24/06/2024.
+//
+
+import Foundation
+
+extension ApiCommentAggregates: ApiContentAggregatesProtocol {
+    public var comments: Int { childCount }
+    
+    static var zero: Self {
+        .init(id: nil, commentId: 0, score: 0, upvotes: 0, downvotes: 0, published: .distantPast, childCount: 0, hotRank: 0)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommentReply+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommentReply+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  ApiCommentReply+Extensions.swift
+//
+//
+//  Created by Sjmarf on 04/07/2024.
+//
+
+import Foundation
+
+extension ApiCommentReply: CacheIdentifiable, Reply1ApiBacker {
+    public var cacheId: Int { id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommentReplyView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommentReplyView+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ApiCommentReplyView+Extensions.swift
+//
+//
+//  Created by Sjmarf on 04/07/2024.
+//
+
+import Foundation
+
+extension ApiCommentReplyView: CacheIdentifiable, Reply2ApiBacker {
+    public var cacheId: Int { commentReply.id }
+    public var reply: any Reply1ApiBacker { commentReply }
+    
+    public var resolvedSaved: Bool { saved ?? false }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommentReportView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommentReportView+Extensions.swift
@@ -1,0 +1,54 @@
+//
+//  ApiCommentReport+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-16.
+//
+
+import Foundation
+
+extension ApiCommentReportView: ReportApiBacker {
+    public var cacheId: Int {
+        var hasher = Hasher()
+        hasher.combine(ReportType.comment)
+        hasher.combine(commentReport.id)
+        return hasher.finalize()
+    }
+    
+    public var id: Int { commentReport.id }
+    public var reason: String { commentReport.reason }
+    public var resolved: Bool { commentReport.resolved }
+    public var published: Date { commentReport.published }
+    public var updated: Date? { commentReport.updated }
+    
+    func toCommentView() -> ApiCommentView? {
+        guard let subscribed, let saved, let creatorBlocked else { return nil }
+        return .init(
+            comment: comment,
+            creator: commentCreator,
+            post: post,
+            community: community,
+            counts: counts,
+            creatorBannedFromCommunity: creatorBannedFromCommunity,
+            subscribed: subscribed,
+            saved: saved,
+            creatorBlocked: creatorBlocked,
+            myVote: myVote,
+            creatorIsModerator: creatorIsModerator,
+            creatorIsAdmin: creatorIsAdmin,
+            bannedFromCommunity: nil // Can we assume this to be false? Can admins be banned from a local community?
+        )
+    }
+    
+    @MainActor
+    func createTarget(api: ApiClient, myPersonId: Int) -> ReportTarget {
+        if let commentView = toCommentView() {
+            return .comment(api.caches.comment2.getModel(api: api, from: commentView))
+        }
+        return .legacyComment(
+            api.caches.comment1.getModel(api: api, from: comment),
+            community: api.caches.community1.getModel(api: api, from: community),
+            creator: api.caches.person1.getModel(api: api, from: commentCreator)
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommunityAggregates+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommunityAggregates+Extensions.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-22.
+//
+
+import Foundation
+
+extension ApiCommunityAggregates {
+    static var zero: Self {
+        .init(
+            id: nil,
+            communityId: 0,
+            subscribers: 0,
+            posts: 0,
+            comments: 0,
+            published: .distantPast,
+            usersActiveDay: 0,
+            usersActiveWeek: 0,
+            usersActiveMonth: 0,
+            usersActiveHalfYear: 0,
+            hotRank: nil,
+            subscribersLocal: 0
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetModlogResponse+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetModlogResponse+Extensions.swift
@@ -1,0 +1,54 @@
+//
+//  ApiGetModlogResponse+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-25.
+//
+
+import Foundation
+
+extension ApiGetModlogResponse {
+    var allEntries: [any ModlogEntryApiBacker] {
+        // Compiler didn't like it when I used `a + b + c + d`
+        var output: [any ModlogEntryApiBacker] = []
+        output += removedPosts ?? []
+        output += lockedPosts ?? []
+        output += featuredPosts ?? []
+        output += adminPurgedPosts ?? []
+        output += removedComments ?? []
+        output += adminPurgedComments ?? []
+        output += removedCommunities ?? []
+        output += adminPurgedCommunities ?? []
+        output += hiddenCommunities ?? []
+        output += transferredToCommunity ?? []
+        output += addedToCommunity ?? []
+        output += added ?? []
+        output += bannedFromCommunity ?? []
+        output += banned ?? []
+        output += adminPurgedPersons ?? []
+        // TODO: 0.20 support add items from the new `modlog` field
+        return output
+    }
+    
+    func getEntries(ofType type: ApiModlogActionType) -> [any ModlogEntryApiBacker] {
+        switch type {
+        case .all: allEntries
+        case .modRemovePost: removedPosts ?? []
+        case .modLockPost: lockedPosts ?? []
+        case .modFeaturePost: featuredPosts ?? []
+        case .modRemoveComment: removedComments ?? []
+        case .modRemoveCommunity: removedCommunities ?? []
+        case .modBanFromCommunity: bannedFromCommunity ?? []
+        case .modAddCommunity: addedToCommunity ?? []
+        case .modTransferCommunity: transferredToCommunity ?? []
+        case .modAdd: added ?? []
+        case .modBan: banned ?? []
+        case .modHideCommunity: hiddenCommunities ?? []
+        case .adminPurgePerson: adminPurgedPersons ?? []
+        case .adminPurgeCommunity: adminPurgedCommunities ?? []
+        case .adminPurgePost: adminPurgedPosts ?? []
+        case .adminPurgeComment: adminPurgedComments ?? []
+        default: []
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetPostResponse+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetPostResponse+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ApiGetPostResponse+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 25/09/2024.
+//
+
+import Foundation
+
+extension ApiGetPostResponse: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+
+    public var actorId: ActorIdentifier { postView.post.actorId }
+    public var id: Int { postView.post.id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetReportCountResponse+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetReportCountResponse+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-15.
+//
+
+import Foundation
+
+extension ApiGetReportCountResponse: UnreadCount.DictionaryConvertible {
+    var unreadCountDictionary: [InboxItemType: Int] {
+        [
+            .postReport: postReports ?? 0,
+            .commentReport: commentReports ?? 0,
+            .messageReport: privateMessageReports ?? 0
+        ]
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetUnreadCountResponse+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetUnreadCountResponse+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  ApiGetUnreadCountResponse+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-15.
+//
+
+import Foundation
+
+extension ApiGetUnreadCountResponse: UnreadCount.DictionaryConvertible {
+    var unreadCountDictionary: [InboxItemType: Int] {
+        [
+            .reply: replies ?? 0,
+            .mention: mentions ?? 0,
+            .message: privateMessages ?? 0
+        ]
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetUnreadRegistrationApplicationCountResponse+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetUnreadRegistrationApplicationCountResponse+Extensions.swift
@@ -1,0 +1,14 @@
+//
+//  ApiGetUnreadRegistrationApplicationCountResponse+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-15.
+//
+
+import Foundation
+
+extension ApiGetUnreadRegistrationApplicationCountResponse: UnreadCount.DictionaryConvertible {
+    var unreadCountDictionary: [InboxItemType: Int] {
+        [.registrationApplication: registrationApplications]
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModAddCommunityView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModAddCommunityView+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  ApiModAddCommunityView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-26.
+//
+
+import Foundation
+
+extension ApiModAddCommunityView: ModlogEntryApiBacker {
+    var published: Date { modAddCommunity.published }
+    var moderatorId: Int { modAddCommunity.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .updatePersonModeratorStatus(
+            person: api.caches.person1.getModel(api: api, from: otherPerson),
+            community: api.caches.community1.getModel(api: api, from: community),
+            appointed: !modAddCommunity.removed
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModAddView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModAddView+Extensions.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2024-12-27.
-//  
+//
 
 import Foundation
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModAddView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModAddView+Extensions.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2024-12-27.
-//
+//  
 
 import Foundation
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModAddView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModAddView+Extensions.swift
@@ -1,0 +1,21 @@
+//
+//  ApiModAddView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-27.
+//
+
+import Foundation
+
+extension ApiModAddView: ModlogEntryApiBacker {
+    var published: Date { modAdd.published }
+    var moderatorId: Int { modAdd.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .updatePersonAdminStatus(
+            person: api.caches.person1.getModel(api: api, from: otherPerson),
+            appointed: !modAdd.removed
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModBanFromCommunityView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModBanFromCommunityView+Extensions.swift
@@ -1,0 +1,24 @@
+//
+//  ApiModBanFromCommunityView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-28.
+//
+
+import Foundation
+
+extension ApiModBanFromCommunityView: ModlogEntryApiBacker {
+    var published: Date { modBanFromCommunity.published }
+    var moderatorId: Int { modBanFromCommunity.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .banPersonFromCommunity(
+            person: api.caches.person1.getModel(api: api, from: otherPerson),
+            community: api.caches.community1.getModel(api: api, from: community),
+            banned: modBanFromCommunity.banned,
+            reason: modBanFromCommunity.reason,
+            expires: modBanFromCommunity.expires
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModBanView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModBanView+Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  ApiModBanView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-28.
+//
+
+import Foundation
+
+extension ApiModBanView: ModlogEntryApiBacker {
+    var published: Date { modBan.published }
+    var moderatorId: Int { modBan.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .banPersonFromInstance(
+            person: api.caches.person1.getModel(api: api, from: otherPerson),
+            banned: modBan.banned,
+            reason: modBan.reason,
+            expires: modBan.expires
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModFeaturePostView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModFeaturePostView+Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  ApiModFeaturePostView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-26.
+//
+
+import Foundation
+
+extension ApiModFeaturePostView: ModlogEntryApiBacker {
+    var published: Date { modFeaturePost.published }
+    var moderatorId: Int { modFeaturePost.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .pinPost(
+            api.caches.post1.getModel(api: api, from: post),
+            community: api.caches.community1.getModel(api: api, from: community),
+            pinned: modFeaturePost.featured,
+            type: modFeaturePost.isFeaturedCommunity ? .community : .local
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModHideCommunityView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModHideCommunityView+Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  ApiModHideCommunityView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-26.
+//
+
+import Foundation
+
+extension ApiModHideCommunityView: ModlogEntryApiBacker {
+    var published: Date { modHideCommunity.published }
+    var moderator: ApiPerson? { admin }
+    var moderatorId: Int { modHideCommunity.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .hideCommunity(
+            api.caches.community1.getModel(api: api, from: community),
+            hidden: modHideCommunity.hidden,
+            reason: modHideCommunity.reason
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModLockPostView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModLockPostView+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-25.
+//
+
+import Foundation
+
+extension ApiModLockPostView: ModlogEntryApiBacker {
+    var published: Date { modLockPost.published }
+    var moderatorId: Int { modLockPost.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .lockPost(
+            api.caches.post1.getModel(api: api, from: post),
+            community: api.caches.community1.getModel(api: api, from: community),
+            locked: modLockPost.locked
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModRemoveCommentView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModRemoveCommentView+Extensions.swift
@@ -1,0 +1,25 @@
+//
+//  ApiModRemoveCommentView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-26.
+//
+
+import Foundation
+
+extension ApiModRemoveCommentView: ModlogEntryApiBacker {
+    var published: Date { modRemoveComment.published }
+    var moderatorId: Int { modRemoveComment.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .removeComment(
+            api.caches.comment1.getModel(api: api, from: comment),
+            creator: api.caches.person1.getModel(api: api, from: otherPerson),
+            post: api.caches.post1.getModel(api: api, from: post),
+            community: api.caches.community1.getModel(api: api, from: community),
+            removed: modRemoveComment.removed,
+            reason: modRemoveComment.reason
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModRemoveCommunityView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModRemoveCommunityView+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  ApiModRemoveCommunityView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-26.
+//
+
+import Foundation
+
+extension ApiModRemoveCommunityView: ModlogEntryApiBacker {
+    var published: Date { modRemoveCommunity.published }
+    var moderatorId: Int { modRemoveCommunity.id }
+
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .removeCommunity(
+            api.caches.community1.getModel(api: api, from: community),
+            removed: modRemoveCommunity.removed,
+            reason: modRemoveCommunity.reason
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModRemovePostView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModRemovePostView+Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  ApiModRemovePostView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-25.
+//
+
+import Foundation
+
+extension ApiModRemovePostView: ModlogEntryApiBacker {
+    var published: Date { modRemovePost.published }
+    var moderatorId: Int { modRemovePost.id }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .removePost(
+            api.caches.post1.getModel(api: api, from: post),
+            community: api.caches.community1.getModel(api: api, from: community),
+            removed: modRemovePost.removed,
+            reason: modRemovePost.reason
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModTransferCommunityView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModTransferCommunityView+Extensions.swift
@@ -1,0 +1,21 @@
+//
+//  ApiModTransferCommunityView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-26.
+//
+
+import Foundation
+
+extension ApiModTransferCommunityView: ModlogEntryApiBacker {
+    var published: Date { modTransferCommunity.published }
+    var moderatorId: Int { modTransferCommunity.id }
+
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType {
+        .transferCommunityOwnership(
+            person: api.caches.person1.getModel(api: api, from: otherPerson),
+            community: api.caches.community1.getModel(api: api, from: community)
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModlogActionType+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModlogActionType+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  ApiModlogActionType+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-28.
+//
+
+import Foundation
+
+extension ApiModlogActionType {
+    static var allFilteredCases: [ApiModlogActionType] = [
+        .modRemovePost,
+        .modLockPost,
+        .modFeaturePost,
+        .modRemoveComment,
+        .modRemoveCommunity,
+        .modBanFromCommunity,
+        .modAddCommunity,
+        .modTransferCommunity,
+        .modAdd,
+        .modBan,
+        .modHideCommunity,
+        .adminPurgePerson,
+        .adminPurgeCommunity,
+        .adminPurgePost,
+        .adminPurgeComment
+    ]
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModlogActionType+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModlogActionType+Extensions.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2024-12-28.
-//  
+//
 
 import Foundation
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModlogActionType+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModlogActionType+Extensions.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2024-12-28.
-//
+//  
 
 import Foundation
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModlogCombinedView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiModlogCombinedView+Extensions.swift
@@ -1,0 +1,10 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-21.
+//
+
+import Foundation
+
+extension ApiModlogCombinedView {}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiMyUserInfo+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiMyUserInfo+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  ApiMyUserInfo+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-01.
+//
+
+import Foundation
+
+extension ApiMyUserInfo: Person3ApiBacker {
+    public var site: ApiSite? { nil }
+    
+    public var person2ApiBacker: any Person2ApiBacker {
+        localUserView
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPersonAggregates+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPersonAggregates+Extensions.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-02-22.
-//  
+//
 
 import Foundation
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPersonAggregates+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPersonAggregates+Extensions.swift
@@ -3,7 +3,7 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-02-22.
-//
+//  
 
 import Foundation
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPersonAggregates+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPersonAggregates+Extensions.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-22.
+//
+
+import Foundation
+
+extension ApiPersonAggregates {
+    static var zero: Self {
+        .init(id: nil, personId: 0, postCount: 0, postScore: nil, commentCount: 0, commentScore: nil)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPersonMention+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPersonMention+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  ApiPersonMention+Extensions.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+extension ApiPersonMention: CacheIdentifiable, Reply1ApiBacker {
+    public var cacheId: Int { id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPersonMentionView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPersonMentionView+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ApiPersonMentionView+Extensions.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+extension ApiPersonMentionView: CacheIdentifiable, Reply2ApiBacker {
+    public var cacheId: Int { personMention.id }
+    public var reply: any Reply1ApiBacker { personMention }
+    
+    public var resolvedSaved: Bool { saved }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPostAggregates+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPostAggregates+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  ApiPostAggregates+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-03.
+//
+
+import Foundation
+
+extension ApiPostAggregates: ApiContentAggregatesProtocol {
+    static var zero: Self {
+        .init(
+            id: nil,
+            postId: 0,
+            comments: 0,
+            score: 0,
+            upvotes: 0,
+            downvotes: 0,
+            published: .distantPast,
+            newestCommentTimeNecro: nil,
+            newestCommentTime: nil,
+            featuredCommunity: false,
+            featuredLocal: false,
+            hotRank: nil,
+            hotRankActive: nil
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPostReportView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPostReportView+Extensions.swift
@@ -1,0 +1,58 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-16.
+//
+
+import Foundation
+
+extension ApiPostReportView: ReportApiBacker {
+    public var cacheId: Int {
+        var hasher = Hasher()
+        hasher.combine(ReportType.post)
+        hasher.combine(postReport.id)
+        return hasher.finalize()
+    }
+    
+    public var id: Int { postReport.id }
+    var reason: String { postReport.reason }
+    var resolved: Bool { postReport.resolved }
+    var published: Date { postReport.published }
+    var updated: Date? { postReport.updated }
+    
+    func toPostView() -> ApiPostView? {
+        guard let subscribed, let saved, let read, let creatorBlocked, let unreadComments else { return nil }
+        return .init(
+            post: post,
+            creator: postCreator,
+            community: community,
+            creatorBannedFromCommunity: creatorBannedFromCommunity,
+            counts: counts,
+            subscribed: subscribed,
+            saved: saved,
+            read: read,
+            creatorBlocked: creatorBlocked,
+            myVote: myVote,
+            unreadComments: unreadComments,
+            creatorIsModerator: creatorIsModerator,
+            creatorIsAdmin: creatorIsAdmin,
+            bannedFromCommunity: nil, // Can we assume this to be false? Can admins be banned from a local community?
+            hidden: hidden,
+            imageDetails: nil,
+            tags: nil // TODO: Store tags here!
+        )
+    }
+    
+    @MainActor
+    func createTarget(api: ApiClient, myPersonId: Int) -> ReportTarget {
+        if let postView = toPostView() {
+            return .post(api.caches.post2.getModel(api: api, from: postView))
+        }
+        return .legacyPost(
+            api.caches.post1.getModel(api: api, from: post),
+            community: api.caches.community1.getModel(api: api, from: community),
+            creator: api.caches.person1.getModel(api: api, from: postCreator)
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPrivateMessage+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPrivateMessage+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  ApiPrivateMessage+Extensions.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+extension ApiPrivateMessage: CacheIdentifiable {
+    public var cacheId: Int { id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPrivateMessageReportView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPrivateMessageReportView+Extensions.swift
@@ -1,0 +1,42 @@
+//
+//  ApiPrivateMessageReportView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-16.
+//
+
+import Foundation
+
+extension ApiPrivateMessageReportView: ReportApiBacker {
+    public var cacheId: Int {
+        var hasher = Hasher()
+        hasher.combine(ReportType.message)
+        hasher.combine(privateMessageReport.id)
+        return hasher.finalize()
+    }
+    
+    public var id: Int { privateMessageReport.id }
+    var reason: String { privateMessageReport.reason }
+    var resolved: Bool { privateMessageReport.resolved }
+    var published: Date { privateMessageReport.published }
+    var updated: Date? { privateMessageReport.updated }
+    
+    func toPrivateMessageView() -> ApiPrivateMessageView {
+        .init(
+            privateMessage: privateMessage,
+            creator: privateMessageCreator,
+            recipient: creator // Only the recipient of the message can report it.
+        )
+    }
+    
+    @MainActor
+    func createTarget(api: ApiClient, myPersonId: Int) -> ReportTarget {
+        .message(
+            api.caches.message2.getModel(
+                api: api,
+                from: toPrivateMessageView(),
+                myPersonId: myPersonId
+            )
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPrivateMessageView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPrivateMessageView+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  ApiPrivateMessageView+Extensions.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+extension ApiPrivateMessageView: CacheIdentifiable {
+    public var cacheId: Int { privateMessage.id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiRegistrationApplication+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiRegistrationApplication+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  ApiRegistrationApplication+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-12.
+//
+
+import Foundation
+
+extension ApiRegistrationApplication: CacheIdentifiable {
+    public var cacheId: Int { id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiRegistrationApplicationView+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiRegistrationApplicationView+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  ApiRegistrationApplicationView+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-12.
+//
+
+import Foundation
+
+extension ApiRegistrationApplicationView: CacheIdentifiable {
+    public var cacheId: Int { registrationApplication.id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiSiteAggregates+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/ApiSiteAggregates+Extensions.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-22.
+//
+
+import Foundation
+
+extension ApiSiteAggregates {
+    static var zero: Self {
+        .init(id: nil, siteId: 0, users: 0, posts: 0, comments: 0, communities: 0, usersActiveDay: 0, usersActiveWeek: 0, usersActiveMonth: 0, usersActiveHalfYear: 0)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/ImageUpload1Backer.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/ImageUpload1Backer.swift
@@ -1,0 +1,13 @@
+//
+//  ImageUpload1Backer.swift
+//
+//
+//  Created by Sjmarf on 26/08/2024.
+//
+
+import Foundation
+
+public protocol ImageUpload1Backer: CacheIdentifiable {
+    var alias: String { get }
+    var deleteToken: String { get }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/ModEntryApiBacker.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/ModEntryApiBacker.swift
@@ -1,0 +1,17 @@
+//
+//  ModlogEntryApiBacker.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-25.
+//
+
+import Foundation
+
+protocol ModlogEntryApiBacker {
+    var moderator: ApiPerson? { get }
+    var published: Date { get }
+    var moderatorId: Int { get }
+    
+    @MainActor
+    func type(api: ApiClient) -> ModlogEntryType
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Person2ApiBacker.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Person2ApiBacker.swift
@@ -1,0 +1,23 @@
+//
+//  Person2ApiBacker.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-02-19.
+//
+
+import Foundation
+
+/// Protocol for API types that contain sufficient information to create a Person2
+public protocol Person2ApiBacker: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    var person: ApiPerson { get }
+    var admin: Bool { get }
+    
+    var counts: ApiPersonAggregates { get }
+}
+
+public extension Person2ApiBacker {
+    var cacheId: Int { id }
+
+    var id: Int { person.id }
+    var actorId: ActorIdentifier { person.actorId }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Person3ApiBacker.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Person3ApiBacker.swift
@@ -1,0 +1,22 @@
+//
+//  Person3ApiBacker.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-01.
+//
+
+import Foundation
+
+// Protocol for types that contain sufficient information to create a Person3
+public protocol Person3ApiBacker: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    var moderates: [ApiCommunityModeratorView] { get }
+    var site: ApiSite? { get }
+    var person2ApiBacker: any Person2ApiBacker { get }
+}
+
+public extension Person3ApiBacker {
+    var cacheId: Int { id }
+    
+    var id: Int { person2ApiBacker.id }
+    var actorId: ActorIdentifier { person2ApiBacker.actorId }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Reply1ApiBacker.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Reply1ApiBacker.swift
@@ -1,0 +1,21 @@
+//
+//  Reply1ApiBacker.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+/// This protocol is conformed to be ``ApiCommentReply`` and ``ApiPersonMention``.
+public protocol Reply1ApiBacker: CacheIdentifiable, Identifiable {
+    var id: Int { get }
+    var recipientId: Int { get }
+    var commentId: Int { get }
+    var read: Bool { get }
+    var published: Date { get }
+}
+
+public extension Reply1ApiBacker {
+    var cacheId: Int { id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Reply2ApiBacker.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Reply2ApiBacker.swift
@@ -1,0 +1,36 @@
+//
+//  Reply2ApiBacker.swift
+//
+//
+//  Created by Sjmarf on 05/07/2024.
+//
+
+import Foundation
+
+/// This protocol is conformed to be ``ApiCommentReplyView`` and ``ApiPersonMentionView``.
+public protocol Reply2ApiBacker: CacheIdentifiable, Identifiable {
+    var reply: any Reply1ApiBacker { get }
+    var comment: ApiComment { get }
+    var creator: ApiPerson { get }
+    var post: ApiPost { get }
+    var community: ApiCommunity { get }
+    var recipient: ApiPerson { get }
+    var creatorBannedFromCommunity: Bool { get }
+    var subscribed: ApiSubscribedType { get }
+    var creatorBlocked: Bool { get }
+    var myVote: Int? { get }
+    /// Added in 0.19.0
+    var creatorIsModerator: Bool? { get }
+    /// Added in 0.19.0
+    var creatorIsAdmin: Bool? { get }
+    /// Added in 0.19.4
+    var bannedFromCommunity: Bool? { get }
+    var counts: ApiCommentAggregates { get }
+    
+    var resolvedSaved: Bool { get }
+}
+
+public extension Reply2ApiBacker {
+    var cacheId: Int { reply.id }
+    var id: Int { reply.id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/ReportApiBacker.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/ReportApiBacker.swift
@@ -1,0 +1,21 @@
+//
+//  ReportApiBacker.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-16.
+//
+
+import Foundation
+
+/// This protocol is conformed to be ``ApiCommentReplyView`` and ``ApiPersonMentionView``.
+protocol ReportApiBacker: CacheIdentifiable, Identifiable where ID == Int {
+    var resolver: ApiPerson? { get }
+    var creator: ApiPerson { get }
+    var reason: String { get }
+    var resolved: Bool { get }
+    var published: Date { get }
+    var updated: Date? { get }
+    
+    @MainActor
+    func createTarget(api: ApiClient, myPersonId: Int) -> ReportTarget
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/Array+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/Array+Extensions.swift
@@ -1,0 +1,26 @@
+//
+//  Array+Prepend.swift
+//  Mlem
+//
+//  Created by David Bureš on 07.05.2023.
+//
+
+import Foundation
+
+public extension Array {
+    mutating func prepend(_ newElement: Element) {
+        insert(newElement, at: 0)
+    }
+    
+    mutating func sortedInsert(_ newElement: Element, for predicate: (Element) -> Bool) {
+        insert(newElement, at: insertionIndex(for: predicate))
+    }
+    
+    subscript(safeIndex index: Int) -> Element? {
+        guard index >= 0, index < endIndex else {
+            return nil
+        }
+        
+        return self[index]
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/JSONDecoder+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/JSONDecoder+Extensions.swift
@@ -1,0 +1,51 @@
+//
+//  JSONDecoder+Extensions.swift
+//  Mlem
+//
+//  Created by Nicholas Lawson on 11/06/2023.
+//
+
+import Foundation
+
+public extension JSONDecoder {
+    static var defaultDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        
+        let formats = [
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ",
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS",
+            "yyyy-MM-dd'T'HH:mm:ssZ",
+            "yyyy-MM-dd'T'HH:mm:ss"
+        ]
+        
+        let formatters = formats.map { format in
+            let formatter = DateFormatter()
+            formatter.timeZone = .gmt
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.dateFormat = format
+            return formatter
+        }
+
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+
+            for formatter in formatters {
+                if let date = formatter.date(from: string) {
+                    return date
+                }
+            }
+
+            // after some discussion we've agreed to fail the modelling if the date
+            // does match _any_ of the above, as based on the current API source code
+            // it should be one of those
+            throw Swift.DecodingError.dataCorrupted(
+                .init(
+                    codingPath: container.codingPath,
+                    debugDescription: "Failed to parse date"
+                )
+            )
+        }
+        return decoder
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/Locale+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/Locale+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-28.
+//
+
+import Foundation
+
+extension Locale.Language {
+    init?(_ apiLanguage: ApiLanguage) {
+        if apiLanguage.code == "und" {
+            return nil
+        } else {
+            self = .init(identifier: apiLanguage.code)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/Locale+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/Locale+Extensions.swift
@@ -3,11 +3,11 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-02-28.
-//  
+//
 
 import Foundation
 
-internal extension Locale.Language {
+extension Locale.Language {
     init?(_ apiLanguage: ApiLanguage) {
         if apiLanguage.code == "und" {
             return nil

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/Locale+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/Locale+Extensions.swift
@@ -3,11 +3,11 @@
 //  MlemMiddleware
 //
 //  Created by Sjmarf on 2025-02-28.
-//
+//  
 
 import Foundation
 
-extension Locale.Language {
+internal extension Locale.Language {
     init?(_ apiLanguage: ApiLanguage) {
         if apiLanguage.code == "und" {
             return nil

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/RandomAccessCollection+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/RandomAccessCollection+Extensions.swift
@@ -1,0 +1,24 @@
+//
+//  RandomAccessCollection+Extensions.swift
+//
+//
+//  Created by Sjmarf on 05/05/2024.
+//
+
+import Foundation
+
+extension RandomAccessCollection {
+    func insertionIndex(for predicate: (Element) -> Bool) -> Index {
+        var slice: SubSequence = self[...]
+
+        while !slice.isEmpty {
+            let middle = slice.index(slice.startIndex, offsetBy: slice.count / 2)
+            if predicate(slice[middle]) {
+                slice = slice[index(after: middle)...]
+            } else {
+                slice = slice[..<middle]
+            }
+        }
+        return slice.startIndex
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/RangeReplaceableCollection+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/RangeReplaceableCollection+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  RangeReplaceableCollection+Extensions.swift
+//
+//
+//  Created by Sjmarf on 11/05/2024.
+//
+
+import Foundation
+
+extension RangeReplaceableCollection {
+    @discardableResult
+    mutating func removeFirst(where predicate: (Element) throws -> Bool) rethrows -> Element? {
+        guard let index = try firstIndex(where: predicate) else { return nil }
+        return remove(at: index)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/String+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/String+Extensions.swift
@@ -1,0 +1,27 @@
+//
+//  String+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-12-10.
+//
+
+import Foundation
+
+public extension String {
+    /// Returns true if the given array of strings contains any word which appears as a substring of this string
+    func isContainedIn(_ strings: [String]) -> Bool {
+        strings.contains { contains($0) }
+    }
+    
+    /// Returns true if the given set of strings contains any word which appears as a substring of this string
+    func isContainedIn(_ strings: Set<String>) -> Bool {
+        strings.contains { contains($0) }
+    }
+    
+    /// Returns true if this string contains any whole word that is in the given set of strings
+    func failsKeywordFilter(_ filteredKeywords: Set<String>) -> Bool {
+        let words = split(separator: /[^[:alnum:]]/) // split on any non-letter/number characters so "keyword's" is filtered as "keyword" "s"
+            .map { $0.lowercased() }
+        return words.contains { filteredKeywords.contains($0) }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
@@ -1,0 +1,115 @@
+//
+//  URL+Identifiable.swift
+//  Mlem
+//
+//  Created by Nicholas Lawson on 04/06/2023.
+//
+
+import Foundation
+
+extension URL: @retroactive Identifiable {
+    public var id: URL { absoluteURL }
+}
+
+public extension URL {
+    static func post(host: String, id: Int) -> Self {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = "/post/\(id)"
+        return components.url! // This will always succeed
+    }
+    
+    static func comment(host: String, id: Int) -> Self {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = "/comment/\(id)"
+        return components.url! // This will always succeed
+    }
+    
+    static func community(host: String, name: String) -> Self {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = "/c/\(name)"
+        return components.url! // This will always succeed
+    }
+
+    static func person(host: String, name: String) -> Self {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = "/u/\(name)"
+        return components.url! // This will always succeed
+    }
+}
+
+public extension URL {
+    // Spec described here: https://join-lemmy.org/docs/contributors/04-api.html#images
+    func withIconSize(_ size: Int?) -> URL {
+        guard scheme == "http" || scheme == "https" else { return self }
+        guard let size else { return self }
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
+            print("Failed to create URLComponents")
+            return appending(queryItems: [.init(name: "thumbnail", value: String(size))])
+        }
+        var queryItems = components.queryItems ?? []
+        queryItems.removeFirst(where: { $0.name == "thumbnail" })
+        queryItems.append(.init(name: "thumbnail", value: String(size)))
+        components.queryItems = queryItems
+        return components.url ?? self
+    }
+    
+    func removingPathComponents() -> URL {
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = host
+        return components.url!
+    }
+    
+    /// Attempts to extract the underlying loops.video media URL from this URL
+    /// - Returns: loops.video media URL if this is a loops.video url and the underlying URL was successfully parsed, nil otherwise
+    func parseEmbeddedLoops() async -> URL? {
+        // TODO: Pending loops.video maturation
+        // - More reliable way of determining if this is a Loops server
+        // - More robust way of extracting media URL (preferably API support)
+        guard host() == "loops.video" else { return nil }
+        
+        do {
+            let urlRegex = /video-src="(?<url>.*)"/
+            let request: URLRequest = .init(url: self)
+            let (websiteContent, _) = try await URLSession.shared.data(for: request)
+            
+            if let str = String(data: websiteContent, encoding: .utf8),
+               let match = str.firstMatch(of: urlRegex),
+               let loopUrl: URL = .init(string: .init(match.url)) {
+                return loopUrl
+            }
+        } catch {
+            print(error)
+        }
+        return nil
+    }
+    
+    /// Path extension of this URL, taking into account image proxy behavior
+    var proxyAwarePathExtension: String? {
+        var ret = pathExtension
+        
+        // image proxies that use url query param don't have pathExtension so we extract it from the embedded url
+        if ret.isEmpty,
+           let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
+           let queryItems = components.queryItems,
+           let baseUrlString = queryItems.first(where: { $0.name == "url" })?.value,
+           let baseUrl = URL(string: baseUrlString) {
+            ret = baseUrl.pathExtension
+        }
+        
+        return ret.isEmpty ? nil : ret.lowercased()
+    }
+    
+    var isMedia: Bool {
+        if scheme == "mlempreview" { return true }
+        return proxyAwarePathExtension?.isContainedIn(["jpg", "jpeg", "png", "webp", "gif", "mp4"]) ?? false
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URLRequest+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URLRequest+Extensions.swift
@@ -1,0 +1,20 @@
+//
+//  URLRequest+Extensions.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-03.
+//
+// https://stackoverflow.com/questions/34705449/how-to-print-http-request-to-console
+
+import Foundation
+
+extension URLRequest {
+    /// Prints this URLRequest in human-readable form
+    func debug() {
+        print("\(httpMethod!) \(url!)")
+        print("Headers:")
+        print(allHTTPHeaderFields ?? [:])
+        print("Body:")
+        print(String(data: httpBody ?? Data(), encoding: .utf8)!)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Comment/SearchCommentFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Comment/SearchCommentFeedLoader.swift
@@ -1,0 +1,121 @@
+//
+//  SearchCommentFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-01-18.
+//
+
+import Foundation
+
+@Observable
+public class SearchCommentFetcher: Fetcher<Comment2> {
+    public enum SortType {
+        case v4(SearchSortType)
+        case v3(CommentSortType)
+    }
+    
+    public var query: String
+    public var listing: ApiListingType
+    public var sort: SortType
+    public var communityId: Int?
+    public var creatorId: Int?
+    
+    init(
+        api: ApiClient,
+        query: String,
+        communityId: Int?,
+        creatorId: Int?,
+        pageSize: Int,
+        listing: ApiListingType,
+        sort: SortType
+    ) {
+        self.query = query
+        self.communityId = communityId
+        self.creatorId = creatorId
+        self.listing = listing
+        self.sort = sort
+        
+        super.init(api: api, pageSize: pageSize)
+    }
+    
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
+        let comments: [Comment2]
+        switch sort {
+        case let .v4(searchSortType):
+            comments = try await api.searchComments(
+                query: query,
+                page: page,
+                limit: pageSize,
+                communityId: communityId,
+                creatorId: creatorId,
+                filter: listing,
+                sort: searchSortType
+            )
+        case let .v3(commentSortType):
+            comments = try await api.searchComments(
+                query: query,
+                page: page,
+                limit: pageSize,
+                communityId: communityId,
+                creatorId: creatorId,
+                filter: listing,
+                sort: commentSortType
+            )
+        }
+        
+        return .init(
+            items: comments,
+            prevCursor: nil,
+            nextCursor: nil
+        )
+    }
+    
+    public func changeApi(to newApi: ApiClient) async {
+        await super.changeApi(to: newApi, context: .none())
+    }
+}
+
+@Observable
+public class SearchCommentFeedLoader: StandardFeedLoader<Comment2> {
+    public var api: ApiClient
+    
+    // force unwrap because this should ALWAYS be a SearchCommentFetcher
+    public var searchCommentFetcher: SearchCommentFetcher { fetcher as! SearchCommentFetcher }
+    
+    public init(
+        api: ApiClient,
+        query: String = "",
+        communityId: Int? = nil,
+        creatorId: Int? = nil,
+        pageSize: Int = 20,
+        listing: ApiListingType = .all,
+        sort: SearchCommentFetcher.SortType = .v4(.top(.allTime))
+    ) {
+        self.api = api
+
+        super.init(
+            filter: .init(),
+            fetcher: SearchCommentFetcher(
+                api: api,
+                query: query,
+                communityId: communityId,
+                creatorId: creatorId,
+                pageSize: pageSize,
+                listing: listing,
+                sort: sort
+            )
+        )
+    }
+    
+    public func refresh(
+        query: String? = nil,
+        listing: ApiListingType? = nil,
+        sort: SearchCommentFetcher.SortType? = nil,
+        clearBeforeRefresh: Bool = false
+    ) async throws {
+        searchCommentFetcher.query = query ?? searchCommentFetcher.query
+        searchCommentFetcher.listing = listing ?? searchCommentFetcher.listing
+        searchCommentFetcher.sort = sort ?? searchCommentFetcher.sort
+        try await refresh(clearBeforeRefresh: clearBeforeRefresh)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
@@ -1,0 +1,80 @@
+//
+//  CommunityFeedLoader.swift
+//
+//
+//  Created by Sjmarf on 08/09/2024.
+//
+
+import Foundation
+
+@Observable
+class CommunityFetcher: Fetcher<Community2> {
+    var query: String
+    var listing: ApiListingType
+    var sort: SearchSortType
+    
+    init(api: ApiClient, query: String, pageSize: Int, listing: ApiListingType, sort: SearchSortType) {
+        self.query = query
+        self.listing = listing
+        self.sort = sort
+        
+        super.init(api: api, pageSize: pageSize)
+    }
+    
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
+        let communities = try await api.searchCommunities(
+            query: query,
+            page: page,
+            limit: pageSize,
+            filter: listing,
+            sort: sort
+        )
+        
+        return .init(
+            items: communities,
+            prevCursor: nil,
+            nextCursor: nil
+        )
+    }
+}
+
+@Observable
+public class CommunityFeedLoader: StandardFeedLoader<Community2> {
+    public var api: ApiClient
+    
+    // force unwrap because this should ALWAYS be a CommunityFetcher
+    var communityFetcher: CommunityFetcher { fetcher as! CommunityFetcher }
+    
+    public init(
+        api: ApiClient,
+        query: String = "",
+        pageSize: Int = 20,
+        listing: ApiListingType = .all,
+        sort: SearchSortType = .top(.allTime)
+    ) {
+        self.api = api
+
+        super.init(
+            filter: .init(),
+            fetcher: CommunityFetcher(
+                api: api,
+                query: query,
+                pageSize: pageSize,
+                listing: listing,
+                sort: sort
+            )
+        )
+    }
+    
+    public func refresh(
+        query: String? = nil,
+        listing: ApiListingType? = nil,
+        sort: SearchSortType? = nil,
+        clearBeforeRefresh: Bool = false
+    ) async throws {
+        communityFetcher.query = query ?? communityFetcher.query
+        communityFetcher.listing = listing ?? communityFetcher.listing
+        communityFetcher.sort = sort ?? communityFetcher.sort
+        try await refresh(clearBeforeRefresh: clearBeforeRefresh)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterContext.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterContext.swift
@@ -1,0 +1,25 @@
+//
+//  FilterContext.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-12-22.
+//
+
+import Foundation
+
+/// Information required to perform filtering
+public struct FilterContext {
+    public let isAdmin: Bool
+    public let moderatedCommunityActorIds: Set<ActorIdentifier>
+    public let filteredKeywords: Set<String>
+    
+    public init(isAdmin: Bool, moderatedCommunityActorIds: Set<ActorIdentifier>, filteredKeywords: Set<String>) {
+        self.isAdmin = isAdmin
+        self.moderatedCommunityActorIds = moderatedCommunityActorIds
+        self.filteredKeywords = filteredKeywords
+    }
+    
+    static func none() -> FilterContext {
+        .init(isAdmin: true, moderatedCommunityActorIds: [], filteredKeywords: [])
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterProviding.swift
@@ -1,0 +1,25 @@
+//
+//  FilterProviding.swift
+//
+//
+//  Created by Eric Andrews on 2024-05-31.
+//
+
+import Foundation
+
+protocol FilterProviding<FilterTarget> {
+    associatedtype FilterTarget
+    
+    /// Given a list of `FilterTarget`s, returns all members that pass the filter and tracks how many members do not
+    /// - Parameter targets: list of `FilterTarget`s to filter
+    func filter(_ targets: [FilterTarget]) -> [FilterTarget]
+    
+    /// Clears the filter and processes all provided targets
+    /// - Parameter targets: optional list of `FilterTarget`s; if present, these will be filtered and the results returned
+    func reset(with targets: [FilterTarget]?) -> [FilterTarget]
+    
+    /// How many items this filter has caught
+    var numFiltered: Int { get }
+    
+    var active: Bool { get set }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filterable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filterable.swift
@@ -1,0 +1,12 @@
+//
+//  Filterable.swift
+//
+//
+//  Created by Eric Andrews on 2024-06-03.
+//
+
+import Foundation
+
+public protocol Filterable {
+    associatedtype FilterType
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/CommentFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/CommentFilter.swift
@@ -1,0 +1,20 @@
+//
+//  CommentFilter.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-10.
+//
+
+import Foundation
+
+public enum CommentFilterType {
+    case todo
+}
+
+public enum CommunityFilterType {
+    case todo
+}
+
+public enum PersonFilterType {
+    case todo
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/DedupeFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/DedupeFilter.swift
@@ -1,0 +1,28 @@
+//
+//  PostDedupeFilter.swift
+//
+//
+//  Created by Eric Andrews on 2024-05-31.
+//
+
+import Foundation
+
+/// Filter that dedupes ActorIdentifiable items by actorId
+class DedupeFilter<FilterTarget: ActorIdentifiable>: FilterProviding {
+    var numFiltered: Int = 0
+    private var seen: Set<ActorIdentifier> = .init()
+    var active: Bool = true
+    
+    func filter(_ targets: [FilterTarget]) -> [FilterTarget] {
+        let ret = targets.filter { seen.insert($0.actorId).inserted }
+        numFiltered += targets.count - ret.count
+        return ret
+    }
+    
+    func reset(with targets: [FilterTarget]?) -> [FilterTarget] {
+        numFiltered = 0
+        seen = .init()
+        if let targets { return filter(targets) }
+        return .init()
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/InboxDedupeFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/InboxDedupeFilter.swift
@@ -1,0 +1,26 @@
+//
+//  InboxDedupeFilter.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-02-01.
+//
+
+/// Filter that dedupes InboxIdentifiable items by inboxId
+class InboxDedupeFilter<FilterTarget: InboxIdentifiable>: FilterProviding {
+    var numFiltered: Int = 0
+    private var seen: Set<Int> = .init()
+    var active: Bool = true
+    
+    func filter(_ targets: [FilterTarget]) -> [FilterTarget] {
+        let ret = targets.filter { seen.insert($0.inboxId).inserted }
+        numFiltered += targets.count - ret.count
+        return ret
+    }
+    
+    func reset(with targets: [FilterTarget]?) -> [FilterTarget] {
+        numFiltered = 0
+        seen = .init()
+        if let targets { return filter(targets) }
+        return .init()
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostKeywordFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostKeywordFilter.swift
@@ -1,0 +1,44 @@
+//
+//  PostKeywordFilter.swift
+//
+//
+//  Created by Eric Andrews on 2024-06-02.
+//
+
+import Foundation
+
+class PostKeywordFilter: FilterProviding {
+    typealias FilterTarget = Post2
+    
+    var numFiltered: Int = 0
+    private var context: FilterContext
+    var active: Bool = true
+    
+    init(context: FilterContext) {
+        self.context = context
+    }
+    
+    func filter(_ targets: [Post2]) -> [Post2] {
+        let ret = targets.filter(shouldPassFilter)
+        numFiltered += targets.count - ret.count
+        return ret
+    }
+    
+    func reset(with targets: [Post2]?) -> [Post2] {
+        numFiltered = 0
+        if let targets { return filter(targets) }
+        return .init()
+    }
+    
+    /// Returns true if the given post should pass the filter, false otherwise
+    public func shouldPassFilter(_ post: Post2) -> Bool {
+        // bypass filter for moderated/administrated posts
+        if context.isAdmin || context.moderatedCommunityActorIds.contains(post.community.actorId) { return true }
+        
+        return !post.title.failsKeywordFilter(context.filteredKeywords)
+    }
+    
+    func updateFilterContext(to context: FilterContext) {
+        self.context = context
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/ReadFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/ReadFilter.swift
@@ -1,0 +1,25 @@
+//
+//  ReadFilter.swift
+//
+//
+//  Created by Eric Andrews on 2024-05-31.
+//
+
+import Foundation
+
+class ReadFilter<FilterTarget: ReadableProviding>: FilterProviding {
+    var numFiltered: Int = 0
+    var active: Bool = true
+    
+    func filter(_ targets: [FilterTarget]) -> [FilterTarget] {
+        let ret = targets.filter { !$0.read }
+        numFiltered += targets.count - ret.count
+        return ret
+    }
+    
+    func reset(with targets: [FilterTarget]?) -> [FilterTarget] {
+        numFiltered = 0
+        if let targets { return filter(targets) }
+        return .init()
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/UserContentFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/UserContentFilter.swift
@@ -1,6 +1,6 @@
 //
 //  PersonContentFilterType.swift
-//  
+//
 //
 //  Created by Eric Andrews on 2024-07-18.
 //

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/UserContentFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/UserContentFilter.swift
@@ -1,0 +1,12 @@
+//
+//  PersonContentFilterType.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-18.
+//
+
+import Foundation
+
+public enum PersonContentFilterType {
+    case todo
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/UserContentFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/UserContentFilter.swift
@@ -1,6 +1,6 @@
 //
 //  PersonContentFilterType.swift
-//
+//  
 //
 //  Created by Eric Andrews on 2024-07-18.
 //

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/InboxItemFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/InboxItemFilter.swift
@@ -1,0 +1,36 @@
+//
+//  InboxItemFilter.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-12-04.
+//
+
+public enum InboxItemFilterType {
+    case read, dedupe
+}
+
+class InboxItemFilter: MultiFilter<InboxItem> {
+    private var readFilter: ReadFilter<InboxItem>
+    private var dedupeFilter: InboxDedupeFilter<InboxItem> = .init()
+    
+    init(showRead: Bool) {
+        self.readFilter = .init()
+        if showRead {
+            readFilter.active = false
+        }
+    }
+
+    override func allFilters() -> [any FilterProviding<InboxItem>] {
+        [
+            readFilter,
+            dedupeFilter
+        ]
+    }
+    
+    override func getFilter(_ toGet: InboxItemFilterType) -> any FilterProviding<InboxItem> {
+        switch toGet {
+        case .read: readFilter
+        case .dedupe: dedupeFilter
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/ModMailItemFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/ModMailItemFilter.swift
@@ -1,0 +1,36 @@
+//
+//  ModMailItemFilter.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-01-31.
+//
+
+public enum ModMailItemFilterType {
+    case read, dedupe
+}
+
+class ModMailItemFilter: MultiFilter<ModMailItem> {
+    private var readFilter: ReadFilter<ModMailItem>
+    private var dedupeFilter: InboxDedupeFilter<ModMailItem> = .init()
+    
+    init(showRead: Bool) {
+        self.readFilter = .init()
+        if showRead {
+            readFilter.active = false
+        }
+    }
+
+    override func allFilters() -> [any FilterProviding<ModMailItem>] {
+        [
+            readFilter,
+            dedupeFilter
+        ]
+    }
+    
+    override func getFilter(_ toGet: ModMailItemFilterType) -> any FilterProviding<ModMailItem> {
+        switch toGet {
+        case .read: readFilter
+        case .dedupe: dedupeFilter
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/ModlogItemFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/ModlogItemFilter.swift
@@ -1,0 +1,18 @@
+//
+//  ModlogItemFilter.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-28.
+//
+
+import Foundation
+
+public enum ModlogEntryFilterType {}
+
+class ModlogEntryFilter: MultiFilter<ModlogEntry> {
+    override func allFilters() -> [any FilterProviding<ModlogEntry>] {
+        []
+    }
+    
+    override func getFilter(_ toGet: ModlogEntryFilterType) -> any FilterProviding<ModlogEntry> {}
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/MultiFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/MultiFilter.swift
@@ -1,0 +1,71 @@
+//
+//  MultiFilter.swift
+//
+//
+//  Created by Eric Andrews on 2024-06-03.
+//
+
+import Foundation
+
+class MultiFilter<FilterTarget: Filterable> {
+    var numFiltered: Int { allFilters().reduce(0) { $0 + $1.numFiltered } }
+    
+    /// Lists all filters in this MultiFilter. Used internally to iterate over filters and perform filtering logic. This function bridges the gap between the generic behavior, which wants a list of `[any FilterProviding<FilterTarget>]` to use in filtering, and the instantiating class, which is far more ergonomic if filters can be declared as simple member variables.
+    /// - Returns: list of all filters in this MultiFilter
+    func allFilters() -> [any FilterProviding<FilterTarget>] { [] }
+    
+    /// Gets a particular optional filter. Used internally to back the `activate`, `deactivate`, and `filteredCount` methods; as with `allFilters`, used to bridge generic and concrete behavior.
+    /// - Parameter toGet: `OptionalFilters` describing the filter to get
+    /// - Returns: filter corresponding to `toGet`
+    func getFilter(_ toGet: FilterTarget.FilterType) -> any FilterProviding<FilterTarget> {
+        preconditionFailure("This method must be implemented by the instantiating class")
+    }
+    
+    func filter(_ targets: [FilterTarget]) -> [FilterTarget] {
+        var ret: [FilterTarget] = targets
+        for filter in allFilters() where filter.active {
+            ret = filter.filter(ret)
+        }
+        return ret
+    }
+    
+    /// Resets this filter and all its children
+    /// - Parameter targets optional; if present, will immediately re-filter all targets
+    /// - Returns result of filtering targets, if present, otherwise an empty array
+    @discardableResult
+    func reset(with targets: [FilterTarget] = .init()) -> [FilterTarget] {
+        var ret = targets
+        for filter in allFilters() {
+            if filter.active {
+                ret = filter.reset(with: ret)
+            } else {
+                _ = filter.reset(with: nil)
+            }
+        }
+        return ret
+    }
+    
+    /// Activates the given filter
+    /// - Parameter filter: filter to activate
+    /// - Returns: true if the filter was successfully activated, false if it was already active
+    func activate(_ toActivate: FilterTarget.FilterType) -> Bool {
+        var filter = getFilter(toActivate)
+        let ret = !filter.active
+        filter.active = true
+        return ret
+    }
+    
+    /// Deactivates the given filter
+    /// - Parameter filter: filter to deactivate
+    /// - Returns: true if the filter was successfully deactivated, false if it was already inactive
+    func deactivate(_ toDeactivate: FilterTarget.FilterType) -> Bool {
+        var filter = getFilter(toDeactivate)
+        let ret = filter.active
+        filter.active = false
+        return ret
+    }
+    
+    func numFiltered(for filter: FilterTarget.FilterType) -> Int {
+        getFilter(filter).numFiltered
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/PostFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/PostFilter.swift
@@ -1,0 +1,48 @@
+//
+//  PostFilter.swift
+//
+//
+//  Created by Eric Andrews on 2024-05-31.
+//
+
+import Foundation
+
+public enum PostFilterType {
+    case read, dedupe, keyword
+}
+
+class PostFilter: MultiFilter<Post2> {
+    private var readFilter: ReadFilter<Post2>
+    private var dedupeFilter: DedupeFilter<Post2> = .init()
+    private var keywordFilter: PostKeywordFilter
+    
+    init(showRead: Bool, context: FilterContext) {
+        self.keywordFilter = .init(context: context)
+        self.readFilter = .init()
+        if showRead {
+            readFilter.active = false
+        }
+    }
+
+    override func allFilters() -> [any FilterProviding<Post2>] {
+        [
+            readFilter,
+            dedupeFilter,
+            keywordFilter
+        ]
+    }
+    
+    override func getFilter(_ toGet: PostFilterType) -> any FilterProviding<Post2> {
+        switch toGet {
+        case .read: readFilter
+        case .dedupe: dedupeFilter
+        case .keyword: keywordFilter
+        }
+    }
+    
+    // MARK: Custom Behavior
+    
+    func updateContext(to context: FilterContext) {
+        keywordFilter.updateFilterContext(to: context)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/ChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/ChildFeedLoader.swift
@@ -1,0 +1,81 @@
+//
+//  ChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-24.
+//
+
+/// Helper class bundling a parent feed loader and a position in a ChildFeedLoader's item list
+class FeedLoaderStream {
+    weak var parent: (any FeedLoading)?
+    var cursor: Int
+    
+    init(parent: (any FeedLoading)? = nil) {
+        self.parent = parent
+        self.cursor = 0
+    }
+}
+
+public class ChildFeedLoader<Item: FeedLoadable>: StandardFeedLoader<Item> {
+    var stream: FeedLoaderStream?
+    var sortType: FeedLoaderSort.SortType
+    
+    init(filter: MultiFilter<Item>, fetcher: Fetcher<Item>, sortType: FeedLoaderSort.SortType) {
+        self.sortType = sortType
+        
+        super.init(filter: filter, fetcher: fetcher)
+    }
+    
+    public func setParent(parent: any FeedLoading<Item>) {
+        stream = .init(parent: parent)
+    }
+    
+    public func nextItemSortVal(sortType: FeedLoaderSort.SortType) async throws -> FeedLoaderSort? {
+        assert(sortType == self.sortType, "Conflicting types for sortType! This will lead to unexpected sorting behavior.")
+        
+        guard let stream, stream.parent != nil else {
+            print("[\(Self.self)] could not find stream or parent")
+            return nil
+        }
+        
+        if stream.cursor < items.count {
+            return items[safeIndex: stream.cursor]?.sortVal(sortType: sortType)
+        } else {
+            if loadingState == .done {
+                print("[\(Self.self)] done loading")
+                return nil
+            }
+            
+            print("[\(Self.self)] out of items (\(items.count)), loading more")
+            try await loadMoreItems()
+            
+            if stream.cursor >= items.count {
+                // NOTE: this assertion can sometimes be tripped by spamming the filter button
+                assert(loadingState == .done, "[\(Item.self) ChildFeedLoader] Invalid loading state \(loadingState)")
+                return nil
+            }
+            
+            print("[\(Self.self)] fetched more items (\(items.count))")
+            return items[stream.cursor].sortVal(sortType: sortType)
+        }
+    }
+    
+    public func consumeNextItem() -> Item? {
+        guard let stream, stream.parent != nil else {
+            assertionFailure("[\(Item.self)] could not find stream or parent")
+            return nil
+        }
+        
+        stream.cursor += 1
+        return items[safeIndex: stream.cursor - 1]
+    }
+    
+    public func clear(clearParent: Bool) async {
+        if clearParent {
+            await stream?.parent?.clear()
+        }
+        
+        stream?.cursor = 0
+        await super.clear()
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoaderItem.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoaderItem.swift
@@ -1,0 +1,15 @@
+//
+//  FeedLoadable.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-10-15.
+//
+
+import Foundation
+
+public protocol FeedLoadable: Filterable, Equatable {
+    associatedtype FilterType
+    var api: ApiClient { get }
+    
+    func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoaderSort.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoaderSort.swift
@@ -1,0 +1,49 @@
+//
+//  FeedLoaderSort.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-10-15.
+//
+import Foundation
+
+public enum FeedLoaderSort: Comparable {
+    case new(Date)
+    
+    public enum SortType {
+        case new
+    }
+}
+
+public extension FeedLoaderSort {
+    var sortType: FeedLoaderSort.SortType {
+        switch self {
+        case .new: .new
+        }
+    }
+    
+    var apiType: ApiSortType {
+        switch self {
+        case .new: .new
+        }
+    }
+    
+    func typeEquals(lhs: FeedLoaderSort, rhs: FeedLoaderSort) -> Bool {
+        lhs.sortType == rhs.sortType
+    }
+    
+    /// Compares two FeedLoaderSorts. Returns true if rhs should be sorted after lhs. Assumes that higher items should be sorted first; thus for some sorts (e.g., "old"), the result will be "flipped," since _lower_ dates should be sorted ahead of higher ones.
+    static func < (lhs: FeedLoaderSort, rhs: FeedLoaderSort) -> Bool {
+        guard lhs.sortType == rhs.sortType else {
+            assertionFailure("Compare called on TrackerSorts with different types")
+            return true
+        }
+        
+        switch lhs {
+        case let .new(lhsDate):
+            switch rhs {
+            case let .new(rhsDate):
+                return lhsDate < rhsDate
+            }
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoading.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoading.swift
@@ -1,0 +1,25 @@
+//
+//  FeedLoading.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-05.
+//
+
+import Foundation
+
+public protocol FeedLoading<Item>: AnyObject {
+    associatedtype Item: FeedLoadable
+    
+    var items: [Item] { get }
+    var loadingState: LoadingState { get }
+    
+    func loadMoreItems() async throws
+    func loadIfThreshold(_ item: Item) throws
+    func refresh(clearBeforeRefresh: Bool) async throws
+    func clear() async
+    func changeApi(to newApi: ApiClient, context: FilterContext) async
+    
+    /// Adds the given item to the beginning of the items array, regardless of whether it should be filtered
+    /// - Warning: when using this method with multi-feed loaders, you must call this on both the parent loader and the relevant child loader!
+    func prependItem(_ newItem: Item)
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoadingState.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoadingState.swift
@@ -1,0 +1,15 @@
+//
+//  FeedLoadingState.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-10-12.
+//
+import Foundation
+
+/// Enum of possible loading states that a loader can be in.
+/// - idle: not currently loading, but more items available to load
+/// - loading: currently loading more items
+/// - done: no more items available to load
+public enum LoadingState: Hashable {
+    case idle, loading, done
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/Fetcher.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/Fetcher.swift
@@ -1,0 +1,115 @@
+//
+//  Fetcher.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-17.
+//
+
+import Observation
+
+enum LoadingResponse<Item: FeedLoadable> {
+    /// Indicates a successful load with more items available to fetch
+    case success([Item])
+    
+    /// Indicates a successful load with no more items available to fetch
+    case done([Item])
+    
+    /// Indicates the load was ignored due to an existing ongoing load
+    case ignored
+    
+    /// Indicates the load was cancelled
+    case cancelled
+    
+    var description: String {
+        switch self {
+        case let .success(items): "success (\(items.count))"
+        case let .done(items): "done (\(items.count))"
+        case .ignored: "ignored"
+        case .cancelled: "cancelled"
+        }
+    }
+}
+
+@Observable
+public class Fetcher<Item: FeedLoadable> {
+    internal(set) var api: ApiClient
+    var pageSize: Int
+    var page: Int
+    private var cursor: String?
+    
+    init(api: ApiClient, pageSize: Int, page: Int = 0) {
+        self.api = api
+        self.pageSize = pageSize
+        self.page = page
+    }
+    
+    /// Helper struct bundling the response from a fetchPage or fetchCursor call
+    struct FetchResponse {
+        /// Items returned
+        public let items: [Item]
+        
+        /// Cursor used to fetch this response, if applicable
+        public let prevCursor: String?
+        
+        /// New cursor, if applicable
+        public let nextCursor: String?
+    }
+    
+    /// Fetches the next page of items
+    func fetch() async throws -> LoadingResponse<Item> {
+        do {
+            if let cursor, page > 0 {
+                print("[\(Item.self) Fetcher] loading cursor \(cursor)")
+                let response = try await fetchCursor(cursor)
+                
+                // if same cursor returned, loading is finished
+                if response.nextCursor == self.cursor {
+                    return .done(response.items)
+                }
+                
+                self.cursor = response.nextCursor
+                return .success(response.items)
+            } else {
+                page += 1
+                print("[\(Item.self) Fetcher] loading page \(page)")
+                let response = try await fetchPage(page)
+                
+                // if nothing returned, loading is finished
+                if response.items.count < pageSize {
+                    print("[\(Item.self) Fetcher] received undersized page (\(response.items.count)/\(pageSize))")
+                    return .done(response.items)
+                }
+                cursor = response.nextCursor
+                return .success(response.items)
+            }
+        } catch is CancellationError {
+            return .cancelled
+        }
+    }
+    
+    /// Fetches the given page of items.
+    /// - Parameters:
+    ///   - page: page number to fetch
+    /// - Returns: tuple of the requested page of items, the cursor returned by the API call (if present), and the number of items that were filtered out.
+    func fetchPage(_ page: Int) async throws -> FetchResponse {
+        preconditionFailure("This method must be implemented by the inheriting class")
+    }
+    
+    /// Fetches items from the given cursor.
+    /// - Parameters:
+    ///   - cursor: cursor to fetch
+    /// - Returns: tuple of the requested page of items, the cursor returned by the API call (if present), and the number of items that were filtered out.
+    func fetchCursor(_ cursor: String) async throws -> FetchResponse {
+        preconditionFailure("This method must be implemented by the inheriting class")
+    }
+    
+    /// Resets the fetcher's page and cursor tracking. This method should only be overridden to handle abnormal pagination behavior (e.g., PersonContentFetcher); it should NOT change loading parameters such as query or sort.
+    func reset() async {
+        page = 0
+        cursor = nil
+    }
+    
+    func changeApi(to newApi: ApiClient, context: FilterContext) async {
+        api = newApi
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -1,0 +1,114 @@
+//
+//  LoadingActor.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-10-27.
+//
+
+import Foundation
+
+enum LoadingError: Error {
+    case noTask
+}
+
+actor LoadingActor<Item: FeedLoadable> {
+    private var done: Bool = false
+    private var loadingTask: Task<Void, Error>?
+    var filter: MultiFilter<Item>
+  
+    private var fetcher: Fetcher<Item>
+    
+    public init(fetcher: Fetcher<Item>, filter: MultiFilter<Item>) {
+        self.fetcher = fetcher
+        self.filter = filter
+    }
+    
+    /// Cancels any ongoing loading and resets the page/cursor to 0
+    func reset() async {
+        loadingTask?.cancel()
+        loadingTask = nil
+        filter.reset()
+        await fetcher.reset()
+        done = false
+    }
+    
+    /// Loads the next page of items.
+    /// - Returns: on success, .success with FetchResponse containing loaded items; if another load is underway, .ignored; if the load is cancelled, .cancelled
+    func load(_ callback: @escaping (LoadingResponse<Item>) async -> Void) async throws {
+        guard !done else {
+            print("[\(Self.self)] ignoring request, finished loading")
+            return
+        }
+        
+        // if already loading something, ignore the request
+        if let loadingTask {
+            print("[\(Self.self)] ignoring request, load underway")
+            // return .ignored
+            _ = try await loadingTask.result.get()
+            print("[\(Self.self)] preexisting load finished, returning")
+            return
+        }
+        
+        // upon completion of load, remove loading task
+        defer { loadingTask = nil }
+        
+        loadingTask = Task<Void, Error> {
+            let response = try await fetchMoreItems()
+            await callback(response)
+        }
+        
+        guard let loadingTask else {
+            assertionFailure("loadingTask is nil!")
+            throw LoadingError.noTask
+        }
+        
+        _ = try await loadingTask.result.get()
+        print("[\(Self.self)] finished loading")
+    }
+    
+    @discardableResult
+    func filterItem(_ target: Item) -> Item? {
+        let filtered = filter.filter([target])
+        return filtered.first
+    }
+    
+    func activateFilter(_ target: Item.FilterType, callback: () async throws -> Void) async throws {
+        loadingTask?.cancel()
+        loadingTask = nil
+        if filter.activate(target) {
+            try await callback()
+        }
+    }
+    
+    func deactivateFilter(_ target: Item.FilterType, callback: () async throws -> Void) async throws {
+        loadingTask?.cancel()
+        loadingTask = nil
+        if filter.deactivate(target) {
+            try await callback()
+        }
+    }
+    
+    // MARK: Helpers
+    
+    private func fetchMoreItems() async throws -> LoadingResponse<Item> {
+        var newItems: [Item] = .init()
+        fetchLoop: repeat {
+            let response = try await fetcher.fetch()
+            
+            switch response {
+            case let .success(items):
+                print("[\(Self.self)] received success (\(items.count))")
+                newItems.append(contentsOf: filter.filter(items))
+            case let .done(items):
+                print("[\(Self.self)] received finished (\(items.count))")
+                newItems.append(contentsOf: filter.filter(items))
+                return .done(newItems)
+            case .cancelled, .ignored:
+                print("[\(Self.self)] load did not complete (\(response.description))")
+                break fetchLoop
+            }
+        } while newItems.count < MiddlewareConstants.infiniteLoadThresholdOffset
+
+        return .success(newItems)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
@@ -1,0 +1,84 @@
+//
+//  MultiFetcher.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-24.
+//
+
+import Observation
+
+@Observable
+class MultiFetcher<Item: FeedLoadable>: Fetcher<Item> {
+    var sources: [ChildFeedLoader<Item>]
+    var sortType: FeedLoaderSort.SortType
+    
+    init(api: ApiClient, pageSize: Int, sources: [ChildFeedLoader<Item>], sortType: FeedLoaderSort.SortType) {
+        self.sources = sources
+        self.sortType = sortType
+        
+        super.init(api: api, pageSize: pageSize)
+    }
+    
+    override func fetch() async throws -> LoadingResponse<Item> {
+        var newItems: [Item] = .init()
+        
+        while newItems.count < pageSize {
+            if let nextItem = try await computeNextItem() {
+                newItems.append(nextItem)
+            } else {
+                print("[\(Self.self)] no next item found")
+                return .done(newItems)
+            }
+        }
+        
+        return .success(newItems)
+    }
+    
+    override func reset() async {
+        for source in sources {
+            await source.clear(clearParent: false)
+            print("[\(Self.self)] source cleared (\(source.loadingState))")
+        }
+        
+        await super.reset()
+    }
+    
+    /// Computes and returns the highest sorted item from the tops of all sources
+    private func computeNextItem() async throws -> Item? {
+        var sortVal: FeedLoaderSort?
+        var sourceToConsume: ChildFeedLoader<Item>?
+        
+        // find the highest-sorted item from the tops of all sources
+        for source in sources {
+            (sortVal, sourceToConsume) = try await compareNextItem(lhsVal: sortVal, lhsSource: sourceToConsume, rhsSource: source)
+        }
+        
+        return sourceToConsume?.consumeNextItem()
+    }
+    
+    private func compareNextItem(
+        lhsVal: FeedLoaderSort?,
+        lhsSource: ChildFeedLoader<Item>?,
+        rhsSource: ChildFeedLoader<Item>
+    ) async throws -> (FeedLoaderSort?, ChildFeedLoader<Item>?) {
+        // if no next item on rhs, return lhs (even if null)
+        guard let rhsVal = try await rhsSource.nextItemSortVal(sortType: sortType) else {
+            return (lhsVal, lhsSource)
+        }
+        
+        // if no lhsVal, rhs next by default
+        guard let lhsVal else {
+            return (rhsVal, rhsSource)
+        }
+        
+        return lhsVal > rhsVal ? (lhsVal, lhsSource) : (rhsVal, rhsSource)
+    }
+    
+    override func changeApi(to newApi: ApiClient, context: FilterContext) async {
+        for source in sources {
+            await source.changeApi(to: newApi, context: context)
+        }
+        
+        await super.changeApi(to: newApi, context: context)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/PrefetchingFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/PrefetchingFeedLoader.swift
@@ -1,0 +1,45 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-25.
+//
+
+import Foundation
+import Nuke
+import Observation
+
+@Observable
+public class PrefetchingFeedLoader<Item: ImagePrefetchProviding & FeedLoadable>: StandardFeedLoader<Item> {
+    public private(set) var prefetchingConfiguration: PrefetchingConfiguration
+
+    init(
+        filter: MultiFilter<Item>,
+        prefetchingConfiguration: PrefetchingConfiguration,
+        fetcher: Fetcher<Item>
+    ) {
+        self.prefetchingConfiguration = prefetchingConfiguration
+        
+        super.init(
+            filter: filter,
+            fetcher: fetcher
+        )
+    }
+  
+    override func processNewItems(_ items: [Item]) {
+        prefetchImages(items)
+    }
+
+    private func prefetchImages(_ items: [Item]) {
+        Task {
+            await prefetchingConfiguration.prefetcher.startPrefetching(with: items.concurrentFlatMap { item -> [ImageRequest] in
+                await item.imageRequests(configuration: self.prefetchingConfiguration)
+            })
+        }
+    }
+    
+    public func setPrefetchingConfiguration(_ config: PrefetchingConfiguration) {
+        prefetchingConfiguration = config
+        prefetchImages(items)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -1,0 +1,164 @@
+//
+//  StandardFeedLoader.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2023-10-15.
+//
+
+import Foundation
+import Observation
+import Semaphore
+
+@Observable
+public class StandardFeedLoader<Item: FeedLoadable>: FeedLoading {
+    public internal(set) var items: [Item] = .init()
+    public internal(set) var loadingState: LoadingState = .loading
+    private(set) var thresholds: Thresholds<Item> = .init()
+    
+    let fetcher: Fetcher<Item>
+    var loadingActor: LoadingActor<Item>
+
+    init(filter: MultiFilter<Item>, fetcher: Fetcher<Item>) {
+        self.fetcher = fetcher
+        self.loadingActor = .init(fetcher: fetcher, filter: filter)
+    }
+
+    // MARK: - State Modification Methods
+    
+    /// Updates the loading state
+    @MainActor
+    func setLoading(_ newState: LoadingState) {
+        loadingState = newState
+        print("[\(Self.self)] set loading state to \(newState)")
+    }
+    
+    /// Sets the items to a new array
+    @MainActor
+    func setItems(_ newItems: [Item]) {
+        processNewItems(newItems)
+        items = newItems
+        thresholds.update(with: newItems)
+    }
+    
+    /// Adds the given items to the items array
+    /// - Parameter toAdd: items to add
+    @MainActor
+    func addItems(_ newItems: [Item]) async {
+        processNewItems(newItems)
+        items.append(contentsOf: newItems)
+        thresholds.update(with: newItems)
+    }
+    
+    @MainActor
+    public func prependItem(_ newItem: Item) {
+        items.prepend(newItem)
+        
+        // filter the item on a background thread for deduping
+        Task {
+            await loadingActor.filterItem(newItem)
+        }
+    }
+    
+    // MARK: - External methods
+
+    /// If the given item is the loading threshold item, loads more content
+    /// This should be called as an .onAppear of every item in a feed that should support infinite scrolling
+    public func loadIfThreshold(_ item: Item) throws {
+        if loadingState == .idle, thresholds.isThreshold(item) {
+            // this is a synchronous function that wraps the loading as a task so that the task is attached to the loader itself, not the view that calls it, and is therefore safe from being cancelled by view redraws
+            Task(priority: .userInitiated) {
+                try await loadMoreItems()
+            }
+        }
+    }
+    
+    /// Loads the next page of items. Returns when more items have been added to the items array or loading is complete, even
+    /// if called while another load is underway
+    public func loadMoreItems() async throws {
+        try await loadMoreItems(overwriteExistingItems: false)
+    }
+    
+    /// Internal loadMoreItems() that allows overwriting existing items, used to back refresh
+    func loadMoreItems(overwriteExistingItems: Bool) async throws {
+        await setLoading(.loading)
+  
+        try await loadingActor.load { response in
+            var newItems: [Item]?
+            var newState: LoadingState
+            
+            switch response {
+            case let .success(items):
+                newItems = items
+                newState = items.count > 0 ? .idle : .done
+            case let .done(items):
+                newItems = items
+                newState = .done
+            case .ignored, .cancelled:
+                print("[\(Self.self)] load did not complete (\(response.description))")
+                newState = .idle
+            }
+            
+            if let newItems {
+                if overwriteExistingItems {
+                    await self.setItems(newItems)
+                } else {
+                    await self.addItems(newItems)
+                }
+            }
+            
+            await self.setLoading(newState)
+            print("[\(Self.self)] loadMoreItems complete")
+        }
+    }
+    
+    public func refresh(clearBeforeRefresh: Bool) async throws {
+        await setLoading(.loading)
+        
+        if clearBeforeRefresh {
+            await setItems(.init())
+        }
+        
+        await loadingActor.reset()
+    
+        try await loadMoreItems(overwriteExistingItems: true)
+    }
+
+    public func clear() async {
+        await loadingActor.reset()
+        await setItems(.init())
+        await setLoading(.idle)
+    }
+    
+    /// Helper function to perform custom post-fetch processing (e.g., prefetching). Override to implement desired behavior.
+    func processNewItems(_ items: [Item]) {}
+    
+    /// Adds a filter to the tracker, removing all current items that do not pass the filter and filtering out all future items that do not pass the filter.
+    /// Use in situations where filtering is handled client-side (e.g., keywords)
+    /// - Parameter newFilter: Item.FilterType describing the filter to apply
+    public func activateFilter(_ target: Item.FilterType) async throws {
+        try await loadingActor.activateFilter(target) {
+            await setItems(loadingActor.filter.reset(with: items))
+            
+            if items.isEmpty {
+                try await refresh(clearBeforeRefresh: false)
+            } else if thresholds.fallback == nil {
+                // if too few items are present after filtering to trigger threshold loading, initiate new load
+                try await loadMoreItems()
+            }
+        }
+    }
+    
+    public func deactivateFilter(_ target: Item.FilterType) async throws {
+        try await loadingActor.deactivateFilter(target) {
+            try await refresh(clearBeforeRefresh: true)
+        }
+    }
+    
+    public func getFilteredCount(for toCount: Item.FilterType) async -> Int {
+        await loadingActor.filter.numFiltered(for: toCount)
+    }
+    
+    public func changeApi(to newApi: ApiClient, context: FilterContext) async {
+        await fetcher.changeApi(to: newApi, context: context)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Helpers/Thresholds.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Helpers/Thresholds.swift
@@ -1,0 +1,27 @@
+//
+//  Thresholds.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-22.
+//
+
+import Foundation
+
+struct Thresholds<Item: FeedLoadable> {
+    var standard: Item?
+    var fallback: Item?
+    
+    func isThreshold(_ item: Item) -> Bool {
+        item == standard || item == fallback
+    }
+    
+    mutating func update(with newItems: [Item]) {
+        if newItems.count < MiddlewareConstants.infiniteLoadThresholdOffset {
+            standard = nil
+            fallback = nil
+        } else {
+            standard = newItems[newItems.count - MiddlewareConstants.infiniteLoadThresholdOffset]
+            fallback = newItems.last
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxChildFeedLoader.swift
@@ -6,7 +6,6 @@
 //
 
 public class InboxChildFeedLoader: ChildFeedLoader<InboxItem> {
-    
     var inboxFetcher: InboxFetcher { fetcher as! InboxFetcher }
     
     public init(api: ApiClient, sortType: FeedLoaderSort.SortType, fetcher: InboxFetcher, showRead: Bool) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxChildFeedLoader.swift
@@ -6,6 +6,7 @@
 //
 
 public class InboxChildFeedLoader: ChildFeedLoader<InboxItem> {
+    
     var inboxFetcher: InboxFetcher { fetcher as! InboxFetcher }
     
     public init(api: ApiClient, sortType: FeedLoaderSort.SortType, fetcher: InboxFetcher, showRead: Bool) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxChildFeedLoader.swift
@@ -1,0 +1,32 @@
+//
+//  InboxChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-12-04.
+//
+
+public class InboxChildFeedLoader: ChildFeedLoader<InboxItem> {
+    var inboxFetcher: InboxFetcher { fetcher as! InboxFetcher }
+    
+    public init(api: ApiClient, sortType: FeedLoaderSort.SortType, fetcher: InboxFetcher, showRead: Bool) {
+        super.init(filter: InboxItemFilter(showRead: showRead), fetcher: fetcher, sortType: sortType)
+    }
+    
+    func hideRead() async throws {
+        try await loadingActor.activateFilter(.read) {
+            await setItems(loadingActor.filter.reset(with: items))
+            inboxFetcher.hideRead(unreadCount: items.count)
+            
+            if items.isEmpty {
+                try await refresh(clearBeforeRefresh: false)
+            }
+        }
+    }
+    
+    func showRead() async throws {
+        try await loadingActor.deactivateFilter(.read) {
+            inboxFetcher.showRead()
+            try await refresh(clearBeforeRefresh: true)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxFeedLoader.swift
@@ -1,0 +1,98 @@
+//
+//  InboxFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-27.
+//
+
+import Foundation
+
+public class InboxFeedLoader: StandardFeedLoader<InboxItem> {
+    var inboxFetcher: MultiFetcher<InboxItem> { fetcher as! MultiFetcher }
+    
+    public init(api: ApiClient, pageSize: Int, sources: [ChildFeedLoader<InboxItem>], sortType: FeedLoaderSort.SortType, showRead: Bool) {
+        super.init(filter: InboxItemFilter(showRead: showRead), fetcher: MultiFetcher(api: api, pageSize: pageSize, sources: sources, sortType: sortType))
+        
+        for source in sources {
+            source.setParent(parent: self)
+        }
+    }
+    
+    public static func setup(
+        api: ApiClient,
+        pageSize: Int,
+        sortType: FeedLoaderSort.SortType,
+        showRead: Bool
+    ) -> (
+        replyFeedLoader: ReplyChildFeedLoader,
+        mentionFeedLoader: MentionChildFeedLoader,
+        messageFeedLoader: MessageChildFeedLoader,
+        inboxFeedLoader: InboxFeedLoader
+    ) {
+        let replyFeedLoader: ReplyChildFeedLoader = .init(
+            api: api,
+            pageSize: pageSize,
+            sortType: sortType,
+            showRead: showRead
+        )
+        let mentionFeedLoader: MentionChildFeedLoader = .init(
+            api: api,
+            pageSize: pageSize,
+            sortType: sortType,
+            showRead: showRead
+        )
+        let messageFeedLoader: MessageChildFeedLoader = .init(
+            api: api,
+            pageSize: pageSize,
+            sortType: sortType,
+            showRead: showRead
+        )
+        
+        let inboxFeedLoader: InboxFeedLoader = .init(
+            api: api,
+            pageSize: pageSize,
+            sources: [replyFeedLoader, mentionFeedLoader, messageFeedLoader],
+            sortType: sortType,
+            showRead: showRead
+        )
+        
+        return (
+            replyFeedLoader,
+            mentionFeedLoader,
+            messageFeedLoader,
+            inboxFeedLoader
+        )
+    }
+    
+    public func hideRead() async throws {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            for source in inboxFetcher.sources {
+                group.addTask {
+                    guard let childSource = source as? InboxChildFeedLoader else {
+                        assertionFailure("Child is not InboxChildFeedLoader")
+                        return
+                    }
+                    try await childSource.hideRead()
+                }
+            }
+        }
+        
+        try await activateFilter(.read)
+    }
+    
+    public func showRead() async throws {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            for source in inboxFetcher.sources {
+                group.addTask {
+                    guard let childSource = source as? InboxChildFeedLoader else {
+                        assertionFailure("Child is not InboxChildFeedLoader")
+                        return
+                    }
+                    try await childSource.showRead()
+                }
+            }
+        }
+
+        try await deactivateFilter(.read)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxFetcher.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxFetcher.swift
@@ -1,0 +1,40 @@
+//
+//  InboxFetcher.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-24.
+//
+
+import Foundation
+
+@Observable
+public class InboxFetcher: Fetcher<InboxItem> {
+    var unreadOnly: Bool
+    
+    init(api: ApiClient, pageSize: Int, unreadOnly: Bool) {
+        self.unreadOnly = unreadOnly
+        super.init(api: api, pageSize: pageSize)
+    }
+    
+    /// Updates fetching behavior to hide read items. Assumes items will NOT be cleared from the associated FeedLoader and that deduping will be handled by that FeedLoader.
+    /// - Parameter unreadCount: number of unread items still present after client-side filtering
+    func hideRead(unreadCount: Int) {
+        guard !unreadOnly else {
+            assertionFailure("Cannot hide read (unreadOnly already true)")
+            return
+        }
+        
+        unreadOnly = true
+        page = Int(floor(Double(unreadCount / pageSize)))
+    }
+    
+    /// Updates fetching behavior to show read posts. Assumes associated FeedLoader will immediately perform a refresh.
+    func showRead() {
+        guard unreadOnly else {
+            assertionFailure("Cannot show read (unreadOnly already false)")
+            return
+        }
+        
+        unreadOnly = false
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxItem.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/InboxItem.swift
@@ -1,0 +1,39 @@
+//
+//  InboxItem.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-02-01.
+//
+
+public enum InboxItem: FeedLoadable, ReadableProviding, InboxIdentifiable {
+    public typealias FilterType = InboxItemFilterType
+    
+    case message(Message2)
+    case reply(Reply2)
+    
+    var baseValue: any FeedLoadable & ActorIdentifiable {
+        switch self {
+        case let .message(message2): message2
+        case let .reply(reply2): reply2
+        }
+    }
+    
+    public var read: Bool {
+        switch self {
+        case let .message(message2): message2.read
+        case let .reply(reply2): reply2.read
+        }
+    }
+    
+    public var api: ApiClient { baseValue.api }
+    
+    public func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        baseValue.sortVal(sortType: sortType)
+    }
+    
+    public var inboxId: Int {
+        var hasher: Hasher = .init()
+        hasher.combine(baseValue.actorId)
+        return hasher.finalize()
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MentionChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MentionChildFeedLoader.swift
@@ -1,0 +1,32 @@
+//
+//  MentionChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-12-02.
+//
+
+public class MentionChildFeedLoader: InboxChildFeedLoader {
+    class Fetcher: InboxFetcher {
+        override func fetchPage(_ page: Int) async throws -> FetchResponse {
+            let response = try await api.getMentions(page: page, limit: pageSize)
+            return .init(
+                items: response.map { .reply($0) },
+                prevCursor: nil,
+                nextCursor: nil
+            )
+        }
+    }
+    
+    public init(api: ApiClient, pageSize: Int, sortType: FeedLoaderSort.SortType, showRead: Bool) {
+        super.init(
+            api: api,
+            sortType: sortType,
+            fetcher: Fetcher(
+                api: api,
+                pageSize: pageSize,
+                unreadOnly: !showRead
+            ),
+            showRead: showRead
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MessageChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MessageChildFeedLoader.swift
@@ -1,0 +1,32 @@
+//
+//  MessageChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-26.
+//
+
+public class MessageChildFeedLoader: InboxChildFeedLoader {
+    class Fetcher: InboxFetcher {
+        override func fetchPage(_ page: Int) async throws -> FetchResponse {
+            let response = try await api.getMessages(page: page, limit: pageSize, unreadOnly: unreadOnly)
+            return .init(
+                items: response.map { .message($0) },
+                prevCursor: nil,
+                nextCursor: nil
+            )
+        }
+    }
+
+    public init(api: ApiClient, pageSize: Int, sortType: FeedLoaderSort.SortType, showRead: Bool) {
+        super.init(
+            api: api,
+            sortType: sortType,
+            fetcher: Fetcher(
+                api: api,
+                pageSize: pageSize,
+                unreadOnly: !showRead
+            ),
+            showRead: showRead
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MessageFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MessageFeedLoader.swift
@@ -1,0 +1,77 @@
+//
+//  MessageFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-22.
+//
+
+import Foundation
+
+@Observable
+class MessageFetcher: Fetcher<Message2> {
+    var personId: Int?
+    
+    init(api: ApiClient, personId: Int?, pageSize: Int) {
+        self.personId = personId
+        
+        super.init(api: api, pageSize: pageSize)
+    }
+    
+    convenience init(person: any Person, pageSize: Int) {
+        self.init(api: person.api, personId: person.id, pageSize: pageSize)
+    }
+    
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
+        let messages = try await api.getMessages(
+            creatorId: personId,
+            page: page,
+            limit: pageSize
+        )
+        
+        return .init(
+            items: messages,
+            prevCursor: nil,
+            nextCursor: nil
+        )
+    }
+}
+
+@Observable
+public class MessageFeedLoader: StandardFeedLoader<Message2> {
+    public var api: ApiClient
+
+    // force unwrap because this should ALWAYS be a MessageFetcher
+    var messageFetcher: MessageFetcher { fetcher as! MessageFetcher }
+
+    public init(
+        api: ApiClient,
+        personId: Int?,
+        pageSize: Int = 20
+    ) {
+        self.api = api
+
+        super.init(
+            filter: .init(),
+            fetcher: MessageFetcher(
+                api: api,
+                personId: personId,
+                pageSize: pageSize
+            )
+        )
+    }
+    
+    public init(
+        person: any Person,
+        pageSize: Int = 20
+    ) {
+        self.api = person.api
+
+        super.init(
+            filter: .init(),
+            fetcher: MessageFetcher(
+                person: person,
+                pageSize: pageSize
+            )
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/ReplyChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/ReplyChildFeedLoader.swift
@@ -1,0 +1,32 @@
+//
+//  ReplyChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-27.
+//
+
+public class ReplyChildFeedLoader: InboxChildFeedLoader {
+    class Fetcher: InboxFetcher {
+        override func fetchPage(_ page: Int) async throws -> FetchResponse {
+            let response = try await api.getReplies(page: page, limit: pageSize, unreadOnly: unreadOnly)
+            return .init(
+                items: response.map { .reply($0) },
+                prevCursor: nil,
+                nextCursor: nil
+            )
+        }
+    }
+
+    public init(api: ApiClient, pageSize: Int, sortType: FeedLoaderSort.SortType, showRead: Bool) {
+        super.init(
+            api: api,
+            sortType: sortType,
+            fetcher: Fetcher(
+                api: api,
+                pageSize: pageSize,
+                unreadOnly: !showRead
+            ),
+            showRead: showRead
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoading.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoading.swift
@@ -1,0 +1,11 @@
+//
+//  InboxFeedLoading.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-02-01.
+//
+
+protocol InboxFeedLoading: FeedLoading {
+    func showRead() async throws
+    func hideRead() async throws
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxIdentifiable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxIdentifiable.swift
@@ -1,0 +1,11 @@
+//
+//  InboxIdentifiable.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-02-01.
+//
+
+public protocol InboxIdentifiable: Equatable {
+    /// Identifier suitable for uniquely distinguishing inbox items from each other
+    var inboxId: Int { get }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ApplicationChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ApplicationChildFeedLoader.swift
@@ -1,0 +1,38 @@
+//
+//  ApplicationChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-12-02.
+//
+
+public class ApplicationChildFeedLoader: ModMailChildFeedLoader {
+    class Fetcher: ModMailFetcher {
+        override func fetchPage(_ page: Int) async throws -> FetchResponse {
+            guard api.isAdmin else { return .init(items: [], prevCursor: nil, nextCursor: nil) }
+            
+            do {
+                let response = try await api.getRegistrationApplications(page: page, limit: pageSize, unreadOnly: unreadOnly)
+                return .init(
+                    items: response.map { .application($0) },
+                    prevCursor: nil,
+                    nextCursor: nil
+                )
+            } catch let ApiClientError.response(response, _) where response.notAdmin {
+                return .init(items: .init(), prevCursor: nil, nextCursor: nil)
+            }
+        }
+    }
+    
+    public init(api: ApiClient, pageSize: Int, sortType: FeedLoaderSort.SortType, showRead: Bool) {
+        super.init(
+            api: api,
+            sortType: sortType,
+            fetcher: Fetcher(
+                api: api,
+                pageSize: pageSize,
+                unreadOnly: !showRead
+            ),
+            showRead: showRead
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/CommentReportChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/CommentReportChildFeedLoader.swift
@@ -1,0 +1,36 @@
+//
+//  CommentReportChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-26.
+//
+
+public class CommentReportChildFeedLoader: ModMailChildFeedLoader {
+    class Fetcher: ModMailFetcher {
+        override func fetchPage(_ page: Int) async throws -> FetchResponse {
+            do {
+                let response = try await api.getCommentReports(page: page, limit: pageSize, unresolvedOnly: unreadOnly)
+                return .init(
+                    items: response.map { .report($0) },
+                    prevCursor: nil,
+                    nextCursor: nil
+                )
+            } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
+                return .init(items: .init(), prevCursor: nil, nextCursor: nil)
+            }
+        }
+    }
+
+    public init(api: ApiClient, pageSize: Int, sortType: FeedLoaderSort.SortType, showRead: Bool) {
+        super.init(
+            api: api,
+            sortType: sortType,
+            fetcher: Fetcher(
+                api: api,
+                pageSize: pageSize,
+                unreadOnly: !showRead
+            ),
+            showRead: showRead
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/MessageReportChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/MessageReportChildFeedLoader.swift
@@ -1,0 +1,38 @@
+//
+//  MessageReportChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-27.
+//
+
+public class MessageReportChildFeedLoader: ModMailChildFeedLoader {
+    class Fetcher: ModMailFetcher {
+        override func fetchPage(_ page: Int) async throws -> FetchResponse {
+            guard api.isAdmin else { return .init(items: [], prevCursor: nil, nextCursor: nil) }
+            
+            do {
+                let response = try await api.getMessageReports(page: page, limit: pageSize, unresolvedOnly: unreadOnly)
+                return .init(
+                    items: response.map { .report($0) },
+                    prevCursor: nil,
+                    nextCursor: nil
+                )
+            } catch let ApiClientError.response(response, _) where response.notAdmin {
+                return .init(items: .init(), prevCursor: nil, nextCursor: nil)
+            }
+        }
+    }
+
+    public init(api: ApiClient, pageSize: Int, sortType: FeedLoaderSort.SortType, showRead: Bool) {
+        super.init(
+            api: api,
+            sortType: sortType,
+            fetcher: Fetcher(
+                api: api,
+                pageSize: pageSize,
+                unreadOnly: !showRead
+            ),
+            showRead: showRead
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailChildFeedLoader.swift
@@ -1,0 +1,32 @@
+//
+//  ModMailChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-12-04.
+//
+
+public class ModMailChildFeedLoader: ChildFeedLoader<ModMailItem>, InboxFeedLoading {
+    var modMailFetcher: ModMailFetcher { fetcher as! ModMailFetcher }
+    
+    public init(api: ApiClient, sortType: FeedLoaderSort.SortType, fetcher: ModMailFetcher, showRead: Bool) {
+        super.init(filter: ModMailItemFilter(showRead: showRead), fetcher: fetcher, sortType: sortType)
+    }
+    
+    func hideRead() async throws {
+        try await loadingActor.activateFilter(.read) {
+            await setItems(loadingActor.filter.reset(with: items))
+            modMailFetcher.hideRead(unreadCount: items.count)
+            
+            if items.isEmpty {
+                try await refresh(clearBeforeRefresh: false)
+            }
+        }
+    }
+    
+    func showRead() async throws {
+        try await loadingActor.deactivateFilter(.read) {
+            modMailFetcher.showRead()
+            try await refresh(clearBeforeRefresh: true)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailFeedLoader.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
-    
     var modMailFetcher: MultiFetcher<ModMailItem> { fetcher as! MultiFetcher }
     
     public init(
@@ -16,13 +15,14 @@ public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
         pageSize: Int,
         sources: [ChildFeedLoader<ModMailItem>],
         sortType: FeedLoaderSort.SortType,
-        showRead: Bool) {
-            super.init(
-                filter: ModMailItemFilter(showRead: showRead),
-                fetcher: MultiFetcher(api: api, pageSize: pageSize, sources: sources, sortType: sortType)
-            )
+        showRead: Bool
+    ) {
+        super.init(
+            filter: ModMailItemFilter(showRead: showRead),
+            fetcher: MultiFetcher(api: api, pageSize: pageSize, sources: sources, sortType: sortType)
+        )
         
-        sources.forEach { source in
+        for source in sources {
             source.setParent(parent: self)
         }
     }
@@ -61,7 +61,8 @@ public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
             pageSize: pageSize,
             sortType: sortType,
             sources: [postReportFeedLoader, commentReportFeedLoader, messageReportFeedLoader],
-            showRead: showRead)
+            showRead: showRead
+        )
         
         let applicationFeedLoader: ApplicationChildFeedLoader = .init(
             api: api,
@@ -83,8 +84,8 @@ public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
     
     public func hideRead() async throws {
         await withThrowingTaskGroup(of: Void.self) { group in
-            modMailFetcher.sources.forEach { source in
-                group.addTask {                    
+            for source in modMailFetcher.sources {
+                group.addTask {
                     guard let childSource = source as? any InboxFeedLoading else {
                         assertionFailure("Child is not ModMailChildFeedLoader")
                         return
@@ -99,7 +100,7 @@ public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
     
     public func showRead() async throws {
         await withThrowingTaskGroup(of: Void.self) { group in
-            modMailFetcher.sources.forEach { source in
+            for source in modMailFetcher.sources {
                 group.addTask {
                     guard let childSource = source as? any InboxFeedLoading else {
                         assertionFailure("Child is not ModMailChildFeedLoader")

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailFeedLoader.swift
@@ -1,0 +1,116 @@
+//
+//  ModMailFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-27.
+//
+
+import Foundation
+
+public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
+    var modMailFetcher: MultiFetcher<ModMailItem> { fetcher as! MultiFetcher }
+    
+    public init(
+        api: ApiClient,
+        pageSize: Int,
+        sources: [ChildFeedLoader<ModMailItem>],
+        sortType: FeedLoaderSort.SortType,
+        showRead: Bool
+    ) {
+        super.init(
+            filter: ModMailItemFilter(showRead: showRead),
+            fetcher: MultiFetcher(api: api, pageSize: pageSize, sources: sources, sortType: sortType)
+        )
+        
+        for source in sources {
+            source.setParent(parent: self)
+        }
+    }
+    
+    public static func setup(
+        api: ApiClient,
+        pageSize: Int,
+        sortType: FeedLoaderSort.SortType,
+        showRead: Bool
+    ) -> (
+        reportFeedLoader: ReportChildFeedLoader,
+        applicationFeedLoader: ApplicationChildFeedLoader,
+        modMailFeedLoader: ModMailFeedLoader
+    ) {
+        let postReportFeedLoader: PostReportChildFeedLoader = .init(
+            api: api,
+            pageSize: pageSize,
+            sortType: sortType,
+            showRead: showRead
+        )
+        let commentReportFeedLoader: CommentReportChildFeedLoader = .init(
+            api: api,
+            pageSize: pageSize,
+            sortType: sortType,
+            showRead: showRead
+        )
+        let messageReportFeedLoader: MessageReportChildFeedLoader = .init(
+            api: api,
+            pageSize: pageSize,
+            sortType: sortType,
+            showRead: showRead
+        )
+        
+        let reportFeedLoader: ReportChildFeedLoader = .init(
+            api: api,
+            pageSize: pageSize,
+            sortType: sortType,
+            sources: [postReportFeedLoader, commentReportFeedLoader, messageReportFeedLoader],
+            showRead: showRead
+        )
+        
+        let applicationFeedLoader: ApplicationChildFeedLoader = .init(
+            api: api,
+            pageSize: pageSize,
+            sortType: sortType,
+            showRead: showRead
+        )
+        
+        let modMailFeedLoader: ModMailFeedLoader = .init(
+            api: api,
+            pageSize: pageSize,
+            sources: [reportFeedLoader, applicationFeedLoader],
+            sortType: sortType,
+            showRead: showRead
+        )
+        
+        return (reportFeedLoader, applicationFeedLoader, modMailFeedLoader)
+    }
+    
+    public func hideRead() async throws {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            for source in modMailFetcher.sources {
+                group.addTask {
+                    guard let childSource = source as? any InboxFeedLoading else {
+                        assertionFailure("Child is not ModMailChildFeedLoader")
+                        return
+                    }
+                    try await childSource.hideRead()
+                }
+            }
+        }
+        
+        try await activateFilter(.read)
+    }
+    
+    public func showRead() async throws {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            for source in modMailFetcher.sources {
+                group.addTask {
+                    guard let childSource = source as? any InboxFeedLoading else {
+                        assertionFailure("Child is not ModMailChildFeedLoader")
+                        return
+                    }
+                    try await childSource.showRead()
+                }
+            }
+        }
+
+        try await deactivateFilter(.read)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailFeedLoader.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
+    
     var modMailFetcher: MultiFetcher<ModMailItem> { fetcher as! MultiFetcher }
     
     public init(
@@ -15,14 +16,13 @@ public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
         pageSize: Int,
         sources: [ChildFeedLoader<ModMailItem>],
         sortType: FeedLoaderSort.SortType,
-        showRead: Bool
-    ) {
-        super.init(
-            filter: ModMailItemFilter(showRead: showRead),
-            fetcher: MultiFetcher(api: api, pageSize: pageSize, sources: sources, sortType: sortType)
-        )
+        showRead: Bool) {
+            super.init(
+                filter: ModMailItemFilter(showRead: showRead),
+                fetcher: MultiFetcher(api: api, pageSize: pageSize, sources: sources, sortType: sortType)
+            )
         
-        for source in sources {
+        sources.forEach { source in
             source.setParent(parent: self)
         }
     }
@@ -61,8 +61,7 @@ public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
             pageSize: pageSize,
             sortType: sortType,
             sources: [postReportFeedLoader, commentReportFeedLoader, messageReportFeedLoader],
-            showRead: showRead
-        )
+            showRead: showRead)
         
         let applicationFeedLoader: ApplicationChildFeedLoader = .init(
             api: api,
@@ -84,8 +83,8 @@ public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
     
     public func hideRead() async throws {
         await withThrowingTaskGroup(of: Void.self) { group in
-            for source in modMailFetcher.sources {
-                group.addTask {
+            modMailFetcher.sources.forEach { source in
+                group.addTask {                    
                     guard let childSource = source as? any InboxFeedLoading else {
                         assertionFailure("Child is not ModMailChildFeedLoader")
                         return
@@ -100,7 +99,7 @@ public class ModMailFeedLoader: StandardFeedLoader<ModMailItem> {
     
     public func showRead() async throws {
         await withThrowingTaskGroup(of: Void.self) { group in
-            for source in modMailFetcher.sources {
+            modMailFetcher.sources.forEach { source in
                 group.addTask {
                     guard let childSource = source as? any InboxFeedLoading else {
                         assertionFailure("Child is not ModMailChildFeedLoader")

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailFetcher.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailFetcher.swift
@@ -1,0 +1,40 @@
+//
+//  ModMailFetcher.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-11-24.
+//
+
+import Foundation
+
+@Observable
+public class ModMailFetcher: Fetcher<ModMailItem> {
+    var unreadOnly: Bool
+    
+    init(api: ApiClient, pageSize: Int, unreadOnly: Bool) {
+        self.unreadOnly = unreadOnly
+        super.init(api: api, pageSize: pageSize)
+    }
+    
+    /// Updates fetching behavior to hide read items. Assumes items will NOT be cleared from the associated FeedLoader and that deduping will be handled by that FeedLoader.
+    /// - Parameter unreadCount: number of unread items still present after client-side filtering
+    func hideRead(unreadCount: Int) {
+        guard !unreadOnly else {
+            assertionFailure("Cannot hide read (unreadOnly already true)")
+            return
+        }
+        
+        unreadOnly = true
+        page = Int(floor(Double(unreadCount / pageSize)))
+    }
+    
+    /// Updates fetching behavior to show read posts. Assumes associated FeedLoader will immediately perform a refresh.
+    func showRead() {
+        guard unreadOnly else {
+            assertionFailure("Cannot show read (unreadOnly already false)")
+            return
+        }
+        
+        unreadOnly = false
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailItem.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ModMailItem.swift
@@ -1,0 +1,40 @@
+//
+//  ModMailItem.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-02-01.
+//
+
+public enum ModMailItem: FeedLoadable, ReadableProviding, InboxIdentifiable {
+    public typealias FilterType = ModMailItemFilterType
+    
+    case report(Report)
+    case application(RegistrationApplication)
+    
+    var baseValue: any FeedLoadable {
+        switch self {
+        case let .report(report): report
+        case let .application(application): application
+        }
+    }
+    
+    public var read: Bool {
+        switch self {
+        case let .report(report): report.resolved
+        case let .application(application): application.resolution != .unresolved
+        }
+    }
+    
+    public var inboxId: Int {
+        switch self {
+        case let .report(report): report.modMailId
+        case let .application(application): application.modMailId
+        }
+    }
+    
+    public var api: ApiClient { baseValue.api }
+    
+    public func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        baseValue.sortVal(sortType: sortType)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/PostReportChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/PostReportChildFeedLoader.swift
@@ -1,0 +1,36 @@
+//
+//  PostReportChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-12-02.
+//
+
+public class PostReportChildFeedLoader: ModMailChildFeedLoader {
+    class Fetcher: ModMailFetcher {
+        override func fetchPage(_ page: Int) async throws -> FetchResponse {
+            do {
+                let response = try await api.getPostReports(page: page, limit: pageSize)
+                return .init(
+                    items: response.map { .report($0) },
+                    prevCursor: nil,
+                    nextCursor: nil
+                )
+            } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
+                return .init(items: .init(), prevCursor: nil, nextCursor: nil)
+            }
+        }
+    }
+    
+    public init(api: ApiClient, pageSize: Int, sortType: FeedLoaderSort.SortType, showRead: Bool) {
+        super.init(
+            api: api,
+            sortType: sortType,
+            fetcher: Fetcher(
+                api: api,
+                pageSize: pageSize,
+                unreadOnly: !showRead
+            ),
+            showRead: showRead
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ReportChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ReportChildFeedLoader.swift
@@ -8,6 +8,7 @@
 class ReportFetcher: MultiFetcher<ModMailItem> {}
 
 public class ReportChildFeedLoader: ChildFeedLoader<ModMailItem>, InboxFeedLoading {
+    
     var reportFetcher: MultiFetcher<ModMailItem> { fetcher as! ReportFetcher }
     
     public init(
@@ -26,14 +27,14 @@ public class ReportChildFeedLoader: ChildFeedLoader<ModMailItem>, InboxFeedLoadi
         
         super.init(filter: ModMailItemFilter(showRead: showRead), fetcher: fetcher, sortType: sortType)
         
-        for source in sources {
+        sources.forEach { source in
             source.setParent(parent: self)
         }
     }
     
     public func hideRead() async throws {
         await withThrowingTaskGroup(of: Void.self) { group in
-            for source in reportFetcher.sources {
+            reportFetcher.sources.forEach { source in
                 group.addTask {
                     guard let childSource = source as? ModMailChildFeedLoader else {
                         assertionFailure("Child is not ModMailChildFeedLoader")
@@ -49,7 +50,7 @@ public class ReportChildFeedLoader: ChildFeedLoader<ModMailItem>, InboxFeedLoadi
     
     public func showRead() async throws {
         await withThrowingTaskGroup(of: Void.self) { group in
-            for source in reportFetcher.sources {
+            reportFetcher.sources.forEach { source in
                 group.addTask {
                     guard let childSource = source as? ModMailChildFeedLoader else {
                         assertionFailure("Child is not ModMailChildFeedLoader")

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ReportChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ReportChildFeedLoader.swift
@@ -8,7 +8,6 @@
 class ReportFetcher: MultiFetcher<ModMailItem> {}
 
 public class ReportChildFeedLoader: ChildFeedLoader<ModMailItem>, InboxFeedLoading {
-    
     var reportFetcher: MultiFetcher<ModMailItem> { fetcher as! ReportFetcher }
     
     public init(
@@ -27,14 +26,14 @@ public class ReportChildFeedLoader: ChildFeedLoader<ModMailItem>, InboxFeedLoadi
         
         super.init(filter: ModMailItemFilter(showRead: showRead), fetcher: fetcher, sortType: sortType)
         
-        sources.forEach { source in
+        for source in sources {
             source.setParent(parent: self)
         }
     }
     
     public func hideRead() async throws {
         await withThrowingTaskGroup(of: Void.self) { group in
-            reportFetcher.sources.forEach { source in
+            for source in reportFetcher.sources {
                 group.addTask {
                     guard let childSource = source as? ModMailChildFeedLoader else {
                         assertionFailure("Child is not ModMailChildFeedLoader")
@@ -50,7 +49,7 @@ public class ReportChildFeedLoader: ChildFeedLoader<ModMailItem>, InboxFeedLoadi
     
     public func showRead() async throws {
         await withThrowingTaskGroup(of: Void.self) { group in
-            reportFetcher.sources.forEach { source in
+            for source in reportFetcher.sources {
                 group.addTask {
                     guard let childSource = source as? ModMailChildFeedLoader else {
                         assertionFailure("Child is not ModMailChildFeedLoader")

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ReportChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ReportChildFeedLoader.swift
@@ -1,0 +1,65 @@
+//
+//  ReportChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-02-01.
+//
+
+class ReportFetcher: MultiFetcher<ModMailItem> {}
+
+public class ReportChildFeedLoader: ChildFeedLoader<ModMailItem>, InboxFeedLoading {
+    var reportFetcher: MultiFetcher<ModMailItem> { fetcher as! ReportFetcher }
+    
+    public init(
+        api: ApiClient,
+        pageSize: Int,
+        sortType: FeedLoaderSort.SortType,
+        sources: [ModMailChildFeedLoader],
+        showRead: Bool
+    ) {
+        let fetcher: ReportFetcher = .init(
+            api: api,
+            pageSize: pageSize,
+            sources: sources,
+            sortType: sortType
+        )
+        
+        super.init(filter: ModMailItemFilter(showRead: showRead), fetcher: fetcher, sortType: sortType)
+        
+        for source in sources {
+            source.setParent(parent: self)
+        }
+    }
+    
+    public func hideRead() async throws {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            for source in reportFetcher.sources {
+                group.addTask {
+                    guard let childSource = source as? ModMailChildFeedLoader else {
+                        assertionFailure("Child is not ModMailChildFeedLoader")
+                        return
+                    }
+                    try await childSource.hideRead()
+                }
+            }
+        }
+        
+        try await activateFilter(.read)
+    }
+    
+    public func showRead() async throws {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            for source in reportFetcher.sources {
+                group.addTask {
+                    guard let childSource = source as? ModMailChildFeedLoader else {
+                        assertionFailure("Child is not ModMailChildFeedLoader")
+                        return
+                    }
+                    try await childSource.showRead()
+                }
+            }
+        }
+
+        try await deactivateFilter(.read)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Modlog/ModlogChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Modlog/ModlogChildFeedLoader.swift
@@ -1,0 +1,16 @@
+//
+//  ModlogChildFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-28.
+//
+
+import Foundation
+
+public class ModlogChildFeedLoader: ChildFeedLoader<ModlogEntry> {
+    var modlogFetcher: ModlogChildFetcher { fetcher as! ModlogChildFetcher }
+    
+    public init(api: ApiClient, sortType: FeedLoaderSort.SortType, fetcher: ModlogChildFetcher) {
+        super.init(filter: ModlogEntryFilter(), fetcher: fetcher, sortType: sortType)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Modlog/ModlogChildFetcher+SharedCache.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Modlog/ModlogChildFetcher+SharedCache.swift
@@ -1,0 +1,47 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-29.
+//
+
+import Foundation
+
+extension ModlogChildFetcher {
+    class SharedCache {
+        typealias TaskResponse = [ApiModlogActionType: [ModlogEntry]]
+        var api: ApiClient
+        let pageSize: Int
+        var communityId: Int?
+        var ongoingTask: Task<TaskResponse, Error>?
+        
+        init(api: ApiClient, pageSize: Int, communityId: Int?) {
+            self.api = api
+            self.pageSize = pageSize
+            self.communityId = communityId
+        }
+        
+        private func fetchItems() async throws -> TaskResponse {
+            let response = try await api.getModlog(page: 1, limit: pageSize, communityId: communityId)
+            return .init(grouping: response, by: { $0.type.type })
+        }
+        
+        @MainActor
+        func get(type: ApiModlogActionType) async throws -> [ModlogEntry] {
+            let task: Task<TaskResponse, Error>
+            if let ongoingTask {
+                task = ongoingTask
+            } else {
+                task = Task { try await fetchItems() }
+                ongoingTask = task
+            }
+            let response = try await task.result.get()
+            return response[type] ?? []
+        }
+        
+        @MainActor
+        func reset() {
+            ongoingTask = nil
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Modlog/ModlogChildFetcher.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Modlog/ModlogChildFetcher.swift
@@ -1,0 +1,48 @@
+//
+//  ModlogChildFetcher.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-28.
+//
+
+import Foundation
+
+@Observable
+public class ModlogChildFetcher: Fetcher<ModlogEntry> {
+    let sharedCache: SharedCache
+    var communityId: Int?
+    var type: ApiModlogActionType
+    
+    init(
+        api: ApiClient,
+        pageSize: Int,
+        sharedCache: SharedCache,
+        communityId: Int?,
+        type: ApiModlogActionType
+    ) {
+        self.communityId = communityId
+        self.type = type
+        self.sharedCache = sharedCache
+        super.init(api: api, pageSize: pageSize)
+    }
+    
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
+        let items: [ModlogEntry]
+        if page == 1 {
+            items = try await sharedCache.get(type: type)
+        } else {
+            items = try await api.getModlog(
+                page: page,
+                limit: pageSize,
+                communityId: communityId,
+                type: type
+            )
+        }
+        
+        return .init(
+            items: items,
+            prevCursor: nil,
+            nextCursor: nil
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Modlog/ModlogFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Modlog/ModlogFeedLoader.swift
@@ -1,0 +1,81 @@
+//
+//  ModlogFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-28.
+//
+
+import Foundation
+
+public class ModlogFeedLoader: StandardFeedLoader<ModlogEntry> {
+    var modlogFetcher: MultiFetcher<ModlogEntry> { fetcher as! MultiFetcher }
+    
+    var modlogSources: [ModlogChildFeedLoader] {
+        (modlogFetcher.sources as? [ModlogChildFeedLoader])!
+    }
+    
+    private var sharedCache: ModlogChildFetcher.SharedCache
+    
+    public init(
+        api: ApiClient,
+        pageSize: Int,
+        communityId: Int?,
+        sortType: FeedLoaderSort.SortType
+    ) {
+        let sharedCache: ModlogChildFetcher.SharedCache = .init(api: api, pageSize: pageSize, communityId: communityId)
+        self.sharedCache = sharedCache
+        
+        let sources: [ModlogChildFeedLoader] = ApiModlogActionType.allFilteredCases.map { type in
+            .init(
+                api: api,
+                sortType: sortType,
+                fetcher: .init(
+                    api: api,
+                    pageSize: pageSize,
+                    sharedCache: sharedCache,
+                    communityId: communityId,
+                    type: type
+                )
+            )
+        }
+        super.init(
+            filter: ModlogEntryFilter(),
+            fetcher: MultiFetcher(api: api, pageSize: pageSize, sources: sources, sortType: sortType)
+        )
+        
+        for source in sources {
+            source.setParent(parent: self)
+        }
+    }
+    
+    public func items(ofType type: ApiModlogActionType?) -> [ModlogEntry] {
+        if let type, type != .all {
+            modlogSources.first { $0.modlogFetcher.type == type }?.items ?? []
+        } else {
+            items
+        }
+    }
+    
+    public func childLoader(ofType type: ApiModlogActionType) -> ModlogChildFeedLoader {
+        modlogSources.first(where: { $0.modlogFetcher.type == type })!
+    }
+    
+    public func refresh(
+        api: ApiClient? = nil,
+        communityId: Int? = nil,
+        clearBeforeRefresh: Bool = false
+    ) async throws {
+        sharedCache.api = api ?? sharedCache.api
+        sharedCache.communityId = communityId
+        for source in modlogSources {
+            await source.changeApi(to: api ?? sharedCache.api, context: .none())
+            source.modlogFetcher.communityId = communityId ?? source.modlogFetcher.communityId
+        }
+        try await refresh(clearBeforeRefresh: clearBeforeRefresh)
+    }
+    
+    override public func refresh(clearBeforeRefresh: Bool) async throws {
+        await sharedCache.reset()
+        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
@@ -1,0 +1,75 @@
+//
+//  PersonFeedLoader.swift
+//
+//
+//  Created by Sjmarf on 08/09/2024.
+//
+
+import Foundation
+
+@Observable
+class PersonFetcher: Fetcher<Person2> {
+    var query: String
+    /// `listing` can be set to `.local` from 0.19.4 onwards.
+    var listing: ApiListingType
+    var sort: SearchSortType
+    
+    init(api: ApiClient, pageSize: Int, query: String, listing: ApiListingType, sort: SearchSortType) {
+        self.query = query
+        self.listing = listing
+        self.sort = sort
+        
+        super.init(api: api, pageSize: pageSize)
+    }
+    
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
+        let communities = try await api.searchPeople(
+            query: query,
+            page: page,
+            limit: pageSize,
+            filter: listing,
+            sort: sort
+        )
+
+        return .init(
+            items: communities,
+            prevCursor: nil,
+            nextCursor: nil
+        )
+    }
+}
+
+@Observable
+public class PersonFeedLoader: StandardFeedLoader<Person2> {
+    public var api: ApiClient
+    
+    // force unwrap because this should ALWAYS be a PersonFetcher
+    var personFetcher: PersonFetcher { fetcher as! PersonFetcher }
+    
+    public init(
+        api: ApiClient,
+        query: String = "",
+        pageSize: Int = 20,
+        listing: ApiListingType = .all,
+        sort: SearchSortType = .top(.allTime)
+    ) {
+        self.api = api
+        
+        super.init(
+            filter: .init(),
+            fetcher: PersonFetcher(api: api, pageSize: pageSize, query: query, listing: listing, sort: sort)
+        )
+    }
+    
+    public func refresh(
+        query: String? = nil,
+        listing: ApiListingType? = nil,
+        sort: SearchSortType? = nil,
+        clearBeforeRefresh: Bool = false
+    ) async throws {
+        personFetcher.query = query ?? personFetcher.query
+        personFetcher.listing = listing ?? personFetcher.listing
+        personFetcher.sort = sort ?? personFetcher.sort
+        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/AggregatePostFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/AggregatePostFeedLoader.swift
@@ -1,0 +1,88 @@
+//
+//  AggregatePostFeedLoader.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-07.
+//
+
+import Foundation
+
+@Observable
+class AggregatePostFetcher: PostFetcher {
+    var feedType: ApiListingType
+    
+    init(api: ApiClient, feedType: ApiListingType, sortType: PostSortType, pageSize: Int) {
+        self.feedType = feedType
+        
+        super.init(api: api, sortType: sortType, pageSize: pageSize)
+    }
+    
+    override func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
+        try await api.getPosts(
+            feed: feedType,
+            sort: sortType,
+            page: page,
+            cursor: cursor,
+            limit: pageSize,
+            filter: nil, // TODO:
+            showHidden: false // TODO:
+        )
+    }
+}
+
+public class AggregatePostFeedLoader: CorePostFeedLoader {
+    // force unwrap because this should ALWAYS be an AggregatePostFetcher
+    var aggregatePostFetcher: AggregatePostFetcher { fetcher as! AggregatePostFetcher }
+    
+    // force unwrap because this should ALWAYS be a PostFetcher
+    private var postFetcher: PostFetcher { fetcher as! PostFetcher }
+        
+    public var sortType: PostSortType { postFetcher.sortType }
+    
+    public init(
+        pageSize: Int,
+        sortType: PostSortType,
+        showReadPosts: Bool,
+        filterContext: FilterContext,
+        prefetchingConfiguration: PrefetchingConfiguration,
+        urlCache: URLCache,
+        api: ApiClient,
+        feedType: ApiListingType
+    ) {
+        super.init(
+            showReadPosts: showReadPosts,
+            filterContext: filterContext,
+            prefetchingConfiguration: prefetchingConfiguration,
+            fetcher: AggregatePostFetcher(
+                api: api,
+                feedType: feedType,
+                sortType: sortType,
+                pageSize: pageSize
+            )
+        )
+    }
+    
+    @MainActor
+    public func changeFeedType(to newFeedType: ApiListingType) async throws {
+        let shouldRefresh = items.isEmpty || aggregatePostFetcher.feedType != newFeedType
+        
+        // always perform assignment--if account changed, feed type will look unchanged but API will be different
+        aggregatePostFetcher.feedType = newFeedType
+        
+        // only refresh if nominal feed type changed
+        if shouldRefresh {
+            try await refresh(clearBeforeRefresh: true)
+        }
+    }
+    
+    /// Changes the post sort type to the specified value and reloads the feed
+    public func changeSortType(to newSortType: PostSortType, forceRefresh: Bool = false) async throws {
+        // don't do anything if sort type not changed
+        guard postFetcher.sortType != newSortType || forceRefresh else {
+            return
+        }
+        
+        postFetcher.sortType = newSortType
+        try await refresh(clearBeforeRefresh: true)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CommunityPostFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CommunityPostFeedLoader.swift
@@ -1,0 +1,86 @@
+//
+//  CommunityPostFeedLoader.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-07.
+//
+
+import Foundation
+
+@Observable
+class CommunityPostFetcher: PostFetcher {
+    var community: any Community
+    
+    init(sortType: PostSortType, pageSize: Int, community: any Community) {
+        self.community = community
+        
+        super.init(api: community.api, sortType: sortType, pageSize: pageSize)
+    }
+    
+    override func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
+        try await community.getPosts(
+            sort: sortType,
+            page: page,
+            cursor: cursor,
+            limit: pageSize,
+            filter: nil, // TODO:
+            showHidden: false // TODO:
+        )
+    }
+}
+
+public class CommunityPostFeedLoader: CorePostFeedLoader {
+    public var community: any Community
+    
+    var communityPostFetcher: CommunityPostFetcher { fetcher as! CommunityPostFetcher }
+    
+    // force unwrap because this should ALWAYS be a PostFetcher
+    private var postFetcher: PostFetcher { fetcher as! PostFetcher }
+    
+    public var sortType: PostSortType { postFetcher.sortType }
+
+    public init(
+        pageSize: Int,
+        sortType: PostSortType,
+        showReadPosts: Bool,
+        filterContext: FilterContext,
+        prefetchingConfiguration: PrefetchingConfiguration,
+        urlCache: URLCache,
+        community: any Community
+    ) {
+        self.community = community
+        super.init(
+            showReadPosts: showReadPosts,
+            filterContext: filterContext,
+            prefetchingConfiguration: prefetchingConfiguration,
+            fetcher: CommunityPostFetcher(sortType: sortType, pageSize: pageSize, community: community)
+        )
+    }
+    
+    override public func changeApi(to newApi: ApiClient, context: FilterContext) async {
+        do {
+            let resolvedCommunity = try await newApi.resolve(url: community.actorId.url)
+            
+            guard let newCommunity = resolvedCommunity as? any Community else {
+                assertionFailure("Did not get community back")
+                return
+            }
+            
+            filter.updateContext(to: context)
+            communityPostFetcher.community = newCommunity
+        } catch {
+            assertionFailure("Couldn't change API")
+        }
+    }
+    
+    /// Changes the post sort type to the specified value and reloads the feed
+    public func changeSortType(to newSortType: PostSortType, forceRefresh: Bool = false) async throws {
+        // don't do anything if sort type not changed
+        guard postFetcher.sortType != newSortType || forceRefresh else {
+            return
+        }
+        
+        postFetcher.sortType = newSortType
+        try await refresh(clearBeforeRefresh: true)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
@@ -1,0 +1,75 @@
+//
+//  CorePostFeedLoader.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-01-04.
+//
+
+import Foundation
+import Nuke
+import Observation
+
+@Observable
+public class PostFetcher: Fetcher<Post2> {
+    var sortType: PostSortType
+    
+    init(api: ApiClient, sortType: PostSortType, pageSize: Int) {
+        self.sortType = sortType
+        
+        super.init(api: api, pageSize: pageSize)
+    }
+    
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
+        let result = try await getPosts(page: page, cursor: nil)
+
+        return .init(
+            items: result.posts,
+            prevCursor: nil,
+            nextCursor: result.cursor
+        )
+    }
+    
+    override func fetchCursor(_ cursor: String) async throws -> FetchResponse {
+        let result = try await getPosts(page: 1, cursor: cursor)
+        
+        return .init(
+            items: result.posts,
+            prevCursor: cursor,
+            nextCursor: result.cursor
+        )
+    }
+    
+    func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
+        preconditionFailure("This method must be implemented by the inheriting class")
+    }
+}
+
+/// Post tracker for use with single feeds. Can easily be extended to load any pure post feed by creating an inheriting class that overrides getPosts().
+@Observable
+public class CorePostFeedLoader: PrefetchingFeedLoader<Post2> {
+    // store reference to the filter used by the LoadingActor so we can modify its filterContext from changeApi
+    var filter: PostFilter
+    
+    init(
+        showReadPosts: Bool,
+        filterContext: FilterContext,
+        prefetchingConfiguration: PrefetchingConfiguration,
+        fetcher: Fetcher<Post2>
+    ) {
+        let filter: PostFilter = .init(showRead: showReadPosts, context: filterContext)
+        self.filter = filter
+        
+        super.init(
+            filter: filter,
+            prefetchingConfiguration: prefetchingConfiguration,
+            fetcher: fetcher
+        )
+    }
+    
+    // MARK: Custom Behavior
+
+    override public func changeApi(to newApi: ApiClient, context: FilterContext) async {
+        filter.updateContext(to: context)
+        await fetcher.changeApi(to: newApi, context: context)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/SearchPostFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/SearchPostFeedLoader.swift
@@ -1,0 +1,109 @@
+//
+//  SearchPostFeedLoader.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 04/10/2024.
+//
+
+import Foundation
+
+@Observable
+public class SearchPostFetcher: Fetcher<Post2> {
+    public enum SortType {
+        case v4(SearchSortType)
+        case v3(PostSortType)
+    }
+    
+    public var query: String
+    public var communityId: Int?
+    public var creatorId: Int?
+    
+    public var listing: ApiListingType
+    
+    public var sortType: SortType
+
+    // setters to allow manual overriding of these for search use cases
+    override public func changeApi(to newApi: ApiClient, context: FilterContext) async {
+        await super.changeApi(to: newApi, context: context)
+    }
+
+    public func setSortType(_ sortType: SortType) { self.sortType = sortType }
+    
+    init(
+        api: ApiClient,
+        sortType: SortType,
+        pageSize: Int,
+        query: String,
+        communityId: Int?,
+        creatorId: Int?,
+        listing: ApiListingType
+    ) {
+        self.query = query
+        self.communityId = communityId
+        self.creatorId = creatorId
+        self.listing = listing
+        self.sortType = sortType
+        
+        super.init(api: api, pageSize: pageSize)
+    }
+    
+    override func fetchPage(_ page: Int) async throws -> Fetcher<Post2>.FetchResponse {
+        let response: [Post2]
+        switch sortType {
+        case let .v4(searchSortType):
+            response = try await api.searchPosts(
+                query: query,
+                page: page,
+                limit: pageSize,
+                communityId: communityId,
+                creatorId: creatorId,
+                filter: listing,
+                sort: searchSortType
+            )
+        case let .v3(postSortType):
+            response = try await api.searchPosts(
+                query: query,
+                page: page,
+                limit: pageSize,
+                communityId: communityId,
+                creatorId: creatorId,
+                filter: listing,
+                sort: postSortType
+            )
+        }
+        return .init(items: response, prevCursor: nil, nextCursor: nil)
+    }
+}
+
+public class SearchPostFeedLoader: CorePostFeedLoader {
+    // force unwrap because this should ALWAYS be a SearchPostFetcher
+    public var searchPostFetcher: SearchPostFetcher { fetcher as! SearchPostFetcher }
+    
+    public init(
+        api: ApiClient,
+        query: String = "",
+        pageSize: Int = 20,
+        sortType: SearchPostFetcher.SortType,
+        creatorId: Int? = nil,
+        communityId: Int? = nil,
+        prefetchingConfiguration: PrefetchingConfiguration,
+        urlCache: URLCache,
+        listing: ApiListingType = .all
+    ) {
+        super.init(
+            showReadPosts: true,
+            filterContext: .none(), // search doesn't filter, only obscures on the frontend
+            prefetchingConfiguration: prefetchingConfiguration,
+            fetcher: SearchPostFetcher(
+                api: api,
+                sortType: sortType,
+                pageSize: pageSize,
+                query: query,
+                communityId: communityId,
+                creatorId: creatorId,
+                listing: listing
+            )
+        )
+        loadingState = .idle
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Prefetching/ImagePrefetchProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Prefetching/ImagePrefetchProviding.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-25.
+//
+
+import Foundation
+import Nuke
+
+public protocol ImagePrefetchProviding {
+    func imageRequests(configuration config: PrefetchingConfiguration) async -> [ImageRequest]
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Prefetching/PrefetchingConfiguration.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Prefetching/PrefetchingConfiguration.swift
@@ -1,0 +1,39 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 10/08/2024.
+//
+
+import Foundation
+import Nuke
+
+public struct PrefetchingConfiguration {
+    public enum ImageResolution {
+        case unlimited, limited(Int)
+    }
+    
+    public var prefetcher: ImagePrefetcher
+    
+    public var imageSize: ImageResolution
+    
+    /// If `nil`, does not fetch avatars.
+    public var avatarSize: Int?
+    
+    let fetchFavicons: Bool
+    let embedLoops: Bool
+    
+    public init(
+        prefetcher: ImagePrefetcher,
+        imageSize: ImageResolution,
+        fetchFavicons: Bool,
+        embedLoops: Bool,
+        avatarSize: Int? = nil
+    ) {
+        self.prefetcher = prefetcher
+        self.imageSize = imageSize
+        self.avatarSize = avatarSize
+        self.fetchFavicons = fetchFavicons
+        self.embedLoops = embedLoops
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContent.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContent.swift
@@ -1,0 +1,60 @@
+//
+//  PersonContent.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-21.
+//
+
+import Foundation
+
+public class PersonContent: Hashable, Equatable, FeedLoadable, ActorIdentifiable {
+    public typealias FilterType = PersonContentFilterType
+    
+    public let wrappedValue: Value
+    
+    public enum Value {
+        // This always comes from GetPersonDetailsRequest, so we can know we're getting Post2 and Comment2
+        case post(Post2)
+        case comment(Comment2)
+    }
+    
+    public init(wrappedValue: PersonContent.Value) {
+        self.wrappedValue = wrappedValue
+    }
+    
+    public func sortVal(sortType: FeedLoaderSort.SortType) -> FeedLoaderSort {
+        switch wrappedValue {
+        case let .post(post2): post2.sortVal(sortType: sortType)
+        case let .comment(comment2): comment2.sortVal(sortType: sortType)
+        }
+    }
+    
+    public var actorId: ActorIdentifier {
+        switch wrappedValue {
+        case let .post(post2): post2.actorId
+        case let .comment(comment2): comment2.actorId
+        }
+    }
+    
+    public var api: ApiClient {
+        switch wrappedValue {
+        case let .post(post2): post2.api
+        case let .comment(comment2): comment2.api
+        }
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        switch wrappedValue {
+        case let .post(post2):
+            hasher.combine(post2)
+            hasher.combine(ContentType.post)
+        case let .comment(comment2):
+            hasher.combine(comment2)
+            hasher.combine(ContentType.comment)
+        }
+    }
+    
+    public static func == (lhs: PersonContent, rhs: PersonContent) -> Bool {
+        lhs.actorId == rhs.actorId
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
@@ -1,0 +1,201 @@
+//
+//  PersonContentFeedLoader.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-09.
+//
+
+import Foundation
+import Nuke
+import Semaphore
+
+/// This is a special type of FeedLoader built for user content, which is uniquely challenging because you cannot load
+/// just posts or just comments, and thus the standard Parent/Child FeedLoader construction does not work without
+/// severe API waste. This solution is a simplified variant of that architecture.
+///
+/// The PersonContentFeedLoader is the parent loader. It is responsible for all data fetching, and keeps track of two
+/// PersonContentStreams, one for Posts and one for Comments. To load a page of items, it consumes and merges the child streams, just as
+/// in the standard Parent/Child FeedLoader; if either stream reaches the end of its items, it triggers a new load, the response from
+/// which is then incorporated into both child streams.
+
+@Observable
+class PersonContentFetcher: Fetcher<PersonContent> {
+    var sortType: FeedLoaderSort.SortType
+    var userId: Int
+    var savedOnly: Bool
+    
+    var postStream: PersonContentStream<Post2>
+    var commentStream: PersonContentStream<Comment2>
+    
+    init(
+        api: ApiClient,
+        pageSize: Int,
+        sortType: FeedLoaderSort.SortType,
+        userId: Int,
+        savedOnly: Bool,
+        withContent: (posts: [Post2], comments: [Comment2])?,
+        prefetchingConfiguration: PrefetchingConfiguration
+    ) {
+        self.sortType = sortType
+        self.userId = userId
+        self.savedOnly = savedOnly
+        self.postStream = .init(items: withContent?.posts, prefetchingConfiguration: prefetchingConfiguration)
+        self.commentStream = .init(items: withContent?.comments, prefetchingConfiguration: prefetchingConfiguration)
+        
+        super.init(api: api, pageSize: pageSize, page: withContent == nil ? 0 : 1)
+    }
+    
+    override func reset() async {
+        postStream.reset()
+        commentStream.reset()
+        
+        await super.reset()
+    }
+    
+    override func fetch() async throws -> LoadingResponse<PersonContent> {
+        var newItems: [PersonContent] = .init()
+        
+        while newItems.count < pageSize {
+            if let nextItem = try await computeNextItem() {
+                newItems.append(nextItem)
+            } else {
+                return .done(newItems)
+            }
+        }
+        
+        return .success(newItems)
+    }
+    
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
+        fatalError("Unsupported loading operation")
+    }
+    
+    override func fetchCursor(_ cursor: String) async throws -> FetchResponse {
+        fatalError("Unsupported loading operation")
+    }
+    
+    /// Returns the next post or comment, depending on which is sorted first
+    private func computeNextItem() async throws -> PersonContent? {
+        // if either postStream or commentStream needs items, load the next page from the API
+        if postStream.needsMoreItems || commentStream.needsMoreItems {
+            page += 1
+            let response = try await api.getContent(authorId: userId, sort: .new, page: page, limit: pageSize, savedOnly: savedOnly)
+            postStream.addItems(response.posts)
+            commentStream.addItems(response.comments)
+        }
+        
+        let nextPost = try await postStream.nextItemSortVal(sortType: sortType)
+        let nextComment = try await commentStream.nextItemSortVal(sortType: sortType)
+        
+        if let nextPost {
+            if let nextComment {
+                // if both next post and next comment, return higher sort
+                return nextPost > nextComment ? postStream.consumeNextItem() : commentStream.consumeNextItem()
+            } else {
+                // if next post but no next comment, return next post
+                return postStream.consumeNextItem()
+            }
+        }
+        
+        // if no next post, always return next comment (this returns nil if no next comment)
+        return commentStream.consumeNextItem()
+    }
+}
+
+public class PersonContentFeedLoader: StandardFeedLoader<PersonContent> {
+    // force unwrap because this should ALWAYS be a PersonContentFetcher
+    var personContentFetcher: PersonContentFetcher { fetcher as! PersonContentFetcher }
+    
+    public var api: ApiClient { personContentFetcher.api }
+    public var userId: Int { personContentFetcher.userId }
+    
+    // MARK: Custom Behavior
+
+    // This FeedLoader is slightly awkward because it functions like a multi-loader but draws its posts and comments from a single API call. The streams act essentially like child loaders, but are populated using custom behavior in the fetcher. This FeedLoader is best understood as a multi-loader with the streams as child loaders.
+    
+    private var postStream: PersonContentStream<Post2> { personContentFetcher.postStream }
+    private var commentStream: PersonContentStream<Comment2> { personContentFetcher.commentStream }
+    
+    // these are used to allow refresh without clear
+    private var tempPostStream: PersonContentStream<Post2>?
+    private var tempCommentStream: PersonContentStream<Comment2>?
+    
+    // convenience accessors for child types
+    public var posts: [PersonContent] { tempPostStream?.items ?? postStream.items }
+    public var postLoadingState: LoadingState { postStream.doneLoading ? .done : loadingState }
+    
+    public var comments: [PersonContent] { tempCommentStream?.items ?? commentStream.items }
+    public var commentLoadingState: LoadingState { commentStream.doneLoading ? .done : loadingState }
+    
+    public init(
+        api: ApiClient,
+        pageSize: Int,
+        userId: Int,
+        sortType: FeedLoaderSort.SortType,
+        savedOnly: Bool,
+        prefetchingConfiguration: PrefetchingConfiguration,
+        withContent: (posts: [Post2], comments: [Comment2])? = nil
+    ) {
+        super.init(filter: MultiFilter(), fetcher: PersonContentFetcher(
+            api: api,
+            pageSize: pageSize,
+            sortType: sortType,
+            userId: userId,
+            savedOnly: savedOnly,
+            withContent: withContent,
+            prefetchingConfiguration: prefetchingConfiguration
+        ))
+    }
+    
+    // MARK: Custom Behavior
+    
+    override public func refresh(clearBeforeRefresh: Bool) async throws {
+        if !clearBeforeRefresh {
+            tempPostStream = postStream
+            tempCommentStream = commentStream
+        }
+        
+        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
+        
+        tempPostStream = nil
+        tempCommentStream = nil
+    }
+    
+    public func changeUser(api: ApiClient, context: FilterContext, userId: Int) async {
+        tempPostStream = postStream
+        tempCommentStream = commentStream
+        
+        await personContentFetcher.changeApi(to: api, context: context)
+        personContentFetcher.userId = userId
+        await loadingActor.reset()
+        await setLoading(.done) // prevent loading more items until refreshed
+    }
+    
+    public func loadIfThreshold(_ item: PersonContent, asChild: Bool) throws {
+        let shouldLoad: Bool
+        if asChild {
+            shouldLoad = switch item.wrappedValue {
+            case .post: postStream.thresholds.isThreshold(item)
+            case .comment: commentStream.thresholds.isThreshold(item)
+            }
+        } else {
+            shouldLoad = thresholds.isThreshold(item)
+        }
+        
+        // regardless of which threshold triggers this, always call loadMoreItems() because there's no item-specific endpoint
+        if shouldLoad {
+            Task(priority: .userInitiated) {
+                try await loadMoreItems()
+            }
+        }
+    }
+    
+    public func setPrefetchingConfiguration(_ config: PrefetchingConfiguration) {
+        postStream.prefetchingConfiguration = config
+        commentStream.prefetchingConfiguration = config
+        
+        postStream.preloadImages(items)
+        // note that this currently doesn't do anything because comments don't support prefetching yet [Eric 2024.11.13]
+        commentStream.preloadImages(items)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentProviding.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-23.
+//
+
+import Foundation
+
+/// Protocol for items that can be converted into a generic PersonContent
+public protocol PersonContentProviding: FeedLoadable {
+    var userContent: PersonContent { get }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentStream.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentStream.swift
@@ -1,0 +1,94 @@
+//
+//  PersonContentStream.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-21.
+//
+
+import CollectionConcurrencyKit
+import Foundation
+import Nuke
+
+// This struct is just a convenience wrapper to handle stream state--all loading operations happen at the FeedLoader level to
+// avoid parent/child concurrency control hell
+public class PersonContentStream<Item: PersonContentProviding> {
+    // From the frontend it is more ergonomic to have these be PersonContent. These are guaranteed to all be of type Item by
+    // guarding assignment behind `init` and `addItems`, which can only take Item.
+    private(set) var items: [PersonContent]
+    var cursor: Int = 0
+    var doneLoading: Bool = false
+    var thresholds: Thresholds<PersonContent>
+    var prefetchingConfiguration: PrefetchingConfiguration
+    
+    init(items: [Item]? = nil, prefetchingConfiguration: PrefetchingConfiguration) {
+        self.prefetchingConfiguration = prefetchingConfiguration
+        self.thresholds = .init()
+        if let items {
+            let personContentItems: [PersonContent] = items.map(\.userContent)
+            self.items = personContentItems
+            thresholds.update(with: personContentItems)
+        } else {
+            self.items = .init()
+        }
+    }
+    
+    var needsMoreItems: Bool { !doneLoading && cursor >= items.count }
+    
+    func reset() {
+        items = .init()
+        cursor = 0
+        doneLoading = false
+        thresholds = .init()
+    }
+    
+    func addItems(_ newItems: [Item]) {
+        let personContentItems: [PersonContent] = newItems.map(\.userContent)
+        preloadImages(personContentItems)
+        items.append(contentsOf: personContentItems)
+        thresholds.update(with: personContentItems)
+        if newItems.isEmpty {
+            doneLoading = true
+        }
+    }
+    
+    /// Gets the sort value of the next item in stream for a given sort type without affecting the cursor. Assumes loading has been handled by the FeedLoader.
+    /// - Returns: sorting value of the next tracker item corresponding to the given sort type
+    /// - Warning: This is NOT a thread-safe function! Only one thread at a time per stream may call this function!
+    func nextItemSortVal(sortType: FeedLoaderSort.SortType) async throws -> FeedLoaderSort? {
+        guard cursor < items.count else {
+            return nil
+        }
+        
+        return items[safeIndex: cursor]?.sortVal(sortType: sortType)
+    }
+    
+    /// Gets the next item in the stream and increments the cursor
+    /// - Returns: next item in the feed stream
+    /// - Warning: This is NOT a thread-safe function! Only one thread at a time per stream may call this function!
+    func consumeNextItem() -> PersonContent? {
+        guard cursor < items.count else {
+            return nil
+        }
+        
+        cursor += 1
+        return items[cursor - 1]
+    }
+    
+    /// Preloads images for the given PersonContent items
+    func preloadImages(_ items: [PersonContent]) {
+        Task {
+            // TODO: prefetch comment images
+            let posts = items.compactMap { item in
+                switch item.wrappedValue {
+                case let .post(post):
+                    return post
+                default: return nil
+                }
+            }
+            
+            await prefetchingConfiguration.prefetcher.startPrefetching(with: posts.concurrentFlatMap { post -> [ImageRequest] in
+                await post.imageRequests(configuration: self.prefetchingConfiguration)
+            })
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Protocols/APIContentAggregatesProtocol.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Protocols/APIContentAggregatesProtocol.swift
@@ -1,0 +1,16 @@
+//
+//  ApiContentAggregatesProtocol.swift
+//  Mlem
+//
+//  Created by Sjmarf on 09/08/2023.
+//
+
+import Foundation
+
+public protocol ApiContentAggregatesProtocol {
+    var score: Int { get }
+    var upvotes: Int { get }
+    var downvotes: Int { get }
+    var published: Date { get }
+    var comments: Int { get }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Protocols/APIContentViewProtocol.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Protocols/APIContentViewProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  ApiContentViewProtocol.swift
+//  Mlem
+//
+//  Created by Sjmarf on 09/08/2023.
+//
+
+import Foundation
+
+protocol ApiContentViewProtocol {
+    associatedtype AggregatesType: ApiContentAggregatesProtocol
+    
+    var post: ApiPost { get }
+    var creator: ApiPerson { get }
+    var community: ApiCommunity { get }
+    var counts: AggregatesType { get }
+    var saved: Bool { get }
+    var myVote: ScoringOperation? { get set }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Protocols/UpgradableProtocol.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Protocols/UpgradableProtocol.swift
@@ -1,0 +1,37 @@
+//
+//  UpgradableProtocol.swift
+//
+//
+//  Created by Eric Andrews on 2024-05-13.
+//
+
+import Foundation
+
+public protocol Upgradable: Observable {
+    associatedtype Base
+    associatedtype MinimumRenderable
+    associatedtype Upgraded
+    
+    var wrappedValue: Base { get }
+    
+    func upgrade(api: ApiClient?, upgradeOperation: ((Base) async throws -> Base)?) async throws
+    func refresh(upgradeOperation: ((Base) async throws -> Base)?) async throws
+    
+    init(_ wrappedValue: Base)
+}
+
+public extension Upgradable {
+    var isRenderable: Bool { wrappedValue is MinimumRenderable }
+    var isUpgraded: Bool { wrappedValue is Upgraded }
+    
+    func upgradeFromLocal() async throws {
+        if let wrappedValue = wrappedValue as? any Resolvable {
+            try await upgrade(
+                api: .getApiClient(url: wrappedValue.allResolvableUrls[0].removingPathComponents(), username: nil),
+                upgradeOperation: nil
+            )
+        } else {
+            assertionFailure()
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Tests/MlemMiddlewareTests/MlemMiddlewareTests.swift
+++ b/Mlem/Packages/MlemMiddleware/Tests/MlemMiddlewareTests/MlemMiddlewareTests.swift
@@ -1,0 +1,12 @@
+@testable import MlemMiddleware
+import XCTest
+
+final class MlemMiddlewareTests: XCTestCase {
+    func testExample() throws {
+        // XCTest Documentation
+        // https://developer.apple.com/documentation/xctest
+
+        // Defining Test Cases and Test Methods
+        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    }
+}


### PR DESCRIPTION
Moved MlemMiddleware to a local package. MlemApiTypes is still a submodule. I'll archive the MlemMiddleware repo when this merges.

I've disabled SwiftLint for the MlemMiddleware folder for now - eventually we should turn this back on, but at present there are a lot of errors (including dozens in MlemApiTypes), so I think it's easier to leave it out of this PR and fix it later