### PR TITLE
Minor localization fixes

### DIFF
--- a/Mlem/App/Views/Pages/Instance/InstanceUptimeView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceUptimeView.swift
@@ -9,6 +9,7 @@ import Charts
 import MlemMiddleware
 import SwiftUI
 
+// swiftlint:disable:next type_body_length
 struct InstanceUptimeView: View {
     @Environment(\.accessibilityDifferentiateWithoutColor) var diffWithoutColor: Bool
     @Environment(\.palette) var palette
@@ -145,10 +146,16 @@ struct InstanceUptimeView: View {
         let resource: LocalizedStringResource
         let color: Color
         if isHealthy {
-            resource = "\(instance.name) is {{online}}"
+            resource = .init(
+                "\(instance.name) is {{online}}",
+                comment: "The word(s) within the curly brackets will be colored green."
+            )
             color = palette.positive
         } else {
-            resource = "\(instance.name) is {{unhealthy}}"
+            resource = .init(
+                "\(instance.name) is {{unhealthy}}",
+                comment: "The word(s) within the curly brackets will be colored red."
+            )
             color = palette.negative
         }
         let string = String(localized: resource)

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -133,7 +133,7 @@ extension NavigationPage {
                 .disabled(instance.version < (minimumVersion ?? .zero))
             } header: {
                 if let minimumVersion {
-                    Text("This feature is only supported for instances running version \(minimumVersion) or later.")
+                    Text("This feature is only supported for instances running version \(String(describing: minimumVersion)) or later.")
                         .padding()
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(.themedCaution.opacity(0.2), in: .rect(cornerRadius: Constants.main.standardSpacing))

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -126,20 +126,22 @@
       }
     },
     "%@ is {{online}}" : {
+      "comment" : "The word(s) within the curly brackets will be colored green.",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "%@ est {{online}}"
           }
         }
       }
     },
     "%@ is {{unhealthy}}" : {
+      "comment" : "The word(s) within the curly brackets will be colored red.",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "%@ est {{unhealthy}}"
           }
         }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -7795,6 +7795,9 @@
         }
       }
     },
+    "This feature is only supported for instances running version %@ or later." : {
+
+    },
     "This field is optional." : {
       "localizations" : {
         "fr" : {


### PR DESCRIPTION
Fixed a string not being included in `Localizable` and added a comment explaining what the `{{` `}}` are for in some localized strings