### PR TITLE
Set default tab to .people on Block List view

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -19,14 +19,14 @@ struct BlockListView: View {
         
         var label: LocalizedStringResource {
             switch self {
-            case .communities: "Communities"
             case .people: "Users"
+            case .communities: "Communities"
             case .instances: "Instances"
             }
         }
     }
     
-    @State var selectedTab: Tab = .communities
+    @State var selectedTab: Tab = .people
     @State var people: [Person1] = []
     @State var communities: [Community1] = []
     @State var instances: [Instance1] = []
@@ -36,22 +36,22 @@ struct BlockListView: View {
             BubblePicker(Tab.allCases, selected: $selectedTab, label: \.label, value: { tab in
                 guard let blockList = (appState.firstSession as? UserSession)?.blocks else { return 0 }
                 switch tab {
-                case .communities:
-                    return blockList.communityCount
                 case .people:
                     return blockList.personCount
+                case .communities:
+                    return blockList.communityCount
                 case .instances:
                     return blockList.instanceCount
                 }
             })
             switch selectedTab {
-            case .communities:
-                SearchResultsView(results: communities.filter(\.blocked)) { community in
-                    CommunityListRow(community, showBlockStatus: false)
-                }
             case .people:
                 SearchResultsView(results: people.filter(\.blocked)) { person in
                     PersonListRow(person, showBlockStatus: false)
+                }
+            case .communities:
+                SearchResultsView(results: communities.filter(\.blocked)) { community in
+                    CommunityListRow(community, showBlockStatus: false)
                 }
             case .instances:
                 SearchResultsView(results: instances.filter(\.blocked)) { instance in


### PR DESCRIPTION
## Issues

- closes #1871

## Description

- Set the default tab to `.people` (Users) in the Block List view.
- Reordered the mentions of tab names in the code from the smallest to the biggest scale (`.people`, `.communities`, `.instances`) for improved code readability.