### PR TITLE
Clean up middleware

### DIFF
--- a/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
@@ -78,7 +78,7 @@ extension Interactable1Providing {
         Task {
             let initialValue = self2.removed
             if feedback.contains(.haptic) {
-                await HapticManager.main.play(haptic: .success, priority: .low)
+                HapticManager.main.play(haptic: .success, priority: .low)
             }
             switch await self2.toggleRemoved(reason: reason).result.get() {
             case .failed:

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -91,7 +91,7 @@ extension Post1Providing {
         feedback: Set<FeedbackType>
     ) async {
         if feedback.contains(.haptic) {
-            await HapticManager.main.play(haptic: .success, priority: .low)
+            HapticManager.main.play(haptic: .success, priority: .low)
         }
         switch result {
         case .failed:

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2+Codable.swift
@@ -24,7 +24,7 @@ extension Comment2 {
                 childCount: commentCount,
                 hotRank: nil
             ),
-            creatorBannedFromCommunity: bannedFromCommunity,
+            creatorBannedFromCommunity: nil,
             subscribed: .notSubscribed,
             saved: saved,
             creatorBlocked: creator.blocked,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2Providing.swift
@@ -15,7 +15,7 @@ public protocol Comment2Providing: Comment1Providing, Interactable2Providing, Pe
     var community: any Community { get }
     var creatorIsModerator: Bool? { get }
     var creatorIsAdmin: Bool? { get }
-    var bannedFromCommunity: Bool { get }
+    var creatorBannedFromCommunity: Bool { get }
 }
 
 public extension Comment2Providing {
@@ -28,7 +28,7 @@ public extension Comment2Providing {
     var saved: Bool { comment2.saved }
     var creatorIsModerator: Bool? { comment2.creatorIsModerator }
     var creatorIsAdmin: Bool? { comment2.creatorIsAdmin }
-    var bannedFromCommunity: Bool { comment2.bannedFromCommunity }
+    var creatorBannedFromCommunity: Bool { comment2.creatorBannedFromCommunity }
     var commentCount: Int { comment2.commentCount }
     
     var creator_: (any Person)? { comment2.creator }
@@ -38,7 +38,7 @@ public extension Comment2Providing {
     var saved_: Bool? { comment2.saved }
     var creatorIsModerator_: Bool? { comment2.creatorIsModerator }
     var creatorIsAdmin_: Bool? { comment2.creatorIsAdmin }
-    var bannedFromCommunity_: Bool? { comment2.bannedFromCommunity }
+    var creatorBannedFromCommunity_: Bool? { comment2.creatorBannedFromCommunity }
     var commentCount_: Int? { comment2.commentCount }
 }
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/CommentStubProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/CommentStubProviding.swift
@@ -30,7 +30,7 @@ public protocol CommentStubProviding: ContentModel, Resolvable {
     var saved_: Bool? { get }
     var creatorIsModerator_: Bool? { get }
     var creatorIsAdmin_: Bool? { get }
-    var bannedFromCommunity_: Bool? { get }
+    var creatorBannedFromCommunity_: Bool? { get }
     var commentCount_: Int? { get }
     
     func upgrade() async throws -> any Comment
@@ -57,7 +57,7 @@ public extension CommentStubProviding {
     var saved_: Bool? { nil }
     var creatorIsModerator_: Bool? { nil }
     var creatorIsAdmin_: Bool? { nil }
-    var bannedFromCommunity_: Bool? { nil }
+    var creatorBannedFromCommunity_: Bool? { nil }
     var commentCount_: Int? { nil }
     
     var depth_: Int? { parentCommentIds_?.count }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community3Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community3Providing.swift
@@ -12,8 +12,7 @@ public protocol Community3Providing: Community2Providing {
     
     var instance: Instance1? { get }
     var moderators: [Person1] { get }
-    var discussionLanguages: [Int] { get }
-    // var defaultPostLanguage: Int? { get }
+    var discussionLanguageIds: Set<Int> { get }
 }
 
 public extension Community3Providing {
@@ -22,13 +21,11 @@ public extension Community3Providing {
     /// This is optional because it's defined as such on ``ApiGetCommunityResponse``. I'm not sure when it actually returns `nil`.
     var instance: Instance1? { community3.instance }
     var moderators: [Person1] { community3.moderators }
-    var discussionLanguages: [Int] { community3.discussionLanguages }
-    // var defaultPostLanguage: Int? { community3.defaultPostLanguage }
+    var discussionLanguageIds: Set<Int> { community3.discussionLanguageIds }
     
     var instance_: Instance1? { community3.instance }
     var moderators_: [Person1]? { community3.moderators }
-    var discussionLanguages_: [Int]? { community3.discussionLanguages }
-    // var defaultPostLanguage_: Int? { community3.defaultPostLanguage }
+    var discussionLanguageIds_: Set<Int>? { community3.discussionLanguageIds }
 }
 
 public extension Community3Providing {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/CommunityStubProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/CommunityStubProviding.swift
@@ -42,8 +42,7 @@ public protocol CommunityStubProviding: ContentModel, Resolvable {
     // From Community3Providing.
     var instance_: Instance1? { get }
     var moderators_: [Person1]? { get }
-    var discussionLanguages_: [Int]? { get }
-    var defaultPostLanguage_: Int? { get }
+    var discussionLanguageIds_: Set<Int>? { get }
     
     func upgrade() async throws -> any Community
 }
@@ -85,6 +84,5 @@ public extension CommunityStubProviding {
     // From Community3Providing.
     var instance_: Instance1? { nil }
     var moderators_: [Person1]? { nil }
-    var discussionLanguages_: [Int]? { nil }
-    var defaultPostLanguage_: Int? { nil }
+    var discussionLanguageIds_: Set<Int>? { nil }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Interactable/Interactable1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Interactable/Interactable1Providing.swift
@@ -16,7 +16,7 @@ public protocol Interactable1Providing: AnyObject, ContentModel, ReportableProvi
     var community_: (any Community)? { get }
     var creatorIsModerator_: Bool? { get }
     var creatorIsAdmin_: Bool? { get }
-    var bannedFromCommunity_: Bool? { get }
+    var creatorBannedFromCommunity_: Bool? { get }
     var commentCount_: Int? { get }
     var votes_: VotesModel? { get }
     var saved_: Bool? { get }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
@@ -13,7 +13,7 @@ public protocol Interactable2Providing: Interactable1Providing, RemovableProvidi
     var community: any Community { get }
     var creatorIsModerator: Bool? { get }
     var creatorIsAdmin: Bool? { get }
-    var bannedFromCommunity: Bool { get }
+    var creatorBannedFromCommunity: Bool { get }
     var commentCount: Int { get }
     var votes: VotesModel { get }
     var saved: Bool { get }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person4Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person4Providing.swift
@@ -14,7 +14,6 @@ public protocol Person4Providing: Person3Providing {
     var email: String? { get }
     var showNsfw: Bool { get }
     var theme: String { get }
-    var defaultSortType: ApiSortType { get }
     var defaultListingType: ApiListingType { get }
     var interfaceLanguage: String { get }
     var showAvatars: Bool { get }
@@ -44,7 +43,6 @@ public extension Person4Providing {
     var email: String? { person4.email }
     var showNsfw: Bool { person4.showNsfw }
     var theme: String { person4.theme }
-    var defaultSortType: ApiSortType { person4.defaultSortType }
     var defaultListingType: ApiListingType { person4.defaultListingType }
     var interfaceLanguage: String { person4.interfaceLanguage }
     var showAvatars: Bool { person4.showAvatars }
@@ -70,7 +68,6 @@ public extension Person4Providing {
     var email_: String? { person4.email }
     var showNsfw_: Bool? { person4.showNsfw }
     var theme_: String? { person4.theme }
-    var defaultSortType_: ApiSortType? { person4.defaultSortType }
     var defaultListingType_: ApiListingType? { person4.defaultListingType }
     var interfaceLanguage_: String? { person4.interfaceLanguage }
     var showAvatars_: Bool? { person4.showAvatars }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+Codable.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2+Codable.swift
@@ -39,7 +39,7 @@ extension Post2 {
             unreadComments: unreadCommentCount,
             creatorIsModerator: creatorIsModerator,
             creatorIsAdmin: creatorIsAdmin,
-            bannedFromCommunity: bannedFromCommunity,
+            bannedFromCommunity: nil,
             hidden: hidden,
             imageDetails: nil,
             communityActions: nil,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
@@ -25,7 +25,7 @@ public extension Post2Providing {
     var community: any Community { post2.community }
     var creatorIsModerator: Bool? { post2.creatorIsModerator }
     var creatorIsAdmin: Bool? { post2.creatorIsAdmin }
-    var bannedFromCommunity: Bool { post2.bannedFromCommunity }
+    var creatorBannedFromCommunity: Bool { post2.creatorBannedFromCommunity }
     var commentCount: Int { post2.commentCount }
     var unreadCommentCount: Int { post2.unreadCommentCount }
     var votes: VotesModel { post2.votes }
@@ -37,7 +37,7 @@ public extension Post2Providing {
     var community_: (any Community)? { post2.community }
     var creatorIsModerator_: Bool? { post2.creatorIsModerator }
     var creatorIsAdmin_: Bool? { post2.creatorIsAdmin }
-    var bannedFromCommunity_: Bool? { post2.bannedFromCommunity }
+    var creatorBannedFromCommunity_: Bool? { post2.creatorBannedFromCommunity }
     var commentCount_: Int? { post2.commentCount }
     var unreadCommentCount_: Int? { post2.unreadCommentCount }
     var votes_: VotesModel? { post2.votes }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post3Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post3Providing.swift
@@ -10,8 +10,6 @@ import Nuke
 
 public protocol Post3Providing: Post2Providing {
     var post3: Post3 { get }
-    
-    var communityModerators: [Person1] { get }
     var crossPosts: [Post2] { get }
 }
 
@@ -22,10 +20,8 @@ public extension Post3Providing {
     var community: any Community { post3.community }
     var community_: (any Community)? { post3.community }
     
-    var communityModerators: [Person1] { post3.communityModerators }
     var crossPosts: [Post2] { post3.crossPosts }
     
-    var communityModerators_: [Person1]? { post3.communityModerators }
     var crossPosts_: [Post2]? { post3.crossPosts }
 }
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/PostStubProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/PostStubProviding.swift
@@ -37,7 +37,7 @@ public protocol PostStubProviding: ContentModel, Resolvable {
     var community_: (any Community)? { get }
     var creatorIsModerator_: Bool? { get }
     var creatorIsAdmin_: Bool? { get }
-    var bannedFromCommunity_: Bool? { get }
+    var creatorBannedFromCommunity_: Bool? { get }
     var commentCount_: Int? { get }
     var unreadCommentCount_: Int? { get }
     var votes_: VotesModel? { get }
@@ -46,7 +46,6 @@ public protocol PostStubProviding: ContentModel, Resolvable {
     var hidden_: Bool? { get }
     
     // From Post3Providing. These are defined as nil in the extension below
-    var communityModerators_: [Person1]? { get }
     var crossPosts_: [Post2]? { get }
     
     func upgrade() async throws -> any Post
@@ -80,7 +79,7 @@ public extension PostStubProviding {
     var community_: (any Community)? { nil }
     var creatorIsModerator_: Bool? { nil }
     var creatorIsAdmin_: Bool? { nil }
-    var bannedFromCommunity_: Bool? { nil }
+    var creatorBannedFromCommunity_: Bool? { nil }
     var commentCount_: Int? { nil }
     var votes_: VotesModel? { nil }
     var unreadCommentCount_: Int? { nil }
@@ -88,6 +87,5 @@ public extension PostStubProviding {
     var read_: Bool? { nil }
     var hidden_: Bool? { nil }
     
-    var communityModerators_: [Person1]? { nil }
     var crossPosts_: [Post2]? { nil }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
@@ -39,7 +39,7 @@ public protocol Reply1Providing:
     var commentCount_: Int? { get }
     var creatorIsModerator_: Bool? { get }
     var creatorIsAdmin_: Bool? { get }
-    var bannedFromCommunity_: Bool? { get }
+    var creatorBannedFromCommunity_: Bool? { get }
     var removed_: Bool? { get }
     var removedManager_: StateManager<Bool>? { get }
     var votes_: VotesModel? { get }
@@ -82,7 +82,7 @@ public extension Reply1Providing {
     var commentCount_: Int? { nil }
     var creatorIsModerator_: Bool? { nil }
     var creatorIsAdmin_: Bool? { nil }
-    var bannedFromCommunity_: Bool? { nil }
+    var creatorBannedFromCommunity_: Bool? { nil }
     var votes_: VotesModel? { nil }
     var saved_: Bool? { nil }
     var removed_: Bool? { nil }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply2.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply2.swift
@@ -34,7 +34,7 @@ public final class Reply2: Reply2Providing, FeedLoadable {
     public var creatorIsModerator: Bool?
     public var creatorIsAdmin: Bool?
     
-    public var bannedFromCommunity: Bool {
+    public var creatorBannedFromCommunity: Bool {
         guard let state = creator.isBannedFromCommunity(community) else {
             assertionFailure("Ban status should be present at this point")
             return false

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Reply/Reply2Providing.swift
@@ -21,7 +21,7 @@ public protocol Reply2Providing: Reply1Providing, Interactable2Providing, ActorI
     var commentCount: Int { get }
     var creatorIsModerator: Bool? { get }
     var creatorIsAdmin: Bool? { get }
-    var bannedFromCommunity: Bool { get }
+    var creatorBannedFromCommunity: Bool { get }
     var removed: Bool { get }
     var removedManager: StateManager<Bool> { get }
 }
@@ -38,7 +38,7 @@ public extension Reply2Providing {
     var commentCount: Int { reply2.commentCount }
     var creatorIsModerator: Bool? { reply2.creatorIsModerator }
     var creatorIsAdmin: Bool? { reply2.creatorIsAdmin }
-    var bannedFromCommunity: Bool { reply2.bannedFromCommunity }
+    var creatorBannedFromCommunity: Bool { reply2.creatorBannedFromCommunity }
     var removed: Bool { reply2.comment.removed }
     var removedManager: StateManager<Bool> { reply2.comment.removedManager }
     
@@ -52,7 +52,7 @@ public extension Reply2Providing {
     var commentCount_: Int? { reply2.commentCount }
     var creatorIsModerator_: Bool? { reply2.creatorIsModerator }
     var creatorIsAdmin_: Bool? { reply2.creatorIsAdmin }
-    var bannedFromCommunity_: Bool? { reply2.bannedFromCommunity }
+    var creatorBannedFromCommunity_: Bool? { reply2.creatorBannedFromCommunity }
 }
 
 public extension Reply2Providing {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Comment/Comment2Snapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Comment/Comment2Snapshot.swift
@@ -46,9 +46,6 @@ public struct Comment2Snapshot: CacheIdentifiable {
         } else {
             self.creatorIsModerator = comment.creatorIsModerator
             self.creatorBannedFromCommunity = comment.creatorBannedFromCommunity ?? false
-            guard let creatorBlocked = comment.creatorBlocked else {
-                throw .responseMissingRequiredData("ApICommentView creatorBlocked")
-            }
         }
         
         if let actions = comment.commentActions {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Reply/Reply2Snapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Reply/Reply2Snapshot.swift
@@ -59,9 +59,6 @@ public struct Reply2Snapshot: CacheIdentifiable {
         } else {
             self.creatorIsModerator = commentReply.creatorIsModerator
             self.creatorBannedFromCommunity = commentReply.creatorBannedFromCommunity ?? false
-            guard let creatorBlocked = commentReply.creatorBlocked else {
-                throw .responseMissingRequiredData("ApiCommentReplyView creatorBlocked")
-            }
         }
         
         if let actions = commentReply.commentActions {
@@ -116,9 +113,6 @@ public struct Reply2Snapshot: CacheIdentifiable {
         } else {
             self.creatorIsModerator = personMention.creatorIsModerator
             self.creatorBannedFromCommunity = personMention.creatorBannedFromCommunity ?? false
-            guard let creatorBlocked = personMention.creatorBlocked else {
-                throw .responseMissingRequiredData("ApiPersonCommentMentionView creatorBlocked")
-            }
         }
         
         if let actions = personMention.commentActions {


### PR DESCRIPTION
Cleaned up some things I missed in #2039. 

Some of these were infinite recursions, which could cause hangs in theory (though I haven't encountered any in practice, yet). This needs to be merged before the next TF release just in case. Don't include this in the patch notes - #2039 hasn't been released to the TF yet. 