### PR TITLE
Fix crosspost share button not enabling with original title

### DIFF
--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView.swift
@@ -87,6 +87,7 @@ struct PostEditorView: View {
         
         titleTextView.text = title
         contentTextView.text = content
+        self._titleIsEmpty = .init(wrappedValue: title.isEmpty)
         self._hasNsfwTag = .init(wrappedValue: nsfw)
         if let url {
             if url.isMedia {


### PR DESCRIPTION
## Issues

- closes #2010

## Description

This PR fixes a bug in the crosspost functionality where the share button would remain disabled even when a title was already filled and a community was selected.

## Implementation Notes

The fix initializes `titleIsEmpty` based on the actual content of the title field (`title.isEmpty`), ensuring the share button activates appropriately when both required conditions (non-empty title and selected community) are met.