### PR TITLE
Fix crash when opening reply editor

### DIFF
--- a/Mlem/App/Views/Shared/Images/Wrappers/SimpleAvatarView.swift
+++ b/Mlem/App/Views/Shared/Images/Wrappers/SimpleAvatarView.swift
@@ -28,7 +28,11 @@ struct SimpleAvatarView: View {
     }
 
     var defaultImage: UIImage {
-        .init(icon: type.icon)!
+        guard let fromIcon: UIImage = .init(icon: type.icon) else {
+            assertionFailure("Could not create default image from \(type.icon)")
+            return .blank
+        }
+        return fromIcon
             .applyingSymbolConfiguration(.init(
                 font: .systemFont(ofSize: 17),
                 scale: .large

--- a/Mlem/Packages/Icons/Sources/Icons/Icon+General.swift
+++ b/Mlem/Packages/Icons/Sources/Icons/Icon+General.swift
@@ -54,7 +54,7 @@ public extension Icon {
         public let signOut: Icon = .init("minus.circle")
         public let attachment: Icon = .init("paperclip")
         public let refresh: Icon = .init("arrow.clockwise")
-        public let select: Icon = .init("selection.pin")
+        public let select: Icon = .init("selection.pin.in.out")
         
         public let chooseFile: Icon = .init("folder")
         public let chooseImage: Icon = .init("photo")

--- a/Mlem/Packages/Icons/Sources/Icons/Icon+Lemmy.swift
+++ b/Mlem/Packages/Icons/Sources/Icons/Icon+Lemmy.swift
@@ -187,7 +187,7 @@ public extension Icon {
         public let subscriptionList: Icon = .init("list.bullet")
         
         @inlinable public var communityAvatar: Icon { community }
-        public let instanceAvatar: Icon = .init("building.2.crop")
+        public let instanceAvatar: Icon = .init("building.2.crop.circle")
         public let personAvatar: Icon = .init("person.crop.circle")
 
         // MARK: - Other

--- a/Mlem/Packages/Icons/Sources/Icons/Icon+Lemmy.swift
+++ b/Mlem/Packages/Icons/Sources/Icons/Icon+Lemmy.swift
@@ -188,7 +188,7 @@ public extension Icon {
         
         @inlinable public var communityAvatar: Icon { community }
         public let instanceAvatar: Icon = .init("building.2.crop")
-        public let personAvatar: Icon = .init("person.crop")
+        public let personAvatar: Icon = .init("person.crop.circle")
 
         // MARK: - Other
 


### PR DESCRIPTION
<!-- 
Thank you for opening a pull request! 

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2007 

## Description

Fixes a crash when opening the reply editor. This was due to `person.crop` failing to resolve to a SFSymbol, which in turn crashed the force unwrap in `SimpleAvatarView:31`. This PR fixes the issue by updating `Icon.personAvatar` to `person.crop.circle` and adding a guard to prevent the force unwrap crashing the app, plus making it easier to debug. Also fixes `.select` not resolving.