### PR TITLE
Add `ApiRepository` Layer

### DIFF
--- a/Mlem/App/Utility/Extensions/MlemMiddleware Mock/MockApiClient+Realistic.swift
+++ b/Mlem/App/Utility/Extensions/MlemMiddleware Mock/MockApiClient+Realistic.swift
@@ -11,9 +11,9 @@ import MlemMiddleware
 extension MockApiClient {
     static let realistic: MockApiClient = {
         let client = MockApiClient()
-        client.posts = PostMockType.Realistic.allCases.map { Post2.mock(.realistic($0), api: client) }
-        client.communities = CommunityMockType.Realistic.allCases.map { Community2.mock(.realistic($0), api: client) }
-        client.people = PersonMockType.Realistic.allCases.map { Person2.mock(.realistic($0), api: client) }
+        client.setPosts(PostMockType.Realistic.allCases.map { Post2.mock(.realistic($0), api: client) })
+        client.setCommunities(CommunityMockType.Realistic.allCases.map { Community2.mock(.realistic($0), api: client) })
+        client.setPeople(PersonMockType.Realistic.allCases.map { Person2.mock(.realistic($0), api: client) })
         return client
     }()
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
@@ -9,17 +9,13 @@ import Foundation
 
 public extension ApiClient {
     func getComment(id: Int) async throws -> Comment2 {
-        let response = try await performingForConnection { connection in
-            try await connection.getComment(id: id)
-        }
-        return await caches.comment2.getModel(api: self, from: response)
+        let snapshot = try await repository.getComment(id: id)
+        return await caches.comment2.getModel(api: self, from: snapshot)
     }
     
     func getComment(url: URL) async throws -> Comment2 {
-        let response = try await performingForConnection { connection in
-            try await connection.getComment(url: url)
-        }
-        return await caches.comment2.getModel(api: self, from: response)
+        let snapshot = try await repository.getComment(url: url)
+        return await caches.comment2.getModel(api: self, from: snapshot)
     }
     
     func getComments(
@@ -30,17 +26,15 @@ public extension ApiClient {
         limit: Int,
         filter: GetContentFilter? = nil
     ) async throws -> [Comment2] {
-        let response = try await performingForConnection { connection in
-            try await connection.getComments(
-                postId: postId,
-                sort: sort,
-                page: page,
-                maxDepth: maxDepth,
-                limit: limit,
-                filter: filter
-            )
-        }
-        return await caches.comment2.getModels(api: self, from: response)
+        let snapshots = try await repository.getComments(
+            postId: postId,
+            sort: sort,
+            page: page,
+            maxDepth: maxDepth,
+            limit: limit,
+            filter: filter
+        )
+        return await caches.comment2.getModels(api: self, from: snapshots)
     }
     
     func getComments(
@@ -51,20 +45,18 @@ public extension ApiClient {
         limit: Int,
         filter: GetContentFilter? = nil
     ) async throws -> [Comment2] {
-        let response = try await performingForConnection { connection in
-            try await connection.getComments(
-                parentId: parentId,
-                sort: sort,
-                page: page,
-                maxDepth: maxDepth,
-                limit: limit,
-                filter: filter
-            )
-        }
-        return await caches.comment2.getModels(api: self, from: response)
+        let snapshots = try await repository.getComments(
+            parentId: parentId,
+            sort: sort,
+            page: page,
+            maxDepth: maxDepth,
+            limit: limit,
+            filter: filter
+        )
+        return await caches.comment2.getModels(api: self, from: snapshots)
     }
     
-    // This method should be removed in favor of the below method once we drop support for versions before Lemmy 1.0
+    // TODO: Remove in favor of the below method once we drop support for versions before Lemmy 1.0
     func searchComments(
         query: String,
         page: Int = 1,
@@ -74,18 +66,16 @@ public extension ApiClient {
         filter: ListingType = .all,
         sort: CommentSortType = .top(.allTime)
     ) async throws -> [Comment2] {
-        let response = try await performingForConnection { connection in
-            try await connection.searchComments(
-                query: query,
-                page: page,
-                limit: limit,
-                communityId: communityId,
-                creatorId: creatorId,
-                filter: filter,
-                sort: sort
-            )
-        }
-        return await caches.comment2.getModels(api: self, from: response)
+        let snapshots = try await repository.searchComments(
+            query: query,
+            page: page,
+            limit: limit,
+            communityId: communityId,
+            creatorId: creatorId,
+            filter: filter,
+            sort: sort
+        )
+        return await caches.comment2.getModels(api: self, from: snapshots)
     }
     
     func searchComments(
@@ -97,52 +87,44 @@ public extension ApiClient {
         filter: ListingType = .all,
         sort: SearchSortType = .top(.allTime)
     ) async throws -> [Comment2] {
-        let response = try await performingForConnection { connection in
-            try await connection.searchComments(
-                query: query,
-                page: page,
-                limit: limit,
-                communityId: communityId,
-                creatorId: creatorId,
-                filter: filter,
-                sort: sort
-            )
-        }
-        return await caches.comment2.getModels(api: self, from: response)
+        let snapshots = try await repository.searchComments(
+            query: query,
+            page: page,
+            limit: limit,
+            communityId: communityId,
+            creatorId: creatorId,
+            filter: filter,
+            sort: sort
+        )
+        return await caches.comment2.getModels(api: self, from: snapshots)
     }
-
+    
     @discardableResult
     func voteOnComment(id: Int, score: ScoringOperation, semaphore: UInt? = nil) async throws -> Comment2 {
-        let response = try await performingForConnection { connection in
-            try await connection.voteOnComment(id: id, score: score)
-        }
+        let snapshot = try await repository.voteOnComment(id: id, score: score)
         return await caches.comment2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
     
     @discardableResult
     func saveComment(id: Int, save: Bool, semaphore: UInt? = nil) async throws -> Comment2 {
-        let response = try await performingForConnection { connection in
-            try await connection.saveComment(id: id, save: save)
-        }
+        let snapshot = try await repository.saveComment(id: id, save: save)
         return await caches.comment2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
     
     @discardableResult
     func deleteComment(id: Int, delete: Bool, semaphore: UInt? = nil) async throws -> Comment2 {
-        let response = try await performingForConnection { connection in
-            try await connection.deleteComment(id: id, delete: delete)
-        }
+        let snapshot = try await repository.deleteComment(id: id, delete: delete)
         return await caches.comment2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
@@ -153,46 +135,38 @@ public extension ApiClient {
         content: String,
         languageId: Int?
     ) async throws -> Comment2 {
-        let response = try await performingForConnection { connection in
-            try await connection.editComment(
-                id: id,
-                content: content,
-                languageId: languageId
-            )
-        }
-        return await caches.comment2.getModel(api: self, from: response)
+        let snapshot = try await repository.editComment(
+            id: id,
+            content: content,
+            languageId: languageId
+        )
+        return await caches.comment2.getModel(api: self, from: snapshot)
     }
     
     // There's also a `replyToPost` method in `ApiClient+Post` for creating a comment on a post
     func replyToComment(postId: Int, parentId: Int?, content: String, languageId: Int? = nil) async throws -> Comment2 {
-        let response = try await performingForConnection { connection in
-            try await connection.replyToComment(
-                postId: postId,
-                parentId: parentId,
-                content: content,
-                languageId: languageId
-            )
-        }
-        return await caches.comment2.getModel(api: self, from: response)
+        let snapshot = try await repository.replyToComment(
+            postId: postId,
+            parentId: parentId,
+            content: content,
+            languageId: languageId
+        )
+        return await caches.comment2.getModel(api: self, from: snapshot)
     }
     
     @discardableResult
     func reportComment(id: Int, reason: String) async throws -> Report {
-        let response = try await performingForConnection { connection in
-            try await connection.reportComment(id: id, reason: reason)
-        }
-        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        let snapshot = try await repository.reportComment(id: id, reason: reason)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn } // TODO: needed?
         return await caches.report.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId
         )
     }
     
     func purgeComment(id: Int, reason: String?) async throws {
-        try await performingForConnection { connection in
-            try await connection.purgeComment(id: id, reason: reason)
-        }
+        try await repository.purgeComment(id: id, reason: reason)
     }
     
     @discardableResult
@@ -202,12 +176,10 @@ public extension ApiClient {
         reason: String?,
         semaphore: UInt? = nil
     ) async throws -> Comment2 {
-        let response = try await performingForConnection { connection in
-            try await connection.removeComment(id: id, remove: remove, reason: reason)
-        }
+        let snapshot = try await repository.removeComment(id: id, remove: remove, reason: reason)
         return await caches.comment2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
@@ -219,17 +191,15 @@ public extension ApiClient {
         page: Int = 1,
         limit: Int = 20
     ) async throws -> [PersonVote] {
-        let response = try await performingForConnection { connection in
-            try await connection.getCommentVotes(
-                id: id,
-                communityId: communityId,
-                page: page,
-                limit: limit
-            )
-        }
+        let snapshot = try await repository.getCommentVotes(
+            id: id,
+            communityId: communityId,
+            page: page,
+            limit: limit
+        )
         return await caches.personVote.getModels(
             api: self,
-            from: response,
+            from: snapshot,
             target: .comment(id: id),
             communityId: communityId
         )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
@@ -157,7 +157,7 @@ public extension ApiClient {
     @discardableResult
     func reportComment(id: Int, reason: String) async throws -> Report {
         let snapshot = try await repository.reportComment(id: id, reason: reason)
-        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn } // TODO: needed?
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.report.getModel(
             api: self,
             from: snapshot,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public extension ApiClient {
     func decodeCommunity(_ data: Community1.CodedData) async throws -> Community1 {
-        guard data.apiUrl == baseUrl else {
+        guard data.apiUrl == repository.baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
         guard try await data.apiMyPersonId == myPersonId else {
@@ -23,7 +23,7 @@ public extension ApiClient {
     }
     
     func decodeCommunity(_ data: Community2.CodedData) async throws -> Community2 {
-        guard data.apiUrl == baseUrl else {
+        guard data.apiUrl == repository.baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
         guard try await data.apiMyPersonId == myPersonId else {
@@ -37,24 +37,18 @@ public extension ApiClient {
     }
     
     func getCommunity(id: Int) async throws -> Community3 {
-        let response = try await performingForConnection { connection in
-            try await connection.getCommunity(id: id)
-        }
-        return await caches.community3.getModel(api: self, from: response)
+        let snapshot = try await repository.getCommunity(id: id)
+        return await caches.community3.getModel(api: self, from: snapshot)
     }
     
     func getCommunity(url: URL) async throws -> Community2 {
-        let response: Community2Snapshot = try await performingForConnection { connection in
-            try await connection.getCommunity(url: url)
-        }
-        return await caches.community2.getModel(api: self, from: response)
+        let snapshot: Community2Snapshot = try await repository.getCommunity(url: url)
+        return await caches.community2.getModel(api: self, from: snapshot)
     }
     
     func getCommunity(url: URL) async throws -> Community3 {
-        let response: Community3Snapshot = try await performingForConnection { connection in
-            try await connection.getCommunity(url: url)
-        }
-        return await caches.community3.getModel(api: self, from: response)
+        let snapshot: Community3Snapshot = try await repository.getCommunity(url: url)
+        return await caches.community3.getModel(api: self, from: snapshot)
     }
     
     func searchCommunities(
@@ -74,17 +68,15 @@ public extension ApiClient {
             sort = .top(.limited(.month))
         }
         
-        let response = try await performingForConnection { connection in
-            try await connection.searchCommunities(
-                query: query,
-                page: page,
-                limit: limit,
-                filter: filter,
-                sort: sort
-            )
-        }
+        let snapshot = try await repository.searchCommunities(
+            query: query,
+            page: page,
+            limit: limit,
+            filter: filter,
+            sort: sort
+        )
         
-        let ret = await caches.community2.getModels(api: self, from: response)
+        let ret = await caches.community2.getModels(api: self, from: snapshot)
         if let subscriptionInfo = hostApi?.subscriptions {
             for community in ret {
                 if let subscribedCommunity = subscriptionInfo.communities.first(where: { $0.actorId == community.actorId }) {
@@ -135,11 +127,9 @@ public extension ApiClient {
         var communities = [Community2Snapshot]()
         
         repeat {
-            let response = try await performingForConnection { connection in
-                try await connection.getSubscriptionList(page: page, limit: limit)
-            }
-            communities.append(contentsOf: response)
-            hasMorePages = response.count >= limit
+            let snapshots = try await repository.getSubscriptionList(page: page, limit: limit)
+            communities.append(contentsOf: snapshots)
+            hasMorePages = snapshots.count >= limit
             page += 1
         } while hasMorePages
             
@@ -151,24 +141,20 @@ public extension ApiClient {
     
     @discardableResult
     func subscribeToCommunity(id: Int, subscribe: Bool, semaphore: UInt?) async throws -> Community2 {
-        let response = try await performingForConnection { connection in
-            try await connection.subscribeToCommunity(id: id, subscribe: subscribe)
-        }
+        let snapshot = try await repository.subscribeToCommunity(id: id, subscribe: subscribe)
         return await caches.community2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
     
     @discardableResult
     func blockCommunity(id: Int, block: Bool, semaphore: UInt? = nil) async throws -> Community2 {
-        let response = try await performingForConnection { connection in
-            try await connection.blockCommunity(id: id, block: block)
-        }
+        let snapshot = try await repository.blockCommunity(id: id, block: block)
         return await caches.community2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
@@ -180,50 +166,44 @@ public extension ApiClient {
         reason: String?,
         semaphore: UInt? = nil
     ) async throws -> Community2 {
-        let response = try await performingForConnection { connection in
-            try await connection.removeCommunity(
-                id: id,
-                remove: remove,
-                reason: reason
-            )
-        }
+        let snapshot = try await repository.removeCommunity(
+            id: id,
+            remove: remove,
+            reason: reason
+        )
         return await caches.community2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
     
     func purgeCommunity(id: Int, reason: String?) async throws {
-        try await performingForConnection { connection in
-            try await connection.purgeCommunity(id: id, reason: reason)
-        }
+        try await repository.purgeCommunity(id: id, reason: reason)
         caches.community1.retrieveModel(cacheId: id)?.purged = true
     }
     
     @discardableResult
     func addModerator(communityId: Int, personId: Int, added: Bool) async throws -> [Person1] {
-        let response = try await performingForConnection { connection in
-            try await connection.addModerator(
+        let snapshots = try await repository.addModerator(
                 communityId: communityId,
                 personId: personId,
                 added: added
             )
-        }
 
-        let updatedModerators = await caches.person1.getModels(api: self, from: response.moderators)
+        let updatedModerators = await caches.person1.getModels(api: self, from: snapshots.moderators)
         
         if let community = caches.community3.retrieveModel(cacheId: communityId) {
             community.moderators = updatedModerators
         }
         
         if let person = caches.person3.retrieveModel(cacheId: personId) {
-            let newModerator = response.moderators.first(where: { $0.id == personId })
+            let newModerator = snapshots.moderators.first(where: { $0.id == personId })
             if added {
-                guard let newModerator else { throw ApiClientError.unsuccessful }
+                guard newModerator != nil else { throw ApiClientError.unsuccessful }
                 await person.moderatedCommunities.append(caches.community1.getModel(
                     api: self,
-                    from: response.community
+                    from: snapshots.community
                 ))
             } else {
                 guard newModerator == nil else { throw ApiClientError.unsuccessful }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public extension ApiClient {
     func decodeCommunity(_ data: Community1.CodedData) async throws -> Community1 {
-        guard data.apiUrl == repository.baseUrl else {
+        guard data.apiUrl == baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
         guard try await data.apiMyPersonId == myPersonId else {
@@ -23,7 +23,7 @@ public extension ApiClient {
     }
     
     func decodeCommunity(_ data: Community2.CodedData) async throws -> Community2 {
-        guard data.apiUrl == repository.baseUrl else {
+        guard data.apiUrl == baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
         guard try await data.apiMyPersonId == myPersonId else {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -32,7 +32,7 @@ public extension ApiClient {
     }
     
     func login(password: String, totpToken: String?) async throws {
-        guard let username = repository.username else { throw ApiClientError.notLoggedIn }
+        guard let username = username else { throw ApiClientError.notLoggedIn }
         let token = try await getAccountToken(usernameOrEmail: username, password: password, totpToken: totpToken)
         updateToken(token)
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -23,28 +23,16 @@ public extension ApiClient {
         return myAdminIndex < targetAdminIndex
     }
     
-    // Returns a raw API type :(
-    // Probably OK because it's part of onboarding, which is cursed and bootstrappy
     func getAccountToken(usernameOrEmail: String, password: String, totpToken: String?) async throws -> String {
-        let response = try await performingForConnection { connection in
-            try await connection.getAccountToken(
-                usernameOrEmail: usernameOrEmail,
-                password: password,
-                totpToken: totpToken
-            )
-        }
-        return response
+        try await repository.getAccountToken(usernameOrEmail: usernameOrEmail, password: password, totpToken: totpToken)
     }
     
     func getUsernameFromToken(token: String) async throws -> String {
-        let response = try await performingForConnection { connection in
-            try await connection.getUsernameFromToken(token: token)
-        }
-        return response
+        try await repository.getUsernameFromToken(token: token)
     }
     
     func login(password: String, totpToken: String?) async throws {
-        guard let username else { throw ApiClientError.notLoggedIn }
+        guard let username = repository.username else { throw ApiClientError.notLoggedIn }
         let token = try await getAccountToken(usernameOrEmail: username, password: password, totpToken: totpToken)
         updateToken(token)
     }
@@ -59,19 +47,7 @@ public extension ApiClient {
         captchaAnswer: String?,
         applicationQuestionResponse: String?
     ) async throws -> SignUpResponse {
-        let response = try await performingForConnection { connection in
-            try await connection.signUp(
-                username: username,
-                password: password,
-                confirmPassword: confirmPassword,
-                showNsfw: showNsfw,
-                email: email,
-                captcha: captcha,
-                captchaAnswer: captchaAnswer,
-                applicationQuestionResponse: applicationQuestionResponse
-            )
-        }
-        return response
+        try await repository.signUp(username: username, password: password, confirmPassword: confirmPassword, showNsfw: showNsfw, email: email, captcha: captcha, captchaAnswer: captchaAnswer, applicationQuestionResponse: applicationQuestionResponse)
     }
     
     @discardableResult
@@ -80,22 +56,13 @@ public extension ApiClient {
         confirmNewPassword: String,
         oldPassword: String
     ) async throws -> String {
-        let token = try await performingForConnection { connection in
-            try await connection.changePassword(
-                newPassword: newPassword,
-                confirmNewPassword: confirmNewPassword,
-                oldPassword: oldPassword
-            )
-        }
+        let token = try await repository.changePassword(newPassword: newPassword, confirmNewPassword: confirmNewPassword, oldPassword: oldPassword)
         updateToken(token)
         return token
     }
     
     func getCaptcha() async throws -> Captcha {
-        let response = try await performingForConnection { connection in
-            try await connection.getCaptcha()
-        }
-        return response
+        try await repository.getCaptcha()
     }
     
     /// Returns an object associated with the given URL.
@@ -110,9 +77,7 @@ public extension ApiClient {
     /// **Importantly, step 2) is only performed if the `ApiClient` is authenticated.**
     ///
     func resolve(url: URL) async throws -> (any ActorIdentifiable & Sharable) {
-        let response = try await performingForConnection { connection in
-            try await connection.resolve(url: url)
-        }
+        let response = try await repository.resolve(url: url)
         return switch response {
         case let .comment(comment):
             await caches.comment2.getModel(api: self, from: comment)
@@ -149,13 +114,11 @@ public extension ApiClient {
     }
     
     func getBlocked() async throws -> (people: [Person1], communities: [Community1], instances: [Instance1]) {
-        let response = try await performingForConnection { connection in
-            try await connection.getBlocked()
-        }
+        let snapshots = try await repository.getBlocked()
         return await (
-            people: caches.person1.getModels(api: self, from: response.people),
-            communities: caches.community1.getModels(api: self, from: response.communities),
-            instances: caches.instance1.getModels(api: self, from: response.instances)
+            people: caches.person1.getModels(api: self, from: snapshots.people),
+            communities: caches.community1.getModels(api: self, from: snapshots.communities),
+            instances: caches.instance1.getModels(api: self, from: snapshots.instances)
         )
     }
     
@@ -169,19 +132,17 @@ public extension ApiClient {
         commentId: Int? = nil,
         type: ModlogEntryType? = nil
     ) async throws -> [ModlogEntry] {
-        let response = try await performingForConnection { connection in
-            try await connection.getModlog(
-                page: page,
-                limit: limit,
-                communityId: communityId,
-                moderatorId: moderatorId,
-                subjectPersonId: subjectPersonId,
-                postId: postId,
-                commentId: commentId,
-                type: type
-            )
-        }
-        return await createModlogEntries(response)
+        let snapshots = try await repository.getModlog(
+            page: page,
+            limit: limit,
+            communityId: communityId,
+            moderatorId: moderatorId,
+            subjectPersonId: subjectPersonId,
+            postId: postId,
+            commentId: commentId,
+            type: type
+        )
+        return await createModlogEntries(snapshots)
     }
     
     @MainActor

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Image.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Image.swift
@@ -13,84 +13,11 @@ public extension ApiClient {
         _ imageData: Data,
         onProgress progressCallback: @escaping (_ progress: Double) -> Void = { _ in }
     ) async throws -> ImageUpload1 {
-        guard let token else { throw ApiClientError.notLoggedIn }
-        var request = mlemUrlRequest(url: baseUrl.appending(path: "pictrs/image"))
-        request.httpMethod = "POST"
-        
-        let boundary = UUID().uuidString
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        
-        let encodedData = createMultiPartForm(
-            boundary: boundary,
-            mimeType: "image/png",
-            fileName: "image/png",
-            imageData: imageData,
-            auth: token
-        )
-        
-        let (data, _) = try await restClient.urlSession.upload(
-            for: request,
-            from: encodedData,
-            delegate: ImageUploadDelegate(callback: progressCallback)
-        )
-        
-        do {
-            let response = try JSONDecoder.defaultDecoder.decode(ApiPictrsUploadResponse.self, from: data)
-            guard let file = response.files?.first else { throw ApiClientError.noEntityFound }
-            return caches.imageUpload1.getModel(api: self, from: file)
-        } catch DecodingError.dataCorrupted {
-            let text = String(decoding: data, as: UTF8.self)
-            if text.contains("413 Request Entity Too Large") {
-                throw ApiClientError.imageTooLarge
-            }
-            throw ApiClientError.decoding(data, nil)
-        }
+        let file = try await repository.uploadImage(imageData, onProgress: progressCallback)
+        return caches.imageUpload1.getModel(api: self, from: file)
     }
     
     func deleteImage(alias: String, deleteToken: String) async throws {
-        guard let token else { throw ApiClientError.notLoggedIn }
-        var request = mlemUrlRequest(url: baseUrl.appending(path: "pictrs/image/delete/\(deleteToken)/\(alias)"))
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        let response = try await restClient.execute(request)
-        if let response = response.1 as? HTTPURLResponse {
-            if response.statusCode != 204 {
-                throw ApiClientError.response(.init(error: "Unexpected status code"), response.statusCode)
-            }
-        }
-    }
-}
-
-private func createMultiPartForm(
-    boundary: String,
-    mimeType: String,
-    fileName: String,
-    imageData: Data,
-    auth: String
-) -> Data {
-    var data = Data()
-    data.append(Data("--\(boundary)\r\n".utf8))
-    data.append(Data("Content-Disposition: form-data; name=\"images[]\"; filename=\"\(fileName)\"\r\n".utf8))
-    data.append(Data("Content-Type: \(mimeType)\r\n\r\n".utf8))
-    data.append(imageData)
-    data.append(Data("\r\n--\(boundary)--\r\n".utf8))
-    return data
-}
-
-private class ImageUploadDelegate: NSObject, URLSessionTaskDelegate {
-    let callback: (Double) -> Void
-    
-    init(callback: @escaping (Double) -> Void) {
-        self.callback = callback
-    }
-    
-    func urlSession(
-        _ session: URLSession,
-        task: URLSessionTask,
-        didSendBodyData bytesSent: Int64,
-        totalBytesSent: Int64,
-        totalBytesExpectedToSend: Int64
-    ) {
-        callback(Double(totalBytesSent) / Double(totalBytesExpectedToSend))
+        try await repository.deleteImage(alias: alias, deleteToken: deleteToken)
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -14,13 +14,13 @@ public extension ApiClient {
         limit: Int,
         unreadOnly: Bool = false
     ) async throws -> [Reply2] {
-        let snapshot = try await repository.getReplies(
-                sort: sort,
-                page: page,
-                limit: limit,
-                unreadOnly: unreadOnly
-            )
-        return await caches.reply2.getModels(api: self, from: snapshot)
+        let snapshots = try await repository.getReplies(
+            sort: sort,
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
+        return await caches.reply2.getModels(api: self, from: snapshots)
     }
     
     func getMentions(
@@ -29,13 +29,13 @@ public extension ApiClient {
         limit: Int,
         unreadOnly: Bool = false
     ) async throws -> [Reply2] {
-        let snapshot = try await repository.getMentions(
-                sort: sort,
-                page: page,
-                limit: limit,
-                unreadOnly: unreadOnly
-            )
-        return await caches.reply2.getModels(api: self, from: snapshot)
+        let snapshots = try await repository.getMentions(
+            sort: sort,
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
+        return await caches.reply2.getModels(api: self, from: snapshots)
     }
     
     func getMessages(
@@ -44,16 +44,16 @@ public extension ApiClient {
         limit: Int,
         unreadOnly: Bool = false
     ) async throws -> [Message2] {
-        let snapshot = try await repository.getMessages(
-                creatorId: creatorId,
-                page: page,
-                limit: limit,
-                unreadOnly: unreadOnly
-            )
+        let snapshots = try await repository.getMessages(
+            creatorId: creatorId,
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.message2.getModels(
             api: self,
-            from: snapshot,
+            from: snapshots,
             myPersonId: myPersonId
         )
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -14,15 +14,13 @@ public extension ApiClient {
         limit: Int,
         unreadOnly: Bool = false
     ) async throws -> [Reply2] {
-        let response = try await performingForConnection { connection in
-            try await connection.getReplies(
+        let snapshot = try await repository.getReplies(
                 sort: sort,
                 page: page,
                 limit: limit,
                 unreadOnly: unreadOnly
             )
-        }
-        return await caches.reply2.getModels(api: self, from: response)
+        return await caches.reply2.getModels(api: self, from: snapshot)
     }
     
     func getMentions(
@@ -31,15 +29,13 @@ public extension ApiClient {
         limit: Int,
         unreadOnly: Bool = false
     ) async throws -> [Reply2] {
-        let response = try await performingForConnection { connection in
-            try await connection.getMentions(
+        let snapshot = try await repository.getMentions(
                 sort: sort,
                 page: page,
                 limit: limit,
                 unreadOnly: unreadOnly
             )
-        }
-        return await caches.reply2.getModels(api: self, from: response)
+        return await caches.reply2.getModels(api: self, from: snapshot)
     }
     
     func getMessages(
@@ -48,26 +44,22 @@ public extension ApiClient {
         limit: Int,
         unreadOnly: Bool = false
     ) async throws -> [Message2] {
-        let response = try await performingForConnection { connection in
-            try await connection.getMessages(
+        let snapshot = try await repository.getMessages(
                 creatorId: creatorId,
                 page: page,
                 limit: limit,
                 unreadOnly: unreadOnly
             )
-        }
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.message2.getModels(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId
         )
     }
     
     func markAllAsRead() async throws {
-        try await performingForConnection { connection in
-            try await connection.markAllAsRead()
-        }
+        try await repository.markAllAsRead()
         for reply in caches.reply1.itemCache.value.values {
             reply.content?.readManager.updateWithReceivedValue(true, semaphore: nil)
         }
@@ -78,9 +70,7 @@ public extension ApiClient {
     }
     
     func markReplyAsRead(id: Int, read: Bool = true, semaphore: UInt? = nil) async throws {
-        try await performingForConnection { connection in
-            try await connection.markReplyAsRead(id: id, read: read)
-        }
+        try await repository.markReplyAsRead(id: id, read: read)
         var hasher = Hasher()
         hasher.combine(id)
         hasher.combine(false) // isMention
@@ -91,9 +81,7 @@ public extension ApiClient {
     }
     
     func markMentionAsRead(id: Int, read: Bool = true, semaphore: UInt? = nil) async throws {
-        try await performingForConnection { connection in
-            try await connection.markMentionAsRead(id: id, read: read)
-        }
+        try await repository.markMentionAsRead(id: id, read: read)
         var hasher = Hasher()
         hasher.combine(id)
         hasher.combine(true) // isMention
@@ -104,19 +92,14 @@ public extension ApiClient {
     }
     
     func markMessageAsRead(id: Int, read: Bool = true, semaphore: UInt? = nil) async throws {
-        try await performingForConnection { connection in
-            try await connection.markMessageAsRead(id: id, read: read)
-        }
+        try await repository.markMessageAsRead(id: id, read: read)
         if let message = caches.message1.retrieveModel(cacheId: id) {
             message.readManager.updateWithReceivedValue(read, semaphore: semaphore)
         }
     }
     
     func getPersonalUnreadCount() async throws -> PersonalUnreadCountSnapshot {
-        let response = try await performingForConnection { connection in
-            try await connection.getPersonalUnreadCount()
-        }
-        return response
+        try await repository.getPersonalUnreadCount()
     }
     
     /// Get an ``UnreadCount`` object that continues to be updated by the ``ApiClient`` whenever an inbox item is marked read/unread.
@@ -128,52 +111,44 @@ public extension ApiClient {
     }
     
     func createMessage(personId: Int, content: String) async throws -> Message2 {
-        let response = try await performingForConnection { connection in
-            try await connection.createMessage(personId: personId, content: content)
-        }
+        let snapshot = try await repository.createMessage(personId: personId, content: content)
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.message2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId
         )
     }
     
     @discardableResult
     func editMessage(id: Int, content: String) async throws -> Message2 {
-        let response = try await performingForConnection { connection in
-            try await connection.editMessage(id: id, content: content)
-        }
+        let snapshot = try await repository.editMessage(id: id, content: content)
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.message2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId
         )
     }
     
     @discardableResult
     func reportMessage(id: Int, reason: String) async throws -> Report {
-        let response = try await performingForConnection { connection in
-            try await connection.reportMessage(id: id, reason: reason)
-        }
+        let snapshot = try await repository.reportMessage(id: id, reason: reason)
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.report.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId
         )
     }
     
     @discardableResult
     func deleteMessage(id: Int, delete: Bool, semaphore: UInt? = nil) async throws -> Message2 {
-        let response = try await performingForConnection { connection in
-            try await connection.deleteMessage(id: id, delete: delete)
-        }
+        let snapshot = try await repository.deleteMessage(id: id, delete: delete)
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.message2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId,
             semaphore: semaphore
         )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -98,10 +98,6 @@ public extension ApiClient {
         }
     }
     
-    func getPersonalUnreadCount() async throws -> PersonalUnreadCountSnapshot {
-        try await repository.getPersonalUnreadCount()
-    }
-    
     /// Get an ``UnreadCount`` object that continues to be updated by the ``ApiClient`` whenever an inbox item is marked read/unread.
     func getUnreadCount(alwaysMakeCalls: Bool = false) async throws -> UnreadCount {
         let unreadCount = unreadCount ?? .init(api: self)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Instance.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Instance.swift
@@ -50,9 +50,9 @@ public extension ApiClient {
     /// Adds or removes an admin from this API's instance
     @discardableResult
     func addAdmin(personId: Int, added: Bool) async throws -> [Person2] {
-        let response = try await repository.addAdmin(personId: personId, added: added)
+        let snapshot = try await repository.addAdmin(personId: personId, added: added)
 
-        let updatedAdministrators = await caches.person2.getModels(api: self, from: response)
+        let updatedAdministrators = await caches.person2.getModels(api: self, from: snapshot)
         
         // update person's admin status
         // only need to do this manually if removing admin, otherwise handled by above caching logic

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Instance.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Instance.swift
@@ -9,10 +9,8 @@ import Foundation
 
 public extension ApiClient {
     func getMyInstance() async throws -> Instance3 {
-        let response = try await performingForConnection { connection in
-            try await connection.getMyInstance()
-        }
-        let model = await caches.instance3.getModel(api: self, from: response)
+        let snapshot = try await repository.getMyInstance()
+        let model = await caches.instance3.getModel(api: self, from: snapshot)
         model.local = true
         _ = await Task { @MainActor in
             myInstance = model
@@ -20,17 +18,10 @@ public extension ApiClient {
         return model
     }
     
-    func getFederatedInstances() async throws -> FederationPolicy {
-        let response = try await performingForConnection { connection in
-            try await connection.getFederatedInstances()
-        }
-        return response
-    }
-    
     /// Returns `true` if federated, `false` if not federated, or `nil` if the status could not be determined.
     func federatedWith(with url: URL) async throws -> FederationStatus? {
         guard let domain = url.host() else { throw ApiClientError.invalidInput }
-        let federatedInstances = try await getFederatedInstances()
+        let federatedInstances = try await repository.getFederatedInstances()
         if !federatedInstances.blocked.isEmpty {
             return federatedInstances.blocked.contains(domain) ? .explicitlyBlocked : .implicitlyAllowed
         } else if !federatedInstances.allowed.isEmpty {
@@ -44,9 +35,7 @@ public extension ApiClient {
     func blockInstance(url: URL, instanceId: Int, block: Bool, semaphore: UInt? = nil) async throws {
         guard let host = url.host() else { throw ApiClientError.invalidInput }
         let actorId: ActorIdentifier = .instance(host: host)
-        try await performingForConnection { connection in
-            try await connection.blockInstance(instanceId: instanceId, block: block)
-        }
+        try await repository.blockInstance(instanceId: instanceId, block: block)
         let newBlockState: Bool = block
         if let instance = caches.instance1.retrieveModel(instanceId: instanceId) {
             instance.blockedManager.updateWithReceivedValue(newBlockState, semaphore: semaphore)
@@ -61,9 +50,7 @@ public extension ApiClient {
     /// Adds or removes an admin from this API's instance
     @discardableResult
     func addAdmin(personId: Int, added: Bool) async throws -> [Person2] {
-        let response = try await performingForConnection { connection in
-            try await connection.addAdmin(personId: personId, added: added)
-        }
+        let response = try await repository.addAdmin(personId: personId, added: added)
 
         let updatedAdministrators = await caches.person2.getModels(api: self, from: response)
         

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Mock.swift
@@ -30,6 +30,20 @@ public class MockApiClient: ApiClient {
         
         self.repository = MockApiRepository(url: url, username: username, posts: posts, communities: communities, people: people, comments: comments)
     }
+    
+    private var mockRepository: MockApiRepository { repository as! MockApiRepository }
+    
+    public func setPosts(_ posts: [Post2]) {
+        mockRepository.posts = posts
+    }
+    
+    public func setCommunities(_ communities: [Community2]) {
+        mockRepository.communities = communities
+    }
+    
+    public func setPeople(_ people: [Person2]) {
+        mockRepository.people = people
+    }
 }
 
 #endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Mock.swift
@@ -9,104 +9,27 @@ import Foundation
 import Rest
 
 #if DEBUG
-    public extension ApiClient {
-        static let mock: MockApiClient = .init()
-    }
 
-    public class MockApiClient: ApiClient {
-        public var posts: [Post2]
-        public var communities: [Community2]
-        public var people: [Person2]
-        public var comments: [Comment2]
-    
-        public init(
-            posts: [Post2] = [],
-            communities: [Community2] = [],
-            people: [Person2] = [],
-            comments: [Comment2] = []
-        ) {
-            self.posts = posts
-            self.communities = communities
-            self.people = people
-            self.comments = comments
-            let url = URL(string: "https://lemmy.world/")!
-            super.init(
-                url: url,
-                username: ""
-            )
-            self.token = "" // Not nil so that the views are interactable
-            let connection = LemmyConnection(baseUrl: url, token: "")
-            connection.setMockContext(.init(siteVersion: .v0_19_9, myPersonId: nil))
-            self.connection = connection
-        }
-    
-        override func perform<Request: RestRequest>(
-            _ request: Request,
-            tokenOverride: String? = nil,
-            requiresToken: Bool = true
-        ) async throws -> Request.Response {
-            if let request = request as? ListPostsRequest, let params = request.parameters {
-                return ApiGetPostsResponse(
-                    posts: posts.map(\.apiPostView),
-                    nextPage: nil,
-                    prevPage: nil
-                ) as! Request.Response
-            }
+public extension ApiClient {
+    static let mock: MockApiClient = .init()
+}
+
+public class MockApiClient: ApiClient {
+    public init(
+        posts: [Post2] = [],
+        communities: [Community2] = [],
+        people: [Person2] = [],
+        comments: [Comment2] = []
+    ) {
+        let url = URL(string: "https://lemmy.world/")!
+        let username = ""
+        super.init(
+            url: url,
+            username: username
+        )
         
-            if let request = request as? ListCommentsRequest, let params = request.parameters {
-                return ApiGetCommentsResponse(
-                    comments: comments.map(\.apiCommentView),
-                    nextPage: nil,
-                    prevPage: nil
-                ) as! Request.Response
-            }
-        
-            if let request = request as? ReadPersonRequest, let params = request.parameters {
-                if let person = people.first(where: { $0.id == params.personId })?.apiPersonView {
-                    return ApiGetPersonDetailsResponse(
-                        personView: person,
-                        comments: nil,
-                        posts: posts.filter { $0.creator.id == params.personId }.map(\.apiPostView),
-                        moderates: [],
-                        site: nil
-                    ) as! Request.Response
-                }
-            }
-        
-            if let request = request as? ResolveObjectRequest, let params = request.parameters {
-                return ApiResolveObjectResponse(
-                    comment: comments.first(where: { $0.actorId.description == params.q })?.apiCommentView,
-                    post: posts.first(where: { $0.actorId.description == params.q })?.apiPostView,
-                    community: communities.first(where: { $0.actorId.description == params.q })?.apiCommunityView,
-                    person: people.first(where: { $0.actorId.description == params.q })?.apiPersonView
-                ) as! Request.Response
-            }
-        
-            if let request = request as? GetCommunityRequest, let params = request.parameters {
-                if let community = communities.first(where: { $0.id == params.id })?.apiCommunityView {
-                    return ApiGetCommunityResponse(
-                        communityView: community,
-                        site: nil,
-                        moderators: [],
-                        discussionLanguages: []
-                    ) as! Request.Response
-                }
-            }
-        
-            if let request = request as? SearchRequest, let params = request.parameters {
-                return ApiSearchResponse(
-                    type_: params.type_,
-                    comments: [],
-                    posts: [],
-                    communities: params.type_ == .communities ? communities.map(\.apiCommunityView) : [],
-                    users: params.type_ == .users ? people.map(\.apiPersonView) : [],
-                    results: nil,
-                    nextPage: nil,
-                    prevPage: nil
-                ) as! Request.Response
-            }
-        
-            throw ApiClientError.insufficientPermissions
-        }
+        self.repository = MockApiRepository(url: url, username: username, posts: posts, communities: communities, people: people, comments: comments)
     }
+}
+
 #endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public extension ApiClient {
     func decodePerson(_ data: Person1.CodedData) async throws -> Person1 {
-        guard data.apiUrl == baseUrl else {
+        guard data.apiUrl == repository.baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
         guard try await data.apiMyPersonId == myPersonId else {
@@ -23,7 +23,7 @@ public extension ApiClient {
     }
     
     func decodePerson(_ data: Person2.CodedData) async throws -> Person2 {
-        guard data.apiUrl == baseUrl else {
+        guard data.apiUrl == repository.baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
         guard try await data.apiMyPersonId == myPersonId else {
@@ -37,31 +37,23 @@ public extension ApiClient {
     }
     
     func getPerson(id: Int) async throws -> Person3 {
-        let response = try await performingForConnection { connection in
-            try await connection.getPerson(id: id)
-        }
-        return await caches.person3.getModel(api: self, from: response)
+        let snapshot = try await repository.getPerson(id: id)
+        return await caches.person3.getModel(api: self, from: snapshot)
     }
     
     func getPerson(url: URL) async throws -> Person2 {
-        let response: Person2Snapshot = try await performingForConnection { connection in
-            try await connection.getPerson(url: url)
-        }
-        return await caches.person2.getModel(api: self, from: response)
+        let snapshot: Person2Snapshot = try await repository.getPerson(url: url)
+        return await caches.person2.getModel(api: self, from: snapshot)
     }
     
     func getPerson(username: String) async throws -> Person3 {
-        let response: Person3Snapshot = try await performingForConnection { connection in
-            try await connection.getPerson(username: username)
-        }
-        return await caches.person3.getModel(api: self, from: response)
+        let snapshot: Person3Snapshot = try await repository.getPerson(username: username)
+        return await caches.person3.getModel(api: self, from: snapshot)
     }
     
     func getPerson(url: URL) async throws -> Person3 {
-        let response: Person3Snapshot = try await performingForConnection { connection in
-            try await connection.getPerson(url: url)
-        }
-        return await caches.person3.getModel(api: self, from: response)
+        let snapshot: Person3Snapshot = try await repository.getPerson(url: url)
+        return await caches.person3.getModel(api: self, from: snapshot)
     }
     
     /// `filter` can be set to `.local` from 0.19.4 onwards.
@@ -72,26 +64,22 @@ public extension ApiClient {
         filter: ListingType = .all,
         sort: SearchSortType = .top(.allTime)
     ) async throws -> [Person2] {
-        let response = try await performingForConnection { connection in
-            try await connection.searchPeople(
-                query: query,
-                page: page,
-                limit: limit,
-                filter: filter,
-                sort: sort
-            )
-        }
-        return await caches.person2.getModels(api: self, from: response)
+        let snapshot = try await repository.searchPeople(
+            query: query,
+            page: page,
+            limit: limit,
+            filter: filter,
+            sort: sort
+        )
+        return await caches.person2.getModels(api: self, from: snapshot)
     }
     
     @discardableResult
     func blockPerson(id: Int, block: Bool, semaphore: UInt? = nil) async throws -> Person2 {
-        let response = try await performingForConnection { connection in
-            try await connection.blockPerson(id: id, block: block)
-        }
+        let snapshot = try await repository.blockPerson(id: id, block: block)
         return await caches.person2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
@@ -105,19 +93,17 @@ public extension ApiClient {
         reason: String?,
         expires: Date? = nil
     ) async throws -> Person2 {
-        let response = try await performingForConnection { connection in
-            try await connection.banPersonFromCommunity(
-                personId: personId,
-                communityId: communityId,
-                ban: ban,
-                removeContent: removeContent,
-                reason: reason,
-                expires: expires
-            )
-        }
+        let snapshot = try await repository.banPersonFromCommunity(
+            personId: personId,
+            communityId: communityId,
+            ban: ban,
+            removeContent: removeContent,
+            reason: reason,
+            expires: expires
+        )
         let person = await caches.person2.getModel(
             api: self,
-            from: response
+            from: snapshot
         )
         person.person1.updateKnownCommunityBanState(id: communityId, banned: ban)
         return person
@@ -131,25 +117,21 @@ public extension ApiClient {
         reason: String?,
         expires: Date? = nil
     ) async throws -> Person2 {
-        let response = try await performingForConnection { connection in
-            try await connection.banPersonFromInstance(
-                personId: personId,
-                ban: ban,
-                removeContent: removeContent,
-                reason: reason,
-                expires: expires
-            )
-        }
+        let snapshot = try await repository.banPersonFromInstance(
+            personId: personId,
+            ban: ban,
+            removeContent: removeContent,
+            reason: reason,
+            expires: expires
+        )
         return await caches.person2.getModel(
             api: self,
-            from: response
+            from: snapshot
         )
     }
     
     func purgePerson(id: Int, reason: String?) async throws {
-        try await performingForConnection { connection in
-            try await connection.purgePerson(id: id, reason: reason)
-        }
+        try await repository.purgePerson(id: id, reason: reason)
         caches.person1.retrieveModel(cacheId: id)?.purged = true
     }
     
@@ -161,37 +143,33 @@ public extension ApiClient {
         savedOnly: Bool? = nil,
         communityId: Int? = nil
     ) async throws -> (person: Person3, posts: [Post2], comments: [Comment2]) {
-        let response = try await performingForConnection { connection in
-            try await connection.getContent(
-                authorId: id,
-                sort: sort,
-                page: page,
-                limit: limit,
-                savedOnly: savedOnly,
-                communityId: communityId
-            )
-        }
+        let snapshot = try await repository.getContent(
+            authorId: id,
+            sort: sort,
+            page: page,
+            limit: limit,
+            savedOnly: savedOnly,
+            communityId: communityId
+        )
         return await (
-            person: caches.person3.getModel(api: self, from: response.person),
-            posts: caches.post2.getModels(api: self, from: response.posts),
-            comments: caches.comment2.getModels(api: self, from: response.comments)
+            person: caches.person3.getModel(api: self, from: snapshot.person),
+            posts: caches.post2.getModels(api: self, from: snapshot.posts),
+            comments: caches.comment2.getModels(api: self, from: snapshot.comments)
         )
     }
     
     func getMyPerson() async throws -> (person: Person4?, instance: Instance3, blocks: BlockList?) {
-        let response = try await performingForConnection { connection in
-            try await connection.getMyPerson()
-        }
-        guard response.person?.person.person.person.name == username else {
+        let snapshot = try await repository.getMyPerson()
+        guard snapshot.person?.person.person.person.name == repository.username else {
             assertionFailure()
             throw ApiClientError.mismatchingToken
         }
         
-        let instance = await caches.instance3.getModel(api: self, from: response.instance)
-        let person = await caches.person4.getOptionalModel(api: self, from: response.person)
+        let instance = await caches.instance3.getModel(api: self, from: snapshot.instance)
+        let person = await caches.person4.getOptionalModel(api: self, from: snapshot.person)
         var blocks: BlockList? = blocks
         
-        if let person, let newBlocks = response.blocks {
+        if person != nil, let newBlocks = snapshot.blocks {
             if let blocks {
                 blocks.update(blocks: newBlocks)
             } else {
@@ -207,9 +185,7 @@ public extension ApiClient {
     }
     
     func deleteAccount(password: String, deleteContent: Bool) async throws {
-        try await performingForConnection { connection in
-            try await connection.deleteAccount(password: password, deleteContent: deleteContent)
-        }
+        try await repository.deleteAccount(password: password, deleteContent: deleteContent)
     }
     
     func editAccountSettings(
@@ -242,37 +218,35 @@ public extension ApiClient {
         showDownvotes: Bool?,
         showUpvotePercentage: Bool?
     ) async throws {
-        try await performingForConnection { connection in
-            try await connection.editAccountSettings(
-                showNsfw: showNsfw,
-                showScores: showScores,
-                theme: theme,
-                defaultListingType: defaultListingType,
-                interfaceLanguage: interfaceLanguage,
-                avatar: avatar,
-                banner: banner,
-                displayName: displayName,
-                email: email,
-                bio: bio,
-                matrixUserId: matrixUserId,
-                showAvatars: showAvatars,
-                sendNotificationsToEmail: sendNotificationsToEmail,
-                botAccount: botAccount,
-                showBotAccounts: showBotAccounts,
-                showReadPosts: showReadPosts,
-                discussionLanguages: discussionLanguages,
-                openLinksInNewTab: openLinksInNewTab,
-                blurNsfw: blurNsfw,
-                autoExpand: autoExpand,
-                infiniteScrollEnabled: infiniteScrollEnabled,
-                postListingMode: postListingMode,
-                enableKeyboardNavigation: enableKeyboardNavigation,
-                enableAnimatedImages: enableAnimatedImages,
-                collapseBotComments: collapseBotComments,
-                showUpvotes: showUpvotes,
-                showDownvotes: showDownvotes,
-                showUpvotePercentage: showUpvotePercentage
-            )
-        }
+        try await repository.editAccountSettings(
+            showNsfw: showNsfw,
+            showScores: showScores,
+            theme: theme,
+            defaultListingType: defaultListingType,
+            interfaceLanguage: interfaceLanguage,
+            avatar: avatar,
+            banner: banner,
+            displayName: displayName,
+            email: email,
+            bio: bio,
+            matrixUserId: matrixUserId,
+            showAvatars: showAvatars,
+            sendNotificationsToEmail: sendNotificationsToEmail,
+            botAccount: botAccount,
+            showBotAccounts: showBotAccounts,
+            showReadPosts: showReadPosts,
+            discussionLanguages: discussionLanguages,
+            openLinksInNewTab: openLinksInNewTab,
+            blurNsfw: blurNsfw,
+            autoExpand: autoExpand,
+            infiniteScrollEnabled: infiniteScrollEnabled,
+            postListingMode: postListingMode,
+            enableKeyboardNavigation: enableKeyboardNavigation,
+            enableAnimatedImages: enableAnimatedImages,
+            collapseBotComments: collapseBotComments,
+            showUpvotes: showUpvotes,
+            showDownvotes: showDownvotes,
+            showUpvotePercentage: showUpvotePercentage
+        )
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public extension ApiClient {
     func decodePerson(_ data: Person1.CodedData) async throws -> Person1 {
-        guard data.apiUrl == repository.baseUrl else {
+        guard data.apiUrl == baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
         guard try await data.apiMyPersonId == myPersonId else {
@@ -23,7 +23,7 @@ public extension ApiClient {
     }
     
     func decodePerson(_ data: Person2.CodedData) async throws -> Person2 {
-        guard data.apiUrl == repository.baseUrl else {
+        guard data.apiUrl == baseUrl else {
             throw ApiClientError.mismatchingUrl
         }
         guard try await data.apiMyPersonId == myPersonId else {
@@ -160,7 +160,7 @@ public extension ApiClient {
     
     func getMyPerson() async throws -> (person: Person4?, instance: Instance3, blocks: BlockList?) {
         let snapshot = try await repository.getMyPerson()
-        guard snapshot.person?.person.person.person.name == repository.username else {
+        guard snapshot.person?.person.person.person.name == username else {
             assertionFailure()
             throw ApiClientError.mismatchingToken
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
@@ -64,14 +64,14 @@ public extension ApiClient {
         filter: ListingType = .all,
         sort: SearchSortType = .top(.allTime)
     ) async throws -> [Person2] {
-        let snapshot = try await repository.searchPeople(
+        let snapshots = try await repository.searchPeople(
             query: query,
             page: page,
             limit: limit,
             filter: filter,
             sort: sort
         )
-        return await caches.person2.getModels(api: self, from: snapshot)
+        return await caches.person2.getModels(api: self, from: snapshots)
     }
     
     @discardableResult
@@ -143,7 +143,7 @@ public extension ApiClient {
         savedOnly: Bool? = nil,
         communityId: Int? = nil
     ) async throws -> (person: Person3, posts: [Post2], comments: [Comment2]) {
-        let snapshot = try await repository.getContent(
+        let snapshots = try await repository.getContent(
             authorId: id,
             sort: sort,
             page: page,
@@ -152,9 +152,9 @@ public extension ApiClient {
             communityId: communityId
         )
         return await (
-            person: caches.person3.getModel(api: self, from: snapshot.person),
-            posts: caches.post2.getModels(api: self, from: snapshot.posts),
-            comments: caches.comment2.getModels(api: self, from: snapshot.comments)
+            person: caches.person3.getModel(api: self, from: snapshots.person),
+            posts: caches.post2.getModels(api: self, from: snapshots.posts),
+            comments: caches.comment2.getModels(api: self, from: snapshots.comments)
         )
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -18,24 +18,22 @@ public extension ApiClient {
         filter: GetContentFilter? = nil,
         showHidden: Bool = false
     ) async throws -> (posts: [Post2], cursor: String?) {
-        let response = try await performingForConnection { connection in
-            try await connection.getPosts(
-                communityId: communityId,
-                sort: sort,
-                page: page,
-                cursor: cursor,
-                limit: limit,
-                filter: filter,
-                showHidden: showHidden
-            )
-        }
+        let snapshots = try await repository.getPosts(
+            communityId: communityId,
+            sort: sort,
+            page: page,
+            cursor: cursor,
+            limit: limit,
+            filter: filter,
+            showHidden: showHidden
+        )
         let posts = await caches.post2.getModels(
             api: self,
-            from: response.posts
+            from: snapshots.posts
         )
-        return (posts: posts, cursor: response.cursor)
+        return (posts: posts, cursor: snapshots.cursor)
     }
-
+    
     // swiftlint:disable:next function_parameter_count
     func getPosts(
         feed: ListingType,
@@ -46,22 +44,20 @@ public extension ApiClient {
         filter: GetContentFilter? = nil,
         showHidden: Bool = false
     ) async throws -> (posts: [Post2], cursor: String?) {
-        let response = try await performingForConnection { connection in
-            try await connection.getPosts(
-                feed: feed,
-                sort: sort,
-                page: page,
-                cursor: cursor,
-                limit: limit,
-                filter: filter,
-                showHidden: showHidden
-            )
-        }
+        let snapshots = try await repository.getPosts(
+            feed: feed,
+            sort: sort,
+            page: page,
+            cursor: cursor,
+            limit: limit,
+            filter: filter,
+            showHidden: showHidden
+        )
         let posts = await caches.post2.getModels(
             api: self,
-            from: response.posts
+            from: snapshots.posts
         )
-        return (posts: posts, cursor: response.cursor)
+        return (posts: posts, cursor: snapshots.cursor)
     }
     
     func getPosts(
@@ -72,34 +68,28 @@ public extension ApiClient {
         limit: Int,
         savedOnly: Bool = false
     ) async throws -> (person: Person3, posts: [Post2]) {
-        let response = try await performingForConnection { connection in
-            try await connection.getPosts(
-                personId: personId,
-                communityId: communityId,
-                sort: sort,
-                page: page,
-                limit: limit,
-                savedOnly: savedOnly
-            )
-        }
+        let snapshots = try await repository.getPosts(
+            personId: personId,
+            communityId: communityId,
+            sort: sort,
+            page: page,
+            limit: limit,
+            savedOnly: savedOnly
+        )
         return await (
-            person: caches.person3.getModel(api: self, from: response.person),
-            posts: caches.post2.getModels(api: self, from: response.posts)
+            person: caches.person3.getModel(api: self, from: snapshots.person),
+            posts: caches.post2.getModels(api: self, from: snapshots.posts)
         )
     }
-        
+    
     func getPost(id: Int) async throws -> Post3 {
-        let response = try await performingForConnection { connection in
-            try await connection.getPost(id: id)
-        }
-        return await caches.post3.getModel(api: self, from: response)
+        let snapshot = try await repository.getPost(id: id)
+        return await caches.post3.getModel(api: self, from: snapshot)
     }
     
     func getPost(url: URL) async throws -> Post2 {
-        let response = try await performingForConnection { connection in
-            try await connection.getPost(url: url)
-        }
-        return await caches.post2.getModel(api: self, from: response)
+        let snapshot = try await repository.getPost(url: url)
+        return await caches.post2.getModel(api: self, from: snapshot)
     }
     
     // This method should be removed in favor of the below method once we drop support for versions before Lemmy 1.0
@@ -112,18 +102,16 @@ public extension ApiClient {
         filter: ListingType = .all,
         sort: PostSortType
     ) async throws -> [Post2] {
-        let response = try await performingForConnection { connection in
-            try await connection.searchPosts(
-                query: query,
-                page: page,
-                limit: limit,
-                communityId: communityId,
-                creatorId: creatorId,
-                filter: filter,
-                sort: sort
-            )
-        }
-        return await caches.post2.getModels(api: self, from: response)
+        let snapshots = try await repository.searchPosts(
+            query: query,
+            page: page,
+            limit: limit,
+            communityId: communityId,
+            creatorId: creatorId,
+            filter: filter,
+            sort: sort
+        )
+        return await caches.post2.getModels(api: self, from: snapshots)
     }
     
     func searchPosts(
@@ -135,18 +123,16 @@ public extension ApiClient {
         filter: ListingType = .all,
         sort: SearchSortType
     ) async throws -> [Post2] {
-        let response = try await performingForConnection { connection in
-            try await connection.searchPosts(
-                query: query,
-                page: page,
-                limit: limit,
-                communityId: communityId,
-                creatorId: creatorId,
-                filter: filter,
-                sort: sort
-            )
-        }
-        return await caches.post2.getModels(api: self, from: response)
+        let snapshots = try await repository.searchPosts(
+            query: query,
+            page: page,
+            limit: limit,
+            communityId: communityId,
+            creatorId: creatorId,
+            filter: filter,
+            sort: sort
+        )
+        return await caches.post2.getModels(api: self, from: snapshots)
     }
     
     /// Mark the given post as read. Works on all versions.
@@ -165,11 +151,9 @@ public extension ApiClient {
                 semaphore: semaphore
             )
         } else {
-            try await performingForConnection { connection in
-                try await connection.markPostAsRead(id: id, read: false)
-                if let post = self.caches.post2.retrieveModel(cacheId: id) {
-                    post.readManager.updateWithReceivedValue(read, semaphore: semaphore)
-                }
+            try await repository.markPostAsRead(id: id, read: false)
+            if let post = self.caches.post2.retrieveModel(cacheId: id) {
+                post.readManager.updateWithReceivedValue(read, semaphore: semaphore)
             }
         }
     }
@@ -194,9 +178,7 @@ public extension ApiClient {
         guard !idsToSend.isEmpty else { return }
         
         do {
-            try await performingForConnection { connection in
-                try await connection.markPostsAsRead(ids: idsToSend)
-            }
+            try await repository.markPostsAsRead(ids: idsToSend)
             await markReadQueue.subtract(ids)
         } catch {
             await markReadQueue.union(markReadQueueCopy)
@@ -218,36 +200,30 @@ public extension ApiClient {
     
     @discardableResult
     func voteOnPost(id: Int, score: ScoringOperation, semaphore: UInt? = nil) async throws -> Post2 {
-        let response = try await performingForConnection { connection in
-            try await connection.voteOnPost(id: id, score: score)
-        }
+        let snapshot = try await repository.voteOnPost(id: id, score: score)
         return await caches.post2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
-
+    
     @discardableResult
     func savePost(id: Int, save: Bool, semaphore: UInt? = nil) async throws -> Post2 {
-        let response = try await performingForConnection { connection in
-            try await connection.savePost(id: id, save: save)
-        }
+        let snapshot = try await repository.savePost(id: id, save: save)
         return await caches.post2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
     
     @discardableResult
     func deletePost(id: Int, delete: Bool, semaphore: UInt? = nil) async throws -> Post2 {
-        let response = try await performingForConnection { connection in
-            try await connection.deletePost(id: id, delete: delete)
-        }
+        let snapshot = try await repository.deletePost(id: id, delete: delete)
         return await caches.post2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
@@ -258,9 +234,7 @@ public extension ApiClient {
         hide: Bool,
         semaphore: UInt? = nil
     ) async throws {
-        try await performingForConnection { connection in
-            try await connection.hidePost(id: id, hide: hide)
-        }
+        try await repository.hidePost(id: id, hide: hide)
         if let post = caches.post2.retrieveModel(cacheId: id) {
             post.hiddenManager.updateWithReceivedValue(hide, semaphore: semaphore)
         }
@@ -276,19 +250,17 @@ public extension ApiClient {
         nsfw: Bool,
         languageId: Int? = nil
     ) async throws -> Post2 {
-        let response = try await performingForConnection { connection in
-            try await connection.createPost(
-                communityId: communityId,
-                title: title,
-                content: content,
-                linkUrl: linkUrl,
-                altText: altText,
-                thumbnail: thumbnail,
-                nsfw: nsfw,
-                languageId: languageId
-            )
-        }
-        return await caches.post2.getModel(api: self, from: response)
+        let snapshot = try await repository.createPost(
+            communityId: communityId,
+            title: title,
+            content: content,
+            linkUrl: linkUrl,
+            altText: altText,
+            thumbnail: thumbnail,
+            nsfw: nsfw,
+            languageId: languageId
+        )
+        return await caches.post2.getModel(api: self, from: snapshot)
     }
     
     @discardableResult
@@ -302,45 +274,37 @@ public extension ApiClient {
         nsfw: Bool,
         languageId: Int? = nil
     ) async throws -> Post2 {
-        let response = try await performingForConnection { connection in
-            try await connection.editPost(
-                id: id,
-                title: title,
-                content: content,
-                linkUrl: linkUrl,
-                altText: altText,
-                thumbnail: thumbnail,
-                nsfw: nsfw,
-                languageId: languageId
-            )
-        }
-        return await caches.post2.getModel(api: self, from: response)
+        let snapshot = try await repository.editPost(
+            id: id,
+            title: title,
+            content: content,
+            linkUrl: linkUrl,
+            altText: altText,
+            thumbnail: thumbnail,
+            nsfw: nsfw,
+            languageId: languageId
+        )
+        return await caches.post2.getModel(api: self, from: snapshot)
     }
-
+    
     func replyToPost(id: Int, content: String, languageId: Int? = nil) async throws -> Comment2 {
-        let response = try await performingForConnection { connection in
-            try await connection.replyToPost(id: id, content: content, languageId: languageId)
-        }
-        return await caches.comment2.getModel(api: self, from: response)
+        let snapshot = try await repository.replyToPost(id: id, content: content, languageId: languageId)
+        return await caches.comment2.getModel(api: self, from: snapshot)
     }
     
     @discardableResult
     func reportPost(id: Int, reason: String) async throws -> Report {
-        let response = try await performingForConnection { connection in
-            try await connection.reportPost(id: id, reason: reason)
-        }
+        let snapshot = try await repository.reportPost(id: id, reason: reason)
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.report.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId
         )
     }
     
     func purgePost(id: Int, reason: String?) async throws {
-        try await performingForConnection { connection in
-            try await connection.purgePost(id: id, reason: reason)
-        }
+        try await repository.purgePost(id: id, reason: reason)
     }
     
     @discardableResult
@@ -350,12 +314,10 @@ public extension ApiClient {
         reason: String?,
         semaphore: UInt? = nil
     ) async throws -> Post2 {
-        let response = try await performingForConnection { connection in
-            try await connection.removePost(id: id, remove: remove, reason: reason)
-        }
+        let snapshot = try await repository.removePost(id: id, remove: remove, reason: reason)
         return await caches.post2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
@@ -367,12 +329,10 @@ public extension ApiClient {
         to target: PostFeatureType,
         semaphore: UInt? = nil
     ) async throws -> Post2 {
-        let response = try await performingForConnection { connection in
-            try await connection.pinPost(id: id, pin: pin, to: target)
-        }
+        let snapshot = try await repository.pinPost(id: id, pin: pin, to: target)
         return await caches.post2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
@@ -383,12 +343,10 @@ public extension ApiClient {
         lock: Bool,
         semaphore: UInt? = nil
     ) async throws -> Post2 {
-        let response = try await performingForConnection { connection in
-            try await connection.lockPost(id: id, lock: lock)
-        }
+        let snapshot = try await repository.lockPost(id: id, lock: lock)
         return await caches.post2.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
@@ -400,17 +358,15 @@ public extension ApiClient {
         page: Int = 1,
         limit: Int = 20
     ) async throws -> [PersonVote] {
-        let response = try await performingForConnection { connection in
-            try await connection.getPostVotes(
-                id: id,
-                communityId: communityId,
-                page: page,
-                limit: limit
-            )
-        }
+        let snapshot = try await repository.getPostVotes(
+            id: id,
+            communityId: communityId,
+            page: page,
+            limit: limit
+        )
         return await caches.personVote.getModels(
             api: self,
-            from: response,
+            from: snapshot,
             target: .post(id: id),
             communityId: communityId
         )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+RegistrationApplication.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+RegistrationApplication.swift
@@ -9,10 +9,7 @@ import Foundation
 
 public extension ApiClient {
     func getRegistrationApplicationCount() async throws -> Int {
-        let response = try await performingForConnection { connection in
-            try await connection.getRegistrationApplicationCount()
-        }
-        return response
+        try await repository.getRegistrationApplicationCount()
     }
     
     func getRegistrationApplications(
@@ -20,14 +17,12 @@ public extension ApiClient {
         limit: Int = 20,
         unreadOnly: Bool = false
     ) async throws -> [RegistrationApplication] {
-        let response = try await performingForConnection { connection in
-            try await connection.getRegistrationApplications(
-                page: page,
-                limit: limit,
-                unreadOnly: unreadOnly
-            )
-        }
-        return await caches.registrationApplication.getModels(api: self, from: response)
+        let snapshot = try await repository.getRegistrationApplications(
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
+        return await caches.registrationApplication.getModels(api: self, from: snapshot)
     }
     
     @discardableResult
@@ -35,12 +30,10 @@ public extension ApiClient {
         id: Int,
         semaphore: UInt? = nil
     ) async throws -> RegistrationApplication {
-        let response = try await performingForConnection { connection in
-            try await connection.approveRegistrationApplication(id: id)
-        }
+        let snapshot = try await repository.approveRegistrationApplication(id: id)
         return await caches.registrationApplication.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }
@@ -51,12 +44,10 @@ public extension ApiClient {
         reason: String?,
         semaphore: UInt? = nil
     ) async throws -> RegistrationApplication {
-        let response = try await performingForConnection { connection in
-            try await connection.denyRegistrationApplication(id: id, reason: reason)
-        }
+        let snapshot = try await repository.denyRegistrationApplication(id: id, reason: reason)
         return await caches.registrationApplication.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             semaphore: semaphore
         )
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Report.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Report.swift
@@ -8,13 +8,6 @@
 import Foundation
 
 public extension ApiClient {
-    func getReportCount(communityId: Int? = nil) async throws -> ReportUnreadCountSnapshot {
-        let response = try await performingForConnection { connection in
-            try await connection.getReportCount(communityId: communityId)
-        }
-        return response
-    }
-    
     func getPostReports(
         page: Int = 1,
         limit: Int = 20,
@@ -22,19 +15,17 @@ public extension ApiClient {
         communityId: Int? = nil,
         postId: Int? = nil
     ) async throws -> [Report] {
-        let response = try await performingForConnection { connection in
-            try await connection.getPostReports(
-                page: page,
-                limit: limit,
-                unresolvedOnly: unresolvedOnly,
-                communityId: communityId,
-                postId: postId
-            )
-        }
+        let snapshot = try await repository.getPostReports(
+            page: page,
+            limit: limit,
+            unresolvedOnly: unresolvedOnly,
+            communityId: communityId,
+            postId: postId
+        )
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.report.getModels(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId
         )
     }
@@ -46,19 +37,17 @@ public extension ApiClient {
         communityId: Int? = nil,
         commentId: Int? = nil
     ) async throws -> [Report] {
-        let response = try await performingForConnection { connection in
-            try await connection.getCommentReports(
-                page: page,
-                limit: limit,
-                unresolvedOnly: unresolvedOnly,
-                communityId: communityId,
-                commentId: commentId
-            )
-        }
+        let snapshot = try await repository.getCommentReports(
+            page: page,
+            limit: limit,
+            unresolvedOnly: unresolvedOnly,
+            communityId: communityId,
+            commentId: commentId
+        )
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.report.getModels(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId
         )
     }
@@ -68,17 +57,15 @@ public extension ApiClient {
         limit: Int = 20,
         unresolvedOnly: Bool = false
     ) async throws -> [Report] {
-        let response = try await performingForConnection { connection in
-            try await connection.getMessageReports(
-                page: page,
-                limit: limit,
-                unresolvedOnly: unresolvedOnly
-            )
-        }
+        let snapshot = try await repository.getMessageReports(
+            page: page,
+            limit: limit,
+            unresolvedOnly: unresolvedOnly
+        )
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.report.getModels(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId
         )
     }
@@ -89,13 +76,11 @@ public extension ApiClient {
         resolved: Bool,
         semaphore: UInt? = nil
     ) async throws -> Report {
-        let response = try await performingForConnection { connection in
-            try await connection.resolvePostReport(id: id, resolved: resolved)
-        }
+        let snapshot = try await repository.resolvePostReport(id: id, resolved: resolved)
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.report.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId,
             semaphore: semaphore
         )
@@ -107,13 +92,11 @@ public extension ApiClient {
         resolved: Bool,
         semaphore: UInt? = nil
     ) async throws -> Report {
-        let response = try await performingForConnection { connection in
-            try await connection.resolveCommentReport(id: id, resolved: resolved)
-        }
+        let snapshot = try await repository.resolveCommentReport(id: id, resolved: resolved)
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.report.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId,
             semaphore: semaphore
         )
@@ -125,13 +108,11 @@ public extension ApiClient {
         resolved: Bool,
         semaphore: UInt? = nil
     ) async throws -> Report {
-        let response = try await performingForConnection { connection in
-            try await connection.resolveMessageReport(id: id, resolved: resolved)
-        }
+        let snapshot = try await repository.resolveMessageReport(id: id, resolved: resolved)
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
         return await caches.report.getModel(
             api: self,
-            from: response,
+            from: snapshot,
             myPersonId: myPersonId,
             semaphore: semaphore
         )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -11,20 +11,9 @@ import Rest
 
 @Observable
 public class ApiClient {
-    private static let supportedConnections: [any InstanceConnection.Type] = [LemmyConnection.self, PieFedConnection.self]
+    internal var repository: ApiRepository
     
-    // url and username MAY NOT be modified! Downstream code expects that a given ApiClient will *always* submit requests from the same user to the same instance.
-    public let baseUrl: URL
-    public let username: String?
-    
-    private var ongoingConnectionDiscoveryTask: Task<Any, Error>?
-    var connection: (any InstanceConnection)?
-    
-    var restClient: RestClient<ApiErrorResponse> = .init()
-
-    public internal(set) var token: String?
-    
-    public var willSendToken: Bool { token != nil }
+    public var willSendToken: Bool { repository.token != nil }
     
     public internal(set) weak var myInstance: Instance3?
     public internal(set) weak var myPerson: Person4?
@@ -36,30 +25,30 @@ public class ApiClient {
     var markReadQueue: MarkReadQueue = .init()
     
     public func ensureContextPresence() async throws {
-        try await getConnection().ensureContextPresence()
+        try await repository.getConnection().ensureContextPresence()
     }
     
     public func supports(_ feature: Feature) async throws -> Bool {
-        try await getConnection().supports(feature)
+        try await repository.getConnection().supports(feature)
     }
     
     public func supportsOrNil(_ feature: Feature) -> Bool? {
-        connection?.supportsOrNil(feature)
+        repository.connection?.supportsOrNil(feature)
     }
     
     public var contextIsFetched: Bool {
-        connection?.contextIsFetched ?? false
+        repository.connection?.contextIsFetched ?? false
     }
 
     public var myPersonId: Int? {
         get async throws {
-            try await getConnection().myPersonId
+            try await repository.getConnection().myPersonId
         }
     }
     
     public var software: SiteSoftware {
         get async throws {
-            let connection = try await getConnection()
+            let connection = try await repository.getConnection()
             return try await .init(type: type(of: connection).softwareType, version: connection.version)
         }
     }
@@ -84,8 +73,7 @@ public class ApiClient {
         url: URL,
         username: String? = nil
     ) {
-        self.baseUrl = url
-        self.username = username
+        self.repository = .init(baseUrl: url, username: username)
     }
     
     public func cleanCaches() {
@@ -95,145 +83,36 @@ public class ApiClient {
     
     /// Return a new guest `ApiClient`.
     public func asGuest() -> ApiClient {
-        .getApiClient(url: baseUrl, username: nil)
+        .getApiClient(url: repository.baseUrl, username: nil)
     }
     
     /// Return a new `ApiClient` targeting the given user.
     public func asUser(name: String) -> ApiClient {
-        .getApiClient(url: baseUrl, username: name)
+        .getApiClient(url: repository.baseUrl, username: name)
     }
     
     /// This should **only** be used when we get a new token for **the same** account!
     public func updateToken(_ newToken: String) {
-        guard username != nil else {
-            assertionFailure()
-            return
-        }
-        connection?.updateToken(newToken)
-        token = newToken
+        repository.updateToken(newToken)
     }
     
-    @discardableResult
-    func perform<Request: RestRequest>(
-        _ request: Request,
-        tokenOverride: String? = nil,
-        requiresToken: Bool = true // This should be `true` for the vast majority of requests, even GET requests
-    ) async throws -> Request.Response {
-        guard !requiresToken || username == nil || token != nil else {
-            throw ApiClientError.noToken
-        }
-        
-        let token = tokenOverride ?? token
-        do throws(RestError) {
-            return try await restClient.perform(baseUrl: baseUrl, request, token: token)
-        } catch {
-            switch error {
-            case let RestError.response(response, statusCode: _):
-                if ApiErrorResponse(error: response).isNotLoggedIn {
-                    throw token == nil ? ApiClientError.notLoggedIn : ApiClientError.invalidSession(self)
-                } else {
-                    throw ApiClientError(from: error)
-                }
-            default:
-                throw ApiClientError(from: error)
-            }
-        }
-    }
-    
-    private func getConnection() async throws -> any InstanceConnection {
-        _ = await ongoingConnectionDiscoveryTask?.result
-        if let connection {
-            return connection
-        }
-        _ = try await getMyInstance()
-        if let connection {
-            return connection
-        }
-        assertionFailure()
-        throw ApiClientError.unsuccessful
-    }
-    
-    @MainActor
-    func performingForConnection<T>(
-        _ callback: @escaping (any InstanceConnection) async throws -> T,
-        file: String = #fileID,
-        function: String = #function,
-        line: Int = #line
-    ) async throws -> T {
-        // Iterate through all possible connections, and attempt the request on all of them in parallel.
-        // As soon as one of the requests succeeds, return the result and cancel the other ongoing requests.
-        // Cache the `InstanceConnection` that succeeded in the `self.connection` property, and use that
-        // for all subsequent calls of `performingForConnection`.
-        
-        // If `performingForConnection` is called and `self.connection` is `nil` but there is another
-        // `performingForConnection` call ongoing, it will wait for the other call to succeed first.
 
-        _ = await self.ongoingConnectionDiscoveryTask?.result
-        if let connection {
-            return try await callback(connection)
-        }
-
-        let ongoingConnectionDiscoveryTask: Task<T, Error> = Task {
-            try await withThrowingTaskGroup(of: (any InstanceConnection, Result<T, Error>).self) { group in
-                for connectionType in Self.supportedConnections {
-                    let connection = connectionType.init(baseUrl: baseUrl, token: token)
-                    group.addTask {
-                        do {
-                            let response = try await callback(connection)
-                            return (connection, .success(response))
-                        } catch {
-                            return (connection, .failure(error))
-                        }
-                    }
-                }
-                
-                while !group.isEmpty {
-                    guard let result = try? await group.next() else {
-                        assertionFailure()
-                        continue
-                    }
-                    do {
-                        let value = try result.1.get()
-                        // Cancel all other tasks once any one task succeeds
-                        group.cancelAll()
-                        self.connection = result.0
-                        self.ongoingConnectionDiscoveryTask = nil
-                        return value
-                    } catch ApiClientError.serverError(404), ApiClientError.featureUnsupported {
-                        // no-op
-                    } catch {
-                        // We *could* set the `connection` here, but I'd rather not just incase some other
-                        // 404-equivalent error is thrown that we haven't accounted for
-                        throw error
-                    }
-                }
-                
-                throw ApiClientError.unableToDetermineSoftware
-            }
-        }
-        
-        self.ongoingConnectionDiscoveryTask = Task {
-            _ = try? await ongoingConnectionDiscoveryTask.result.get()
-        }
-        
-        return try await ongoingConnectionDiscoveryTask.result.get()
-    }
 }
 
 extension ApiClient: CacheIdentifiable {
     public var cacheId: Int {
-        ApiClient.apiClientCache.getCacheId(url: baseUrl, username: username)
+        ApiClient.apiClientCache.getCacheId(url: repository.baseUrl, username: repository.username)
     }
 }
 
 extension ApiClient: ActorIdentifiable {
-    public var actorId: ActorIdentifier { .instance(host: baseUrl.host()!) }
+    public var actorId: ActorIdentifier { .instance(host: repository.baseUrl.host()!) }
 }
 
 extension ApiClient: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(baseUrl)
-        hasher.combine(username)
+        hasher.combine(repository.baseUrl)
+        hasher.combine(repository.username)
     }
     
     public static func == (lhs: ApiClient, rhs: ApiClient) -> Bool {
@@ -243,7 +122,7 @@ extension ApiClient: Hashable {
 
 extension ApiClient: CustomDebugStringConvertible {
     public var debugDescription: String {
-        "ApiClient(\(host), authenticated: \(token != nil))"
+        "ApiClient(\(host), authenticated: \(repository.token != nil))"
     }
 }
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -11,7 +11,7 @@ import Rest
 
 @Observable
 public class ApiClient {
-    internal var repository: ApiRepository
+    var repository: ApiRepository
     
     public var willSendToken: Bool { repository.token != nil }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -40,6 +40,12 @@ public class ApiClient {
         repository.connection?.contextIsFetched ?? false
     }
 
+    public var username: String? { repository.username }
+    
+    public var baseUrl: URL { repository.baseUrl }
+    
+    public var token: String? { repository.token }
+    
     public var myPersonId: Int? {
         get async throws {
             try await repository.getConnection().myPersonId
@@ -83,12 +89,12 @@ public class ApiClient {
     
     /// Return a new guest `ApiClient`.
     public func asGuest() -> ApiClient {
-        .getApiClient(url: repository.baseUrl, username: nil)
+        .getApiClient(url: baseUrl, username: nil)
     }
     
     /// Return a new `ApiClient` targeting the given user.
     public func asUser(name: String) -> ApiClient {
-        .getApiClient(url: repository.baseUrl, username: name)
+        .getApiClient(url: baseUrl, username: name)
     }
     
     /// This should **only** be used when we get a new token for **the same** account!
@@ -101,18 +107,18 @@ public class ApiClient {
 
 extension ApiClient: CacheIdentifiable {
     public var cacheId: Int {
-        ApiClient.apiClientCache.getCacheId(url: repository.baseUrl, username: repository.username)
+        ApiClient.apiClientCache.getCacheId(url: baseUrl, username: username)
     }
 }
 
 extension ApiClient: ActorIdentifiable {
-    public var actorId: ActorIdentifier { .instance(host: repository.baseUrl.host()!) }
+    public var actorId: ActorIdentifier { .instance(host: baseUrl.host()!) }
 }
 
 extension ApiClient: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(repository.baseUrl)
-        hasher.combine(repository.username)
+        hasher.combine(baseUrl)
+        hasher.combine(username)
     }
     
     public static func == (lhs: ApiClient, rhs: ApiClient) -> Bool {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
@@ -20,7 +20,7 @@ public enum ApiClientError: Error {
     case response(ApiErrorResponse, Int)
     case cancelled
     case notLoggedIn
-    case invalidSession // (ApiClient)
+    case invalidSession
     case decoding(Data, Error?)
     case insufficientPermissions
     /// Thrown when a `false` value of `SuccessResponse` is returned

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
@@ -20,7 +20,7 @@ public enum ApiClientError: Error {
     case response(ApiErrorResponse, Int)
     case cancelled
     case notLoggedIn
-    case invalidSession(ApiClient)
+    case invalidSession // (ApiClient)
     case decoding(Data, Error?)
     case insufficientPermissions
     /// Thrown when a `false` value of `SuccessResponse` is returned

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Comment.swift
@@ -1,0 +1,190 @@
+//
+//  ApiRepository+Comment.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-02.
+//
+
+import Foundation
+
+extension ApiRepository {
+    func getComment(id: Int) async throws -> Comment2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getComment(id: id)
+        }
+    }
+    
+    func getComment(url: URL) async throws -> Comment2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getComment(url: url)
+        }
+    }
+    
+    func getComments(
+        postId: Int,
+        sort: CommentSortType,
+        page: Int,
+        maxDepth: Int? = nil,
+        limit: Int,
+        filter: GetContentFilter? = nil
+    ) async throws -> [Comment2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.getComments(
+                postId: postId,
+                sort: sort,
+                page: page,
+                maxDepth: maxDepth,
+                limit: limit,
+                filter: filter
+            )
+        }
+    }
+    
+    func getComments(
+        parentId: Int,
+        sort: CommentSortType,
+        page: Int,
+        maxDepth: Int? = nil,
+        limit: Int,
+        filter: GetContentFilter? = nil
+    ) async throws -> [Comment2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.getComments(
+                parentId: parentId,
+                sort: sort,
+                page: page,
+                maxDepth: maxDepth,
+                limit: limit,
+                filter: filter
+            )
+        }
+    }
+    
+    // TODO: Remove in favor of the below method once we drop support for versions before Lemmy 1.0
+    func searchComments(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int? = nil,
+        creatorId: Int? = nil,
+        filter: ListingType = .all,
+        sort: CommentSortType = .top(.allTime)
+    ) async throws -> [Comment2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.searchComments(
+                query: query,
+                page: page,
+                limit: limit,
+                communityId: communityId,
+                creatorId: creatorId,
+                filter: filter,
+                sort: sort
+            )
+        }
+    }
+    
+    func searchComments(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int? = nil,
+        creatorId: Int? = nil,
+        filter: ListingType = .all,
+        sort: SearchSortType = .top(.allTime)
+    ) async throws -> [Comment2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.searchComments(
+                query: query,
+                page: page,
+                limit: limit,
+                communityId: communityId,
+                creatorId: creatorId,
+                filter: filter,
+                sort: sort
+            )
+        }
+    }
+    
+    func voteOnComment(id: Int, score: ScoringOperation, semaphore: UInt? = nil) async throws -> Comment2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.voteOnComment(id: id, score: score)
+        }
+    }
+    
+    func saveComment(id: Int, save: Bool, semaphore: UInt? = nil) async throws -> Comment2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.saveComment(id: id, save: save)
+        }
+    }
+    
+    func deleteComment(id: Int, delete: Bool, semaphore: UInt? = nil) async throws -> Comment2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.deleteComment(id: id, delete: delete)
+        }
+    }
+    
+    func editComment(
+        id: Int,
+        content: String,
+        languageId: Int?
+    ) async throws -> Comment2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.editComment(
+                id: id,
+                content: content,
+                languageId: languageId
+            )
+        }
+    }
+    
+    // There's also a `replyToPost` method in `ApiRepository+Post` for creating a comment on a post
+    func replyToComment(postId: Int, parentId: Int?, content: String, languageId: Int? = nil) async throws -> Comment2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.replyToComment(
+                postId: postId,
+                parentId: parentId,
+                content: content,
+                languageId: languageId
+            )
+        }
+    }
+    
+    func reportComment(id: Int, reason: String) async throws -> ReportSnapshot {
+        try await performingForConnection { connection in
+            try await connection.reportComment(id: id, reason: reason)
+        }
+    }
+    
+    func purgeComment(id: Int, reason: String?) async throws {
+        try await performingForConnection { connection in
+            try await connection.purgeComment(id: id, reason: reason)
+        }
+    }
+    
+    func removeComment(
+        id: Int,
+        remove: Bool,
+        reason: String?,
+        semaphore: UInt? = nil
+    ) async throws -> Comment2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.removeComment(id: id, remove: remove, reason: reason)
+        }
+    }
+    
+    func getCommentVotes(
+        id: Int,
+        communityId: Int,
+        page: Int = 1,
+        limit: Int = 20
+    ) async throws -> [PersonVoteSnapshot] {
+        try await performingForConnection { connection in
+            try await connection.getCommentVotes(
+                id: id,
+                communityId: communityId,
+                page: page,
+                limit: limit
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Community.swift
@@ -1,0 +1,96 @@
+//
+//  ApiRepository+Community.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-02.
+//
+
+import Foundation
+
+extension ApiRepository {
+    func getCommunity(id: Int) async throws -> Community3Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getCommunity(id: id)
+        }
+    }
+    
+    // TODO: needed? (redundant with below?)
+    func getCommunity(url: URL) async throws -> Community2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getCommunity(url: url)
+        }
+    }
+    
+    func getCommunity(url: URL) async throws -> Community3Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getCommunity(url: url)
+        }
+    }
+    
+    func searchCommunities(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        filter: ListingType = .all,
+        sort: SearchSortType,
+        hostApi: ApiClient? = nil
+    ) async throws -> [Community2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.searchCommunities(
+                query: query,
+                page: page,
+                limit: limit,
+                filter: filter,
+                sort: sort
+            )
+        }
+    }
+    
+    func getSubscriptionList(page: Int, limit: Int) async throws -> [Community2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.getSubscriptionList(page: page, limit: limit)
+        }
+    }
+    
+    func subscribeToCommunity(id: Int, subscribe: Bool) async throws -> Community2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.subscribeToCommunity(id: id, subscribe: subscribe)
+        }
+    }
+    
+    func blockCommunity(id: Int, block: Bool, semaphore: UInt? = nil) async throws -> Community2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.blockCommunity(id: id, block: block)
+        }
+    }
+    
+    func removeCommunity(
+        id: Int,
+        remove: Bool,
+        reason: String?
+    ) async throws -> Community2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.removeCommunity(
+                id: id,
+                remove: remove,
+                reason: reason
+            )
+        }
+    }
+    
+    func purgeCommunity(id: Int, reason: String?) async throws {
+        try await performingForConnection { connection in
+            try await connection.purgeCommunity(id: id, reason: reason)
+        }
+    }
+    
+    func addModerator(communityId: Int, personId: Int, added: Bool) async throws -> (moderators: [Person1Snapshot], community: Community1Snapshot) {
+        try await performingForConnection { connection in
+            try await connection.addModerator(
+                communityId: communityId,
+                personId: personId,
+                added: added
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Community.swift
@@ -14,7 +14,6 @@ extension ApiRepository {
         }
     }
     
-    // TODO: needed? (redundant with below?)
     func getCommunity(url: URL) async throws -> Community2Snapshot {
         try await performingForConnection { connection in
             try await connection.getCommunity(url: url)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+General.swift
@@ -1,0 +1,106 @@
+//
+//  ApiRepository+General.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-02.
+//
+
+import Foundation
+
+extension ApiRepository {
+    func getAccountToken(usernameOrEmail: String, password: String, totpToken: String?) async throws -> String {
+        try await performingForConnection { connection in
+            try await connection.getAccountToken(
+                usernameOrEmail: usernameOrEmail,
+                password: password,
+                totpToken: totpToken
+            )
+        }
+    }
+    
+    func getUsernameFromToken(token: String) async throws -> String {
+        try await performingForConnection { connection in
+            try await connection.getUsernameFromToken(token: token)
+        }
+    }
+    
+    func signUp(
+        username: String,
+        password: String,
+        confirmPassword: String,
+        showNsfw: Bool,
+        email: String?,
+        captcha: Captcha?,
+        captchaAnswer: String?,
+        applicationQuestionResponse: String?
+    ) async throws -> SignUpResponse {
+        try await performingForConnection { connection in
+            try await connection.signUp(
+                username: username,
+                password: password,
+                confirmPassword: confirmPassword,
+                showNsfw: showNsfw,
+                email: email,
+                captcha: captcha,
+                captchaAnswer: captchaAnswer,
+                applicationQuestionResponse: applicationQuestionResponse
+            )
+        }
+    }
+    
+    func changePassword(
+        newPassword: String,
+        confirmNewPassword: String,
+        oldPassword: String
+    ) async throws -> String {
+        try await performingForConnection { connection in
+            try await connection.changePassword(
+                newPassword: newPassword,
+                confirmNewPassword: confirmNewPassword,
+                oldPassword: oldPassword
+            )
+        }
+    }
+    
+    func getCaptcha() async throws -> Captcha {
+        try await performingForConnection { connection in
+            try await connection.getCaptcha()
+        }
+    }
+    
+    func resolve(url: URL) async throws -> ResolvedContent {
+        try await performingForConnection { connection in
+            try await connection.resolve(url: url)
+        }
+    }
+    
+    func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [Instance1Snapshot]) {
+        try await performingForConnection { connection in
+            try await connection.getBlocked()
+        }
+    }
+    
+    func getModlog(
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int? = nil,
+        moderatorId: Int? = nil,
+        subjectPersonId: Int? = nil,
+        postId: Int? = nil,
+        commentId: Int? = nil,
+        type: ModlogEntryType? = nil
+    ) async throws -> [ModlogEntrySnapshot] {
+        try await performingForConnection { connection in
+            try await connection.getModlog(
+                page: page,
+                limit: limit,
+                communityId: communityId,
+                moderatorId: moderatorId,
+                subjectPersonId: subjectPersonId,
+                postId: postId,
+                commentId: commentId,
+                type: type
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Image.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Image.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Rest
 
-public extension ApiRepository {
+extension ApiRepository {
     func uploadImage(
         _ imageData: Data,
         onProgress progressCallback: @escaping (_ progress: Double) -> Void = { _ in }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Image.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Image.swift
@@ -1,0 +1,97 @@
+//
+//  ApiRepository+Image.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-03.
+//
+
+import Foundation
+import Rest
+
+public extension ApiRepository {
+    func uploadImage(
+        _ imageData: Data,
+        onProgress progressCallback: @escaping (_ progress: Double) -> Void = { _ in }
+    ) async throws -> ApiPictrsFile {
+        guard let token else { throw ApiClientError.notLoggedIn }
+        var request = mlemUrlRequest(url: baseUrl.appending(path: "pictrs/image"))
+        request.httpMethod = "POST"
+        
+        let boundary = UUID().uuidString
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        
+        let encodedData = createMultiPartForm(
+            boundary: boundary,
+            mimeType: "image/png",
+            fileName: "image/png",
+            imageData: imageData,
+            auth: token
+        )
+        
+        let (data, _) = try await restClient.urlSession.upload(
+            for: request,
+            from: encodedData,
+            delegate: ImageUploadDelegate(callback: progressCallback)
+        )
+        
+        do {
+            let response = try JSONDecoder.defaultDecoder.decode(ApiPictrsUploadResponse.self, from: data)
+            guard let file = response.files?.first else { throw ApiClientError.noEntityFound }
+            return file
+        } catch DecodingError.dataCorrupted {
+            let text = String(decoding: data, as: UTF8.self)
+            if text.contains("413 Request Entity Too Large") {
+                throw ApiClientError.imageTooLarge
+            }
+            throw ApiClientError.decoding(data, nil)
+        }
+    }
+    
+    func deleteImage(alias: String, deleteToken: String) async throws {
+        guard let token else { throw ApiClientError.notLoggedIn }
+        var request = mlemUrlRequest(url: baseUrl.appending(path: "pictrs/image/delete/\(deleteToken)/\(alias)"))
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        let response = try await restClient.execute(request)
+        if let response = response.1 as? HTTPURLResponse {
+            if response.statusCode != 204 {
+                throw ApiClientError.response(.init(error: "Unexpected status code"), response.statusCode)
+            }
+        }
+    }
+}
+
+private func createMultiPartForm(
+    boundary: String,
+    mimeType: String,
+    fileName: String,
+    imageData: Data,
+    auth: String
+) -> Data {
+    var data = Data()
+    data.append(Data("--\(boundary)\r\n".utf8))
+    data.append(Data("Content-Disposition: form-data; name=\"images[]\"; filename=\"\(fileName)\"\r\n".utf8))
+    data.append(Data("Content-Type: \(mimeType)\r\n\r\n".utf8))
+    data.append(imageData)
+    data.append(Data("\r\n--\(boundary)--\r\n".utf8))
+    return data
+}
+
+private class ImageUploadDelegate: NSObject, URLSessionTaskDelegate {
+    let callback: (Double) -> Void
+    
+    init(callback: @escaping (Double) -> Void) {
+        self.callback = callback
+    }
+    
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didSendBodyData bytesSent: Int64,
+        totalBytesSent: Int64,
+        totalBytesExpectedToSend: Int64
+    ) {
+        callback(Double(totalBytesSent) / Double(totalBytesExpectedToSend))
+    }
+}
+

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
@@ -1,0 +1,110 @@
+//
+//  ApiRepository+Inbox.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-03.
+//
+
+extension ApiRepository {
+    func getReplies(
+        sort: CommentSortType = .new,
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool = false
+    ) async throws -> [Reply2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.getReplies(
+                sort: sort,
+                page: page,
+                limit: limit,
+                unreadOnly: unreadOnly
+            )
+        }
+    }
+    
+    func getMentions(
+        sort: CommentSortType = .new,
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool = false
+    ) async throws -> [Reply2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.getMentions(
+                sort: sort,
+                page: page,
+                limit: limit,
+                unreadOnly: unreadOnly
+            )
+        }
+    }
+    
+    func getMessages(
+        creatorId: Int? = nil,
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool = false
+    ) async throws -> [Message2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.getMessages(
+                creatorId: creatorId,
+                page: page,
+                limit: limit,
+                unreadOnly: unreadOnly
+            )
+        }
+    }
+    
+    func markAllAsRead() async throws {
+        try await performingForConnection { connection in
+            try await connection.markAllAsRead()
+        }
+    }
+    
+    func markReplyAsRead(id: Int, read: Bool = true, semaphore: UInt? = nil) async throws {
+        try await performingForConnection { connection in
+            try await connection.markReplyAsRead(id: id, read: read)
+        }
+    }
+    
+    func markMentionAsRead(id: Int, read: Bool = true, semaphore: UInt? = nil) async throws {
+        try await performingForConnection { connection in
+            try await connection.markMentionAsRead(id: id, read: read)
+        }
+    }
+    
+    func markMessageAsRead(id: Int, read: Bool = true, semaphore: UInt? = nil) async throws {
+        try await performingForConnection { connection in
+            try await connection.markMessageAsRead(id: id, read: read)
+        }
+    }
+    
+    func getPersonalUnreadCount() async throws -> PersonalUnreadCountSnapshot {
+        try await performingForConnection { connection in
+            try await connection.getPersonalUnreadCount()
+        }
+    }
+    
+    func createMessage(personId: Int, content: String) async throws -> Message2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.createMessage(personId: personId, content: content)
+        }
+    }
+    
+    func editMessage(id: Int, content: String) async throws -> Message2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.editMessage(id: id, content: content)
+        }
+    }
+    
+    func reportMessage(id: Int, reason: String) async throws -> ReportSnapshot {
+        try await performingForConnection { connection in
+            try await connection.reportMessage(id: id, reason: reason)
+        }
+    }
+    
+    func deleteMessage(id: Int, delete: Bool, semaphore: UInt? = nil) async throws -> Message2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.deleteMessage(id: id, delete: delete)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Instance.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Instance.swift
@@ -5,7 +5,7 @@
 //  Created by Eric Andrews on 2025-07-02.
 //
 
-public extension ApiRepository {
+extension ApiRepository {
     func getMyInstance() async throws -> Instance3Snapshot {
         return try await performingForConnection { connection in
             try await connection.getMyInstance()

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Instance.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Instance.swift
@@ -1,0 +1,33 @@
+//
+//  ApiRepository+Instance.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-02.
+//
+
+public extension ApiRepository {
+    func getMyInstance() async throws -> Instance3Snapshot {
+        return try await performingForConnection { connection in
+            try await connection.getMyInstance()
+        }
+    }
+    
+    func getFederatedInstances() async throws -> FederationPolicy {
+        let response = try await performingForConnection { connection in
+            try await connection.getFederatedInstances()
+        }
+        return response
+    }
+    
+    func blockInstance(instanceId: Int, block: Bool) async throws {
+        try await performingForConnection { connection in
+            try await connection.blockInstance(instanceId: instanceId, block: block)
+        }
+    }
+    
+    func addAdmin(personId: Int, added: Bool) async throws -> [Person2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.addAdmin(personId: personId, added: added)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Mock.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Mock.swift
@@ -1,0 +1,112 @@
+//
+//  ApiRepository+Mock.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-03.
+//
+
+import Foundation
+import Rest
+
+#if DEBUG
+
+class MockApiRepository: ApiRepository {
+     var posts: [Post2]
+     var communities: [Community2]
+     var people: [Person2]
+     var comments: [Comment2]
+    
+    init(
+        url: URL,
+        username: String,
+        posts: [Post2] = [],
+        communities: [Community2] = [],
+        people: [Person2] = [],
+        comments: [Comment2] = []
+    ) {
+        self.posts = posts
+        self.communities = communities
+        self.people = people
+        self.comments = comments
+        
+        super.init(
+            baseUrl: url,
+            username: username
+        )
+        self.token = "" // Not nil so that the views are interactable
+        let connection = LemmyConnection(baseUrl: url, token: "")
+        connection.setMockContext(.init(siteVersion: .v0_19_9, myPersonId: nil))
+        self.connection = connection
+    }
+    
+    override func perform<Request: RestRequest>(
+        _ request: Request,
+        tokenOverride: String? = nil,
+        requiresToken: Bool = true
+    ) async throws -> Request.Response {
+        if let request = request as? ListPostsRequest, let params = request.parameters {
+            return ApiGetPostsResponse(
+                posts: posts.map(\.apiPostView),
+                nextPage: nil,
+                prevPage: nil
+            ) as! Request.Response
+        }
+    
+        if let request = request as? ListCommentsRequest, let params = request.parameters {
+            return ApiGetCommentsResponse(
+                comments: comments.map(\.apiCommentView),
+                nextPage: nil,
+                prevPage: nil
+            ) as! Request.Response
+        }
+    
+        if let request = request as? ReadPersonRequest, let params = request.parameters {
+            if let person = people.first(where: { $0.id == params.personId })?.apiPersonView {
+                return ApiGetPersonDetailsResponse(
+                    personView: person,
+                    comments: nil,
+                    posts: posts.filter { $0.creator.id == params.personId }.map(\.apiPostView),
+                    moderates: [],
+                    site: nil
+                ) as! Request.Response
+            }
+        }
+    
+        if let request = request as? ResolveObjectRequest, let params = request.parameters {
+            return ApiResolveObjectResponse(
+                comment: comments.first(where: { $0.actorId.description == params.q })?.apiCommentView,
+                post: posts.first(where: { $0.actorId.description == params.q })?.apiPostView,
+                community: communities.first(where: { $0.actorId.description == params.q })?.apiCommunityView,
+                person: people.first(where: { $0.actorId.description == params.q })?.apiPersonView
+            ) as! Request.Response
+        }
+    
+        if let request = request as? GetCommunityRequest, let params = request.parameters {
+            if let community = communities.first(where: { $0.id == params.id })?.apiCommunityView {
+                return ApiGetCommunityResponse(
+                    communityView: community,
+                    site: nil,
+                    moderators: [],
+                    discussionLanguages: []
+                ) as! Request.Response
+            }
+        }
+    
+        if let request = request as? SearchRequest, let params = request.parameters {
+            return ApiSearchResponse(
+                type_: params.type_,
+                comments: [],
+                posts: [],
+                communities: params.type_ == .communities ? communities.map(\.apiCommunityView) : [],
+                users: params.type_ == .users ? people.map(\.apiPersonView) : [],
+                results: nil,
+                nextPage: nil,
+                prevPage: nil
+            ) as! Request.Response
+        }
+    
+        throw ApiClientError.insufficientPermissions
+    }
+}
+
+#endif

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Person.swift
@@ -1,0 +1,199 @@
+//
+//  ApiRepository+Person.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-03.
+//
+
+import Foundation
+
+extension ApiRepository {
+    func getPerson(id: Int) async throws -> Person3Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getPerson(id: id)
+        }
+    }
+    
+    func getPerson(url: URL) async throws -> Person2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getPerson(url: url)
+        }
+    }
+    
+    func getPerson(username: String) async throws -> Person3Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getPerson(username: username)
+        }
+    }
+    
+    func getPerson(url: URL) async throws -> Person3Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getPerson(url: url)
+        }
+    }
+    
+    /// `filter` can be set to `.local` from 0.19.4 onwards.
+    func searchPeople(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        filter: ListingType = .all,
+        sort: SearchSortType = .top(.allTime)
+    ) async throws -> [Person2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.searchPeople(
+                query: query,
+                page: page,
+                limit: limit,
+                filter: filter,
+                sort: sort
+            )
+        }
+    }
+    
+    func blockPerson(id: Int, block: Bool, semaphore: UInt? = nil) async throws -> Person2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.blockPerson(id: id, block: block)
+        }
+    }
+    
+    func banPersonFromCommunity(
+        personId: Int,
+        communityId: Int,
+        ban: Bool,
+        removeContent: Bool,
+        reason: String?,
+        expires: Date? = nil
+    ) async throws -> Person2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.banPersonFromCommunity(
+                personId: personId,
+                communityId: communityId,
+                ban: ban,
+                removeContent: removeContent,
+                reason: reason,
+                expires: expires
+            )
+        }
+    }
+    
+    func banPersonFromInstance(
+        personId: Int,
+        ban: Bool,
+        removeContent: Bool,
+        reason: String?,
+        expires: Date? = nil
+    ) async throws -> Person2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.banPersonFromInstance(
+                personId: personId,
+                ban: ban,
+                removeContent: removeContent,
+                reason: reason,
+                expires: expires
+            )
+        }
+    }
+    
+    func purgePerson(id: Int, reason: String?) async throws {
+        try await performingForConnection { connection in
+            try await connection.purgePerson(id: id, reason: reason)
+        }
+    }
+    
+    func getContent(
+        authorId id: Int,
+        sort: PostSortType,
+        page: Int,
+        limit: Int,
+        savedOnly: Bool? = nil,
+        communityId: Int? = nil
+    ) async throws -> (person: Person3Snapshot, posts: [Post2Snapshot], comments: [Comment2Snapshot]) {
+        try await performingForConnection { connection in
+            try await connection.getContent(
+                authorId: id,
+                sort: sort,
+                page: page,
+                limit: limit,
+                savedOnly: savedOnly,
+                communityId: communityId
+            )
+        }
+    }
+    
+    func getMyPerson() async throws -> (person: Person4Snapshot?, instance: Instance3Snapshot, blocks: BlockListSnapshot?) {
+        try await performingForConnection { connection in
+            try await connection.getMyPerson()
+        }
+    }
+    
+    func deleteAccount(password: String, deleteContent: Bool) async throws {
+        try await performingForConnection { connection in
+            try await connection.deleteAccount(password: password, deleteContent: deleteContent)
+        }
+    }
+    
+    func editAccountSettings(
+        showNsfw: Bool?,
+        showScores: Bool?,
+        theme: String?,
+        defaultListingType: ListingType?,
+        interfaceLanguage: String?,
+        avatar: String?,
+        banner: String?,
+        displayName: String?,
+        email: String?,
+        bio: String?,
+        matrixUserId: String?,
+        showAvatars: Bool?,
+        sendNotificationsToEmail: Bool?,
+        botAccount: Bool?,
+        showBotAccounts: Bool?,
+        showReadPosts: Bool?,
+        discussionLanguages: [Int]?,
+        openLinksInNewTab: Bool?,
+        blurNsfw: Bool?,
+        autoExpand: Bool?,
+        infiniteScrollEnabled: Bool?,
+        postListingMode: PostFeedViewMode?,
+        enableKeyboardNavigation: Bool?,
+        enableAnimatedImages: Bool?,
+        collapseBotComments: Bool?,
+        showUpvotes: Bool?,
+        showDownvotes: Bool?,
+        showUpvotePercentage: Bool?
+    ) async throws {
+        try await performingForConnection { connection in
+            try await connection.editAccountSettings(
+                showNsfw: showNsfw,
+                showScores: showScores,
+                theme: theme,
+                defaultListingType: defaultListingType,
+                interfaceLanguage: interfaceLanguage,
+                avatar: avatar,
+                banner: banner,
+                displayName: displayName,
+                email: email,
+                bio: bio,
+                matrixUserId: matrixUserId,
+                showAvatars: showAvatars,
+                sendNotificationsToEmail: sendNotificationsToEmail,
+                botAccount: botAccount,
+                showBotAccounts: showBotAccounts,
+                showReadPosts: showReadPosts,
+                discussionLanguages: discussionLanguages,
+                openLinksInNewTab: openLinksInNewTab,
+                blurNsfw: blurNsfw,
+                autoExpand: autoExpand,
+                infiniteScrollEnabled: infiniteScrollEnabled,
+                postListingMode: postListingMode,
+                enableKeyboardNavigation: enableKeyboardNavigation,
+                enableAnimatedImages: enableAnimatedImages,
+                collapseBotComments: collapseBotComments,
+                showUpvotes: showUpvotes,
+                showDownvotes: showDownvotes,
+                showUpvotePercentage: showUpvotePercentage
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Post.swift
@@ -1,0 +1,289 @@
+//
+//  ApiRepository+Post.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-03.
+//
+
+import Foundation
+
+extension ApiRepository {
+    // swiftlint:disable:next function_parameter_count
+    func getPosts(
+        communityId: Int,
+        sort: PostSortType,
+        page: Int,
+        cursor: String?,
+        limit: Int,
+        filter: GetContentFilter? = nil,
+        showHidden: Bool = false
+    ) async throws -> (posts: [Post2Snapshot], cursor: String?) {
+        try await performingForConnection { connection in
+            try await connection.getPosts(
+                communityId: communityId,
+                sort: sort,
+                page: page,
+                cursor: cursor,
+                limit: limit,
+                filter: filter,
+                showHidden: showHidden
+            )
+        }
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func getPosts(
+        feed: ListingType,
+        sort: PostSortType,
+        page: Int,
+        cursor: String?,
+        limit: Int,
+        filter: GetContentFilter? = nil,
+        showHidden: Bool = false
+    ) async throws -> (posts: [Post2Snapshot], cursor: String?) {
+        try await performingForConnection { connection in
+            try await connection.getPosts(
+                feed: feed,
+                sort: sort,
+                page: page,
+                cursor: cursor,
+                limit: limit,
+                filter: filter,
+                showHidden: showHidden
+            )
+        }
+    }
+    
+    func getPosts(
+        personId: Int,
+        communityId: Int? = nil,
+        sort: PostSortType = .new,
+        page: Int,
+        limit: Int,
+        savedOnly: Bool = false
+    ) async throws -> (person: Person3Snapshot, posts: [Post2Snapshot]) {
+        try await performingForConnection { connection in
+            try await connection.getPosts(
+                personId: personId,
+                communityId: communityId,
+                sort: sort,
+                page: page,
+                limit: limit,
+                savedOnly: savedOnly
+            )
+        }
+    }
+        
+    func getPost(id: Int) async throws -> Post3Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getPost(id: id)
+        }
+    }
+    
+    func getPost(url: URL) async throws -> Post2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getPost(url: url)
+        }
+    }
+    
+    // This method should be removed in favor of the below method once we drop support for versions before Lemmy 1.0
+    func searchPosts(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int? = nil,
+        creatorId: Int? = nil,
+        filter: ListingType = .all,
+        sort: PostSortType
+    ) async throws -> [Post2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.searchPosts(
+                query: query,
+                page: page,
+                limit: limit,
+                communityId: communityId,
+                creatorId: creatorId,
+                filter: filter,
+                sort: sort
+            )
+        }
+    }
+    
+    func searchPosts(
+        query: String,
+        page: Int = 1,
+        limit: Int = 20,
+        communityId: Int? = nil,
+        creatorId: Int? = nil,
+        filter: ListingType = .all,
+        sort: SearchSortType
+    ) async throws -> [Post2Snapshot] {
+        try await performingForConnection { connection in
+            try await connection.searchPosts(
+                query: query,
+                page: page,
+                limit: limit,
+                communityId: communityId,
+                creatorId: creatorId,
+                filter: filter,
+                sort: sort
+            )
+        }
+    }
+    
+    func markPostAsRead(
+        id: Int,
+        read: Bool = true
+    ) async throws {
+        try await performingForConnection { connection in
+            try await connection.markPostAsRead(id: id, read: false)
+        }
+    }
+    
+    func markPostsAsRead(
+        ids: Set<Int>
+    ) async throws {
+        try await performingForConnection { connection in
+            try await connection.markPostsAsRead(ids: ids)
+        }
+    }
+    
+    func voteOnPost(id: Int, score: ScoringOperation) async throws -> Post2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.voteOnPost(id: id, score: score)
+        }
+    }
+
+    func savePost(id: Int, save: Bool) async throws -> Post2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.savePost(id: id, save: save)
+        }
+    }
+    
+    func deletePost(id: Int, delete: Bool) async throws -> Post2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.deletePost(id: id, delete: delete)
+        }
+    }
+    
+    /// Added in 0.19.4
+    func hidePost(
+        id: Int,
+        hide: Bool
+    ) async throws {
+        try await performingForConnection { connection in
+            try await connection.hidePost(id: id, hide: hide)
+        }
+    }
+    
+    func createPost(
+        communityId: Int,
+        title: String,
+        content: String? = nil,
+        linkUrl: URL? = nil,
+        altText: String? = nil,
+        thumbnail: URL? = nil,
+        nsfw: Bool,
+        languageId: Int? = nil
+    ) async throws -> Post2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.createPost(
+                communityId: communityId,
+                title: title,
+                content: content,
+                linkUrl: linkUrl,
+                altText: altText,
+                thumbnail: thumbnail,
+                nsfw: nsfw,
+                languageId: languageId
+            )
+        }
+    }
+    
+    func editPost(
+        id: Int,
+        title: String,
+        content: String? = nil,
+        linkUrl: URL? = nil,
+        altText: String? = nil,
+        thumbnail: URL? = nil,
+        nsfw: Bool,
+        languageId: Int? = nil
+    ) async throws -> Post2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.editPost(
+                id: id,
+                title: title,
+                content: content,
+                linkUrl: linkUrl,
+                altText: altText,
+                thumbnail: thumbnail,
+                nsfw: nsfw,
+                languageId: languageId
+            )
+        }
+    }
+
+    func replyToPost(id: Int, content: String, languageId: Int? = nil) async throws -> Comment2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.replyToPost(id: id, content: content, languageId: languageId)
+        }
+    }
+    
+    func reportPost(id: Int, reason: String) async throws -> ReportSnapshot {
+        try await performingForConnection { connection in
+            try await connection.reportPost(id: id, reason: reason)
+        }
+    }
+    
+    func purgePost(id: Int, reason: String?) async throws {
+        try await performingForConnection { connection in
+            try await connection.purgePost(id: id, reason: reason)
+        }
+    }
+    
+    func removePost(
+        id: Int,
+        remove: Bool,
+        reason: String?
+    ) async throws -> Post2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.removePost(id: id, remove: remove, reason: reason)
+        }
+    }
+    
+    func pinPost(
+        id: Int,
+        pin: Bool,
+        to target: PostFeatureType
+    ) async throws -> Post2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.pinPost(id: id, pin: pin, to: target)
+        }
+    }
+    
+    func lockPost(
+        id: Int,
+        lock: Bool
+    ) async throws -> Post2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.lockPost(id: id, lock: lock)
+        }
+    }
+    
+    func getPostVotes(
+        id: Int,
+        communityId: Int,
+        page: Int = 1,
+        limit: Int = 20
+    ) async throws -> [PersonVoteSnapshot] {
+        try await performingForConnection { connection in
+            try await connection.getPostVotes(
+                id: id,
+                communityId: communityId,
+                page: page,
+                limit: limit
+            )
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+RegistrationApplication.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+RegistrationApplication.swift
@@ -1,0 +1,43 @@
+//
+//  ApiRepository+RegistrationApplication.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-03.
+//
+
+extension ApiRepository {
+    func getRegistrationApplicationCount() async throws -> Int {
+        try await performingForConnection { connection in
+            try await connection.getRegistrationApplicationCount()
+        }
+    }
+    
+    func getRegistrationApplications(
+        page: Int = 1,
+        limit: Int = 20,
+        unreadOnly: Bool = false
+    ) async throws -> [RegistrationApplicationSnapshot] {
+        try await performingForConnection { connection in
+            try await connection.getRegistrationApplications(
+                page: page,
+                limit: limit,
+                unreadOnly: unreadOnly
+            )
+        }
+    }
+    
+    func approveRegistrationApplication(id: Int) async throws -> RegistrationApplicationSnapshot {
+        try await performingForConnection { connection in
+            try await connection.approveRegistrationApplication(id: id)
+        }
+    }
+    
+    func denyRegistrationApplication(
+        id: Int,
+        reason: String?
+    ) async throws -> RegistrationApplicationSnapshot {
+        try await performingForConnection { connection in
+            try await connection.denyRegistrationApplication(id: id, reason: reason)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Report.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Report.swift
@@ -1,0 +1,91 @@
+//
+//  ApiRepository+Report.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-03.
+//
+
+extension ApiRepository {
+    func getReportCount(communityId: Int? = nil) async throws -> ReportUnreadCountSnapshot {
+        try await performingForConnection { connection in
+            try await connection.getReportCount(communityId: communityId)
+        }
+    }
+    
+    func getPostReports(
+        page: Int = 1,
+        limit: Int = 20,
+        unresolvedOnly: Bool = false,
+        communityId: Int? = nil,
+        postId: Int? = nil
+    ) async throws -> [ReportSnapshot] {
+        try await performingForConnection { connection in
+            try await connection.getPostReports(
+                page: page,
+                limit: limit,
+                unresolvedOnly: unresolvedOnly,
+                communityId: communityId,
+                postId: postId
+            )
+        }
+    }
+    
+    func getCommentReports(
+        page: Int = 1,
+        limit: Int = 20,
+        unresolvedOnly: Bool = false,
+        communityId: Int? = nil,
+        commentId: Int? = nil
+    ) async throws -> [ReportSnapshot] {
+        try await performingForConnection { connection in
+            try await connection.getCommentReports(
+                page: page,
+                limit: limit,
+                unresolvedOnly: unresolvedOnly,
+                communityId: communityId,
+                commentId: commentId
+            )
+        }
+    }
+    
+    func getMessageReports(
+        page: Int = 1,
+        limit: Int = 20,
+        unresolvedOnly: Bool = false
+    ) async throws -> [ReportSnapshot] {
+        try await performingForConnection { connection in
+            try await connection.getMessageReports(
+                page: page,
+                limit: limit,
+                unresolvedOnly: unresolvedOnly
+            )
+        }
+    }
+    
+    func resolvePostReport(
+        id: Int,
+        resolved: Bool
+    ) async throws -> ReportSnapshot {
+        try await performingForConnection { connection in
+            try await connection.resolvePostReport(id: id, resolved: resolved)
+        }
+    }
+    
+    func resolveCommentReport(
+        id: Int,
+        resolved: Bool
+    ) async throws -> ReportSnapshot {
+        try await performingForConnection { connection in
+            try await connection.resolveCommentReport(id: id, resolved: resolved)
+        }
+    }
+    
+    func resolveMessageReport(
+        id: Int,
+        resolved: Bool
+    ) async throws -> ReportSnapshot {
+        try await performingForConnection { connection in
+            try await connection.resolveMessageReport(id: id, resolved: resolved)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
@@ -1,0 +1,146 @@
+//
+//  ApiRepository.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-02.
+//
+
+import Rest
+import Foundation
+
+/// This class represents an abstract interface on top of the underlying Connection; it is responsible for managing the Connection and
+/// serving consistent Snapshot models to higher layers.
+public class ApiRepository {
+    private static let supportedConnections: [any InstanceConnection.Type] = [LemmyConnection.self, PieFedConnection.self]
+    
+    public let baseUrl: URL
+    public let username: String?
+    
+    private var ongoingConnectionDiscoveryTask: Task<Any, Error>?
+    var connection: (any InstanceConnection)?
+    
+    var restClient: RestClient<ApiErrorResponse> = .init()
+    
+    public internal(set) var token: String?
+    
+    public init(baseUrl: URL, username: String? = nil) {
+        self.baseUrl = baseUrl
+        self.username = username
+    }
+    
+    func updateToken(_ newToken: String) {
+        guard username != nil else {
+            assertionFailure()
+            return
+        }
+        
+        connection?.updateToken(newToken)
+        token = newToken
+    }
+    
+    @discardableResult
+    func perform<Request: RestRequest>(
+        _ request: Request,
+        tokenOverride: String? = nil,
+        requiresToken: Bool = true // This should be `true` for the vast majority of requests, even GET requests
+    ) async throws -> Request.Response {
+        guard !requiresToken || username == nil || token != nil else {
+            throw ApiClientError.noToken
+        }
+        
+        let token = tokenOverride ?? token
+        do throws(RestError) {
+            return try await restClient.perform(baseUrl: baseUrl, request, token: token)
+        } catch {
+            switch error {
+            case let RestError.response(response, statusCode: _):
+                if ApiErrorResponse(error: response).isNotLoggedIn {
+                    throw token == nil ? ApiClientError.notLoggedIn : ApiClientError.invalidSession // (self)
+                } else {
+                    throw ApiClientError(from: error)
+                }
+            default:
+                throw ApiClientError(from: error)
+            }
+        }
+    }
+    
+    func getConnection() async throws -> any InstanceConnection {
+        _ = await ongoingConnectionDiscoveryTask?.result
+        if let connection {
+            return connection
+        }
+        _ = try await getMyInstance()
+        if let connection {
+            return connection
+        }
+        assertionFailure()
+        throw ApiClientError.unsuccessful
+    }
+    
+    @MainActor
+    func performingForConnection<T>(
+        _ callback: @escaping (any InstanceConnection) async throws -> T,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) async throws -> T {
+        // Iterate through all possible connections, and attempt the request on all of them in parallel.
+        // As soon as one of the requests succeeds, return the result and cancel the other ongoing requests.
+        // Cache the `InstanceConnection` that succeeded in the `self.connection` property, and use that
+        // for all subsequent calls of `performingForConnection`.
+        
+        // If `performingForConnection` is called and `self.connection` is `nil` but there is another
+        // `performingForConnection` call ongoing, it will wait for the other call to succeed first.
+
+        _ = await self.ongoingConnectionDiscoveryTask?.result
+        if let connection {
+            return try await callback(connection)
+        }
+
+        let ongoingConnectionDiscoveryTask: Task<T, Error> = Task {
+            try await withThrowingTaskGroup(of: (any InstanceConnection, Result<T, Error>).self) { group in
+                for connectionType in Self.supportedConnections {
+                    let connection = connectionType.init(baseUrl: baseUrl, token: token)
+                    group.addTask {
+                        do {
+                            let response = try await callback(connection)
+                            return (connection, .success(response))
+                        } catch {
+                            return (connection, .failure(error))
+                        }
+                    }
+                }
+                
+                while !group.isEmpty {
+                    guard let result = try? await group.next() else {
+                        assertionFailure()
+                        continue
+                    }
+                    do {
+                        let value = try result.1.get()
+                        // Cancel all other tasks once any one task succeeds
+                        group.cancelAll()
+                        self.connection = result.0
+                        self.ongoingConnectionDiscoveryTask = nil
+                        return value
+                    } catch ApiClientError.serverError(404), ApiClientError.featureUnsupported {
+                        // no-op
+                    } catch {
+                        // We *could* set the `connection` here, but I'd rather not just incase some other
+                        // 404-equivalent error is thrown that we haven't accounted for
+                        throw error
+                    }
+                }
+                
+                throw ApiClientError.unableToDetermineSoftware
+            }
+        }
+        
+        self.ongoingConnectionDiscoveryTask = Task {
+            _ = try? await ongoingConnectionDiscoveryTask.result.get()
+        }
+        
+        return try await ongoingConnectionDiscoveryTask.result.get()
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
@@ -13,20 +13,20 @@ import Foundation
 ///
 /// The data access methods in here are all intentionally dumb--they just make calls and return snapshots. Validation, enrichment,
 /// and other business logic that must occur before serving the final model to the app should be performed by the consumer of the repository.
-class ApiRepository {
+internal class ApiRepository {
     private static let supportedConnections: [any InstanceConnection.Type] = [LemmyConnection.self, PieFedConnection.self]
     
-    public let baseUrl: URL
-    public let username: String?
+    let baseUrl: URL
+    let username: String?
     
     private var ongoingConnectionDiscoveryTask: Task<Any, Error>?
     var connection: (any InstanceConnection)?
     
     var restClient: RestClient<ApiErrorResponse> = .init()
     
-    public internal(set) var token: String?
+    var token: String?
     
-    public init(baseUrl: URL, username: String? = nil) {
+    init(baseUrl: URL, username: String? = nil) {
         self.baseUrl = baseUrl
         self.username = username
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
@@ -10,7 +10,10 @@ import Foundation
 
 /// This class represents an abstract interface on top of the underlying Connection; it is responsible for managing the Connection and
 /// serving consistent Snapshot models to higher layers.
-public class ApiRepository {
+///
+/// The data access methods in here are all intentionally dumb--they just make calls and return snapshots. Validation, enrichment,
+/// and other business logic that must occur before serving the final model to the app should be performed by the consumer of the repository.
+class ApiRepository {
     private static let supportedConnections: [any InstanceConnection.Type] = [LemmyConnection.self, PieFedConnection.self]
     
     public let baseUrl: URL
@@ -38,7 +41,6 @@ public class ApiRepository {
         token = newToken
     }
     
-    @discardableResult
     func perform<Request: RestRequest>(
         _ request: Request,
         tokenOverride: String? = nil,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -96,7 +96,7 @@ public final class UnreadCount {
             returning: [InboxItemType: Int].self
         ) { taskGroup in
             taskGroup.addTask {
-                try await self.api.getPersonalUnreadCount().unreadCountDictionary
+                try await self.api.repository.getPersonalUnreadCount().unreadCountDictionary
             }
             if !alwaysMakeCalls, self.api.username != nil, self.api.myPerson == nil || self.api.myInstance == nil {
                 // The theoretical solution to this is to store the moderated

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -106,7 +106,7 @@ public final class UnreadCount {
             if alwaysMakeCalls || !(self.api.myPerson?.moderatedCommunities.isEmpty ?? false) || self.api.isAdmin {
                 taskGroup.addTask {
                     do {
-                        return try await self.api.getReportCount(communityId: nil).unreadCountDictionary
+                        return try await self.api.repository.getReportCount(communityId: nil).unreadCountDictionary
                     } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
                         return [:]
                     }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- progress towards #2111 

## Description

This PR extracts all direct `Connection` and `RestClient` calls out of the `ApiClient` and into the `ApiRepository`. The `ApiRepository` is internal to `MlemMiddleware` and is responsible for handling the `Connection` logic; its methods return `Snapshot`s, which the `ApiClient` then consumes and processes into frontend-ready models.

This PR does not alter the `ApiClient`'s app-facing API (except for removing `getReportCount`, which was returning a `Snapshot`; the call to `ApiClient.getReportCount` has been replaced with a direct repository call). This means that there is currently a lot of boilerplate passthrough code, which will be removed as responsibility for state tracking is migrated to the new system.