### PR TITLE
Expose removed content in `CommentPage` if navigated to from modlog

### DIFF
--- a/Mlem/App/Utility/Extensions/EnvironmentValues+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/EnvironmentValues+Extensions.swift
@@ -19,6 +19,7 @@ extension EnvironmentValues {
     @Entry var isRootView: Bool = false
     
     @Entry var scrollProxy: ScrollViewProxy?
+    @Entry var exposeRemovedContent: Bool = false
     
     var appState: AppState? { self[AppState.self] }
     var navigation: NavigationLayer? { self[NavigationLayer.self] }

--- a/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
@@ -12,8 +12,23 @@ import Rest
 import SwiftUI
 import Theming
 
+enum MarkdownConfigurationType {
+    case `default`, defaultBlurred, dimmed, caption, inverted, removedContent
+}
+
 extension MarkdownConfiguration {
-    static func `default`(palette: Theming.Palette) -> MarkdownConfiguration { .init(
+    init(type: MarkdownConfigurationType, palette: Palette) {
+        self = switch type {
+        case .default: .default(palette: palette)
+        case .defaultBlurred: .defaultBlurred(palette: palette)
+        case .dimmed: .dimmed(palette: palette)
+        case .caption: .caption(palette: palette)
+        case .inverted: .inverted(palette: palette)
+        case .removedContent: .removedContent(palette: palette)
+        }
+    }
+    
+    static func `default`(palette: Palette) -> MarkdownConfiguration { .init(
         inlineImageLoader: loadInlineImage,
         imageBlockView: { imageView($0, shouldBlur: false) },
         wrapCodeBlockLines: Settings.get(\.markdown_wrapCodeBlockLines),
@@ -27,13 +42,13 @@ extension MarkdownConfiguration {
         codeFontScaleFactor: 0.9
     ) }
     
-    static func defaultBlurred(palette: Theming.Palette) -> MarkdownConfiguration {
+    static func defaultBlurred(palette: Palette) -> MarkdownConfiguration {
         var config = Self.default(palette: palette)
         config.imageBlockView = { imageView($0, shouldBlur: true) }
         return config
     }
     
-    static func dimmed(palette: Theming.Palette) -> MarkdownConfiguration {
+    static func dimmed(palette: Palette) -> MarkdownConfiguration {
         var config = Self.default(palette: palette)
         
         // Don't load any images; they will remain as placeholders
@@ -46,19 +61,29 @@ extension MarkdownConfiguration {
         return config
     }
     
-    static func caption(palette: Theming.Palette) -> MarkdownConfiguration {
+    static func caption(palette: Palette) -> MarkdownConfiguration {
         var config = Self.default(palette: palette)
         config.font = .preferredFont(forTextStyle: .caption1)
         return config
     }
     
-    static func inverted(palette: Theming.Palette) -> MarkdownConfiguration {
+    static func inverted(palette: Palette) -> MarkdownConfiguration {
         var config = Self.default(palette: palette)
         config.primaryColor = palette.contrastingLabel
         config.secondaryColor = palette.contrastingLabel.opacity(0.8)
         config.spoilerHeaderBackgroundColor = palette.contrastingLabel.opacity(0.1)
         config.spoilerOutlineColor = palette.contrastingLabel.opacity(0.5)
         config.codeBackgroundColor = palette.contrastingLabel.opacity(0.1)
+        return config
+    }
+    
+    static func removedContent(palette: Palette) -> MarkdownConfiguration {
+        var config = Self.default(palette: palette)
+        config.primaryColor = palette.negative
+        config.secondaryColor = palette.negative.opacity(0.8)
+        config.spoilerHeaderBackgroundColor = palette.negative.opacity(0.1)
+        config.spoilerOutlineColor = palette.negative.opacity(0.5)
+        config.codeBackgroundColor = palette.negative.opacity(0.1)
         return config
     }
 }

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -234,7 +234,7 @@ struct ModlogEntryView: View {
     
     @ViewBuilder
     func commentLink(comment: Comment1) -> some View {
-        NavigationLink(.comment(comment)) {
+        NavigationLink(.comment(comment, exposeRemovedContent: true)) {
             VStack {
                 Text(comment.content)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
@@ -48,7 +48,7 @@ struct LargePostBodyView: View {
             }
             if let content = post.content {
                 if isPostPage {
-                    MarkdownWithLinkList(content, shouldBlur: shouldBlur)
+                    MarkdownWithLinkList(content, configuration: .defaultBlurred)
                 } else {
                     // Cut down on compute time for very long text posts by only rendering the first 4 blocks
                     MarkdownText(

--- a/Mlem/App/Views/Shared/CommentBodyView.swift
+++ b/Mlem/App/Views/Shared/CommentBodyView.swift
@@ -10,21 +10,30 @@ import MlemMiddleware
 import SwiftUI
 
 struct CommentBodyView: View {
+    @Environment(\.exposeRemovedContent) var exposeRemovedContent
+    
     @Setting(\.comment_compact) var compactComments
     
     let comment: any Comment
     
     var body: some View {
         if comment.deleted {
-            Text("Comment was deleted")
-                .italic()
-                .foregroundStyle(.themedSecondary)
+            missingContentMessage("Comment was deleted")
         } else if comment.removed {
-            Text("Comment was removed")
-                .italic()
-                .foregroundStyle(.themedSecondary)
+            if exposeRemovedContent {
+                MarkdownWithLinkList(comment.content, configuration: .removedContent, showLinkCaptions: !compactComments)
+            } else {
+                missingContentMessage("Comment was removed")
+            }
         } else {
             MarkdownWithLinkList(comment.content, showLinkCaptions: !compactComments)
         }
+    }
+    
+    @ViewBuilder
+    func missingContentMessage(_ label: LocalizedStringResource) -> some View {
+        Text(label)
+            .italic()
+            .foregroundStyle(.themedSecondary)
     }
 }

--- a/Mlem/App/Views/Shared/ExpandedPost/CommentPage.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/CommentPage.swift
@@ -18,13 +18,20 @@ struct CommentPage: View {
     let initialComments: [Comment2]?
     @State var tracker: CommentTreeTracker?
     let showViewPostButton: Bool
-    
+    let exposeRemovedContent: Bool
+
     @State var post: Post3?
     
-    init(comment: AnyComment, initialComments: [Comment2]?, showViewPostButton: Bool = false) {
+    init(
+        comment: AnyComment,
+        initialComments: [Comment2]?,
+        showViewPostButton: Bool = false,
+        exposeRemovedContent: Bool = false
+    ) {
         self.comment = comment
         self.showViewPostButton = showViewPostButton
         self.initialComments = initialComments
+        self.exposeRemovedContent = exposeRemovedContent
         if let comment = comment.wrappedValue as? any Comment {
             self._tracker = .init(wrappedValue: .init(root: .comment(comment, parentCount: 1)))
         } else {
@@ -125,6 +132,7 @@ struct CommentPage: View {
                 }
             }
         }
+        .environment(\.exposeRemovedContent, exposeRemovedContent)
     }
     
     var currentDepth: Int {

--- a/Mlem/App/Views/Shared/MarkdownWithLinkList.swift
+++ b/Mlem/App/Views/Shared/MarkdownWithLinkList.swift
@@ -18,18 +18,26 @@ struct MarkdownWithLinkList: View {
     @State var linksCollapsed: Bool = true
     
     let blocks: [BlockNode]
-    let shouldBlur: Bool
+    let markdownConfiguration: MarkdownConfigurationType
     let showLinkCaptions: Bool
     
-    init(_ blocks: [BlockNode], shouldBlur: Bool = false, showLinkCaptions: Bool = true) {
+    init(
+        _ blocks: [BlockNode],
+        configuration: MarkdownConfigurationType = .default,
+        showLinkCaptions: Bool = true
+    ) {
         self.blocks = blocks
-        self.shouldBlur = shouldBlur
+        self.markdownConfiguration = configuration
         self.showLinkCaptions = showLinkCaptions
     }
     
-    init(_ markdown: String, shouldBlur: Bool = false, showLinkCaptions: Bool = true) {
+    init(
+        _ markdown: String,
+        configuration: MarkdownConfigurationType = .default,
+        showLinkCaptions: Bool = true
+    ) {
         self.blocks = .init(markdown)
-        self.shouldBlur = shouldBlur
+        self.markdownConfiguration = configuration
         self.showLinkCaptions = showLinkCaptions
     }
     
@@ -39,7 +47,7 @@ struct MarkdownWithLinkList: View {
     
     var body: some View {
         VStack(spacing: Constants.main.standardSpacing) {
-            Markdown(blocks, configuration: shouldBlur ? .defaultBlurred(palette: palette) : .default(palette: palette))
+            Markdown(blocks, configuration: .init(type: markdownConfiguration, palette: palette))
             if tappableLinksDisplayMode != .disabled {
                 linksView(blocks.links.filter { !$0.insideSpoiler })
             }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -62,8 +62,13 @@ extension NavigationPage {
         case let .post(post, scrollTargetedComment, communityContext, _):
             PostPage(post: post, scrollTargetedComment: scrollTargetedComment?.wrappedValue)
                 .environment(\.communityContext, communityContext?.wrappedValue)
-        case let .comment(comment, comments: comments, showViewPostButton):
-            CommentPage(comment: comment, initialComments: comments, showViewPostButton: showViewPostButton)
+        case let .comment(comment, comments: comments, showViewPostButton, exposeRemovedContent):
+            CommentPage(
+                comment: comment,
+                initialComments: comments,
+                showViewPostButton: showViewPostButton,
+                exposeRemovedContent: exposeRemovedContent
+            )
         case let .person(person, visitContext):
             PersonView(person: person, visitContext: visitContext)
         case let .createComment(context, commentTreeTracker):

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -24,7 +24,7 @@ enum NavigationPage: Hashable {
         communityContext: HashWrapper<any Community1Providing>? = nil,
         navigationNamespace: Namespace.ID? = nil
     )
-    case comment(_ comment: AnyComment, comments: [Comment2]?, showViewPostButton: Bool)
+    case comment(_ comment: AnyComment, comments: [Comment2]?, showViewPostButton: Bool, exposeRemovedContent: Bool)
     case community(_ community: AnyCommunity, visitContext: VisitHistory.VisitContext)
     case person(_ person: AnyPerson, visitContext: VisitHistory.VisitContext)
     case instance(_ instance: InstanceHashWrapper, visitContext: VisitHistory.VisitContext)
@@ -89,9 +89,15 @@ enum NavigationPage: Hashable {
     static func comment(
         _ comment: any CommentStubProviding,
         comments: [Comment2]? = nil,
-        showViewPostButton: Bool = true
+        showViewPostButton: Bool = true,
+        exposeRemovedContent: Bool = false
     ) -> NavigationPage {
-        Self.comment(.init(comment), comments: comments, showViewPostButton: showViewPostButton)
+        Self.comment(
+            .init(comment),
+            comments: comments,
+            showViewPostButton: showViewPostButton,
+            exposeRemovedContent: exposeRemovedContent
+        )
     }
     
     static func person(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Comment+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Comment+CacheExtensions.swift
@@ -12,6 +12,10 @@ extension Comment1: CacheIdentifiable {
     
     @MainActor
     func update(with snapshot: Comment1Snapshot, semaphore: UInt? = nil) {
+        // If the comment is removed, the API returns an empty string
+        // for the `comment/list` endpoint, but returns the comment content
+        // in the modlog endpoint. This `if` statement prevents the comment
+        // content being overwritten with that empty string.
         if !snapshot.removed {
             setIfChanged(\.content, snapshot.content)
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Comment+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Comment+CacheExtensions.swift
@@ -12,7 +12,9 @@ extension Comment1: CacheIdentifiable {
     
     @MainActor
     func update(with snapshot: Comment1Snapshot, semaphore: UInt? = nil) {
-        setIfChanged(\.content, snapshot.content)
+        if !snapshot.removed {
+            setIfChanged(\.content, snapshot.content)
+        }
         setIfChanged(\.created, snapshot.created)
         setIfChanged(\.updated, snapshot.updated)
         setIfChanged(\.distinguished, snapshot.distinguished)


### PR DESCRIPTION
If you navigate to a `CommentPage` from the modlog, it'll now show the original comment content rather than "comment was removed". This applies to all removed comments in the thread. Removed comments are shown in red.