### PR TITLE
Don't require space in spoiler opener

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3348,7 +3348,7 @@
 			repositoryURL = "https://github.com/mlemgroup/LemmyMarkdownUI";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.11.0;
+				minimumVersion = 0.12.0;
 			};
 		};
 		0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/LemmyMarkdownUI",
       "state" : {
-        "revision" : "958ab436dce0ed4050fb65f1122e19eeef036e1c",
-        "version" : "0.11.0"
+        "revision" : "624644674e0466e83fbf0dcdf52af2c6e5e70c6c",
+        "version" : "0.12.0"
       }
     },
     {


### PR DESCRIPTION
Before this PR, only `::: spoiler` was recognized as valid - `:::spoiler` was not. This has been corrected in this PR. 

Closes #2069 