### PR TITLE
Add YouTube thumbnail support for link previews

### DIFF
--- a/Mlem/App/Views/Shared/WebsitePreviewView.swift
+++ b/Mlem/App/Views/Shared/WebsitePreviewView.swift
@@ -57,7 +57,7 @@ struct WebsitePreviewView: View {
     
     var complex: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let thumbnailUrl = link.thumbnail {
+            if let thumbnailUrl = link.effectiveThumbnail {
                 MediaView(
                     url: thumbnailUrl,
                     controlState: .constant(.init(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostLink.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostLink.swift
@@ -27,6 +27,14 @@ public struct PostLink: Equatable {
         return "website"
     }
     
+    public var effectiveThumbnail: URL? {
+        if let providedThumbnail = thumbnail {
+            return providedThumbnail
+        }
+        
+        return content.youTubeThumbnailUrl
+    }
+    
     public init(content: URL, thumbnail: URL?, label: String) {
         self.content = content
         self.thumbnail = thumbnail

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostLink.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostLink.swift
@@ -28,11 +28,7 @@ public struct PostLink: Equatable {
     }
     
     public var effectiveThumbnail: URL? {
-        if let providedThumbnail = thumbnail {
-            return providedThumbnail
-        }
-        
-        return content.youTubeThumbnailUrl
+        return thumbnail ?? content.youTubeThumbnailUrl
     }
     
     public init(content: URL, thumbnail: URL?, label: String) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
@@ -113,4 +113,42 @@ public extension URL {
         if scheme == "mlempreview" { return true }
         return proxyAwarePathExtension?.isContainedIn(["jpg", "jpeg", "png", "webp", "gif", "mp4"]) ?? false
     }
+    
+    var isYouTubeLink: Bool {
+        guard let host = host()?.lowercased() else { return false }
+        return host == "youtube.com" || host == "www.youtube.com" || host == "youtu.be" || host == "m.youtube.com"
+    }
+    
+    var youTubeVideoId: String? {
+        guard isYouTubeLink else { return nil }
+        
+        let host = host()?.lowercased() ?? ""
+        
+        if host == "youtu.be" {
+            let pathComponents = pathComponents
+            if pathComponents.count > 1 {
+                return pathComponents[1]
+            }
+        } else if host == "youtube.com" || host == "www.youtube.com" || host == "m.youtube.com" {
+            guard let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
+                  let queryItems = components.queryItems,
+                  let videoId = queryItems.first(where: { $0.name == "v" })?.value else {
+                let pathComponents = pathComponents
+                if pathComponents.count > 2, pathComponents[1] == "embed" {
+                    return pathComponents[2]
+                }
+                
+                return nil
+            }
+            
+            return videoId
+        }
+        
+        return nil
+    }
+    
+    var youTubeThumbnailUrl: URL? {
+        guard let videoId = youTubeVideoId else { return nil }
+        return URL(string: "https://img.youtube.com/vi/\(videoId)/mqdefault.jpg")
+    }
 }


### PR DESCRIPTION
## Issues

- closes #2061

## Description

Adds YouTube thumbnail support for link previews.

## Implementation Notes

- Implemented `effectiveThumbnail` in `PostLink.swift`
- Updated `WebsitePreviewView.swift` to use the new `effectiveThumbnail` property