### PR TITLE
Use filled symbol variant for mute

### DIFF
--- a/Mlem/App/Views/Pages/ImageViewer+Views.swift
+++ b/Mlem/App/Views/Pages/ImageViewer+Views.swift
@@ -248,6 +248,7 @@ extension ImageViewer {
         } label: {
             Image(icon: controlState.muted ? .general.mute : .general.unmute)
                 .scaledToFit()
+                .symbolVariant(.fill)
                 .frame(width: 22, height: 22)
                 .contentTransition(.symbolEffect(.replace, options: .speed(2)))
                 .padding(Constants.main.standardSpacing + 4) // +3 to match .title2 implicit padding plus offset

--- a/Mlem/App/Views/Shared/Images/Helpers/AnimationControlLayer.swift
+++ b/Mlem/App/Views/Shared/Images/Helpers/AnimationControlLayer.swift
@@ -63,6 +63,7 @@ private struct AnimationControlLayer: ViewModifier {
         if controlState.audioAvailable {
             Image(icon: controlState.muted ? .general.mute : .general.unmute)
                 .resizable()
+                .symbolVariant(.fill)
                 .scaledToFit()
                 .frame(width: 15, height: 15)
                 .padding(5)


### PR DESCRIPTION
Reverts regression introduced by the icons PR