### PR TITLE
Generalize `ShareInstancePickerView` sizing logic

### DIFF
--- a/Mlem/App/Views/Shared/ShareInstancePickerView.swift
+++ b/Mlem/App/Views/Shared/ShareInstancePickerView.swift
@@ -15,8 +15,6 @@ struct ShareInstancePickerView: View {
     
     let entity: any Sharable
     
-    @State private var sheetContentHeight: CGFloat = SheetHeightKey.defaultValue
-    
     var body: some View {
         VStack(spacing: 16) {
             HStack {
@@ -42,16 +40,7 @@ struct ShareInstancePickerView: View {
         }
         .padding(16)
         .presentationBackground(.themedGroupedBackground)
-        .overlay {
-            GeometryReader { proxy in
-                Color.clear.preference(
-                    key: SheetHeightKey.self,
-                    value: proxy.size.height
-                )
-            }
-        }
-        .onPreferenceChange(SheetHeightKey.self) { sheetContentHeight = $0 }
-        .presentationDetents([.height(sheetContentHeight)])
+        .presentationDetentFitsContent()
     }
     
     @ViewBuilder
@@ -132,14 +121,6 @@ struct ShareInstancePickerView: View {
             ToastModel.main.removeToast(id: toastId)
             handleError(error)
         }
-    }
-}
-
-struct SheetHeightKey: PreferenceKey {
-    static var defaultValue: CGFloat = 500
-    
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
     }
 }
 

--- a/Mlem/Packages/ComponentViews/Sources/ComponentViews/FitContentPresentationDetentViewModifier.swift
+++ b/Mlem/Packages/ComponentViews/Sources/ComponentViews/FitContentPresentationDetentViewModifier.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  ComponentViews
+//
+//  Created by Sjmarf on 2025-06-15.
+//
+
+import SwiftUI
+
+private struct FitContentPresentationDetentViewModifier: ViewModifier {
+    let otherDetents: Set<PresentationDetent>
+    
+    @State private var sheetContentHeight: CGFloat = SheetHeightKey.defaultValue
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: SheetHeightKey.self,
+                        value: proxy.size.height
+                    )
+                }
+            }
+            .onPreferenceChange(SheetHeightKey.self) { sheetContentHeight = $0 }
+            .presentationDetents(otherDetents.union([.height(sheetContentHeight)]))
+    }
+}
+
+public extension View {
+    func presentationDetentFitsContent(
+        _ otherDetents: Set<PresentationDetent> = []
+    ) -> some View {
+        modifier(FitContentPresentationDetentViewModifier(otherDetents: otherDetents))
+    }
+}
+
+private struct SheetHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 500
+    
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}


### PR DESCRIPTION
The instance picker sheet that appears when you have your share preferences set to "ask every time" has some custom sizing logic that makes the sheet match the size of its content. In this PR I've generalized that logic into a view extension that we could reuse elsewhere if we needed to.