### PR TITLE
Fix single-frame "animated" images

### DIFF
--- a/Mlem/App/Views/Shared/Images/Core/Animated/AnimatedImageView.swift
+++ b/Mlem/App/Views/Shared/Images/Core/Animated/AnimatedImageView.swift
@@ -25,6 +25,12 @@ struct AnimatedImageView: UIViewRepresentable {
             return imageView
         }
         
+        // gifs and webps can be "animated" with only 1 frame, in which case they should be treated as still images
+        guard animatedImage.animatedImageFrameCount > 1 else {
+            controlState.animationAvailable = false
+            return imageView
+        }
+        
         if controlState.scrubbingAvailable {
             // loads all frames, which enables smooth backwards scrubbing
             Task {

--- a/Mlem/App/Views/Shared/Images/Core/MediaControlState.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaControlState.swift
@@ -65,6 +65,8 @@ class MediaControlState {
         return (position: minuteSecondString(from: playbackPosition * duration), duration: minuteSecondString(from: duration))
     }
     
+    var canAnimate: Bool { animationAvailable && enableAnimation }
+    
     var url: URL?
     
     /// Creates a new MediaControlState

--- a/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
@@ -42,7 +42,7 @@ extension MediaView {
         
         @ViewBuilder
         var content: some View {
-            if controlState.enableAnimation, media.isAnimated {
+            if controlState.canAnimate, media.isAnimated {
                 animatedContent
             } else {
                 Image(uiImage: uiImage)

--- a/Mlem/App/Views/Shared/Images/Helpers/AnimationControlLayer.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/AnimationControlLayer.swift
@@ -14,7 +14,7 @@ private struct AnimationControlLayer: ViewModifier {
     @State var showControls: Bool = true
     
     func body(content: Content) -> some View {
-        if controlState.animationAvailable, controlState.enableAnimation, controlState.enableControlOverlay {
+        if controlState.canAnimate, controlState.enableControlOverlay {
             contentWithControls(content: content)
         } else {
             content


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1911 

## Description

Adds logic to handle single-frame animated images. `AnimatedImageView` now updates `MediaControlState.animationAvailable` to `false` after the image is decoded if the image only has 1 frame.