### PR TITLE
Add collapse, collapse parent, and collapse to top comment actions

### DIFF
--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -272,6 +272,14 @@ enum Icons {
     static let chooseFile: String = "folder"
     static let add: String = "plus"
     
+    // collapse actions
+    static let collapse: String = "minus.rectangle"
+    static let collapseFill: String = "minus.rectangle.fill"
+    static let collapseParent: String = "chevron.up.square"
+    static let collapseParentFill: String = "chevron.up.square.fill"
+    static let collapseToTop: String = "arrow.up.to.line.square"
+    static let collapseToTopFill: String = "arrow.up.to.line.square.fill"
+    
     // settings
     static let upvoteOnSave: String = "arrow.up.heart"
     static let readIndicatorSetting: String = "book"

--- a/Mlem/App/Configuration/Icons.swift
+++ b/Mlem/App/Configuration/Icons.swift
@@ -273,12 +273,15 @@ enum Icons {
     static let add: String = "plus"
     
     // collapse actions
-    static let collapse: String = "minus.rectangle"
-    static let collapseFill: String = "minus.rectangle.fill"
-    static let collapseParent: String = "chevron.up.square"
-    static let collapseParentFill: String = "chevron.up.square.fill"
-    static let collapseToTop: String = "arrow.up.to.line.square"
-    static let collapseToTopFill: String = "arrow.up.to.line.square.fill"
+    static let collapse: String = "minus"
+    static let collapseSquare: String = "minus.rectangle"
+    static let collapseSquareFill: String = "minus.rectangle.fill"
+    static let collapseParent: String = "chevron.up"
+    static let collapseParentSquare: String = "chevron.up.square"
+    static let collapseParentSquareFill: String = "chevron.up.square.fill"
+    static let collapseToTop: String = "arrow.up.to.line"
+    static let collapseToTopSquare: String = "arrow.up.to.line.square"
+    static let collapseToTopSquareFill: String = "arrow.up.to.line.square.fill"
     
     // settings
     static let upvoteOnSave: String = "arrow.up.heart"

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -23,6 +23,9 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
         case resolve
         case remove
         case ban
+        case collapse
+        case collapseParent
+        case collapseToTop
         
         static var defaultWidgets: [ActionType] { [
             .upvote,
@@ -51,6 +54,9 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             case .resolve: .resolve(isOn: false)
             case .remove: .remove(isOn: false)
             case .ban: .banFromCommunity(isOn: false)
+            case .collapse: .collapse()
+            case .collapseParent: .collapseParent()
+            case .collapseToTop: .collapseToTop()
             }
         }
         
@@ -60,6 +66,7 @@ struct CommentBarConfiguration: InteractionBarConfiguration {
             case .downvote: context.votes_?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
             case .save: [.saved]
             case .reply, .share, .selectText, .report, .resolve, .remove, .ban: []
+            case .collapse, .collapseParent, .collapseToTop: []
             }
         }
     }

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -285,7 +285,8 @@ extension ActionAppearance {
             label: "Collapse",
             color: .themedColorfulAccent(4),
             icon: Icons.collapse,
-            swipeIcon2: Icons.collapseFill
+            swipeIcon1: Icons.collapseSquare,
+            swipeIcon2: Icons.collapseSquareFill
         )
     }
     
@@ -294,7 +295,8 @@ extension ActionAppearance {
             label: "Collapse Parent",
             color: .themedColorfulAccent(4),
             icon: Icons.collapseParent,
-            swipeIcon2: Icons.collapseParentFill
+            swipeIcon1: Icons.collapseParentSquare,
+            swipeIcon2: Icons.collapseParentSquareFill
         )
     }
     
@@ -303,7 +305,8 @@ extension ActionAppearance {
             label: "Collapse to Top",
             color: .themedColorfulAccent(4),
             icon: Icons.collapseToTop,
-            swipeIcon2: Icons.collapseToTopFill
+            swipeIcon1: Icons.collapseToTopSquare,
+            swipeIcon2: Icons.collapseToTopSquareFill
         )
     }
 }

