### PR TITLE
Handle Multi-Word Keyword Filters

### DIFF
--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -113,7 +113,7 @@ class Settings: ObservableObject {
         }
     }
     
-    var codable: CodableSettings { .init(from: self, filteredKeywords: FiltersTracker.main.filteredKeywords) }
+    var codable: CodableSettings { .init(from: self, filteredKeywords: FiltersTracker.main.rawKeywords) }
     
     @MainActor
     func restore(from systemSetting: SystemSetting) {

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -100,7 +100,7 @@ private func parseKeywordsAndPhrases(from rawKeywords: Set<String>) -> (keywords
     var phrases: Set<[String]> = .init()
     for keyword in rawKeywords {
         if keyword.contains(" ") {
-            phrases.insert(keyword.split(separator: " ").map(\.lowercased))
+            phrases.insert(keyword.split(separator: " ").map { $0.lowercased() })
         } else {
             keywords.insert(keyword)
         }

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -100,7 +100,7 @@ private func parseKeywordsAndPhrases(from rawKeywords: Set<String>) -> (keywords
     var phrases: Set<[String]> = .init()
     for keyword in rawKeywords {
         if keyword.contains(" ") {
-            phrases.insert(keyword.split(separator: " ").map { $0.lowercased() })
+            phrases.insert(keyword.split(separator: " ").map(\.lowercased))
         } else {
             keywords.insert(keyword)
         }

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -16,21 +16,31 @@ class FiltersTracker {
     
     var isAdmin: Bool
     var moderatedCommunityActorIds: Set<ActorIdentifier>
-    private(set) var filteredKeywords: Set<String>
+
+    /// User-entered strings to filter
+    private(set) var rawKeywords: Set<String>
+    
+    /// Single word keywords to filter
+    private(set) var keywords: Set<String>
+    
+    /// Multi-word phrases to filter
+    private(set) var phrases: Set<[String]>
+    
     var keywordFilterEnabled: Bool
     
     var filterContext: FilterContext {
         .init(
             isAdmin: isAdmin,
             moderatedCommunityActorIds: moderatedCommunityActorIds,
-            filteredKeywords: keywordFilterEnabled ? filteredKeywords : .init()
+            filteredKeywords: keywordFilterEnabled ? keywords : .init(),
+            filteredPhrases: keywordFilterEnabled ? phrases : .init()
         )
     }
     
     var changeHash: Int {
         var hasher = Hasher()
         hasher.combine(moderatedCommunityActorIds)
-        hasher.combine(filteredKeywords)
+        hasher.combine(rawKeywords)
         hasher.combine(keywordFilterEnabled)
         return hasher.finalize()
     }
@@ -41,27 +51,30 @@ class FiltersTracker {
         
         self.isAdmin = AppState.main.firstPerson?.isAdmin ?? false
         self.moderatedCommunityActorIds = AppState.main.firstPerson?.moderatedCommunityActorIds ?? .init()
-        self.filteredKeywords = persistenceRepository.loadFilteredKeywords()
+        let rawKeywords = persistenceRepository.loadFilteredKeywords()
+        self.rawKeywords = rawKeywords
+        (self.keywords, self.phrases) = parseKeywordsAndPhrases(from: rawKeywords)
         self.keywordFilterEnabled = keywordFilterEnabled
     }
     
     @MainActor
     private func setFilteredKeywords(to filteredKeywords: Set<String>) {
-        self.filteredKeywords = filteredKeywords
+        self.rawKeywords = filteredKeywords
+        (self.keywords, self.phrases) = parseKeywordsAndPhrases(from: filteredKeywords)
     }
     
     func addFilteredKeyword(_ keyword: String) async {
         do {
-            try await setFilteredKeywords(to: persistenceRepository.saveFilteredKeywords(filteredKeywords.union([keyword])))
+            try await setFilteredKeywords(to: persistenceRepository.saveFilteredKeywords(rawKeywords.union([keyword])))
         } catch {
             handleError(error)
         }
     }
     
     func removeFilteredKeyword(_ keyword: String) async {
-        assert(filteredKeywords.contains(keyword), "Filtered keywords does not contain \(keyword)")
+        assert(rawKeywords.contains(keyword), "Filtered keywords does not contain \(keyword)")
         do {
-            try await setFilteredKeywords(to: persistenceRepository.saveFilteredKeywords(filteredKeywords.subtracting([keyword])))
+            try await setFilteredKeywords(to: persistenceRepository.saveFilteredKeywords(rawKeywords.subtracting([keyword])))
         } catch {
             handleError(error)
         }
@@ -76,10 +89,23 @@ class FiltersTracker {
     }
     
     func postWouldBeFiltered(_ post: any Post) -> Bool {
-        keywordFilterEnabled && post.title.failsKeywordFilter(filteredKeywords)
+        keywordFilterEnabled && post.title.failsKeywordFilter(keywords: keywords, phrases: phrases)
     }
     
     static var main: FiltersTracker = .init()
+}
+
+private func parseKeywordsAndPhrases(from rawKeywords: Set<String>) -> (keywords: Set<String>, phrases: Set<[String]>) {
+    var keywords: Set<String> = .init()
+    var phrases: Set<[String]> = .init()
+    for keyword in rawKeywords {
+        if keyword.contains(" ") {
+            phrases.insert(keyword.split(separator: " ").map { $0.lowercased() })
+        } else {
+            keywords.insert(keyword)
+        }
+    }
+    return (keywords, phrases)
 }
 
 // The persisted file serves as the source of truth for filters. Since it's much more convenient to use FiltersTracker,

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -44,7 +44,7 @@ struct FiltersSettingsView: View {
                         Task {
                             if let url = await downloadTextToFileSystem(
                                 fileName: "keywords.txt",
-                                text: filtersTracker.filteredKeywords.joined(separator: "\n")
+                                text: filtersTracker.rawKeywords.joined(separator: "\n")
                             ) {
                                 navigation.model?.shareInfo = .init(url: url)
                             } else {
@@ -75,7 +75,7 @@ struct FiltersSettingsView: View {
                 saveNewKeyword()
             }
         
-        ForEach(filtersTracker.filteredKeywords.sorted(by: <), id: \.self) { filter in
+        ForEach(filtersTracker.rawKeywords.sorted(by: <), id: \.self) { filter in
             HStack {
                 Text(filter)
                 
@@ -103,7 +103,7 @@ struct FiltersSettingsView: View {
     }
     
     func deleteKeyword(_ keyword: String) {
-        guard filtersTracker.filteredKeywords.contains(keyword) else {
+        guard filtersTracker.rawKeywords.contains(keyword) else {
             return
         }
         

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetySettingsView.swift
@@ -65,7 +65,7 @@ struct SafetySettingsView: View {
     }
     
     var keywordFiltersNavigationLinkValue: LocalizedStringResource {
-        if filtersTracker.filteredKeywords.isEmpty { return "None" }
+        if filtersTracker.rawKeywords.isEmpty { return "None" }
         return keywordFilterEnabled ? "On" : "Off"
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/String+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/String+Extensions.swift
@@ -18,10 +18,85 @@ public extension String {
         strings.contains { contains($0) }
     }
     
-    /// Returns true if this string contains any whole word that is in the given set of strings
+    /// Returns true if this string contains:
+    /// - Any single word that matches a single word in filteredKeywords
+    /// - Any sequence of words that precisely matches a multi-word phrase in filteredKeywords
     func failsKeywordFilter(_ filteredKeywords: Set<String>) -> Bool {
-        let words = split(separator: /[^[:alnum:]]/) // split on any non-letter/number characters so "keyword's" is filtered as "keyword" "s"
+        // parse single keywords from multi-word phrases
+        var keywords: Set<String> = .init()
+        var phrases: Set<[String]> = .init()
+        for keyword in filteredKeywords {
+            if keyword.contains(" ") {
+                phrases.insert(keyword.split(separator: " ").map { $0.lowercased() })
+            } else {
+                keywords.insert(keyword)
+            }
+        }
+        
+        // split on any non-letter/number characters so "keyword's" is filtered as "keyword" "s"
+        let words = split(separator: /[^[:alnum:]]/)
             .map { $0.lowercased() }
+        
+        var partialMatches: [PartialMatch] = .init()
+        for word in words {
+            // check single keywords
+            if keywords.contains(word) { return true }
+            
+            // check if any partial matches succeed
+            var matchedPhrase: Bool = false
+            partialMatches = partialMatches.filter { partial in
+                switch partial.matchNextWord(word) {
+                case .failed: return false
+                case .partial: return true
+                case .matched:
+                    matchedPhrase = true
+                    return true
+                }
+            }
+            if matchedPhrase { return true }
+            
+            // check if this word starts a new partial match
+            for phrase in phrases {
+                guard let firstWord = phrase.first else {
+                    assertionFailure("Invalid phrase (no first element)")
+                    continue
+                }
+                if word == firstWord {
+                    partialMatches.append(.init(phrase: phrase))
+                }
+            }
+        }
+        
         return words.contains { filteredKeywords.contains($0) }
+    }
+}
+
+private enum MatchState {
+    case partial, failed, matched
+}
+
+private class PartialMatch {
+    private let phrase: [String]
+    private var index: Int = 1 // starts at 1 because only initialized if first word matches
+    
+    init(phrase: [String]) {
+        assert(phrase.count > 0, "Invalid phrase")
+        self.phrase = phrase
+    }
+    
+    func matchNextWord(_ word: String) -> MatchState {
+        guard let nextWord = phrase[safeIndex: index] else {
+            assertionFailure("No next word!")
+            return .failed
+        }
+        if word == nextWord {
+            if index == phrase.count - 1 {
+                return .matched
+            } else {
+                index += 1
+                return .partial
+            }
+        }
+        return .failed
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/String+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/String+Extensions.swift
@@ -21,18 +21,7 @@ public extension String {
     /// Returns true if this string contains:
     /// - Any single word that matches a single word in filteredKeywords
     /// - Any sequence of words that precisely matches a multi-word phrase in filteredKeywords
-    func failsKeywordFilter(_ filteredKeywords: Set<String>) -> Bool {
-        // parse single keywords from multi-word phrases
-        var keywords: Set<String> = .init()
-        var phrases: Set<[String]> = .init()
-        for keyword in filteredKeywords {
-            if keyword.contains(" ") {
-                phrases.insert(keyword.split(separator: " ").map { $0.lowercased() })
-            } else {
-                keywords.insert(keyword)
-            }
-        }
-        
+    func failsKeywordFilter(keywords: Set<String>, phrases: Set<[String]>) -> Bool {
         // split on any non-letter/number characters so "keyword's" is filtered as "keyword" "s"
         let words = split(separator: /[^[:alnum:]]/)
             .map { $0.lowercased() }
@@ -67,7 +56,7 @@ public extension String {
             }
         }
         
-        return words.contains { filteredKeywords.contains($0) }
+        return false
     }
 }
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterContext.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterContext.swift
@@ -12,14 +12,21 @@ public struct FilterContext {
     public let isAdmin: Bool
     public let moderatedCommunityActorIds: Set<ActorIdentifier>
     public let filteredKeywords: Set<String>
+    public let filteredPhrases: Set<[String]>
     
-    public init(isAdmin: Bool, moderatedCommunityActorIds: Set<ActorIdentifier>, filteredKeywords: Set<String>) {
+    public init(
+        isAdmin: Bool,
+        moderatedCommunityActorIds: Set<ActorIdentifier>,
+        filteredKeywords: Set<String>,
+        filteredPhrases: Set<[String]>
+    ) {
         self.isAdmin = isAdmin
         self.moderatedCommunityActorIds = moderatedCommunityActorIds
         self.filteredKeywords = filteredKeywords
+        self.filteredPhrases = filteredPhrases
     }
     
     static func none() -> FilterContext {
-        .init(isAdmin: true, moderatedCommunityActorIds: [], filteredKeywords: [])
+        .init(isAdmin: true, moderatedCommunityActorIds: [], filteredKeywords: [], filteredPhrases: [])
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostKeywordFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostKeywordFilter.swift
@@ -35,7 +35,7 @@ class PostKeywordFilter: FilterProviding {
         // bypass filter for moderated/administrated posts
         if context.isAdmin || context.moderatedCommunityActorIds.contains(post.community.actorId) { return true }
         
-        return !post.title.failsKeywordFilter(context.filteredKeywords)
+        return !post.title.failsKeywordFilter(keywords: context.filteredKeywords, phrases: context.filteredPhrases)
     }
     
     func updateFilterContext(to context: FilterContext) {


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1852 

## Description

Improves the keyword filtering filtering algorithm to handle multi-word phrases. Phrases are matched on a word-by-word basis, so `multi phrase` is matched as `[multi, phrase]` against the split test string. This produces the following filter behavior:
- `title with multi phrase in it`: filtered
- `title with multi phrase's in it`: filtered
- `title with multi's phrase in it`: not filtered

## Implementation Notes

`FiltersTracker` is now responsible for parsing the raw user-provided keyword strings into a set of single word filters and multi-word phrase filters. Filters are still coded and stored as whole strings both to avoid coding compatibility problems and to make adding and removing keywords simpler.