### PR TITLE
Improve Mark Read on Scroll Reliability

### DIFF
--- a/Mlem/App/Views/Shared/PostGridView.swift
+++ b/Mlem/App/Views/Shared/PostGridView.swift
@@ -56,10 +56,10 @@ struct PostGridView: View {
                 }
             }
             .onDisappear {
-                if let firstAccount = AppState.main.firstAccount as? UserAccount {
+                if let api = postFeedLoader.items.first?.api {
                     Task {
                         do {
-                            try await firstAccount.api.flushPostReadQueue()
+                            try await api.flushPostReadQueue()
                         } catch {
                             handleError(error)
                         }

--- a/Mlem/App/Views/Shared/PostGridView.swift
+++ b/Mlem/App/Views/Shared/PostGridView.swift
@@ -55,6 +55,17 @@ struct PostGridView: View {
                     handleError(error)
                 }
             }
+            .onDisappear {
+                if let firstAccount = AppState.main.firstAccount as? UserAccount {
+                    Task {
+                        do {
+                            try await firstAccount.api.flushPostReadQueue()
+                        } catch {
+                            handleError(error)
+                        }
+                    }
+                }
+            }
             .toolbar { FeedToolbarOptions() }
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -287,7 +287,7 @@ public extension ApiClient {
     
     func flushPostReadQueue() async throws {
         if await !markReadQueue.ids.isEmpty {
-            try await markPostsAsRead(ids: [], read: true)
+            try await markPostsAsRead(ids: [])
         }
     }
     


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1998 

## Description

This behavior was caused by the `flushPostReadQueue` not being called in certain cases. Previously, that method was called:
- When moving the app into the background
- When switching accounts
- When marking a post read

However, if the user scrolled a `PostGridView`, left that page without interacting, and returned, none of the flush triggers were hit and so the posts were reset to unread.

This PR fixes that by adding a call to `flushPostReadQueue` whenever a `PostGridView` disappears.