### PR TITLE
[#2032] Fix localized elapsed time on profile

### DIFF
--- a/Mlem/App/Utility/Extensions/Date+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Date+Extensions.swift
@@ -8,16 +8,33 @@
 import SwiftUI
 
 extension Date {
-    // Returns strings like "3 seconds ago" and "10 days ago"
-    func getRelativeTime(date: Date = .now, unitsStyle: RelativeDateTimeFormatter.UnitsStyle = .full) -> String {
+    /// Forges a localized `String` with inside the computed elapsed time between `self` and another `Date`.
+    /// Uses a `RelativeDateTimeFormatter` and a given units style.
+    ///
+    /// For example, if the `self` is date 04/11/2023 and `date` is 15/05/2025, will return "2 years ago" (localized).
+    ///
+    /// - Parameters:
+    ///    - date: The date to comapre with `self`, by default `Date.now`
+    ///    - unitsStyle: The style of the string to forge, by default `RelativeDateTimeFormatter.UnitsStyle.full`
+    /// - Returns String: The localized string based.
+    public func getRelativeTime(date: Date = .now, unitsStyle: RelativeDateTimeFormatter.UnitsStyle = .full) -> String {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = unitsStyle
-
-        return formatter.localizedString(for: self, relativeTo: date)
+        // Need to get rid of hours and keep only a simple pure date to have the relative date time formatter working
+        return formatter.localizedString(for: shortered, relativeTo: date)
     }
-    
-    // Returns strings like "5/10/2023"
-    var dateString: String {
+
+    /// Returns `self` but with only the day, the month and the year, i.e. the current date without hours.
+    /// If the conversion fails, returns `self` as is.
+    public var shortered: Date {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "dd/mm/yyyy"
+        return dateFormatter.date(from: dateString) ?? self
+    }
+
+    /// Returns the current `Date` as a shorter version in `String`.
+    /// For example if the date in the 5th of October 2023, returns "5/10/2023"
+    public var dateString: String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .none

--- a/Mlem/App/Utility/Extensions/Date+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Date+Extensions.swift
@@ -20,23 +20,12 @@ extension Date {
     public func getRelativeTime(date: Date = .now, unitsStyle: RelativeDateTimeFormatter.UnitsStyle = .full) -> String {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = unitsStyle
-        // Need to get rid of hours and keep only a simple pure date to have the relative date time formatter working
-        // Using date components to truncate useless data is not relevant as relative date time formatter
-        // cannot process sunch down rounded values
-        return formatter.localizedString(for: shortered, relativeTo: date)
-    }
-
-    /// Returns `self` but with only the day, the month and the year, i.e. the current date without hours.
-    /// If the conversion fails, returns `self` as is.
-    public var shortered: Date {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale.current
-//        dateFormatter.dateFormat = "dd/MM/yyyy"
-        return dateFormatter.date(from: dateString) ?? self
+        return formatter.localizedString(for: self, relativeTo: date)
     }
 
     /// Returns the current `Date` as a shorter version in `String`.
-    /// For example if the date in the 5th of October 2023, returns "5/10/2023"
+    /// For example if the date in the 5th of October 2023, returns "5/10/2023".
+    /// Uses the current locale to let the `DateFormatter` apply the suitable date format depending to the user needs.
     public var dateString: String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .short

--- a/Mlem/App/Utility/Extensions/Date+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Date+Extensions.swift
@@ -11,16 +11,18 @@ extension Date {
     /// Forges a localized `String` with inside the computed elapsed time between `self` and another `Date`.
     /// Uses a `RelativeDateTimeFormatter` and a given units style.
     ///
-    /// For example, if the `self` is date 04/11/2023 and `date` is 15/05/2025, will return "2 years ago" (localized).
+    /// For example, if the `self` is date 04/11/2023 and `date` is 15/05/2025, will return "1 year ago" (localized).
     ///
     /// - Parameters:
-    ///    - date: The date to comapre with `self`, by default `Date.now`
+    ///    - date: The date to compare with `self`, by default `Date.now`
     ///    - unitsStyle: The style of the string to forge, by default `RelativeDateTimeFormatter.UnitsStyle.full`
     /// - Returns String: The localized string based.
     public func getRelativeTime(date: Date = .now, unitsStyle: RelativeDateTimeFormatter.UnitsStyle = .full) -> String {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = unitsStyle
         // Need to get rid of hours and keep only a simple pure date to have the relative date time formatter working
+        // Using date components to truncate useless data is not relevant as relative date time formatter
+        // cannot process sunch down rounded values
         return formatter.localizedString(for: shortered, relativeTo: date)
     }
 
@@ -28,7 +30,7 @@ extension Date {
     /// If the conversion fails, returns `self` as is.
     public var shortered: Date {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "dd/mm/yyyy"
+        dateFormatter.dateFormat = "dd/MM/yyyy"
         return dateFormatter.date(from: dateString) ?? self
     }
 

--- a/Mlem/App/Utility/Extensions/Date+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Date+Extensions.swift
@@ -30,7 +30,8 @@ extension Date {
     /// If the conversion fails, returns `self` as is.
     public var shortered: Date {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "dd/MM/yyyy"
+        dateFormatter.locale = Locale.current
+//        dateFormatter.dateFormat = "dd/MM/yyyy"
         return dateFormatter.date(from: dateString) ?? self
     }
 
@@ -40,6 +41,7 @@ extension Date {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .none
+        dateFormatter.locale = Locale.current
         return dateFormatter.string(from: self)
     }
     

--- a/Mlem/App/Views/Shared/ProfileDateView.swift
+++ b/Mlem/App/Views/Shared/ProfileDateView.swift
@@ -34,6 +34,11 @@ struct ProfileDateView: View {
         profilable.createdRecently ? .lemmy.newAccountFlair : .lemmy.cakeDay
     }
     
+    /// Returns a `String` with the cake date and a custom message depending to if today is cake day or not.
+    /// If the current day is not the cake day, forges a `String` with relative time between the cake date and today.
+    /// In that case the result string is in *full* unit style so as to improve vocalization of the date with *Voice Over¨.
+    /// - Parameter date: the date to process, here the profile creation daye
+    /// - Returns String: The enriched string to add in the profile
     func format(_ date: Date) -> String {
         if profilable.isCakeDay {
             // It's possible for it to be a user's cake day without their account age quite being 365 days.
@@ -42,6 +47,6 @@ struct ProfileDateView: View {
             let components = Calendar.current.dateComponents([.year], from: startDate, to: .now)
             return "\(date.dateString), " + String(localized: "\(components.year ?? 0) years ago today!")
         }
-        return "\(date.dateString), \(date.getRelativeTime(unitsStyle: .abbreviated))"
+        return "\(date.dateString), \(date.getRelativeTime(unitsStyle: .full))"
     }
 }

--- a/MlemTests/DateTests.swift
+++ b/MlemTests/DateTests.swift
@@ -1,0 +1,82 @@
+//
+// Software Name: Mlem
+// SPDX-FileCopyrightText: Copyright (c) Mlem Group
+// SPDX-License-Identifier: GPL-3.0
+//
+// This software is distributed under the GNU General Public License v3.0 license,
+// the text of which is available at https://www.gnu.org/licenses/gpl-3.0-standalone.html
+// or see the "LICENSE" file for more details.
+//
+
+import SwiftUI
+import Testing
+
+/// Contains tests cases to check some `Date` extensions utils
+struct DateTests {
+    @Test(
+        "Get relative time must return the localized expected elapsed time for not cake day and more than one year",
+        .bug("https://github.com/mlemgroup/mlem/issues/2032")
+    )
+    func get_relative_time_returns_localized_string_for_more_than_one_year() {
+        let dateFormatter = DateFormatter()
+        var profileCreationDate: Date, someDate: Date
+
+        // Given
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        profileCreationDate = dateFormatter.date(from: "2023-11-14 12:05:00 +0000")!
+        dateFormatter.dateFormat = "dd/mm/yyyy"
+        someDate = dateFormatter.date(from: "15/05/2025")!
+        
+        // When
+        let relativeTimeString = profileCreationDate.getRelativeTime(date: someDate, unitsStyle: .full)
+        
+        // Then
+        // NOTE: Supposed the language of the device / simulator under tests is english
+        #expect(relativeTimeString == "2 years ago")
+    }
+    
+    @Test("Shortered date must have same day, month and year")
+    func shortered_date_must_have_same_day_month_and_year() {
+        let dateFormatter = DateFormatter()
+        var someDate: Date, shortered: Date
+        var someDateComponents: DateComponents, shorteredComponents: DateComponents
+
+        // Given
+        dateFormatter.dateFormat = "dd/mm/yyyy"
+        someDate = dateFormatter.date(from: "04/11/2023")!
+        // When
+        shortered = someDate.shortered
+        // Then
+        someDateComponents = Calendar.current.dateComponents([.month, .day, .year], from: someDate)
+        shorteredComponents = Calendar.current.dateComponents([.month, .day, .year], from: shortered)
+        #expect(someDateComponents.day == shorteredComponents.day)
+        #expect(someDateComponents.month == shorteredComponents.month)
+        #expect(someDateComponents.year == shorteredComponents.year)
+        
+        // Given
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        someDate = dateFormatter.date(from: "2025-01-14 23:05:00 +0000")!
+        // When
+        shortered = someDate.shortered
+        // Then
+        someDateComponents = Calendar.current.dateComponents([.month, .day, .year], from: someDate)
+        shorteredComponents = Calendar.current.dateComponents([.month, .day, .year], from: shortered)
+        #expect(someDateComponents.day == shorteredComponents.day)
+        #expect(someDateComponents.month == shorteredComponents.month)
+        #expect(someDateComponents.year == shorteredComponents.year)
+    }
+    
+    @Test("Date string of some date must be in dd/mm/yyyy format")
+    func date_string_must_be_in_ddmmyyy_format() {
+        // Given
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        let someDate = dateFormatter.date(from: "2023-11-04 10:05:00 +0000")!
+        
+        // When
+        let dateString = someDate.dateString
+        
+        // Then
+        #expect(dateString == "04/11/2023")
+    }
+}

--- a/MlemTests/DateTests.swift
+++ b/MlemTests/DateTests.swift
@@ -136,18 +136,4 @@ struct DateTests {
         // Then
         #expect(relativeTimeString == "42 seconds ago")
     }
-    
-    @Test("Date string of some date must be in dd/mm/yyyy format")
-    func date_string_must_be_in_ddmmyyy_format() {
-        // Given
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
-        let someDate = dateFormatter.date(from: "2023-11-04 10:05:00 +0000")!
-        
-        // When
-        let dateString = someDate.dateString
-        
-        // Then
-        #expect(dateString == "04/11/2023")
-    }
 }

--- a/MlemTests/DateTests.swift
+++ b/MlemTests/DateTests.swift
@@ -24,7 +24,7 @@ struct DateTests {
         // Given
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
         profileCreationDate = dateFormatter.date(from: "2023-11-14 12:05:00 +0000")!
-        dateFormatter.dateFormat = "dd/mm/yyyy"
+        dateFormatter.dateFormat = "dd/MM/yyyy"
         someDate = dateFormatter.date(from: "15/05/2025")!
         
         // When
@@ -32,7 +32,7 @@ struct DateTests {
         
         // Then
         // NOTE: Supposed the language of the device / simulator under tests is english
-        #expect(relativeTimeString == "2 years ago")
+        #expect(relativeTimeString == "1 year ago")
     }
     
     @Test("Shortered date must have same day, month and year")

--- a/MlemTests/DateTests.swift
+++ b/MlemTests/DateTests.swift
@@ -11,7 +11,8 @@
 import SwiftUI
 import Testing
 
-/// Contains tests cases to check some `Date` extensions utils
+/// Contains tests cases to check some `Date` extensions utils.
+/// NOTE: Supposed the language of the device / simulator under tests is english
 struct DateTests {
     @Test(
         "Get relative time must return the localized expected elapsed time for not cake day and more than one year",
@@ -31,39 +32,109 @@ struct DateTests {
         let relativeTimeString = profileCreationDate.getRelativeTime(date: someDate, unitsStyle: .full)
         
         // Then
-        // NOTE: Supposed the language of the device / simulator under tests is english
         #expect(relativeTimeString == "1 year ago")
     }
     
-    @Test("Shortered date must have same day, month and year")
-    func shortered_date_must_have_same_day_month_and_year() {
+    @Test("Get relative time must return the elapsed days for accounts of several days old")
+    func get_relative_time_must_return_elapsed_days_for_accounts_of_several_days_old() {
         let dateFormatter = DateFormatter()
-        var someDate: Date, shortered: Date
-        var someDateComponents: DateComponents, shorteredComponents: DateComponents
+        var profileCreationDate: Date, profileCreationDateABitLater: Date
 
         // Given
-        dateFormatter.dateFormat = "dd/mm/yyyy"
-        someDate = dateFormatter.date(from: "04/11/2023")!
-        // When
-        shortered = someDate.shortered
-        // Then
-        someDateComponents = Calendar.current.dateComponents([.month, .day, .year], from: someDate)
-        shorteredComponents = Calendar.current.dateComponents([.month, .day, .year], from: shortered)
-        #expect(someDateComponents.day == shorteredComponents.day)
-        #expect(someDateComponents.month == shorteredComponents.month)
-        #expect(someDateComponents.year == shorteredComponents.year)
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        profileCreationDate = dateFormatter.date(from: "2025-05-16 12:05:00 +0000")!
+        profileCreationDateABitLater = dateFormatter.date(from: "2025-05-20 15:30:22 +0000")!
         
+        // When
+        let relativeTimeString = profileCreationDate.getRelativeTime(date: profileCreationDateABitLater, unitsStyle: .full)
+        
+        // Then
+        #expect(relativeTimeString == "4 days ago")
+    }
+
+    @Test("Get relative time must return the elapsed weeks for accounts of several weeks old")
+    func get_relative_time_must_return_elapsed_days_for_accounts_of_several_weeks_old() {
+        let dateFormatter = DateFormatter()
+        var profileCreationDate: Date, profileCreationDateABitLater: Date
+
         // Given
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
-        someDate = dateFormatter.date(from: "2025-01-14 23:05:00 +0000")!
+        profileCreationDate = dateFormatter.date(from: "2025-05-01 12:05:00 +0000")!
+        profileCreationDateABitLater = dateFormatter.date(from: "2025-05-15 15:30:22 +0000")!
+        
         // When
-        shortered = someDate.shortered
+        let relativeTimeString = profileCreationDate.getRelativeTime(date: profileCreationDateABitLater, unitsStyle: .full)
+        
         // Then
-        someDateComponents = Calendar.current.dateComponents([.month, .day, .year], from: someDate)
-        shorteredComponents = Calendar.current.dateComponents([.month, .day, .year], from: shortered)
-        #expect(someDateComponents.day == shorteredComponents.day)
-        #expect(someDateComponents.month == shorteredComponents.month)
-        #expect(someDateComponents.year == shorteredComponents.year)
+        #expect(relativeTimeString == "2 weeks ago")
+    }
+
+    @Test("Get relative time must return the elapsed months for accounts of several months old")
+    func get_relative_time_must_return_elapsed_months_for_accounts_of_several_months_old() {
+        let dateFormatter = DateFormatter()
+        var profileCreationDate: Date, profileCreationDateABitLater: Date
+
+        // Given
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        profileCreationDate = dateFormatter.date(from: "2025-05-16 12:05:00 +0000")!
+        profileCreationDateABitLater = dateFormatter.date(from: "2025-12-16 15:30:22 +0000")!
+        
+        // When
+        let relativeTimeString = profileCreationDate.getRelativeTime(date: profileCreationDateABitLater, unitsStyle: .full)
+        
+        // Then
+        #expect(relativeTimeString == "7 months ago")
+    }
+    
+    @Test("Get relative time must return the elapsed hours for accounts younger than one day but older than one hour")
+    func get_relative_time_must_return_elapsed_hours_for_accounts_of_several_hours_old() {
+        let dateFormatter = DateFormatter()
+        var profileCreationDate: Date, profileCreationDateABitLater: Date
+
+        // Given
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        profileCreationDate = dateFormatter.date(from: "2025-05-16 12:05:00 +0000")!
+        profileCreationDateABitLater = dateFormatter.date(from: "2025-05-16 15:30:22 +0000")!
+        
+        // When
+        let relativeTimeString = profileCreationDate.getRelativeTime(date: profileCreationDateABitLater, unitsStyle: .full)
+        
+        // Then
+        #expect(relativeTimeString == "3 hours ago")
+    }
+
+    @Test("Get relative time must return the elapsed minutes for accounts younger than one hour")
+    func get_relative_time_must_return_elapsed_hours_for_accounts_of_less_one_hour_old() {
+        let dateFormatter = DateFormatter()
+        var profileCreationDate: Date, profileCreationDateABitLater: Date
+
+        // Given
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        profileCreationDate = dateFormatter.date(from: "2025-05-16 12:05:00 +0000")!
+        profileCreationDateABitLater = dateFormatter.date(from: "2025-05-16 12:30:22 +0000")!
+        
+        // When
+        let relativeTimeString = profileCreationDate.getRelativeTime(date: profileCreationDateABitLater, unitsStyle: .full)
+
+        // Then
+        #expect(relativeTimeString == "25 minutes ago")
+    }
+
+    @Test("Get relative time must return the elapsed seconds for accounts of some seconds old")
+    func get_relative_time_must_return_elapsed_seconds_for_accounts_of_some_seconds_old() {
+        let dateFormatter = DateFormatter()
+        var profileCreationDate: Date, profileCreationDateABitLater: Date
+
+        // Given
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        profileCreationDate = dateFormatter.date(from: "2025-05-16 12:05:00 +0000")!
+        profileCreationDateABitLater = dateFormatter.date(from: "2025-05-16 12:05:42 +0000")!
+        
+        // When
+        let relativeTimeString = profileCreationDate.getRelativeTime(date: profileCreationDateABitLater, unitsStyle: .full)
+
+        // Then
+        #expect(relativeTimeString == "42 seconds ago")
     }
     
     @Test("Date string of some date must be in dd/mm/yyyy format")


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2032

## Description

<!-- Describe what this PR does at a high level (e.g., "adds a toggle to do <thing>") -->

The elapsed time since the creation of the Lemmy account displayed on the profile now has the expected value.
The value is computed and does not display for example "-1" if the account is more than 2 years.
The string is also displayed in full format so as to help understandability and *Voice Over* vocalization.

## Implementation Notes

<!-- Any information about the code that would be helpful for reviewing -->
- Use the dates in the expected format so as to allow the `RelativeDateTimeFormatter` to process them (i.e. otherwise fail if hours are in dates)
- Change units style to have a more understandable string representation of the elapsed time
- Add unit tests to ensure the date calculations remain the expected ones
- Make some properties and function public to allow unit tests