--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -279,4 +279,31 @@ extension ActionAppearance {
     static func viewVotes() -> Self {
         .init(label: "View Votes", color: .themedAccent, icon: Icons.votes)
     }
+        
+    static func collapse() -> Self {
+        .init(
+            label: "Collapse",
+            color: .themedColorfulAccent(4),
+            icon: Icons.collapse,
+            swipeIcon2: Icons.collapseFill
+        )
+    }
+    
+    static func collapseParent() -> Self {
+        .init(
+            label: "Collapse Parent",
+            color: .themedColorfulAccent(4),
+            icon: Icons.collapseParent,
+            swipeIcon2: Icons.collapseParentFill
+        )
+    }
+    
+    static func collapseToTop() -> Self {
+        .init(
+            label: "Collapse to Top",
+            color: .themedColorfulAccent(4),
+            icon: Icons.collapseToTop,
+            swipeIcon2: Icons.collapseToTopFill
+        )
+    }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -115,6 +115,7 @@ extension Comment1Providing {
         false
     }
     
+    // swiftlint:disable:next cyclomatic_complexity
     func action(
         appState: AppState,
         type: CommentBarConfiguration.ActionType,
@@ -134,6 +135,9 @@ extension Comment1Providing {
         case .resolve: reportContext?.resolveAction(appState: appState, feedback: [.haptic])
         case .remove: removeAction(appState: appState).disabled(!canModerate)
         case .ban: reportContext?.contextualBanAction(appState: appState)
+        case .collapse: collapseAction(commentTreeTracker: commentTreeTracker)
+        case .collapseParent: collapseParentAction(commentTreeTracker: commentTreeTracker)
+        case .collapseToTop: collapseToTopAction(commentTreeTracker: commentTreeTracker)
         }
     }
     
@@ -186,6 +190,36 @@ extension Comment1Providing {
             id: "viewVotes\(uid)",
             appearance: .viewVotes(),
             callback: callback
+        )
+    }
+    
+    func collapseAction(commentTreeTracker: CommentTreeTracker? = nil) -> BasicAction {
+        .init(
+            id: "collapse\(uid)",
+            appearance: .collapse(),
+            callback: { @MainActor in
+                commentTreeTracker?.nodesKeyedByActorId[self.actorId]?.collapsed = true
+            }
+        )
+    }
+    
+    func collapseParentAction(commentTreeTracker: CommentTreeTracker? = nil) -> BasicAction {
+        .init(
+            id: "collapseParent\(uid)",
+            appearance: .collapseParent(),
+            callback: { @MainActor in
+                commentTreeTracker?.nodesKeyedByActorId[self.actorId]?.parent?.collapsed = true
+            }
+        )
+    }
+    
+    func collapseToTopAction(commentTreeTracker: CommentTreeTracker? = nil) -> BasicAction {
+        .init(
+            id: "collapseToTop\(uid)",
+            appearance: .collapseToTop(),
+            callback: { @MainActor in
+                commentTreeTracker?.nodesKeyedByActorId[self.actorId]?.topParent.collapsed = true
+            }
         )
     }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -212,7 +212,8 @@ extension Comment1Providing {
             appearance: .collapseParent(),
             callback: { @MainActor in
                 withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .default) {
-                    commentTreeTracker?.nodesKeyedByActorId[self.actorId]?.parent?.collapsed.toggle()
+                    guard let comment = commentTreeTracker?.nodesKeyedByActorId[self.actorId] else { return }
+                    (comment.parent ?? comment).collapsed.toggle()
                 }
             }
         )

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import MlemMiddleware
+import SwiftUI
 
 extension Comment1Providing {
     private var self2: (any Comment2Providing)? { self as? any Comment2Providing }
@@ -198,7 +199,9 @@ extension Comment1Providing {
             id: "collapse\(uid)",
             appearance: .collapse(),
             callback: { @MainActor in
-                commentTreeTracker?.nodesKeyedByActorId[self.actorId]?.collapsed = true
+                withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .default) {
+                    commentTreeTracker?.nodesKeyedByActorId[self.actorId]?.collapsed.toggle()
+                }
             }
         )
     }
