### PR TITLE
Fix mod mail showing the reporter as the reported content creator

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Comment/Comment2Snapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Comment/Comment2Snapshot.swift
@@ -28,7 +28,7 @@ public struct Comment2Snapshot: CacheIdentifiable {
     
     public init(from comment: ApiCommentView) throws(ApiClientError) {
         self.comment = try .init(from: comment.comment)
-        self.creator = try .init(from: comment.creator)
+        self.creator = try .init(from: comment.commentCreator)
         self.post = try .init(from: comment.post)
         self.community = try .init(from: comment.community)
         

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Comment/Comment2Snapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Comment/Comment2Snapshot.swift
@@ -28,7 +28,7 @@ public struct Comment2Snapshot: CacheIdentifiable {
     
     public init(from comment: ApiCommentView) throws(ApiClientError) {
         self.comment = try .init(from: comment.comment)
-        self.creator = try .init(from: comment.commentCreator)
+        self.creator = try .init(from: comment.creator)
         self.post = try .init(from: comment.post)
         self.community = try .init(from: comment.community)
         
@@ -67,7 +67,7 @@ public struct Comment2Snapshot: CacheIdentifiable {
     
     public init(from report: ApiCommentReportView) throws(ApiClientError) {
         self.comment = try .init(from: report.comment)
-        self.creator = try .init(from: report.creator)
+        self.creator = try .init(from: report.commentCreator)
         self.post = try .init(from: report.post)
         self.community = try .init(from: report.community)
         

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Post/Post2Snapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Post/Post2Snapshot.swift
@@ -82,7 +82,7 @@ public struct Post2Snapshot: CacheIdentifiable {
     
     init(from report: ApiPostReportView) throws(ApiClientError) {
         self.post = try .init(from: report.post)
-        self.creator = try .init(from: report.creator)
+        self.creator = try .init(from: report.postCreator)
         self.community = try .init(from: report.community)
         
         if let counts = report.counts {


### PR DESCRIPTION
This bug was introduced when I added the snapshot structs (so it's not in the App Store version of Mlem)