### PR TITLE
Consistent blocking behavior for instances

### DIFF
--- a/Mlem/App/Models/MlemStats/MlemStats.swift
+++ b/Mlem/App/Models/MlemStats/MlemStats.swift
@@ -88,7 +88,7 @@ class MlemStats {
         
         return instances.filter { instance in
             let actorId = ActorIdentifier.instance(host: instance.host)
-            return blocks.instanceIdOfBlockedInstance(actorId: actorId) == nil
+            return !blocks.contains(instanceActorId: actorId)
         }
     }
 }

--- a/Mlem/App/Models/MlemStats/MlemStats.swift
+++ b/Mlem/App/Models/MlemStats/MlemStats.swift
@@ -66,15 +66,29 @@ class MlemStats {
                     || $0.name.localizedCaseInsensitiveContains(query)
             } ?? []
         }
+        
+        let filteredInstances = filterBlockedInstances(instances)
+        
         switch sort {
         case .score:
-            return instances
+            return filteredInstances
         case .users:
-            return instances.sorted { $0.userCount > $1.userCount }
+            return filteredInstances.sorted { $0.userCount > $1.userCount }
         case .alphabetical:
-            return instances.sorted { $0.host < $1.host }
+            return filteredInstances.sorted { $0.host < $1.host }
         case .version:
-            return instances.sorted { $0.version > $1.version }
+            return filteredInstances.sorted { $0.version > $1.version }
+        }
+    }
+    
+    private func filterBlockedInstances(_ instances: [InstanceSummary]) -> [InstanceSummary] {
+        guard let session = AppState.main.firstSession as? UserSession, let blocks = session.blocks else {
+            return instances
+        }
+        
+        return instances.filter { instance in
+            let actorId = ActorIdentifier.instance(host: instance.host)
+            return blocks.instanceIdOfBlockedInstance(actorId: actorId) == nil
         }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -55,7 +55,7 @@ struct BlockListView: View {
                 }
             case .instances:
                 SearchResultsView(results: instances.filter(\.blocked)) { instance in
-                    InstanceListRow(instance)
+                    InstanceListRow(instance, showBlockStatus: false)
                 }
             }
         }