@@ -208,7 +211,9 @@ extension Comment1Providing {
             id: "collapseParent\(uid)",
             appearance: .collapseParent(),
             callback: { @MainActor in
-                commentTreeTracker?.nodesKeyedByActorId[self.actorId]?.parent?.collapsed = true
+                withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .default) {
+                    commentTreeTracker?.nodesKeyedByActorId[self.actorId]?.parent?.collapsed.toggle()
+                }
             }
         )
     }
@@ -218,7 +223,9 @@ extension Comment1Providing {
             id: "collapseToTop\(uid)",
             appearance: .collapseToTop(),
             callback: { @MainActor in
-                commentTreeTracker?.nodesKeyedByActorId[self.actorId]?.topParent.collapsed = true
+                withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .default) {
+                    commentTreeTracker?.nodesKeyedByActorId[self.actorId]?.topParent.collapsed.toggle()
+                }
             }
         )
     }

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Views.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Views.swift
@@ -24,6 +24,7 @@ extension ExpandedPostView {
     }
     
     @ViewBuilder
+    // swiftlint:disable:next function_body_length
     func commentTree(tracker: CommentTreeTracker, scrollProxy: ScrollViewProxy) -> some View {
         ForEach(generateViewTree(for: tracker.nodes), id: \.hashValue) { item in
             Group {
@@ -42,9 +43,19 @@ extension ExpandedPostView {
                         if tapCommentsToCollapse {
                             withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .default) {
                                 node.collapsed.toggle()
-                                if node.collapsed {
-                                    scrollProxy.scrollTo(comment.actorId)
-                                }
+                            }
+                        }
+                    }
+                    .onChange(of: node.collapsed) { _, isCollapsed in
+                        guard isCollapsed else { return }
+                        
+                        withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .default) {
+                            if node == node.topParent,
+                               let topParentIndex = tracker.nodes.firstIndex(of: node),
+                               topParentIndex + 1 < tracker.nodes.count {
+                                scrollProxy.scrollTo(tracker.nodes[topParentIndex + 1].actorId, anchor: .top)
+                            } else {
+                                scrollProxy.scrollTo(comment.actorId)
                             }
                         }
                     }

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Views.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Views.swift
@@ -24,7 +24,6 @@ extension ExpandedPostView {
     }
     
     @ViewBuilder
-    // swiftlint:disable:next function_body_length
     func commentTree(tracker: CommentTreeTracker, scrollProxy: ScrollViewProxy) -> some View {
         ForEach(generateViewTree(for: tracker.nodes), id: \.hashValue) { item in
             Group {
@@ -50,13 +49,7 @@ extension ExpandedPostView {
                         guard isCollapsed else { return }
                         
                         withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .default) {
-                            if node == node.topParent,
-                               let topParentIndex = tracker.nodes.firstIndex(of: node),
-                               topParentIndex + 1 < tracker.nodes.count {
-                                scrollProxy.scrollTo(tracker.nodes[topParentIndex + 1].actorId, anchor: .top)
-                            } else {
-                                scrollProxy.scrollTo(comment.actorId)
-                            }
+                            scrollProxy.scrollTo(comment.actorId)
                         }
                     }
                     .quickSwipes(

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -2022,6 +2022,12 @@
         }
       }
     },
+    "Collapse" : {
+
+    },
+    "Collapse Parent" : {
+
+    },
     "Collapse Post" : {
       "localizations" : {
         "fr" : {
@@ -2031,6 +2037,9 @@
           }
         }
       }
+    },
+    "Collapse to Top" : {
+
     },
     "Comment" : {
       "localizations" : {


### PR DESCRIPTION
## Issues

- closes #210

## Description
Adds three new comment collapse swipe actions: Collapse, Collapse Parent, and Collapse to Top. These actions allow users to quickly collapse comments and comment threads.

## Implementation Notes
- Uses existing CommentTreeTracker with minimal new code
- Added 6 new SF Symbols icons for filled and unfilled states of each action
- Animated scrolling automatically handles focus after collapse using `onChange(of: node.collapsed)`
- Actions are available for user configuration <ins>but not included in defaults</ins>