### PR TITLE
Contextual infostack coloring

### DIFF
--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUICore
+import MlemMiddleware
 
 struct CommentBarConfiguration: InteractionBarConfiguration {
     enum ActionType: String, ActionTypeProviding {
@@ -53,10 +54,10 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        var associatedReadout: Set<Configuration.ReadoutType> {
+        func associatedReadout(context: any Interactable1Providing) -> Set<Configuration.ReadoutType> {
             switch self {
-            case .upvote: [.upvote, .score]
-            case .downvote: [.downvote, .score]
+            case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
+            case .downvote: context.votes_?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
             case .save: [.saved]
             case .reply, .share, .selectText, .report, .resolve, .remove, .ban: []
             }
@@ -82,11 +83,11 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        var associatedReadout: Set<Configuration.ReadoutType> {
+        func associatedReadout(context: any Interactable1Providing) -> Set<Configuration.ReadoutType> {
             switch self {
             case .score: [.upvote, .downvote, .score]
-            case .upvote: [.upvote, .score]
-            case .downvote: [.downvote, .score]
+            case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
+            case .downvote: context.votes_?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
             case .reply: []
             }
         }

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -10,6 +10,8 @@ import SwiftUICore
 
 struct CommentBarConfiguration: InteractionBarConfiguration {
     enum ActionType: String, ActionTypeProviding {
+        typealias Configuration = CommentBarConfiguration // swiftlint:disable:this nesting
+        
         case upvote
         case downvote
         case save
@@ -50,9 +52,20 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             case .ban: .banFromCommunity(isOn: false)
             }
         }
+        
+        var associatedReadout: Set<Configuration.ReadoutType> {
+            switch self {
+            case .upvote: [.upvote, .score]
+            case .downvote: [.downvote, .score]
+            case .save: [.saved]
+            case .reply, .share, .selectText, .report, .resolve, .remove, .ban: []
+            }
+        }
     }
     
     enum CounterType: String, CounterTypeProviding {
+        typealias Configuration = CommentBarConfiguration // swiftlint:disable:this nesting
+        
         case score
         case upvote
         case downvote
@@ -66,6 +79,15 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             case .upvote: .upvote()
             case .downvote: .downvote()
             case .reply: .reply()
+            }
+        }
+        
+        var associatedReadout: Set<Configuration.ReadoutType> {
+            switch self {
+            case .score: [.upvote, .downvote, .score]
+            case .upvote: [.upvote, .score]
+            case .downvote: [.downvote, .score]
+            case .reply: []
             }
         }
     }

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -54,7 +54,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        func associatedReadout(context: any Interactable1Providing) -> Set<Configuration.ReadoutType> {
+        func associatedReadouts(context: any Interactable1Providing) -> Set<Configuration.ReadoutType> {
             switch self {
             case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
             case .downvote: context.votes_?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
@@ -83,7 +83,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        func associatedReadout(context: any Interactable1Providing) -> Set<Configuration.ReadoutType> {
+        func associatedReadouts(context: any Interactable1Providing) -> Set<Configuration.ReadoutType> {
             switch self {
             case .score: [.upvote, .downvote, .score]
             case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -57,11 +57,9 @@ extension InteractionBarConfiguration {
     var all: [Item] { leading + trailing }
     
     func associatedReadouts(context: any Interactable1Providing) -> Set<ReadoutType> {
-        var ret: Set<ReadoutType> = .init()
-        for element in all {
-            ret.formUnion(element.associatedReadouts(context: context))
-        }
-        return ret
+        all.reduce(into: Set<ReadoutType>(), { result, element in
+            result.formUnion(element.associatedReadouts(context: context))
+        })
     }
 }
 

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUICore
+import MlemMiddleware
 
 protocol InteractionBarConfiguration: Codable, Equatable {
     associatedtype ActionType: ActionTypeProviding
@@ -55,10 +56,10 @@ extension InteractionBarConfiguration {
     
     var all: [Item] { leading + trailing }
     
-    var associatedReadout: Set<ReadoutType> {
+    func associatedReadout(context: any Interactable1Providing) -> Set<ReadoutType> {
         var ret: Set<ReadoutType> = .init()
         for element in all {
-            ret.formUnion(element.associatedReadout)
+            ret.formUnion(element.associatedReadout(context: context))
         }
         return ret
     }
@@ -109,16 +110,16 @@ enum InteractionConfigurationItem<
         }
     }
     
-    var associatedReadout: Set<ReadoutType> {
+    func associatedReadout(context: any Interactable1Providing) -> Set<ReadoutType> {
         switch self {
         case let .action(actionType):
-            guard let ret = actionType.associatedReadout as? Set<ReadoutType> else {
+            guard let ret = actionType.associatedReadout(context: context) as? Set<ReadoutType> else {
                 assertionFailure("Could not cast to ReadoutType")
                 return []
             }
             return ret
         case let .counter(counterType):
-            guard let ret = counterType.associatedReadout as? Set<ReadoutType> else {
+            guard let ret = counterType.associatedReadout(context: context) as? Set<ReadoutType> else {
                 assertionFailure("Could not cast to ReadoutType")
                 return []
             }
@@ -134,7 +135,7 @@ protocol ActionTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable 
     
     static var defaultWidgets: [Self] { get }
     
-    var associatedReadout: Set<Configuration.ReadoutType> { get }
+    func associatedReadout(context: any Interactable1Providing) -> Set<Configuration.ReadoutType>
 }
 
 protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
@@ -144,7 +145,7 @@ protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable
     
     static var defaultWidgets: [Self] { get }
     
-    var associatedReadout: Set<Configuration.ReadoutType> { get }
+    func associatedReadout(context: any Interactable1Providing) -> Set<Configuration.ReadoutType>
 }
 
 protocol ReadoutTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -56,10 +56,10 @@ extension InteractionBarConfiguration {
     
     var all: [Item] { leading + trailing }
     
-    func associatedReadout(context: any Interactable1Providing) -> Set<ReadoutType> {
+    func associatedReadouts(context: any Interactable1Providing) -> Set<ReadoutType> {
         var ret: Set<ReadoutType> = .init()
         for element in all {
-            ret.formUnion(element.associatedReadout(context: context))
+            ret.formUnion(element.associatedReadouts(context: context))
         }
         return ret
     }
@@ -110,16 +110,16 @@ enum InteractionConfigurationItem<
         }
     }
     
-    func associatedReadout(context: any Interactable1Providing) -> Set<ReadoutType> {
+    func associatedReadouts(context: any Interactable1Providing) -> Set<ReadoutType> {
         switch self {
         case let .action(actionType):
-            guard let ret = actionType.associatedReadout(context: context) as? Set<ReadoutType> else {
+            guard let ret = actionType.associatedReadouts(context: context) as? Set<ReadoutType> else {
                 assertionFailure("Could not cast to ReadoutType")
                 return []
             }
             return ret
         case let .counter(counterType):
-            guard let ret = counterType.associatedReadout(context: context) as? Set<ReadoutType> else {
+            guard let ret = counterType.associatedReadouts(context: context) as? Set<ReadoutType> else {
                 assertionFailure("Could not cast to ReadoutType")
                 return []
             }
@@ -135,7 +135,7 @@ protocol ActionTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable 
     
     static var defaultWidgets: [Self] { get }
     
-    func associatedReadout(context: any Interactable1Providing) -> Set<Configuration.ReadoutType>
+    func associatedReadouts(context: any Interactable1Providing) -> Set<Configuration.ReadoutType>
 }
 
 protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
@@ -145,7 +145,7 @@ protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable
     
     static var defaultWidgets: [Self] { get }
     
-    func associatedReadout(context: any Interactable1Providing) -> Set<Configuration.ReadoutType>
+    func associatedReadouts(context: any Interactable1Providing) -> Set<Configuration.ReadoutType>
 }
 
 protocol ReadoutTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -13,7 +13,7 @@ protocol InteractionBarConfiguration: Codable, Equatable {
     associatedtype CounterType: CounterTypeProviding
     associatedtype ReadoutType: ReadoutTypeProviding
     
-    typealias Item = InteractionConfigurationItem<ActionType, CounterType>
+    typealias Item = InteractionConfigurationItem<ActionType, CounterType, ReadoutType>
     
     var leading: [Item] { get set }
     var trailing: [Item] { get set }
@@ -54,6 +54,14 @@ extension InteractionBarConfiguration {
     }
     
     var all: [Item] { leading + trailing }
+    
+    var associatedReadout: Set<ReadoutType> {
+        var ret: Set<ReadoutType> = .init()
+        for element in all {
+            ret.formUnion(element.associatedReadout)
+        }
+        return ret
+    }
 }
 
 // swiftlint:disable:next type_name
@@ -61,7 +69,10 @@ enum InteractionBarConfigurationConversionType {
     case swipe, bar
 }
 
-enum InteractionConfigurationItem<ActionType: ActionTypeProviding, CounterType: CounterTypeProviding>: Codable, Hashable {
+enum InteractionConfigurationItem<
+    ActionType: ActionTypeProviding,
+    CounterType: CounterTypeProviding,
+    ReadoutType: ReadoutTypeProviding>: Codable, Hashable {
     case action(ActionType)
     case counter(CounterType)
     
@@ -69,7 +80,10 @@ enum InteractionConfigurationItem<ActionType: ActionTypeProviding, CounterType: 
         CounterType.allCases.map { .counter($0) } + ActionType.allCases.map { .action($0) }
     }
     
-    fileprivate func convert<A: ActionTypeProviding, C: CounterTypeProviding>() -> InteractionConfigurationItem<A, C>? {
+    fileprivate func convert<
+        A: ActionTypeProviding,
+        C: CounterTypeProviding,
+        R: ReadoutTypeProviding>() -> InteractionConfigurationItem<A, C, R>? {
         switch self {
         case let .action(action):
             if let value = A(rawValue: action.rawValue) {
@@ -94,18 +108,43 @@ enum InteractionConfigurationItem<ActionType: ActionTypeProviding, CounterType: 
             counter.appearance.leading == nil || counter.appearance.trailing == nil ? 2 : 3
         }
     }
+    
+    var associatedReadout: Set<ReadoutType> {
+        switch self {
+        case let .action(actionType):
+            guard let ret = actionType.associatedReadout as? Set<ReadoutType> else {
+                assertionFailure("Could not cast to ReadoutType")
+                return []
+            }
+            return ret
+        case let .counter(counterType):
+            guard let ret = counterType.associatedReadout as? Set<ReadoutType> else {
+                assertionFailure("Could not cast to ReadoutType")
+                return []
+            }
+            return ret
+        }
+    }
 }
 
 protocol ActionTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
+    associatedtype Configuration: InteractionBarConfiguration
+    
     var appearance: ActionAppearance { get }
     
     static var defaultWidgets: [Self] { get }
+    
+    var associatedReadout: Set<Configuration.ReadoutType> { get }
 }
 
 protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
+    associatedtype Configuration: InteractionBarConfiguration
+    
     var appearance: CounterAppearance { get }
     
     static var defaultWidgets: [Self] { get }
+    
+    var associatedReadout: Set<Configuration.ReadoutType> { get }
 }
 
 protocol ReadoutTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -10,6 +10,8 @@ import SwiftUICore
 
 struct PostBarConfiguration: InteractionBarConfiguration {
     enum ActionType: String, ActionTypeProviding {
+        typealias Configuration = PostBarConfiguration // swiftlint:disable:this nesting
+        
         case upvote
         case downvote
         case save
@@ -62,9 +64,20 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             case .ban: .banFromCommunity(isOn: false)
             }
         }
+        
+        var associatedReadout: Set<PostBarConfiguration.ReadoutType> {
+            switch self {
+            case .upvote: [.upvote, .score]
+            case .downvote: [.downvote, .score]
+            case .save: [.saved]
+            case .reply, .share, .selectText, .hide, .block, .report, .crossPost, .lock, .pin, .resolve, .remove, .ban: []
+            }
+        }
     }
     
     enum CounterType: String, CounterTypeProviding {
+        typealias Configuration = PostBarConfiguration // swiftlint:disable:this nesting
+        
         case score
         case upvote
         case downvote
@@ -78,6 +91,15 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             case .upvote: .upvote()
             case .downvote: .downvote()
             case .reply: .reply()
+            }
+        }
+        
+        var associatedReadout: Set<PostBarConfiguration.ReadoutType> {
+            switch self {
+            case .score: [.upvote, .downvote, .score]
+            case .upvote: [.upvote, .score]
+            case .downvote: [.downvote, .score]
+            case .reply: []
             }
         }
     }

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUICore
+import MlemMiddleware
 
 struct PostBarConfiguration: InteractionBarConfiguration {
     enum ActionType: String, ActionTypeProviding {
@@ -65,10 +66,10 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        var associatedReadout: Set<PostBarConfiguration.ReadoutType> {
+        func associatedReadout(context: any Interactable1Providing) -> Set<PostBarConfiguration.ReadoutType> {
             switch self {
-            case .upvote: [.upvote, .score]
-            case .downvote: [.downvote, .score]
+            case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
+            case .downvote: context.votes_?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
             case .save: [.saved]
             case .reply, .share, .selectText, .hide, .block, .report, .crossPost, .lock, .pin, .resolve, .remove, .ban: []
             }
@@ -94,11 +95,11 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        var associatedReadout: Set<PostBarConfiguration.ReadoutType> {
+        func associatedReadout(context: any Interactable1Providing) -> Set<PostBarConfiguration.ReadoutType> {
             switch self {
             case .score: [.upvote, .downvote, .score]
-            case .upvote: [.upvote, .score]
-            case .downvote: [.downvote, .score]
+            case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
+            case .downvote: context.votes_?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
             case .reply: []
             }
         }

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -66,7 +66,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        func associatedReadout(context: any Interactable1Providing) -> Set<PostBarConfiguration.ReadoutType> {
+        func associatedReadouts(context: any Interactable1Providing) -> Set<PostBarConfiguration.ReadoutType> {
             switch self {
             case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
             case .downvote: context.votes_?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
@@ -95,7 +95,7 @@ struct PostBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        func associatedReadout(context: any Interactable1Providing) -> Set<PostBarConfiguration.ReadoutType> {
+        func associatedReadouts(context: any Interactable1Providing) -> Set<PostBarConfiguration.ReadoutType> {
             switch self {
             case .score: [.upvote, .downvote, .score]
             case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUICore
+import MlemMiddleware
 
 struct ReplyBarConfiguration: InteractionBarConfiguration {
     enum ActionType: String, ActionTypeProviding {
@@ -40,10 +41,10 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        var associatedReadout: Set<ReplyBarConfiguration.ReadoutType> {
+        func associatedReadout(context: any Interactable1Providing) -> Set<ReplyBarConfiguration.ReadoutType> {
             switch self {
-            case .upvote: [.upvote, .score]
-            case .downvote: [.downvote, .score]
+            case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
+            case .downvote: context.votes_?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
             case .save: [.saved]
             case .reply, .markRead, .selectText, .report: []
             }
@@ -69,11 +70,11 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        var associatedReadout: Set<ReplyBarConfiguration.ReadoutType> {
+        func associatedReadout(context: any Interactable1Providing) -> Set<ReplyBarConfiguration.ReadoutType> {
             switch self {
             case .score: [.upvote, .downvote, .score]
-            case .upvote: [.upvote, .score]
-            case .downvote: [.downvote, .score]
+            case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
+            case .downvote: context.votes_?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
             case .reply: []
             }
         }

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -10,6 +10,8 @@ import SwiftUICore
 
 struct ReplyBarConfiguration: InteractionBarConfiguration {
     enum ActionType: String, ActionTypeProviding {
+        typealias Configuration = ReplyBarConfiguration // swiftlint:disable:this nesting
+        
         case upvote
         case downvote
         case save
@@ -37,9 +39,20 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             case .report: .report()
             }
         }
+        
+        var associatedReadout: Set<ReplyBarConfiguration.ReadoutType> {
+            switch self {
+            case .upvote: [.upvote, .score]
+            case .downvote: [.downvote, .score]
+            case .save: [.saved]
+            case .reply, .markRead, .selectText, .report: []
+            }
+        }
     }
     
     enum CounterType: String, CounterTypeProviding {
+        typealias Configuration = ReplyBarConfiguration // swiftlint:disable:this nesting
+        
         case score
         case upvote
         case downvote
@@ -53,6 +66,15 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             case .upvote: .upvote()
             case .downvote: .downvote()
             case .reply: .reply()
+            }
+        }
+        
+        var associatedReadout: Set<ReplyBarConfiguration.ReadoutType> {
+            switch self {
+            case .score: [.upvote, .downvote, .score]
+            case .upvote: [.upvote, .score]
+            case .downvote: [.downvote, .score]
+            case .reply: []
             }
         }
     }

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -41,7 +41,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        func associatedReadout(context: any Interactable1Providing) -> Set<ReplyBarConfiguration.ReadoutType> {
+        func associatedReadouts(context: any Interactable1Providing) -> Set<ReplyBarConfiguration.ReadoutType> {
             switch self {
             case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
             case .downvote: context.votes_?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
@@ -70,7 +70,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             }
         }
         
-        func associatedReadout(context: any Interactable1Providing) -> Set<ReplyBarConfiguration.ReadoutType> {
+        func associatedReadouts(context: any Interactable1Providing) -> Set<ReplyBarConfiguration.ReadoutType> {
             switch self {
             case .score: [.upvote, .downvote, .score]
             case .upvote: context.votes_?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -153,11 +153,12 @@ extension Comment1Providing {
     func readout(type: CommentBarConfiguration.ReadoutType, showColor: Bool) -> Readout? {
         switch type {
         case .created: createdReadout
-        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout
-        case .upvote: upvoteReadout
-        case .downvote: api.downvotesEnabled ? downvoteReadout : nil
+        // swiftlint:disable:next void_function_in_ternary
+        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout(showColor: showColor)
+        case .upvote: upvoteReadout(showColor: showColor)
+        case .downvote: api.downvotesEnabled ? downvoteReadout(showColor: showColor) : nil
         case .comment: commentReadout
-        case .saved: savedReadout
+        case .saved: savedReadout(showColor: showColor)
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -150,10 +150,10 @@ extension Comment1Providing {
         }
     }
     
-    func readout(type: CommentBarConfiguration.ReadoutType) -> Readout? {
+    func readout(type: CommentBarConfiguration.ReadoutType, showColor: Bool) -> Readout? {
         switch type {
         case .created: createdReadout
-        case .score: api.downvotesEnabled ? scoreReadout : upvoteReadout
+        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout
         case .upvote: upvoteReadout
         case .downvote: api.downvotesEnabled ? downvoteReadout : nil
         case .comment: commentReadout

--- a/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
@@ -209,23 +209,23 @@ extension Interactable1Providing {
         )
     }
     
-    var upvoteReadout: Readout {
+    func upvoteReadout(showColor: Bool) -> Readout {
         let isOn = self2?.votes.myVote == .upvote
         return Readout(
             id: "upvote\(uid)",
             label: self2?.votes.upvotes.description,
             icon: isOn ? Icons.upvoteSquareFill : Icons.upvoteSquare,
-            color: isOn ? .themedUpvote : nil
+            color: isOn && showColor ? .themedUpvote : nil
         )
     }
     
-    var downvoteReadout: Readout {
+    func downvoteReadout(showColor: Bool) -> Readout {
         let isOn = self2?.votes.myVote == .downvote
         return Readout(
             id: "downvote\(uid)",
             label: self2?.votes.downvotes.description,
             icon: isOn ? Icons.downvoteSquareFill : Icons.downvoteSquare,
-            color: isOn ? .themedDownvote : nil
+            color: isOn && showColor ? .themedDownvote : nil
         )
     }
     
@@ -247,13 +247,13 @@ extension Interactable1Providing {
         )
     }
     
-    var savedReadout: Readout {
+    func savedReadout(showColor: Bool) -> Readout {
         let isOn = saved_ ?? false
         return .init(
             id: "saved\(uid)",
             label: nil,
             icon: isOn ? Icons.saveFill : Icons.save,
-            color: isOn ? .themedSave : nil
+            color: isOn && showColor ? .themedSave : nil
         )
     }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
@@ -187,7 +187,7 @@ extension Interactable1Providing {
         )
     }
     
-    var scoreReadout: Readout {
+    func scoreReadout(showColor: Bool) -> Readout {
         let icon: String
         let color: ThemedColor?
         switch self2?.votes.myVote {
@@ -205,7 +205,7 @@ extension Interactable1Providing {
             id: "score\(uid)",
             label: self2?.votes.total.description,
             icon: icon,
-            color: color
+            color: showColor ? color : nil
         )
     }
     

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -261,11 +261,12 @@ extension Post1Providing {
     func readout(type: PostBarConfiguration.ReadoutType, showColor: Bool) -> Readout? {
         switch type {
         case .created: createdReadout
-        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout
-        case .upvote: upvoteReadout
-        case .downvote: api.downvotesEnabled ? downvoteReadout : nil
+        // swiftlint:disable:next void_function_in_ternary
+        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout(showColor: showColor)
+        case .upvote: upvoteReadout(showColor: showColor)
+        case .downvote: api.downvotesEnabled ? downvoteReadout(showColor: showColor) : nil
         case .comment: commentReadout
-        case .saved: savedReadout
+        case .saved: savedReadout(showColor: showColor)
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -258,10 +258,10 @@ extension Post1Providing {
         }
     }
     
-    func readout(type: PostBarConfiguration.ReadoutType) -> Readout? {
+    func readout(type: PostBarConfiguration.ReadoutType, showColor: Bool) -> Readout? {
         switch type {
         case .created: createdReadout
-        case .score: api.downvotesEnabled ? scoreReadout : upvoteReadout
+        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout
         case .upvote: upvoteReadout
         case .downvote: api.downvotesEnabled ? downvoteReadout : nil
         case .comment: commentReadout

--- a/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
@@ -59,11 +59,12 @@ extension Reply1Providing {
     func readout(type: ReplyBarConfiguration.ReadoutType, showColor: Bool) -> Readout? {
         switch type {
         case .created: createdReadout
-        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout
-        case .upvote: upvoteReadout
-        case .downvote: api.downvotesEnabled ? downvoteReadout : nil
+        // swiftlint:disable:next void_function_in_ternary
+        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout(showColor: showColor)
+        case .upvote: upvoteReadout(showColor: showColor)
+        case .downvote: api.downvotesEnabled ? downvoteReadout(showColor: showColor) : nil
         case .comment: commentReadout
-        case .saved: savedReadout
+        case .saved: savedReadout(showColor: showColor)
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
@@ -56,10 +56,10 @@ extension Reply1Providing {
         }
     }
     
-    func readout(type: ReplyBarConfiguration.ReadoutType) -> Readout? {
+    func readout(type: ReplyBarConfiguration.ReadoutType, showColor: Bool) -> Readout? {
         switch type {
         case .created: createdReadout
-        case .score: api.downvotesEnabled ? scoreReadout : upvoteReadout
+        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout
         case .upvote: upvoteReadout
         case .downvote: api.downvotesEnabled ? downvoteReadout : nil
         case .comment: commentReadout

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
@@ -88,7 +88,7 @@ struct CompactPostView: View {
                 } else {
                     titleAndHostView
                 }
-                InfoStackView(post: post, readouts: readouts, showColor: true)
+                InfoStackView(post: post, readouts: readouts, coloredReadouts: .init()) // TODO: NOW
             }
             .frame(maxWidth: .infinity)
             

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
@@ -88,7 +88,7 @@ struct CompactPostView: View {
                 } else {
                     titleAndHostView
                 }
-                InfoStackView(post: post, readouts: readouts, coloredReadouts: .init()) // TODO: NOW
+                InfoStackView(post: post, readouts: readouts, coloredReadouts: .init(PostBarConfiguration.ReadoutType.allCases))
             }
             .frame(maxWidth: .infinity)
             

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/Feed Post Components/CrossPostListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/Feed Post Components/CrossPostListView.swift
@@ -50,9 +50,9 @@ struct CrossPostListView: View {
                             GridRow {
                                 FullyQualifiedLabelView(crossPost.community, labelStyle: .medium, blurred: crossPost.nsfw)
                                     .frame(maxWidth: .infinity, alignment: .leading)
-                                ReadoutView(readout: crossPost.createdReadout, showColor: true)
-                                ReadoutView(readout: crossPost.scoreReadout, showColor: true)
-                                ReadoutView(readout: crossPost.commentReadout, showColor: true)
+                                ReadoutView(readout: crossPost.createdReadout)
+                                ReadoutView(readout: crossPost.scoreReadout(showColor: true))
+                                ReadoutView(readout: crossPost.commentReadout)
                             }
                             .contentShape(.rect)
                             .onTapGesture {

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -140,7 +140,7 @@ struct CommentView<EmbeddedContent: View>: View {
                 InfoStackView(
                     comment: comment,
                     readouts: InteractionBarTracker.main.commentInteractionBar.readouts,
-                    showColor: true
+                    coloredReadouts: .init() // TODO: NOW
                 )
                 .layoutPriority(1)
             }

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -140,7 +140,7 @@ struct CommentView<EmbeddedContent: View>: View {
                 InfoStackView(
                     comment: comment,
                     readouts: InteractionBarTracker.main.commentInteractionBar.readouts,
-                    coloredReadouts: .init() // TODO: NOW
+                    coloredReadouts: .init(CommentBarConfiguration.ReadoutType.allCases)
                 )
                 .layoutPriority(1)
             }

--- a/Mlem/App/Views/Shared/InfoStackView.swift
+++ b/Mlem/App/Views/Shared/InfoStackView.swift
@@ -10,12 +10,11 @@ import SwiftUI
 
 struct InfoStackView: View {
     let readouts: [Readout]
-    let showColor: Bool
     
     var body: some View {
         HStack(spacing: 12) {
             ForEach(readouts, id: \.viewId) { readout in
-                ReadoutView(readout: readout, showColor: showColor)
+                ReadoutView(readout: readout)
             }
         }
         .geometryGroup()
@@ -26,7 +25,6 @@ struct ReadoutView: View {
     @Environment(\.palette) var palette
     
     let readout: Readout
-    let showColor: Bool
     
     var body: some View {
         HStack(spacing: 2) {
@@ -47,29 +45,34 @@ struct ReadoutView: View {
                     .foregroundStyle(readout.valueColor ?? .themedSecondary)
             }
         }
-        .foregroundStyle((showColor ? readout.color : nil) ?? .themedSecondary)
+        .foregroundStyle(readout.color ?? .themedSecondary)
         .font(.footnote)
         .lineLimit(1)
     }
 }
 
 extension InfoStackView {
-    init(post: any Post1Providing, readouts: [PostBarConfiguration.ReadoutType?], showColor: Bool) {
+    init(post: any Post1Providing, readouts: [PostBarConfiguration.ReadoutType?], coloredReadouts: Set<PostBarConfiguration.ReadoutType>) {
         self.readouts = readouts.compactMap {
-            if let readoutType = $0 { return post.readout(type: readoutType) }
+            if let readoutType = $0 { return post.readout(type: readoutType, showColor: coloredReadouts.contains(readoutType)) }
             return nil
         }
-        self.showColor = showColor
     }
     
-    init(comment: any Comment1Providing, readouts: [CommentBarConfiguration.ReadoutType], showColor: Bool) {
-        self.readouts = readouts.compactMap { comment.readout(type: $0) }
-        self.showColor = showColor
+    init(
+        comment: any Comment1Providing,
+        readouts: [CommentBarConfiguration.ReadoutType],
+        coloredReadouts: Set<CommentBarConfiguration.ReadoutType>
+    ) {
+        self.readouts = readouts.compactMap { comment.readout(type: $0, showColor: coloredReadouts.contains($0)) }
     }
     
-    init(reply: any Reply1Providing, readouts: [ReplyBarConfiguration.ReadoutType], showColor: Bool) {
-        self.readouts = readouts.compactMap { reply.readout(type: $0) }
-        self.showColor = showColor
+    init(
+        reply: any Reply1Providing,
+        readouts: [ReplyBarConfiguration.ReadoutType],
+        coloredReadouts: Set<ReplyBarConfiguration.ReadoutType>
+    ) {
+        self.readouts = readouts.compactMap { reply.readout(type: $0, showColor: coloredReadouts.contains($0)) }
     }
 }
 

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
@@ -43,14 +43,9 @@ struct InteractionBarView: View {
             communityContext: communityContext,
             reportContext: reportContext
         )
-        var associatedReadouts: Set<PostBarConfiguration.ReadoutType> = .init()
-        configuration.leading.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout(context: post))
-        }
-        configuration.trailing.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout(context: post))
-        }
-        
+        var associatedReadouts = configuration.all.reduce(into: Set<PostBarConfiguration.ReadoutType>(), { result, widget in
+            result.formUnion(widget.associatedReadout(context: post))
+        })
         self.readouts = configuration.readouts.compactMap { readout in
             post.readout(type: readout, showColor: !associatedReadouts.contains(readout))
         }
@@ -83,13 +78,9 @@ struct InteractionBarView: View {
             communityContext: communityContext,
             reportContext: reportContext
         )
-        var associatedReadouts: Set<CommentBarConfiguration.ReadoutType> = .init()
-        configuration.leading.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout(context: comment))
-        }
-        configuration.trailing.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout(context: comment))
-        }
+        var associatedReadouts = configuration.all.reduce(into: Set<CommentBarConfiguration.ReadoutType>(), { result, widget in
+            result.formUnion(widget.associatedReadout(context: comment))
+        })
         self.readouts = configuration.readouts.compactMap { readout in
             comment.readout(type: readout, showColor: !associatedReadouts.contains(readout))
         }
@@ -102,13 +93,9 @@ struct InteractionBarView: View {
     ) {
         self.leading = .init(appState: appState, reply: reply, items: configuration.leading)
         self.trailing = .init(appState: appState, reply: reply, items: configuration.trailing)
-        var associatedReadouts: Set<ReplyBarConfiguration.ReadoutType> = .init()
-        configuration.leading.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout(context: reply))
-        }
-        configuration.trailing.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout(context: reply))
-        }
+        var associatedReadouts = configuration.all.reduce(into: Set<ReplyBarConfiguration.ReadoutType>(), { result, widget in
+            result.formUnion(widget.associatedReadout(context: reply))
+        })
         self.readouts = configuration.readouts.compactMap { readout in
             reply.readout(type: readout, showColor: !associatedReadouts.contains(readout))
         }

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
@@ -43,7 +43,7 @@ struct InteractionBarView: View {
             communityContext: communityContext,
             reportContext: reportContext
         )
-        var associatedReadouts = configuration.all.reduce(into: Set<PostBarConfiguration.ReadoutType>(), { result, widget in
+        let associatedReadouts = configuration.all.reduce(into: Set<PostBarConfiguration.ReadoutType>(), { result, widget in
             result.formUnion(widget.associatedReadouts(context: post))
         })
         self.readouts = configuration.readouts.compactMap { readout in
@@ -78,7 +78,7 @@ struct InteractionBarView: View {
             communityContext: communityContext,
             reportContext: reportContext
         )
-        var associatedReadouts = configuration.all.reduce(into: Set<CommentBarConfiguration.ReadoutType>(), { result, widget in
+        let associatedReadouts = configuration.all.reduce(into: Set<CommentBarConfiguration.ReadoutType>(), { result, widget in
             result.formUnion(widget.associatedReadouts(context: comment))
         })
         self.readouts = configuration.readouts.compactMap { readout in
@@ -93,7 +93,7 @@ struct InteractionBarView: View {
     ) {
         self.leading = .init(appState: appState, reply: reply, items: configuration.leading)
         self.trailing = .init(appState: appState, reply: reply, items: configuration.trailing)
-        var associatedReadouts = configuration.all.reduce(into: Set<ReplyBarConfiguration.ReadoutType>(), { result, widget in
+        let associatedReadouts = configuration.all.reduce(into: Set<ReplyBarConfiguration.ReadoutType>(), { result, widget in
             result.formUnion(widget.associatedReadouts(context: reply))
         })
         self.readouts = configuration.readouts.compactMap { readout in

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
@@ -44,11 +44,11 @@ struct InteractionBarView: View {
             reportContext: reportContext
         )
         var associatedReadouts: Set<PostBarConfiguration.ReadoutType> = .init()
-        configuration.leading.forEach { action in
-            associatedReadouts.formUnion(action.associatedReadout)
+        configuration.leading.forEach { widget in
+            associatedReadouts.formUnion(widget.associatedReadout)
         }
-        configuration.trailing.forEach { action in
-            associatedReadouts.formUnion(action.associatedReadout)
+        configuration.trailing.forEach { widget in
+            associatedReadouts.formUnion(widget.associatedReadout)
         }
         
         self.readouts = configuration.readouts.compactMap { readout in
@@ -83,7 +83,16 @@ struct InteractionBarView: View {
             communityContext: communityContext,
             reportContext: reportContext
         )
-        self.readouts = configuration.readouts.compactMap { comment.readout(type: $0, showColor: false) } // TODO: NOW
+        var associatedReadouts: Set<CommentBarConfiguration.ReadoutType> = .init()
+        configuration.leading.forEach { widget in
+            associatedReadouts.formUnion(widget.associatedReadout)
+        }
+        configuration.trailing.forEach { widget in
+            associatedReadouts.formUnion(widget.associatedReadout)
+        }
+        self.readouts = configuration.readouts.compactMap { readout in
+            comment.readout(type: readout, showColor: !associatedReadouts.contains(readout))
+        }
     }
     
     init(
@@ -93,7 +102,16 @@ struct InteractionBarView: View {
     ) {
         self.leading = .init(appState: appState, reply: reply, items: configuration.leading)
         self.trailing = .init(appState: appState, reply: reply, items: configuration.trailing)
-        self.readouts = configuration.readouts.compactMap { reply.readout(type: $0, showColor: false) } // TODO: NOW
+        var associatedReadouts: Set<ReplyBarConfiguration.ReadoutType> = .init()
+        configuration.leading.forEach { widget in
+            associatedReadouts.formUnion(widget.associatedReadout)
+        }
+        configuration.trailing.forEach { widget in
+            associatedReadouts.formUnion(widget.associatedReadout)
+        }
+        self.readouts = configuration.readouts.compactMap { readout in
+            reply.readout(type: readout, showColor: !associatedReadouts.contains(readout))
+        }
     }
 
     var body: some View {

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
@@ -43,7 +43,17 @@ struct InteractionBarView: View {
             communityContext: communityContext,
             reportContext: reportContext
         )
-        self.readouts = configuration.readouts.compactMap { post.readout(type: $0) }
+        var associatedReadouts: Set<PostBarConfiguration.ReadoutType> = .init()
+        configuration.leading.forEach { action in
+            associatedReadouts.formUnion(action.associatedReadout)
+        }
+        configuration.trailing.forEach { action in
+            associatedReadouts.formUnion(action.associatedReadout)
+        }
+        
+        self.readouts = configuration.readouts.compactMap { readout in
+            post.readout(type: readout, showColor: !associatedReadouts.contains(readout))
+        }
     }
     
     init(
@@ -73,7 +83,7 @@ struct InteractionBarView: View {
             communityContext: communityContext,
             reportContext: reportContext
         )
-        self.readouts = configuration.readouts.compactMap { comment.readout(type: $0) }
+        self.readouts = configuration.readouts.compactMap { comment.readout(type: $0, showColor: false) } // TODO: NOW
     }
     
     init(
@@ -83,14 +93,14 @@ struct InteractionBarView: View {
     ) {
         self.leading = .init(appState: appState, reply: reply, items: configuration.leading)
         self.trailing = .init(appState: appState, reply: reply, items: configuration.trailing)
-        self.readouts = configuration.readouts.compactMap { reply.readout(type: $0) }
+        self.readouts = configuration.readouts.compactMap { reply.readout(type: $0, showColor: false) } // TODO: NOW
     }
 
     var body: some View {
         HStack(spacing: Constants.main.doubleSpacing) {
             ForEach(leading, id: \.viewId, content: widgetView)
                 .fixedSize(horizontal: true, vertical: false)
-            InfoStackView(readouts: readouts, showColor: false)
+            InfoStackView(readouts: readouts)
                 .frame(maxWidth: .infinity, alignment: infoStackAlignment)
                 .padding(infoStackPaddingEdges, -Constants.main.doubleSpacing)
             ForEach(trailing, id: \.viewId, content: widgetView)

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
@@ -45,10 +45,10 @@ struct InteractionBarView: View {
         )
         var associatedReadouts: Set<PostBarConfiguration.ReadoutType> = .init()
         configuration.leading.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout)
+            associatedReadouts.formUnion(widget.associatedReadout(context: post))
         }
         configuration.trailing.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout)
+            associatedReadouts.formUnion(widget.associatedReadout(context: post))
         }
         
         self.readouts = configuration.readouts.compactMap { readout in
@@ -85,10 +85,10 @@ struct InteractionBarView: View {
         )
         var associatedReadouts: Set<CommentBarConfiguration.ReadoutType> = .init()
         configuration.leading.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout)
+            associatedReadouts.formUnion(widget.associatedReadout(context: comment))
         }
         configuration.trailing.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout)
+            associatedReadouts.formUnion(widget.associatedReadout(context: comment))
         }
         self.readouts = configuration.readouts.compactMap { readout in
             comment.readout(type: readout, showColor: !associatedReadouts.contains(readout))
@@ -104,10 +104,10 @@ struct InteractionBarView: View {
         self.trailing = .init(appState: appState, reply: reply, items: configuration.trailing)
         var associatedReadouts: Set<ReplyBarConfiguration.ReadoutType> = .init()
         configuration.leading.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout)
+            associatedReadouts.formUnion(widget.associatedReadout(context: reply))
         }
         configuration.trailing.forEach { widget in
-            associatedReadouts.formUnion(widget.associatedReadout)
+            associatedReadouts.formUnion(widget.associatedReadout(context: reply))
         }
         self.readouts = configuration.readouts.compactMap { readout in
             reply.readout(type: readout, showColor: !associatedReadouts.contains(readout))

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
@@ -44,7 +44,7 @@ struct InteractionBarView: View {
             reportContext: reportContext
         )
         var associatedReadouts = configuration.all.reduce(into: Set<PostBarConfiguration.ReadoutType>(), { result, widget in
-            result.formUnion(widget.associatedReadout(context: post))
+            result.formUnion(widget.associatedReadouts(context: post))
         })
         self.readouts = configuration.readouts.compactMap { readout in
             post.readout(type: readout, showColor: !associatedReadouts.contains(readout))
@@ -79,7 +79,7 @@ struct InteractionBarView: View {
             reportContext: reportContext
         )
         var associatedReadouts = configuration.all.reduce(into: Set<CommentBarConfiguration.ReadoutType>(), { result, widget in
-            result.formUnion(widget.associatedReadout(context: comment))
+            result.formUnion(widget.associatedReadouts(context: comment))
         })
         self.readouts = configuration.readouts.compactMap { readout in
             comment.readout(type: readout, showColor: !associatedReadouts.contains(readout))
@@ -94,7 +94,7 @@ struct InteractionBarView: View {
         self.leading = .init(appState: appState, reply: reply, items: configuration.leading)
         self.trailing = .init(appState: appState, reply: reply, items: configuration.trailing)
         var associatedReadouts = configuration.all.reduce(into: Set<ReplyBarConfiguration.ReadoutType>(), { result, widget in
-            result.formUnion(widget.associatedReadout(context: reply))
+            result.formUnion(widget.associatedReadouts(context: reply))
         })
         self.readouts = configuration.readouts.compactMap { readout in
             reply.readout(type: readout, showColor: !associatedReadouts.contains(readout))


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1929 

## Description

Reworks the info stack coloring logic to color readouts displaying information that is not captured in a widget. This involves a couple minor architecture changes:
- `showColor` is now a parameter to the `.readout` methods provided on `Post`/`Comment`/`Reply`, rather than a blanket parameter to the entire `InfoStack`
  - `showColor` is no longer a parameter on `InfoStack`
  - Convenience initializers for `InfoStackView` now take `coloredReadouts` instead; the default initializer assumes that `Readout` is correctly configured for the desired coloring behavior.
- `ActionTypeProviding` and `CounterTypeProviding` now expose `.associatedReadouts`, which returns the set of readouts that are redundant with the particular action or counter.
  - `InteractionConfigurationItem` also exposes this as a passthrough function to the underlying type
  - Because the score readout's redundancy can depend on upvote/downvote state (e.g., if the user has an upvote widget but no downvote widget, score should be colored when the item is downvoted but not upvoted), `.associatedReadouts` takes in the relevant `Interactable1Providing` as a parameter