--- a/Mlem/App/Views/Shared/Search/Results/CommunityListRowBody.swift
+++ b/Mlem/App/Views/Shared/Search/Results/CommunityListRowBody.swift
@@ -52,14 +52,14 @@ struct CommunityListRowBody<Content: View>: View {
     }
     
     var title: String {
-        var suffix = ""
+        var title = community.name
         if community.blocked, showBlockStatus {
-            suffix.append(" ∙ Blocked")
+            title = title + " ∙ " + String(localized: "Blocked")
         }
         if community.nsfw {
-            suffix.append("∙ NSFW")
+            title = title + " ∙ " + String(localized: "NSFW")
         }
-        return community.name + suffix
+        return title
     }
 
     var body: some View {

--- a/Mlem/App/Views/Shared/Search/Results/InstanceListRow.swift
+++ b/Mlem/App/Views/Shared/Search/Results/InstanceListRow.swift
@@ -23,24 +23,26 @@ struct InstanceListRow<Content2: View>: View {
     init(
         _ instance: any Instance,
         @ViewBuilder content: @escaping () -> Content2 = { EmptyView() },
+        showBlockStatus: Bool = true,
         readout: Content.Readout? = nil,
         visitContext: VisitHistory.VisitContext = .other
     ) {
         self.instance = instance
         self.summary = nil
-        self.content = .init(instance, content: content, readout: readout)
+        self.content = .init(instance, content: content, showBlockStatus: showBlockStatus, readout: readout)
         self.visitContext = visitContext
     }
     
     init(
         _ summary: InstanceSummary,
         @ViewBuilder content: @escaping () -> Content2 = { EmptyView() },
+        showBlockStatus: Bool = true,
         readout: Content.Readout? = nil,
         visitContext: VisitHistory.VisitContext = .other
     ) where Content2 == EmptyView {
         self.summary = summary
         self.instance = nil
-        self.content = .init(summary, content: content, readout: readout)
+        self.content = .init(summary, content: content, showBlockStatus: showBlockStatus, readout: readout)
         self.visitContext = visitContext
     }
     

--- a/Mlem/App/Views/Shared/Search/Results/InstanceListRowBody.swift
+++ b/Mlem/App/Views/Shared/Search/Results/InstanceListRowBody.swift
@@ -5,8 +5,10 @@
 //  Created by Eric Andrews on 2024-03-07.
 //
 
+import Icons
 import MlemMiddleware
 import SwiftUI
+import Theming
 
 struct InstanceListRowBody<Content: View>: View {
     enum Readout { case users }
@@ -18,16 +20,19 @@ struct InstanceListRowBody<Content: View>: View {
     let instance: (any Instance)?
     let summary: InstanceSummary?
     let readout: Readout?
+    let showBlockStatus: Bool
     
     @ViewBuilder let content: () -> Content
 
     init(
         _ instance: any Instance,
         @ViewBuilder content: @escaping () -> Content = { EmptyView() },
+        showBlockStatus: Bool = true,
         readout: Readout? = nil
     ) {
         self.instance = instance
         self.summary = nil
+        self.showBlockStatus = showBlockStatus
         self.content = content
         self.readout = readout
     }
@@ -35,16 +40,34 @@ struct InstanceListRowBody<Content: View>: View {
     init(
         _ summary: InstanceSummary,
         @ViewBuilder content: @escaping () -> Content = { EmptyView() },
+        showBlockStatus: Bool = true,
         readout: Readout? = nil
     ) {
         self.summary = summary
         self.instance = nil
+        self.showBlockStatus = showBlockStatus
         self.content = content
         self.readout = readout
     }
     
-    var host: String {
-        instance?.host ?? summary?.host ?? ""
+    var isBlocked: Bool {
+        guard showBlockStatus else { return false }
+        if let instance {
+            return instance.blocked_ ?? false
+        }
+        if let summary, let session = AppState.main.firstSession as? UserSession, let blocks = session.blocks {
+            let actorId = ActorIdentifier.instance(host: summary.host)
+            return blocks.instanceIdOfBlockedInstance(actorId: actorId) != nil
+        }
+        return false
+    }
+    
+    var title: String {
+        let hostText = instance?.host ?? summary?.host ?? ""
+        if isBlocked {
+            return hostText + " ∙ Blocked"
+        }
+        return hostText
     }
     
     var avatar: URL? {
@@ -57,14 +80,22 @@ struct InstanceListRowBody<Content: View>: View {
 
     var body: some View {
         HStack(spacing: Constants.main.standardSpacing) {
-            CircleCroppedImageView(
-                url: avatar?.withIconSize(128),
-                frame: Constants.main.listRowAvatarSize,
-                fallback: .instanceAvatar
-            )
+            if isBlocked {
+                Image(icon: .general.hide)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 30, height: 30)
+                    .padding(9)
+            } else {
+                CircleCroppedImageView(
+                    url: avatar?.withIconSize(128),
+                    frame: Constants.main.listRowAvatarSize,
+                    fallback: .instanceAvatar
+                )
+            }
             
             VStack(alignment: .leading, spacing: 2) {
-                Text(host)
+                Text(title)
                     .foregroundStyle(isEnabled ? .themedPrimary : .themedSecondary)
                     .lineLimit(1)
                 if let version {

--- a/Mlem/App/Views/Shared/Search/Results/InstanceListRowBody.swift
+++ b/Mlem/App/Views/Shared/Search/Results/InstanceListRowBody.swift
@@ -53,11 +53,11 @@ struct InstanceListRowBody<Content: View>: View {
     var isBlocked: Bool {
         guard showBlockStatus else { return false }
         if let instance {
-            return instance.blocked_ ?? false
+            return instance.blocked
         }
         if let summary, let session = AppState.main.firstSession as? UserSession, let blocks = session.blocks {
             let actorId = ActorIdentifier.instance(host: summary.host)
-            return blocks.instanceIdOfBlockedInstance(actorId: actorId) != nil
+            return blocks.contains(instanceActorId: actorId)
         }
         return false
     }
@@ -65,7 +65,7 @@ struct InstanceListRowBody<Content: View>: View {
     var title: String {
         let hostText = instance?.host ?? summary?.host ?? ""
         if isBlocked {
-            return hostText + " ∙ Blocked"
+            return hostText + " ∙ " + String(localized: "Blocked")
         }
         return hostText
     }

--- a/Mlem/App/Views/Shared/Search/Results/PersonListRowBody.swift
+++ b/Mlem/App/Views/Shared/Search/Results/PersonListRowBody.swift
@@ -50,7 +50,7 @@ struct PersonListRowBody<Content: View>: View {
     
     var title: String {
         if person.blocked, showBlockStatus {
-            return "\(person.displayName) ∙ Blocked"
+            return person.displayName + " ∙ " + String(localized: "Blocked")
         } else {
             return person.displayName
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/BlockList.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/BlockList.swift
@@ -149,6 +149,10 @@ public class BlockList {
         communities.keys.contains(community.actorId)
     }
     
+    public func contains(instanceActorId: ActorIdentifier) -> Bool {
+        instances.keys.contains(instanceActorId)
+    }
+    
     public func contains(_ instance: any InstanceStubProviding) -> Bool {
         instances.keys.contains(instance.actorId)
     }


### PR DESCRIPTION
## Issues

- closes #1591

## Description

Filter blocked instances from search results and add visual indicators for blocked instances to maintain consistent UI with other blocked things.

## Implementation Notes

- Added filter for blocked instances in `MlemStats.searchInstances`
- Added blocked status indicator to instance rows with `.general.hide` icon and " ∙ Blocked" text
- Added `showBlockStatus` parameter (defaults to true)