### PR TITLE
feat: '@' and '!' hotkeys for changing tabs in search

### DIFF
--- a/Mlem/App/Views/Shared/Search/SearchView.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView.swift
@@ -94,7 +94,13 @@ struct SearchView: View {
             .toolbar { PasteLinkButtonView() }
             .scrollDismissesKeyboard(.interactively)
             .onChange(of: query) {
-                if page != .home {
+                if query.hasPrefix("@") {
+                    selectedTab = .people
+                    query = ""
+                    page = .recents
+                    searchBarFocused = true
+                    contentChangeTriggerRefresh(onlyRefreshIfEmpty: false)
+                } else if page != .home {
                     if query.isEmpty {
                         page = .recents
                     } else {

--- a/Mlem/App/Views/Shared/Search/SearchView.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView.swift
@@ -93,18 +93,18 @@ struct SearchView: View {
             .navigationSearchBarHiddenWhenScrolling(false)
             .toolbar { PasteLinkButtonView() }
             .scrollDismissesKeyboard(.interactively)
-            .onChange(of: query) {
-                if query.hasPrefix("@") {
-                    selectedTab = .people
+            .onChange(of: query) { _, newValue in
+                switch newValue {
+                case let str where str.hasPrefix("@"), let str where str.hasPrefix("!"):
+                    selectedTab = str.hasPrefix("@") ? .people : .communities
                     query = ""
                     page = .recents
                     searchBarFocused = true
                     contentChangeTriggerRefresh(onlyRefreshIfEmpty: false)
-                } else if page != .home {
-                    if query.isEmpty {
-                        page = .recents
-                    } else {
-                        page = .results
+                    
+                default:
+                    if page != .home {
+                        page = query.isEmpty ? .recents : .results
                     }
                 }
             }


### PR DESCRIPTION
## Issues

- closes #1816

## Description

When a user types `@`, the app immediately switches to the Users tab, clears the search input, and keeps the search bar focused for typing a username.

## Implementation Notes

Added logic to detect when `@` is typed in the search bar using the `onChange(of: query)` handler.