### PR TITLE
Add contextual fallbacks for proxy errors

### DIFF
--- a/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
@@ -5,11 +5,10 @@
 //  Created by Eric Andrews on 2025-01-15.
 //
 
-import SwiftUI
 import Media
+import SwiftUI
 
 extension MediaView {
-    
     @ViewBuilder
     var image: some View {
         CoreMediaView(
@@ -44,13 +43,24 @@ extension MediaView {
     
     @ViewBuilder
     var coreFallbackImage: some View {
-        let fallback: Fallback = loader.loading == .proxyFailed ? .proxyFailure : fallback
+        // Use contextual fallback icons even when proxy fails.
+        let contextualFallback: Fallback = if loader.loading == .proxyFailed {
+            switch fallback {
+            case .personAvatar, .communityAvatar, .instanceAvatar:
+                fallback
+            default:
+                .proxyFailure
+            }
+        } else {
+            fallback
+        }
+        
         GeometryReader { geo in
-            Image(icon: fallback.icon)
+            Image(icon: contextualFallback.icon)
                 .resizable()
                 .scaledToFit()
-                .symbolVariant(fallback.fallbackStyle == .avatar ? .circle.fill : .none)
-                .frame(width: geo.size.width * fallback.scaleFactor)
+                .symbolVariant(contextualFallback.fallbackStyle == .avatar ? .circle.fill : .none)
+                .frame(width: geo.size.width * contextualFallback.scaleFactor)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }

--- a/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
@@ -45,12 +45,7 @@ extension MediaView {
     var coreFallbackImage: some View {
         // Use contextual fallback icons even when proxy fails.
         let contextualFallback: Fallback = if loader.loading == .proxyFailed {
-            switch fallback {
-            case .personAvatar, .communityAvatar, .instanceAvatar:
-                fallback
-            default:
-                .proxyFailure
-            }
+            fallback.fallbackStyle == .avatar ? fallback : .proxyFailure
         } else {
             fallback
         }


### PR DESCRIPTION
## Issues

- closes #2000

## Description

This PR implements contextual fallback icons for image proxy failures. When profile pictures can't be loaded, users will see the appropriate avatar icon (person, community, or instance) rather than the generic proxy failure indicator.

## Implementation Notes

Modified `coreFallbackImage` in `MediaView+Views.swift` to preserve the entity type (person, community, instance) during proxy failures.