### PR TITLE
fix post editor search error

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
@@ -112,12 +112,19 @@ public extension ApiClient {
                 // TODO: favorites
             }
         }
-        if let hostApi {
-            let resolvedCommunities: [URL: Community2] = try await hostApi.resolve(urls: ret.map { $0.resolvableUrl(from: .host) })
-            for community in ret {
-                if let resolvedCommunity = resolvedCommunities[community.resolvableUrl(from: .host)] {
-                    community.blockedManager.addSibling(resolvedCommunity.blockedManager)
+        
+        // if on a foreign host, resolve communities to populate subscription status.
+        if let hostApi, hostApi !== self {
+            do {
+                let resolvedCommunities: [URL: Community2] = try await hostApi.resolve(urls: ret.map { $0.resolvableUrl(from: .host) })
+                for community in ret {
+                    if let resolvedCommunity = resolvedCommunities[community.resolvableUrl(from: .host)] {
+                        community.blockedManager.addSibling(resolvedCommunity.blockedManager)
+                    }
                 }
+            } catch {
+                // if this fails, don't fail the whole call
+                print("Failed to resolve community URLs: \(error)")
             }
         }
         return ret

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
@@ -124,6 +124,7 @@ public extension ApiClient {
                 }
             } catch {
                 // if this fails, don't fail the whole call
+                // TODO: error toast (depends on packaged error handling)
                 print("Failed to resolve community URLs: \(error)")
             }
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -142,7 +142,7 @@ public class ApiClient {
         
         let urlRequest = try urlRequest(from: request, tokenOverride: tokenOverride)
         // this line intentionally left commented for convenient future debugging
-//        urlRequest.debug()
+        // urlRequest.debug()
         let (data, response) = try await execute(urlRequest, tokenOverride: tokenOverride)
         if let response = response as? HTTPURLResponse {
             if response.statusCode >= 500 { // Error code for server being offline.


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2058 

## Description

Searching within your own instance sometimes causes resolution failures. I'm not sure at this point whether that's an issue when searching on foreign hosts--I haven't been able to repro in that context.

In either event, there's no reason to perform the resolution step if the search is being made on `hostApi`, so I've added a check to disable it in that case.

I've also added error handling on the resolution step to prevent the entire search from failing if the resolution step fails--it's better IMO to display the search results sans subscription status than fail the whole search.