### PR TITLE
Instance Community List

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */ = {isa = PBXBuildFile; productRef = CD4368C02AE23FD400BD8BD1 /* Semaphore */; };
 		CD43E8B32BF2C24E007C3D71 /* ContentLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD43E8B22BF2C24E007C3D71 /* ContentLoader.swift */; };
 		CD45CB0D2D1880E8008BC729 /* FiltersSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD45CB0C2D1880E3008BC729 /* FiltersSettingsView.swift */; };
+		CD4B66DA2DCE809D00D28EB4 /* InstanceUptimeView+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4B66D92DCE809A00D28EB4 /* InstanceUptimeView+Views.swift */; };
 		CD4BAD352B4B2C0B00A1E726 /* FeedsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD342B4B2C0B00A1E726 /* FeedsView.swift */; };
 		CD4D583F2B86855F00B82964 /* MlemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D583E2B86855F00B82964 /* MlemTests.swift */; };
 		CD4D58412B86858100B82964 /* MlemUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4D58402B86858100B82964 /* MlemUITests.swift */; };
@@ -453,6 +454,7 @@
 		CD87BEC32D5132BE0099F190 /* FilterViolationWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD87BEC22D5132BB0099F190 /* FilterViolationWarning.swift */; };
 		CD8DB93A2D22004000EB0C7B /* Animations.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DB9392D22003D00EB0C7B /* Animations.swift */; };
 		CD8DCAF92C5E92E8003E4DD7 /* Profile1Providing+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DCAF82C5E92E8003E4DD7 /* Profile1Providing+Extensions.swift */; };
+		CD93420B2DCD069800945333 /* InstanceUptimeView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD93420A2DCD069800945333 /* InstanceUptimeView+Logic.swift */; };
 		CD9857A42C5E7F9D0084C71F /* NsfwOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9857A32C5E7F9D0084C71F /* NsfwOverlayView.swift */; };
 		CD9BD5812D8F8F7D0006AB7F /* ZoomRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9BD5802D8F8F750006AB7F /* ZoomRecognizer.swift */; };
 		CD9CFA2A2C2E1E8400739BBC /* FeedHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9CFA292C2E1E8400739BBC /* FeedHeaderView.swift */; };
