### PR TITLE
Scrub Bugfix

### DIFF
--- a/Mlem/App/Views/Pages/ImageViewer+Views.swift
+++ b/Mlem/App/Views/Pages/ImageViewer+Views.swift
@@ -171,7 +171,7 @@ extension ImageViewer {
                             .offset(x: (controlState.scrubTarget ?? controlState.playbackPosition) * width)
                             .onAppear {
                                 // set playbackBarHitbox to be a bit thicker than the real hitbox
-                                let realHitbox = geo.frame(in: .named("ImageViewer"))
+                                let realHitbox = geo.frame(in: .global)
                                 playbackBarHitbox = .init(
                                     x: realHitbox.minX,
                                     y: realHitbox.maxY - 80,
@@ -184,6 +184,7 @@ extension ImageViewer {
                 .environment(\.colorScheme, .dark)
         }
         .padding(.horizontal, Constants.main.standardSpacing)
+        .allowsHitTesting(false)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Pages/ImageViewer.swift
+++ b/Mlem/App/Views/Pages/ImageViewer.swift
@@ -149,7 +149,6 @@ struct ImageViewer: View {
         .quickLookPreview($quickLookUrl)
         .background(ClearBackgroundView())
         .statusBarHidden(!isDismissing)
-        .coordinateSpace(name: "ImageViewer")
     }
     
     func dragMoved(value: BridgeDragValue) {

--- a/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/BridgeDragValue.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/BridgeDragValue.swift
@@ -20,11 +20,12 @@ struct BridgeDragValue {
         self.startLocation = startLocation
     }
     
-    init(uiPanGesture: UIPanGestureRecognizer) {
+    init(uiPanGesture: UIPanGestureRecognizer, startLocation: CGPoint?) {
+        assert(startLocation != nil, "startLocation was nil")
         let uiVelocity = uiPanGesture.velocity(in: nil)
         let uiTranslation = uiPanGesture.translation(in: nil)
         self.velocity = .init(width: uiVelocity.x, height: uiVelocity.y)
         self.translation = .init(width: uiTranslation.x, height: uiTranslation.y)
-        self.startLocation = uiPanGesture.location(in: nil)
+        self.startLocation = startLocation ?? .zero
     }
 }

--- a/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/ZoomRecognizerCoordinator+Logic.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/ZoomRecognizerCoordinator+Logic.swift
@@ -99,14 +99,18 @@ extension ZoomRecognizerCoordinator {
         switch gesture.state {
         case .possible:
             break
-        case .began, .changed:
-            customDragMoved?(.init(uiPanGesture: gesture))
+        case .began:
+            customPanStartLocation = gesture.location(in: nil)
+            customDragMoved?(.init(uiPanGesture: gesture, startLocation: customPanStartLocation))
+        case .changed:
+            customDragMoved?(.init(uiPanGesture: gesture, startLocation: customPanStartLocation))
         case .ended, .cancelled:
+            customPanStartLocation = nil
             if let customDragEnded {
                 customDragEnded()
             }
         case .failed:
-            break
+            customPanStartLocation = nil
         default:
             assertionFailure("Unrecognized state")
         }

--- a/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/ZoomRecognizerCoordinator.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/ZoomRecognizerCoordinator.swift
@@ -39,6 +39,8 @@ class ZoomRecognizerCoordinator: NSObject, UIGestureRecognizerDelegate {
     
     var panType: PanType = .none
     
+    var customPanStartLocation: CGPoint?
+    
     /// Computes the maximum allowed offsets for a given scale.
     /// - Note: to get the minimum offset, multiply the return value by -1.
     lazy var maxOffsets: CachedComputation<CGFloat, CGSize> = .init { input in


### PR DESCRIPTION
Fixes some minor scrubbing issues:
- Playback bar hitbox coordinate space was offset from intended location; fixed by using `.global` coordinate space, which matches what the `ZoomRecognizer` uses
- Dragging exactly on the playback bar didn't do anything; fixed by disabling hit detection on that view
- Scrub speed could still be changed when dragging the playback head; fixed by correctly tracking start location in `ZoomRecognizerCoordinator`