### PR TITLE
Fix gifv handling

### DIFF
--- a/Mlem/Packages/Rest/Sources/RestClient/MlemUrlRequest.swift
+++ b/Mlem/Packages/Rest/Sources/RestClient/MlemUrlRequest.swift
@@ -8,6 +8,15 @@
 import Foundation
 
 public func mlemUrlRequest(url: URL) -> URLRequest {
+    var url = url
+    // .gifv is secretly just mp4; replacing the extension here ensures it is picked up by the NukeVideo decoder
+    if url.pathExtension == "gifv" {
+        if let fixedUrl: URL = .init(string: url.absoluteString.replacingOccurrences(of: ".gifv", with: ".mp4")) {
+            url = fixedUrl
+        } else {
+            assertionFailure("Could not create fixed URL for \(url)")
+        }
+    }
     var ret = URLRequest(url: url)
     ret.addValue("MlemUserAgent", forHTTPHeaderField: "User-Agent")
     return ret


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2038 

## Description

`.gifv` is actually just an `.mp4` in a funny hat, but NukeVideo, which does our `.mp4` handling, doesn't natively handle `.gifv`. This PR adds logic to `mlemUrlRequest` to automatically convert `<some-url>.gifv` to `<some-url>.mp4`; as long as all our `URLRequest`s are produced through `mlemUrlRequest`, this ensures that it is handled correctly downstream.
