### PR TITLE
Fix always blurring images in post body

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostBodyView.swift
@@ -48,7 +48,7 @@ struct LargePostBodyView: View {
             }
             if let content = post.content {
                 if isPostPage {
-                    MarkdownWithLinkList(content, configuration: .defaultBlurred)
+                    MarkdownWithLinkList(content, configuration: shouldBlur ? .defaultBlurred : .default)
                 } else {
                     // Cut down on compute time for very long text posts by only rendering the first 4 blocks
                     MarkdownText(


### PR DESCRIPTION
Fixes a bug introduced in #2098 that caused all images inside a post to be blurred.