### PR TITLE
Fix connecting to locally running Lemmy instance

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
@@ -65,6 +65,7 @@ public extension URL {
         var components = URLComponents()
         components.scheme = scheme
         components.host = host
+        components.port = port
         return components.url!
     }
     


### PR DESCRIPTION
Connecting to `localhost:8536` wasn't working