@@ -931,6 +933,7 @@
 		CD3FC67F2D4A75050088E63B /* CounterApperance+StaticValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CounterApperance+StaticValues.swift"; sourceTree = "<group>"; };
 		CD43E8B22BF2C24E007C3D71 /* ContentLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLoader.swift; sourceTree = "<group>"; };
 		CD45CB0C2D1880E3008BC729 /* FiltersSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersSettingsView.swift; sourceTree = "<group>"; };
+		CD4B66D92DCE809A00D28EB4 /* InstanceUptimeView+Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InstanceUptimeView+Views.swift"; sourceTree = "<group>"; };
 		CD4BAD342B4B2C0B00A1E726 /* FeedsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedsView.swift; sourceTree = "<group>"; };
 		CD4D583E2B86855F00B82964 /* MlemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlemTests.swift; sourceTree = "<group>"; };
 		CD4D58402B86858100B82964 /* MlemUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlemUITests.swift; sourceTree = "<group>"; };
@@ -981,6 +984,7 @@
 		CD87BEC22D5132BB0099F190 /* FilterViolationWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViolationWarning.swift; sourceTree = "<group>"; };
 		CD8DB9392D22003D00EB0C7B /* Animations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animations.swift; sourceTree = "<group>"; };
 		CD8DCAF82C5E92E8003E4DD7 /* Profile1Providing+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Profile1Providing+Extensions.swift"; sourceTree = "<group>"; };
+		CD93420A2DCD069800945333 /* InstanceUptimeView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InstanceUptimeView+Logic.swift"; sourceTree = "<group>"; };
 		CD9857A32C5E7F9D0084C71F /* NsfwOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NsfwOverlayView.swift; sourceTree = "<group>"; };
 		CD9BD5802D8F8F750006AB7F /* ZoomRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomRecognizer.swift; sourceTree = "<group>"; };
 		CD9CFA292C2E1E8400739BBC /* FeedHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedHeaderView.swift; sourceTree = "<group>"; };
@@ -1111,6 +1115,8 @@
 		030BCB192C3EA5E20037680F /* Instance */ = {
 			isa = PBXGroup;
 			children = (
+				CD4B66D92DCE809A00D28EB4 /* InstanceUptimeView+Views.swift */,
+				CD93420A2DCD069800945333 /* InstanceUptimeView+Logic.swift */,
 				03AFD0E22C3C0C540054B8AD /* InstanceView.swift */,
 				035394982CA1B20B00795AA5 /* InstanceView+Logic.swift */,
 				030BCB1A2C3EA5FD0037680F /* InstanceDetailsView.swift */,
@@ -2650,6 +2656,7 @@
 				032C32182C36F70300595286 /* ReplyBarConfiguration.swift in Sources */,
 				CDD4A0A02C8B985D0001AD1A /* ImportExportSettingsView.swift in Sources */,
 				03B431B62C454D49001A1EB5 /* UIImage+Extensions.swift in Sources */,
+				CD93420B2DCD069800945333 /* InstanceUptimeView+Logic.swift in Sources */,
 				CD1446212A5B328E00610EF1 /* Privacy Policy.swift in Sources */,
 				03AFD0E32C3C0C540054B8AD /* InstanceView.swift in Sources */,
 				CDD4A09C2C8A122F0001AD1A /* Settings.swift in Sources */,
@@ -2740,6 +2747,7 @@
 				CD4D58B52B86BFFB00B82964 /* PersistenceRepository+Dependency.swift in Sources */,
 				03A630F12D497674009A47A6 /* ShieldsBadgeView.swift in Sources */,
 				CD4D58EB2B86E63300B82964 /* AssociatedColor.swift in Sources */,
+				CD4B66DA2DCE809D00D28EB4 /* InstanceUptimeView+Views.swift in Sources */,
 				CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */,
 				039F588F2C7B599800C61658 /* ThemeLabel.swift in Sources */,
 				037029A32D6B9B8400B749DF /* ContentView+Tab.swift in Sources */,

--- a/Mlem/App/Views/Pages/Instance/InstanceDetailsView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceDetailsView.swift
@@ -62,7 +62,7 @@ struct InstanceDetailsView: View {
                         
                         if case let .success(uptimeData) = uptimeData {
                             NavigationLink(.instanceUptime(instance: instance, uptimeData: uptimeData)) {
-                                (Text("Details ") + Text(Image(icon: .general.forward)))
+                                (Text("Details") + Text(verbatim: " ") + Text(Image(icon: .general.forward)))
                                     .font(.footnote)
                                     .foregroundStyle(.themedAccent)
                             }

--- a/Mlem/App/Views/Pages/Instance/InstanceDetailsView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceDetailsView.swift
@@ -54,37 +54,14 @@ struct InstanceDetailsView: View {
             }
             
             FormSection {
-                VStack(spacing: Constants.main.standardSpacing) {
-                    HStack {
-                        Text("Uptime")
-                        
-                        Spacer()
-                        
-                        if case let .success(uptimeData) = uptimeData {
-                            NavigationLink(.instanceUptime(instance: instance, uptimeData: uptimeData)) {
-                                (Text("Details") + Text(verbatim: " ") + Text(Image(icon: .general.forward)))
-                                    .font(.footnote)
-                                    .foregroundStyle(.themedAccent)
-                            }
-                        }
+                if case let .success(uptimeData) = uptimeData {
+                    NavigationLink(.instanceUptime(instance: instance, uptimeData: uptimeData)) {
+                        uptimeSummary
                     }
-                    
-                    switch uptimeData {
-                    case let .success(uptimeData):
-                        RecentUptimeChecks(results: uptimeData.results)
-                    case .unavailable:
-                        Text("Data not available")
-                            .italic()
-                            .foregroundStyle(.themedWarning)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    case let .failure(error):
-                        ErrorView(.init(error: error))
-                    default:
-                        ProgressView()
-                            .padding(Constants.main.halfSpacing)
-                    }
+                    .buttonStyle(.plain)
+                } else {
+                    uptimeSummary
                 }
-                .padding(Constants.main.standardSpacing)
             }
             
             FormSection {
@@ -254,5 +231,40 @@ struct InstanceDetailsView: View {
             value: value ? "Yes" : "No",
             color: value ? .themedPositive : .themedNegative
         )
+    }
+    
+    @ViewBuilder
+    var uptimeSummary: some View {
+        VStack(spacing: Constants.main.standardSpacing) {
+            HStack {
+                Text("Uptime")
+                
+                Spacer()
+                
+                if case let .success(uptimeData) = uptimeData {
+                    // NavigationLink(.instanceUptime(instance: instance, uptimeData: uptimeData)) {
+                        (Text("Details") + Text(verbatim: " ") + Text(Image(icon: .general.forward)))
+                            .font(.footnote)
+                            .foregroundStyle(.themedAccent)
+                    // }
+                }
+            }
+            
+            switch uptimeData {
+            case let .success(uptimeData):
+                RecentUptimeChecks(results: uptimeData.results)
+            case .unavailable:
+                Text("Data not available")
+                    .italic()
+                    .foregroundStyle(.themedWarning)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            case let .failure(error):
+                ErrorView(.init(error: error))
+            default:
+                ProgressView()
+                    .padding(Constants.main.halfSpacing)
+            }
+        }
+        .padding(Constants.main.standardSpacing)
     }
 }

--- a/Mlem/App/Views/Pages/Instance/InstanceDetailsView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceDetailsView.swift
@@ -12,10 +12,21 @@ import Theming
 
 struct InstanceDetailsView: View {
     @State private var showingSlurRegex: Bool = false
+    @State var uptimeData: UptimeDataStatus?
     
     let instance: any Instance
     
     var body: some View {
+        content
+            .task {
+                let fetchedData = await loadUptimeData(instance: instance)
+                withAnimation(.easeOut(duration: 0.2)) {
+                    uptimeData = fetchedData
+                }
+            }
+    }
+    
+    var content: some View {
         VStack(spacing: 16) {
             FormSection {
                 ProfileDateView(profilable: instance)
@@ -40,6 +51,40 @@ struct InstanceDetailsView: View {
             
             if let activeUserCount = instance.activeUserCount_ {
                 ActiveUserCountView(activeUserCount: activeUserCount)
+            }
+            
+            FormSection {
+                VStack(spacing: Constants.main.standardSpacing) {
+                    HStack {
+                        Text("Uptime")
+                        
+                        Spacer()
+                        
+                        if case let .success(uptimeData) = uptimeData {
+                            NavigationLink(.instanceUptime(instance: instance, uptimeData: uptimeData)) {
+                                (Text("Details ") + Text(Image(icon: .general.forward)))
+                                    .font(.footnote)
+                                    .foregroundStyle(.themedAccent)
+                            }
+                        }
+                    }
+                    
+                    switch uptimeData {
+                    case let .success(uptimeData):
+                        RecentUptimeChecks(results: uptimeData.results)
+                    case .unavailable:
+                        Text("Data not available")
+                            .italic()
+                            .foregroundStyle(.themedWarning)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    case let .failure(error):
+                        ErrorView(.init(error: error))
+                    default:
+                        ProgressView()
+                            .padding(Constants.main.halfSpacing)
+                    }
+                }
+                .padding(Constants.main.standardSpacing)
             }
             
             FormSection {

--- a/Mlem/App/Views/Pages/Instance/InstanceUptimeView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceUptimeView+Logic.swift
@@ -1,0 +1,30 @@
+//
+//  InstanceUptimeView+Logic..swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2025-05-08.
+//
+
+import MlemMiddleware
+import Foundation
+
+enum UptimeDataStatus {
+    case success(UptimeData)
+    case unavailable
+    case failure(Error)
+}
+
+func loadUptimeData(instance: any Instance) async -> UptimeDataStatus {
+    if let url = instance.uptimeDataUrl {
+        do {
+            let data = try await URLSession.shared.data(from: url).0
+            let uptimeData = try JSONDecoder.defaultDecoder.decode(UptimeData.self, from: data)
+            return .success(uptimeData)
+        } catch {
+            handleError(error)
+            return .failure(error)
+        }
+    } else {
+        return .unavailable
+    }
+}

--- a/Mlem/App/Views/Pages/Instance/InstanceUptimeView+Views.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceUptimeView+Views.swift
@@ -1,0 +1,53 @@
+//
+//  InstanceUptimeView+Views.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2025-05-09.
+//
+
+import SwiftUICore
+
+struct RecentUptimeChecks: View {
+    @Environment(\.accessibilityDifferentiateWithoutColor) var diffWithoutColor: Bool
+    
+    let results: [UptimeResponseTime]
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 3) {
+                ForEach(results) { result in
+                    if diffWithoutColor {
+                        Image(icon: result.success ? .uptime.online : .uptime.offline)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .symbolVariant(.circle.fill)
+                            .foregroundStyle(result.success ? .themedPositive : .themedNegative)
+                            .frame(maxWidth: 20)
+                            .frame(maxWidth: 25)
+                    } else {
+                        Circle()
+                            .fill(result.success ? .themedPositive : .themedNegative)
+                            .frame(maxWidth: 20)
+                            .frame(maxWidth: 25)
+                    }
+                }
+            }
+            HStack {
+                Text(timeOnlyFormatter.string(from: results.first?.timestamp ?? .now))
+                Spacer()
+                Text(timeOnlyFormatter.string(from: results.last?.timestamp ?? .now))
+            }
+            .font(.footnote)
+            .foregroundStyle(.themedSecondary)
+            .frame(maxWidth: CGFloat(results.count * 25 + (results.count - 1) * 3))
+            .padding(.top, 4)
+        }
+    }
+    
+    var timeOnlyFormatter: DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeStyle = .short
+        dateFormatter.dateStyle = .none
+        return dateFormatter
+    }
+}

--- a/Mlem/App/Views/Pages/Instance/InstanceUptimeView+Views.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceUptimeView+Views.swift
@@ -16,20 +16,19 @@ struct RecentUptimeChecks: View {
         VStack(alignment: .leading, spacing: 3) {
             HStack(spacing: 3) {
                 ForEach(results) { result in
+                Group {
                     if diffWithoutColor {
                         Image(icon: result.success ? .uptime.online : .uptime.offline)
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .symbolVariant(.circle.fill)
-                            .foregroundStyle(result.success ? .themedPositive : .themedNegative)
-                            .frame(maxWidth: 20)
-                            .frame(maxWidth: 25)
                     } else {
                         Circle()
-                            .fill(result.success ? .themedPositive : .themedNegative)
-                            .frame(maxWidth: 20)
-                            .frame(maxWidth: 25)
                     }
+                }
+                 .foregroundStyle(result.success ? .themedPositive : .themedNegative)
+                .frame(maxWidth: 20)
+                .frame(maxWidth: 25)
                 }
             }
             HStack {

--- a/Mlem/App/Views/Pages/Instance/InstanceUptimeView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceUptimeView.swift
@@ -9,7 +9,6 @@ import Charts
 import MlemMiddleware
 import SwiftUI
 
-// swiftlint:disable:next type_body_length
 struct InstanceUptimeView: View {
     @Environment(\.accessibilityDifferentiateWithoutColor) var diffWithoutColor: Bool
     @Environment(\.palette) var palette
@@ -18,15 +17,40 @@ struct InstanceUptimeView: View {
     @State var showingAllDowntimes: Bool = false
     
     let instance: any Instance
-    let uptimeData: UptimeData
+    @State var uptimeData: UptimeData
+    
+    var uptimeRefreshTimer = Timer.publish(every: 30, tolerance: 0.5, on: .main, in: .common)
+        .autoconnect()
+    
+    var body: some View {
+        ScrollView {
+            content
+        }
+        .background(.themedGroupedBackground)
+        .onReceive(uptimeRefreshTimer) { _ in
+            Task {
+                let uptimeStatus = await loadUptimeData(instance: instance)
+                switch uptimeStatus {
+                case .success(let uptimeData):
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        self.uptimeData = uptimeData
+                    }
+                case .unavailable:
+                    assertionFailure("Uptime data unavailable.")
+                case .failure(let error):
+                    handleError(error)
+                }
+            }
+        }
+    }
     
     @ViewBuilder
-    var body: some View {
+    var content: some View {
         VStack(alignment: .leading, spacing: 0) {
             section { summary }
                 .padding(.bottom, 10)
             section("Recent Checks") {
-                recentChecks
+                RecentUptimeChecks(results: uptimeData.results)
                     .padding(.horizontal)
                     .padding(.vertical, 15)
             }
@@ -169,37 +193,6 @@ struct InstanceUptimeView: View {
     }
     
     @ViewBuilder
-    var recentChecks: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 3) {
-                ForEach(uptimeData.results) { result in
-                    if diffWithoutColor {
-                        Image(icon: result.success ? .uptime.online : .uptime.offline)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .symbolVariant(.circle.fill)
-                            .foregroundStyle(result.success ? .themedPositive : .themedNegative)
-                            .frame(maxWidth: 20)
-                            .frame(maxWidth: 25)
-                    } else {
-                        Circle()
-                            .fill(result.success ? .themedPositive : .themedNegative)
-                            .frame(maxWidth: 20)
-                            .frame(maxWidth: 25)
-                    }
-                }
-            }
-            HStack {
-                footnote(timeOnlyFormatter.string(from: uptimeData.results.first?.timestamp ?? .now))
-                Spacer()
-                footnote(timeOnlyFormatter.string(from: uptimeData.results.last?.timestamp ?? .now))
-            }
-            .frame(maxWidth: CGFloat(uptimeData.results.count * 25 + (uptimeData.results.count - 1) * 3))
-            .padding(.top, 4)
-        }
-    }
-    
-    @ViewBuilder
     var responseTimeChart: some View {
         Chart {
             ForEach(uptimeData.results) { node in
@@ -268,13 +261,6 @@ struct InstanceUptimeView: View {
         Text(title)
             .font(.footnote)
             .foregroundStyle(.themedSecondary)
-    }
-    
-    var timeOnlyFormatter: DateFormatter {
-        let dateFormatter = DateFormatter()
-        dateFormatter.timeStyle = .short
-        dateFormatter.dateStyle = .none
-        return dateFormatter
     }
 
     func formatMilliseconds(_ milliseconds: Int) -> String {

--- a/Mlem/App/Views/Pages/Instance/InstanceUptimeView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceUptimeView.swift
@@ -25,6 +25,7 @@ struct InstanceUptimeView: View {
     var body: some View {
         ScrollView {
             content
+                .padding(.top, 16)
         }
         .background(.themedGroupedBackground)
         .onReceive(uptimeRefreshTimer) { _ in
@@ -42,6 +43,7 @@ struct InstanceUptimeView: View {
                 }
             }
         }
+        .navigationTitle("Uptime")
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -15,6 +15,7 @@ extension InstanceView {
             output.append(.uptime)
         }
         output.append(.safety)
+        output.append(.communities)
         return output
     }
     

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -9,13 +9,6 @@ import MlemMiddleware
 import SwiftUI
 
 extension InstanceView {
-    var tabs: [Tab] {
-        var output: [Tab] = [.about, .administration, .details]
-        output.append(.safety)
-        output.append(.communities)
-        return output
-    }
-    
     func logVisit(_ instance: any Instance3Providing) {
         guard let visitContext else { return }
         if let session = (appState.firstSession as? UserSession), let visitHistory = session.visitHistory {

--- a/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView+Logic.swift
@@ -11,9 +11,6 @@ import SwiftUI
 extension InstanceView {
     var tabs: [Tab] {
         var output: [Tab] = [.about, .administration, .details]
-        if instance.canFetchUptime {
-            output.append(.uptime)
-        }
         output.append(.safety)
         output.append(.communities)
         return output
@@ -74,25 +71,6 @@ extension InstanceView {
         }
         
         return .init(trailingActions: [person.addAdminAction(instance: myInstance, isOn: isAdmin)])
-    }
-    
-    func attemptToLoadUptimeData() {
-        print("Fetching uptime data...")
-        if let url = instance.uptimeDataUrl {
-            Task {
-                do {
-                    let data = try await URLSession.shared.data(from: url).0
-                    let uptimeData = try JSONDecoder.defaultDecoder.decode(UptimeData.self, from: data)
-                    DispatchQueue.main.async {
-                        withAnimation(.easeOut(duration: 0.2)) {
-                            self.uptimeData = .success(uptimeData)
-                        }
-                    }
-                } catch {
-                    handleError(error)
-                }
-            }
-        }
     }
     
     func attemptToLoadFediseerData() {

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -13,29 +13,20 @@ import Theming
 
 struct InstanceView: View {
     enum Tab: String, CaseIterable, Identifiable {
-        case about, administration, details, uptime, safety, communities
+        case about, administration, details, safety, communities
         
         var label: LocalizedStringResource {
             switch self {
             case .about: "About"
+            case .communities: "Communities"
             case .administration: "Administration"
             case .details: "Details"
-            case .uptime: "Uptime"
             case .safety: "Trust & Safety"
-            case .communities: "Communities"
             }
         }
         
         var id: Self { self }
     }
-    
-    enum UptimeDataStatus {
-        case success(UptimeData)
-        case failure(Error)
-    }
-    
-    var uptimeRefreshTimer = Timer.publish(every: 30, tolerance: 0.5, on: .main, in: .common)
-        .autoconnect()
     
     @Environment(AppState.self) var appState
     @Environment(NavigationLayer.self) var navigation
@@ -46,7 +37,6 @@ struct InstanceView: View {
 
     // This is fetched from the instance itself, not from the logged-in account.
     @State var instance: any InstanceStubProviding
-    @State var uptimeData: UptimeDataStatus?
     @State var fediseerData: FediseerData?
     @State var upgradeState: LoadingState = .idle
     @State var communityLoader: CommunityFeedLoader
@@ -124,19 +114,15 @@ struct InstanceView: View {
                         .paletteBorder(cornerRadius: Constants.main.standardSpacing)
                         .padding([.horizontal, .bottom], Constants.main.standardSpacing)
                 }
+            case .communities:
+                communities()
             case .details:
                 InstanceDetailsView(instance: instance)
             case .administration:
                 administrationTab(instance: instance)
-            case .uptime:
-                uptimeTab(instance: instance)
-                    .onAppear(perform: attemptToLoadUptimeData)
-                    .onReceive(uptimeRefreshTimer) { _ in attemptToLoadUptimeData() }
             case .safety:
                 safetyTab(instance: instance)
                     .onAppear(perform: attemptToLoadFediseerData)
-            case .communities:
-                communities()
             }
         }
         .toolbar {
@@ -176,20 +162,6 @@ struct InstanceView: View {
             }
         }
         .padding([.horizontal, .bottom], Constants.main.standardSpacing)
-    }
-    
-    @ViewBuilder
-    func uptimeTab(instance: any Instance) -> some View {
-        switch uptimeData {
-        case let .success(uptimeData):
-            InstanceUptimeView(instance: instance, uptimeData: uptimeData)
-        case let .failure(error):
-            ErrorView(.init(error: error))
-                .padding(.top, 5)
-        default:
-            ProgressView()
-                .padding(.top, 30)
-        }
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -58,7 +58,10 @@ struct InstanceView: View {
     
     init(instance: any InstanceStubProviding, visitContext: VisitHistory.VisitContext?) {
         self._instance = .init(wrappedValue: instance)
-        self._communityLoader = .init(wrappedValue: .init(api: .getApiClient(url: instance.actorId.hostUrl, username: nil)))
+        self._communityLoader = .init(wrappedValue: .init(
+            api: .getApiClient(url: instance.actorId.hostUrl, username: nil),
+            hostApi: instance.api
+        ))
         self.visitContext = visitContext
     }
     

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -13,7 +13,7 @@ import Theming
 
 struct InstanceView: View {
     enum Tab: String, CaseIterable, Identifiable {
-        case about, administration, details, uptime, safety
+        case about, administration, details, uptime, safety, communities
         
         var label: LocalizedStringResource {
             switch self {
@@ -22,6 +22,7 @@ struct InstanceView: View {
             case .details: "Details"
             case .uptime: "Uptime"
             case .safety: "Trust & Safety"
+            case .communities: "Communities"
             }
         }
         
@@ -48,6 +49,7 @@ struct InstanceView: View {
     @State var uptimeData: UptimeDataStatus?
     @State var fediseerData: FediseerData?
     @State var upgradeState: LoadingState = .idle
+    @State var communityLoader: CommunityFeedLoader
     
     @State var selectedTab: Tab = .about
     
@@ -56,6 +58,7 @@ struct InstanceView: View {
     
     init(instance: any InstanceStubProviding, visitContext: VisitHistory.VisitContext?) {
         self._instance = .init(wrappedValue: instance)
+        self._communityLoader = .init(wrappedValue: .init(api: instance.api))
         self.visitContext = visitContext
     }
     
@@ -129,6 +132,8 @@ struct InstanceView: View {
             case .safety:
                 safetyTab(instance: instance)
                     .onAppear(perform: attemptToLoadFediseerData)
+            case .communities:
+                communities()
             }
         }
         .toolbar {
@@ -192,5 +197,28 @@ struct InstanceView: View {
             ProgressView()
                 .padding(.top, 30)
         }
+    }
+    
+    @ViewBuilder
+    func communities() -> some View {
+        LazyVStack(spacing: 0) {
+            SearchResultsView(results: communityLoader.items) { community in
+                CommunityListRow(
+                    community,
+                    readout: .subscribers,
+                    visitContext: .other
+                )
+                .onAppear {
+                    do {
+                        try communityLoader.loadIfThreshold(community)
+                    } catch {
+                        handleError(error)
+                    }
+                }
+            }
+            EndOfFeedView(feedLoader: communityLoader, viewType: .hobbit)
+        }
+        .animation(.easeOut(duration: 0.1), value: communityLoader.items.isEmpty)
+        .loadFeed(communityLoader)
     }
 }

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -58,7 +58,7 @@ struct InstanceView: View {
     
     init(instance: any InstanceStubProviding, visitContext: VisitHistory.VisitContext?) {
         self._instance = .init(wrappedValue: instance)
-        self._communityLoader = .init(wrappedValue: .init(api: instance.api))
+        self._communityLoader = .init(wrappedValue: .init(api: .getApiClient(url: instance.actorId.hostUrl, username: nil)))
         self.visitContext = visitContext
     }
     
@@ -219,6 +219,12 @@ struct InstanceView: View {
             EndOfFeedView(feedLoader: communityLoader, viewType: .hobbit)
         }
         .animation(.easeOut(duration: 0.1), value: communityLoader.items.isEmpty)
-        .loadFeed(communityLoader)
+        .task {
+            do {
+                try await communityLoader.refresh(listing: .local)
+            } catch {
+                handleError(error)
+            }
+        }
     }
 }

--- a/Mlem/App/Views/Pages/Instance/InstanceView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceView.swift
@@ -13,7 +13,7 @@ import Theming
 
 struct InstanceView: View {
     enum Tab: String, CaseIterable, Identifiable {
-        case about, administration, details, safety, communities
+        case about, communities, administration, details, safety
         
         var label: LocalizedStringResource {
             switch self {
@@ -101,7 +101,7 @@ struct InstanceView: View {
             )
             .padding([.horizontal, .bottom], Constants.main.standardSpacing)
             BubblePicker(
-                tabs,
+                Tab.allCases,
                 selected: $selectedTab,
                 label: { $0.label }
             )

--- a/Mlem/App/Views/Pages/Instance/UptimeData.swift
+++ b/Mlem/App/Views/Pages/Instance/UptimeData.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-struct UptimeData: Codable {
+struct UptimeData: Codable, Hashable {
     let results: [UptimeResponseTime]
     let events: [UptimeEvent]
     
@@ -27,7 +27,7 @@ struct UptimeData: Codable {
     }
 }
 
-struct UptimeResponseTime: Codable, Identifiable {
+struct UptimeResponseTime: Codable, Identifiable, Hashable {
     let success: Bool
     let duration: Int
     let timestamp: Date
@@ -39,8 +39,9 @@ struct UptimeResponseTime: Codable, Identifiable {
     var id: Int { Int(timestamp.timeIntervalSince1970) }
 }
 
-struct UptimeEvent: Codable, Identifiable {
+struct UptimeEvent: Codable, Identifiable, Hashable {
     enum EventType: String, Codable {
+        case start = "START"
         case healthy = "HEALTHY"
         case unhealthy = "UNHEALTHY"
     }

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -71,7 +71,7 @@ struct CommentView<EmbeddedContent: View>: View {
                 CommentBarView(depth: comment.depth, inFeed: inFeed)
                 
                 VStack(alignment: .leading, spacing: 0) {
-                    VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
+                    VStack(alignment: .leading, spacing: Constants.main.compactSpacing) {
                         if !inFeed {
                             authorAndMenu.padding(.top, Constants.main.standardSpacing)
                         }
@@ -80,6 +80,15 @@ struct CommentView<EmbeddedContent: View>: View {
                             CommentBodyView(comment: comment)
                                 .padding(.trailing, 2)
                             embeddedContent
+                        }
+                        
+                        if compact, !collapsed {
+                            InfoStackView(
+                                comment: comment,
+                                readouts: commentInteractionBar.readouts,
+                                coloredReadouts: .init(CommentBarConfiguration.ReadoutType.allCases)
+                            )
+                            .layoutPriority(1)
                         }
                     }
                     .padding(.horizontal, Constants.main.standardSpacing)
@@ -125,14 +134,6 @@ struct CommentView<EmbeddedContent: View>: View {
         HStack(spacing: 0) {
             FullyQualifiedLinkView(comment.creator_, labelStyle: .small)
             Spacer()
-            if compact {
-                InfoStackView(
-                    comment: comment,
-                    readouts: commentInteractionBar.readouts,
-                    coloredReadouts: .init(CommentBarConfiguration.ReadoutType.allCases)
-                )
-                .layoutPriority(1)
-            }
             Group {
                 if collapsed {
                     Image(icon: .general.expand)

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -150,6 +150,8 @@ extension NavigationPage {
             FediseerOpinionListView(instance: instance.wrappedValue, opinionType: opinionType, fediseerData: data)
         case .fediseerInfo:
             FediseerInfoView()
+        case let .instanceUptime(instance, uptimeData):
+            InstanceUptimeView(instance: instance.wrappedValue, uptimeData: uptimeData)
         case let .deleteAccount(account):
             DeleteAccountView(account: account)
         case let .bypassImageProxy(callback):

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -30,6 +30,7 @@ enum NavigationPage: Hashable {
     case instanceOpinionList(instance: InstanceHashWrapper, opinionType: FediseerOpinionType, data: FediseerData)
     case messageFeed(_ person: AnyPerson, messageContent: String, focusTextField: Bool, editing: MessageHashWrapper?)
     case fediseerInfo
+    case instanceUptime(_ instance: HashWrapper<any Instance>, _ uptimeData: UptimeData)
     case externalApiInfo(api: ApiClient, actorId: ActorIdentifier)
     case imageViewer(_ url: URL)
     case communityPicker(api: ApiClient?, callback: HashWrapper<(Community2, NavigationLayer) -> Void>)
@@ -135,6 +136,13 @@ enum NavigationPage: Hashable {
             opinionType: opinionType,
             data: data
         )
+    }
+    
+    static func instanceUptime(
+        instance: any Instance,
+        uptimeData: UptimeData
+    ) -> NavigationPage {
+        .instanceUptime(.init(wrappedValue: instance), uptimeData)
     }
     
     static func messageFeed(

--- a/Mlem/App/Views/Shared/Search/SearchView+Logic.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView+Logic.swift
@@ -73,10 +73,11 @@ extension SearchView {
     }
     
     private func refreshCommunities(clearBeforeRefresh: Bool) async throws {
+        let refreshApi = getRefreshApi(for: communityFilters.instance)
         await communityLoader.changeApi(
-            to: getRefreshApi(for: communityFilters.instance),
+            to: refreshApi,
             context: filtersTracker.filterContext,
-            hostApi: appState.firstApi
+            hostApi: refreshApi == appState.firstApi ? nil : appState.firstApi
         )
         try await communityLoader.refresh(
             query: query,

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -2561,6 +2561,9 @@
         }
       }
     },
+    "Data not available" : {
+
+    },
     "Days:" : {
       "localizations" : {
         "fr" : {
@@ -2722,6 +2725,9 @@
           }
         }
       }
+    },
+    "Details " : {
+
     },
     "Developer" : {
       "localizations" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -2726,9 +2726,6 @@
         }
       }
     },
-    "Details " : {
-
-    },
     "Developer" : {
       "localizations" : {
         "fr" : {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
@@ -96,17 +96,10 @@ public extension ApiClient {
             }
         }
         if let hostApi {
-            await withTaskGroup(of: Void.self) {  group in
-                ret.forEach { community in
-                    group.addTask {
-                        do {
-                            if let resolvedCommunity = try await hostApi.resolve(url: community.resolvableUrl(from: .host)) as? any Community {
-                                community.blockedManager.addSibling(resolvedCommunity.blockedManager)
-                            }
-                        } catch {
-                            print("Failed to resolve \(community.actorId)")
-                        }
-                    }
+            let resolvedCommunities: [URL: Community2] = try await hostApi.resolve(urls: ret.map { $0.resolvableUrl(from: .host) })
+            ret.forEach { community in
+                if let resolvedCommunity = resolvedCommunities[community.resolvableUrl(from: .host)] {
+                    community.blockedManager.addSibling(resolvedCommunity.blockedManager)
                 }
             }
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -139,6 +139,29 @@ public extension ApiClient {
         throw ApiClientError.noEntityFound
     }
     
+    func resolve<Value: ActorIdentifiable & Sharable>(urls: [URL]) async throws -> [URL: Value] {
+        try await withThrowingTaskGroup(of: (url: URL, value: Value)?.self) { group in
+            urls.forEach { url in
+                group.addTask {
+                    if let value = try await self.resolve(url: url) as? Value {
+                        return (url, value)
+                    }
+                    return nil
+                }
+            }
+            
+            var collected: [URL: Value] = .init()
+            
+            for try await result in group {
+                if let result {
+                    collected[result.url] = result.value
+                }
+            }
+            
+            return collected
+        }
+    }
+    
     func getBlocked() async throws -> (people: [Person1], communities: [Community1], instances: [Instance1]) {
         let request = GetSiteRequest(endpoint: .v3)
         let response = try await perform(request)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
@@ -53,7 +53,8 @@ public class CommunityFeedLoader: StandardFeedLoader<Community2> {
         query: String = "",
         pageSize: Int = 20,
         listing: ApiListingType = .all,
-        sort: SearchSortType = .top(.allTime)
+        sort: SearchSortType = .top(.allTime),
+        hostApi: ApiClient? = nil
     ) {
         self.api = api
 
@@ -65,7 +66,7 @@ public class CommunityFeedLoader: StandardFeedLoader<Community2> {
                 pageSize: pageSize,
                 listing: listing,
                 sort: sort,
-                hostApi: nil
+                hostApi: hostApi
             )
         )
     }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1137 

## Description

- Adds a "Communities" tab to `InstanceView` that lists the local communities, ordered by subscriber count
- Removes the "Uptime" tab of `InstanceView`
- Adds an uptime readout to the "Details" tab of `InstanceView`
- Adds an uptime nav page linked to by the aforementioned readout

## Implementation Notes

Also implements a multi-URL invocation of `ApiClient.resolve`, which resolves objects in parallel and returns a map of ActorId to resolved object.
