### PR TITLE
Minor zoom performance

### DIFF
--- a/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/MomentumStatus.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/MomentumStatus.swift
@@ -9,8 +9,6 @@ import Foundation
 
 /// Tracks the current momentum and computes position based on time
 class MomentumStatus {
-    private let boundResetDuration: Double = 0.3
-
     /// Time at which the current x momentum began
     var xt0: CFTimeInterval?
 
@@ -38,11 +36,11 @@ class MomentumStatus {
     init(initialVelocity: CGPoint, xOob: Bool, yOob: Bool) {
         self.xv0 = initialVelocity.x
         self.xOob = xOob
-        self.xUnitCurve = xOob ? PolynomialBoundReset(duration: 0.25) : SinusoidalFriction()
+        self.xUnitCurve = xOob ? PolynomialBoundReset.main : SinusoidalFriction.main
         
         self.yv0 = initialVelocity.y
         self.yOob = yOob
-        self.yUnitCurve = yOob ? PolynomialBoundReset(duration: 0.25) : SinusoidalFriction()
+        self.yUnitCurve = yOob ? PolynomialBoundReset.main : SinusoidalFriction.main
     }
     
     func position(at time: CFTimeInterval) -> (CGSize, active: Bool) {
@@ -72,7 +70,7 @@ class MomentumStatus {
         xOob = true
         xv0 = xUnitCurve.velocity(at: time - xt0) * xv0
         self.xt0 = time
-        xUnitCurve = PolynomialBoundBounce(duration: boundResetDuration)
+        xUnitCurve = PolynomialBoundBounce.main
     }
     
     func yLeftBounds(at time: CFTimeInterval) {
@@ -87,6 +85,6 @@ class MomentumStatus {
         yOob = true
         yv0 = yUnitCurve.velocity(at: time - yt0) * yv0
         self.yt0 = time
-        yUnitCurve = PolynomialBoundBounce(duration: boundResetDuration)
+        yUnitCurve = PolynomialBoundBounce.main
     }
 }

--- a/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/ZoomCurves.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/ZoomCurves.swift
@@ -14,6 +14,8 @@ protocol ZoomCurve {
 }
 
 class SinusoidalFriction: ZoomCurve {
+    static var main: SinusoidalFriction { .init() }
+    
     func value(at progress: Double) -> (Double, active: Bool) {
         guard progress < 1 else { return (0.5, false) }
         return (((.pi * progress) + sin(.pi * progress)) / (2 * .pi), true)
@@ -29,6 +31,8 @@ class SinusoidalFriction: ZoomCurve {
 /// The underlying curve equation is y = x^3 + x^2.
 /// The maximum output value is 1/3 * duration; to maintain a slope of 1 at y = 0, the curve shape is scaled by duration on both axes
 class PolynomialBoundBounce: ZoomCurve {
+    static var main: PolynomialBoundBounce { PolynomialBoundBounce(duration: 0.3) }
+    
     var duration: Double
     
     init(duration: Double = 1) {
@@ -50,6 +54,8 @@ class PolynomialBoundBounce: ZoomCurve {
 /// ZoomCurve matching the shape of PolynomialBoundBounce, but starting at the furthest point of the bounce (1) and gently returning to 0.
 /// The maximum output value is 1; this curve only scales with duration along the x axis.
 class PolynomialBoundReset: ZoomCurve {
+    static var main: PolynomialBoundReset { .init(duration: 0.25) }
+    
     var duration: Double
     
     init(duration: Double = 1) {

--- a/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/ZoomRecognizerCoordinator+Logic.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/ZoomRecognizer/ZoomRecognizerCoordinator+Logic.swift
@@ -188,7 +188,7 @@ extension ZoomRecognizerCoordinator {
         
         // TODO: optimize this to use the full 120fps available on ProMotion displays
         let link = CADisplayLink(target: self, selector: #selector(tickMomentum))
-        link.preferredFrameRateRange = .init(minimum: 80, maximum: 100, __preferred: 100)
+        link.preferredFrameRateRange = .init(minimum: 70, maximum: 90, __preferred: 90)
         link.add(to: .current, forMode: .default)
         self.link = link
     }


### PR DESCRIPTION
Minor tweaks to improve the zoom performance--at 120fps, the first few frames are a bit choppy. This PR implements two tweaks:
- Turn down the `CADisplayLink` max fps. 100 was a bit optimistic, 90 feels much more reliable
- Use static singletons for zoom curves to eliminate redundant initialization