### PR TITLE
Improve "jump back to position" button logic

### DIFF
--- a/Mlem/App/Models/CommentTreeNode.swift
+++ b/Mlem/App/Models/CommentTreeNode.swift
@@ -26,9 +26,9 @@ class CommentTreeNode: Identifiable, Hashable {
         children.append(child)
     }
     
-    func tree() -> [CommentTreeNode] {
+    func tree(hideIfCollapsed: Bool = true) -> [CommentTreeNode] {
         if comment.creator.blocked { return [] }
-        if collapsed { return [self] }
+        if collapsed, hideIfCollapsed { return [self] }
         return children.reduce([self]) { $0 + $1.tree() }
     }
     

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Logic.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Logic.swift
@@ -30,6 +30,13 @@ extension ExpandedPostView {
             default: false
             }
         }
+        
+        var commentActorId: ActorIdentifier? {
+            switch self {
+            case let .revisit(topVisibleCommentAtLastVisit: value): value
+            default: nil
+            }
+        }
     }
 
     enum CommentTreeViewType: Hashable {
@@ -49,7 +56,20 @@ extension ExpandedPostView {
     }
     
     var showLoadingSymbol: Bool {
-        !(scrollTargetedComment == nil || (post is any Post3Providing && scrolledToscrollTargetedComment))
+        !(scrollTargetedComment == nil || (post is any Post3Providing && scrolledToScrollTargetedComment))
+    }
+    
+    func showScrollToLastVisitButton(post: any Post) -> Bool {
+        guard (post.commentCount_ ?? 0) > 10 else { return false }
+        var commentId = previousVisitRecord?.commentActorId
+        if topVisibleItem.isAtPost, commentId == nil {
+            commentId = topVisibleItem.furthestVisitedComment
+        }
+        guard let commentId, let tracker else { return false }
+        let nodes = tracker.nodes.reduce([]) { $0 + $1.tree(hideIfCollapsed: false) }
+        let index = nodes.firstIndex { $0.actorId == commentId }
+        guard let index else { return false }
+        return index > 1
     }
     
     func togglePostCollapsed() {
@@ -92,12 +112,31 @@ extension ExpandedPostView {
         if (topVisibleItem.wrappedValue == postActorId) != topVisibleItem.isAtPost {
             topVisibleItem.isAtPost.toggle()
         }
+        updateHistory()
+    }
+    
+    private func updateHistory() {
+        guard let postActorId = post?.actorId_ else { return }
         if let commentActorId = topVisibleItem.wrappedValue, topVisibleItem.wrappedValue != postActorId {
             expandedPostHistoryTracker.insert(postActorId: postActorId, commentActorId: commentActorId)
+            if let furthestVisitedComment = topVisibleItem.furthestVisitedComment, let tracker {
+                let nodes = tracker.nodes.reduce([]) { $0 + $1.tree(hideIfCollapsed: false) }
+                let furthestVisitedCommentIndex = nodes.firstIndex { $0.actorId == furthestVisitedComment }
+                let newVisitedCommentIndex = nodes.firstIndex { $0.actorId == commentActorId }
+                if let furthestVisitedCommentIndex, let newVisitedCommentIndex {
+                    if furthestVisitedCommentIndex > newVisitedCommentIndex { return }
+                }
+            }
+            topVisibleItem.furthestVisitedComment = commentActorId
         }
     }
     
     func scrollToLastVisitedPosition() {
+        if let furthestVisitedComment = topVisibleItem.furthestVisitedComment {
+            jumpButtonTarget = furthestVisitedComment
+            return
+        }
+        
         switch previousVisitRecord {
         case let .revisit(topVisibleCommentAtLastVisit: topVisibleCommentAtLastVisit):
             jumpButtonTarget = topVisibleCommentAtLastVisit

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 class TopVisibleItemContainer {
     // This doesn't need to trigger view updates
     @ObservationIgnored var wrappedValue: ActorIdentifier?
+    var furthestVisitedComment: ActorIdentifier?
     var isAtPost: Bool = true
 }
 
@@ -35,7 +36,7 @@ struct ExpandedPostView<Content: View>: View {
     @Binding var tracker: CommentTreeTracker?
     @State var scrollTargetedComment: (any CommentStubProviding)?
 
-    @State var scrolledToscrollTargetedComment: Bool = false
+    @State var scrolledToScrollTargetedComment: Bool = false
     @State var jumpButtonTarget: ActorIdentifier?
     @State var topVisibleItem: TopVisibleItemContainer = .init()
     @State var postCollapsed: Bool = false
@@ -149,7 +150,7 @@ struct ExpandedPostView<Content: View>: View {
                         // Without a slight delay here, `scrollTo` can sometimes fail. I'm not sure why this is.
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                             proxy.scrollTo(scrollTargetedComment.actorId_, anchor: .center)
-                            scrolledToscrollTargetedComment = true
+                            scrolledToScrollTargetedComment = true
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             self.scrollTargetedComment = nil
@@ -165,11 +166,10 @@ struct ExpandedPostView<Content: View>: View {
                     }
                 }
                 .overlay(alignment: jumpButton.alignment) {
-                    let shouldShowLastVisitButton = (previousVisitRecord?.isRevisit ?? false) && (post.commentCount_ ?? 0) > 10
                     JumpButtonsView(
                         showJumpButton: (tracker?.nodes.count ?? 0) > 1,
                         topVisibleItem: topVisibleItem,
-                        scrollToLastVisitedPosition: shouldShowLastVisitButton ? scrollToLastVisitedPosition : nil,
+                        scrollToLastVisitedPosition: showScrollToLastVisitButton(post: post) ? scrollToLastVisitedPosition : nil,
                         scrollToNextComment: scrollToNextComment,
                         scrollToPreviousComment: scrollToPreviousComment
                     )


### PR DESCRIPTION
In addition to showing the button when you return to a thread you've visited previously, the jump back to position button will now also be shown if you scroll back to the top of the post you're visiting for the first time.

If you're reading a comment thread and want to quickly check something in the post, you can scroll to the top (e.g. by tapping the status bar). Then, the jump button will appear to take you back to where you were in the comment thread.