### PR TITLE
[#2034] Add missing french translations, fix basic toast instanciation for `urlCopyError`case

### DIFF
--- a/Mlem/App/Views/Shared/Toast/ToastType.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastType.swift
@@ -120,8 +120,8 @@ enum ToastType: Hashable {
     }
     
     static var urlCopyError: ToastType {
-        .basic(
-            title: "No URL Copied",
+        basic(
+            "No URL Copied",
             subtitle: "Copy a URL to the clipboard, then try again.",
             icon: nil,
             color: .themedAccent,

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -9203,9 +9203,6 @@
       }
     },
     "Would you like to open this email address in your mail app?" : {
-<<<<<<< HEAD
-
-=======
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -9214,7 +9211,6 @@
           }
         }
       }
->>>>>>> 80b76dfa (fix: missing french translations, basic toast for URL copy error never translated (#2034))
     },
     "Wrap Code Block Lines" : {
       "localizations" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -604,7 +604,14 @@
       }
     },
     "Account Created %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compte crée %@"
+          }
+        }
+      }
     },
     "Accounts" : {
       "localizations" : {
@@ -1830,7 +1837,14 @@
       }
     },
     "Choose whether to show a user's account age next to their username." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir d'afficher ou non l'âge du compte d'un utilisateur à côté de son nom d'utilisateur."
+          }
+        }
+      }
     },
     "Choose whether to show a warning when opening a page that is likely to contain sensitive content." : {
       "localizations" : {
@@ -2339,6 +2353,17 @@
         }
       }
     },
+    "Copy a URL to the clipboard, then try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier une URL dans le presse-papiers, et essayer à nouveau."
+          }
+        }
+      }
+    },
     "Copy All" : {
       "localizations" : {
         "fr" : {
@@ -2562,7 +2587,14 @@
       }
     },
     "Data not available" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Donnée non disponible"
+          }
+        }
+      }
     },
     "Days:" : {
       "localizations" : {
@@ -3516,7 +3548,14 @@
       }
     },
     "For New Accounts Only" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pour les nouveaux comptes seulement"
+          }
+        }
+      }
     },
     "General" : {
       "localizations" : {
@@ -4045,8 +4084,8 @@
       "localizations" : {
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "john_doe"
+            "state" : "translated",
+            "value" : "jean_dupont"
           }
         }
       }
@@ -4056,14 +4095,22 @@
       "localizations" : {
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "john_doe@example.com"
+            "state" : "translated",
+            "value" : "jean_dupont@exemple.com"
           }
         }
       }
     },
     "john@example.com" : {
-      "comment" : "Translate \"john\" into the equivalent placeholder name in your language, and \"example.com\" into a suitable example domain for your locale. The placeholder name should be as short as possible, as this string is displayed in contexts where there may not be much space horizontally."
+      "comment" : "Translate \"john\" into the equivalent placeholder name in your language, and \"example.com\" into a suitable example domain for your locale. The placeholder name should be as short as possible, as this string is displayed in contexts where there may not be much space horizontally.",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "jean@exemple.com"
+          }
+        }
+      }
     },
     "Join Discord Server" : {
       "localizations" : {
@@ -4606,7 +4653,14 @@
       }
     },
     "Mlem uses a Google API to fetch website icon URLs. If you'd prefer not to use this, you can choose to hide website icons." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mlem utilise une API Google pour récupérer les URL des icônes de sites web. Si vous préférez ne pas l'utiliser, vous pouvez choisir de masquer les icônes de sites web."
+          }
+        }
+      }
     },
     "Mlem will always try to load from the proxy first." : {
       "localizations" : {
@@ -5046,6 +5100,17 @@
         }
       }
     },
+    "No URL Copied" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas d’URL copiée"
+          }
+        }
+      }
+    },
     "Non-Text Indicators" : {
       "localizations" : {
         "fr" : {
@@ -5287,7 +5352,14 @@
       }
     },
     "Open Mail App" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir l’application de mails"
+          }
+        }
+      }
     },
     "Open URL from Clipboard" : {
       "localizations" : {
@@ -7066,7 +7138,14 @@
       }
     },
     "Show Account Age" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l’âge du compte"
+          }
+        }
+      }
     },
     "Show All Actions in Feed" : {
       "localizations" : {
@@ -9126,7 +9205,18 @@
       }
     },
     "Would you like to open this email address in your mail app?" : {
+<<<<<<< HEAD
 
+=======
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Souhaitez-vous ouvrir cette adresse e-mail dans votre application de messagerie?"
+          }
+        }
+      }
+>>>>>>> 80b76dfa (fix: missing french translations, basic toast for URL copy error never translated (#2034))
     },
     "Wrap Code Block Lines" : {
       "localizations" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -2354,7 +2354,6 @@
       }
     },
     "Copy a URL to the clipboard, then try again." : {
-      "extractionState" : "manual",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -5101,7 +5100,6 @@
       }
     },
     "No URL Copied" : {
-      "extractionState" : "manual",
       "localizations" : {
         "fr" : {
           "stringUnit" : {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2034

## Description

<!-- Describe what this PR does at a high level (e.g., "adds a toggle to do <thing>") -->

I spotted in *dev* rbanch some missing wording in french, mainly for toasts.
The toast displayed in case of error during URL copy is also never translated.

## Implementation Notes

<!-- Any information about the code that would be helpful for reviewing -->
- Added missing translations
- Fix generation of basic toast (using the static helper and not directly the enum case as explained in comment in the code)