### PR TITLE
PieFed Inbox

### DIFF
--- a/Mlem/App/Models/Session/UserSession.swift
+++ b/Mlem/App/Models/Session/UserSession.swift
@@ -48,9 +48,7 @@ class UserSession: Session {
                 self.blocks = blocks
                 self.instance = instance
                 
-                if software.supports(.inbox) {
-                    self.unreadCount = try await api.getUnreadCount()
-                }
+                self.unreadCount = try await api.getUnreadCount()
             } catch {
                 handleError(error)
             }

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+LoadFeed.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+LoadFeed.swift
@@ -13,11 +13,12 @@ private struct LoadFeed: ViewModifier {
     @Setting(\.post_size) var postSize
     
     let feedLoader: (any FeedLoading)?
+    let shouldLoad: Bool
     
     func body(content: Content) -> some View {
         content
-            .onChange(of: feedLoader == nil, initial: true) {
-                if let feedLoader, feedLoader.items.isEmpty {
+            .onChange(of: onChangeHash, initial: true) {
+                if let feedLoader, feedLoader.items.isEmpty, shouldLoad {
                     // wrapping this in a Task instead of using .task prevents cancellation errors from the parent view de-rendering
                     Task {
                         do {
@@ -32,11 +33,18 @@ private struct LoadFeed: ViewModifier {
                 (feedLoader as? CorePostFeedLoader)?.setPrefetchingConfiguration(.forPostSize(postSize))
             }
     }
+    
+    var onChangeHash: Int {
+        var hasher = Hasher()
+        hasher.combine(feedLoader == nil)
+        hasher.combine(shouldLoad)
+        return hasher.finalize()
+    }
 }
 
 extension View {
     /// Convenience modifier. Attach to a view to load items from the given FeedLoading on appear if the given FeedLoading has no items
-    func loadFeed(_ feedLoader: (any FeedLoading)?) -> some View {
-        modifier(LoadFeed(feedLoader: feedLoader))
+    func loadFeed(_ feedLoader: (any FeedLoading)?, shouldLoad: Bool = true) -> some View {
+        modifier(LoadFeed(feedLoader: feedLoader, shouldLoad: shouldLoad))
     }
 }

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -192,7 +192,9 @@ struct CommunityView: View {
     @ViewBuilder
     func moderationTab(community: any Community) -> some View {
         VStack(spacing: Constants.main.standardSpacing) {
-            ModlogButtonView(community: community)
+            if community.api.supportsOrNil(.modlog) ?? true {
+                ModlogButtonView(community: community)
+            }
 
             VStack(spacing: Constants.main.halfSpacing) {
                 ForEach(community.moderators_ ?? []) { person in

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
@@ -33,7 +33,11 @@ extension InboxView {
                 }
                 
                 EndOfFeedView(feedLoader: feedLoader, viewType: .cartoon)
-            } header: { sectionHeader }
+            } header: {
+                if appState.firstApi.supportsOrNil(.privateMessaging) ?? false {
+                    sectionHeader
+                }
+            }
         }
         .animation(.easeOut(duration: 0.1), value: feedLoader.items.isEmpty)
     }

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
@@ -69,15 +69,19 @@ struct InboxView: View {
     }
     
     var feedLoader: StandardFeedLoader<InboxItem> {
-        switch selectedTab {
-        case .all:
-            inboxFeedLoader
-        case .replies:
+        if appState.firstApi.supportsOrNil(.privateMessaging) ?? false {
+            switch selectedTab {
+            case .all:
+                inboxFeedLoader
+            case .replies:
+                replyFeedLoader
+            case .mentions:
+                mentionFeedLoader
+            case .messages:
+                messageFeedLoader
+            }
+        } else {
             replyFeedLoader
-        case .mentions:
-            mentionFeedLoader
-        case .messages:
-            messageFeedLoader
         }
     }
     
@@ -89,7 +93,7 @@ struct InboxView: View {
     }
     
     var availableFeeds: [Feed] {
-        if appState.isModOrAdmin {
+        if appState.isModOrAdmin, appState.firstApi.supportsOrNil(.viewReports) ?? false {
             return [.inbox, .modMail]
         }
         return [.inbox]
@@ -98,18 +102,13 @@ struct InboxView: View {
     var body: some View {
         if appState.firstSession is GuestSession {
             signedOutInfoView
-        } else if !(appState.firstApi.supportsOrNil(.inbox) ?? true) {
-            Text("Accessing the inbox on PieFed isn't implemented yet.")
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-                .padding()
         } else {
             content
                 .themedGroupedBackground()
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar { toolbar }
                 .loadFeed(inboxFeedLoader)
-                .loadFeed(modMailFeedLoader)
+                .loadFeed(modMailFeedLoader, shouldLoad: appState.firstApi.supportsOrNil(.viewReports) ?? false)
                 .onChange(of: appState.firstApi, initial: false) {
                     if appState.firstAccount is UserAccount {
                         Task {
@@ -124,10 +123,14 @@ struct InboxView: View {
                         do {
                             if showRead {
                                 try await inboxFeedLoader.showRead()
-                                try await modMailFeedLoader.showRead()
+                                if appState.firstApi.supportsOrNil(.viewReports) ?? false {
+                                    try await modMailFeedLoader.showRead()
+                                }
                             } else {
                                 try await inboxFeedLoader.hideRead()
-                                try await modMailFeedLoader.hideRead()
+                                if appState.firstApi.supportsOrNil(.viewReports) ?? false {
+                                    try await modMailFeedLoader.hideRead()
+                                }
                             }
                         } catch {
                             handleError(error)
@@ -192,8 +195,10 @@ struct InboxView: View {
             switch selectedFeed {
             case .inbox:
                 try await inboxFeedLoader.refresh(clearBeforeRefresh: false)
-                Task {
-                    try await modMailFeedLoader.refresh(clearBeforeRefresh: false)
+                if appState.firstApi.supportsOrNil(.viewReports) ?? false {
+                    Task {
+                        try await modMailFeedLoader.refresh(clearBeforeRefresh: false)
+                    }
                 }
             case .modMail:
                 try await modMailFeedLoader.refresh(clearBeforeRefresh: false)

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -599,9 +599,6 @@
         }
       }
     },
-    "Accessing the inbox on PieFed isn't implemented yet." : {
-
-    },
     "Account" : {
       "localizations" : {
         "fr" : {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -31,7 +31,9 @@ public enum Feature: Hashable {
     case logIn
     case signUp
     
+    case viewReports
+    case privateMessaging
     case commentTreeSortedByDepth
-    case inbox
+    case uploadImages
     case editAccountSettings
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/PersonalUnreadCountSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/PersonalUnreadCountSnapshot+PieFed.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-07-04.
+//
+
+import Foundation
+
+public extension PersonalUnreadCountSnapshot {
+    init(from response: PieFedGetUnreadCountResponse) throws(ApiClientError) {
+        self.replies = response.replies
+        self.mentions = response.mentions
+        self.messages = response.privateMessages
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -103,22 +103,25 @@ public final class UnreadCount {
                 // community IDs in `ApiClient.Context` and `await` them here.
                 print("Warning: ApiClient.myPerson or ApiClient.myInstance is nil at UnreadCount refresh - this may lead to unneeded API calls")
             }
-            if alwaysMakeCalls || !(self.api.myPerson?.moderatedCommunities.isEmpty ?? false) || self.api.isAdmin {
-                taskGroup.addTask {
-                    do {
-                        return try await self.api.repository.getReportCount(communityId: nil).unreadCountDictionary
-                    } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
-                        return [:]
+            
+            if try await self.api.supports(.viewReports) {
+                if alwaysMakeCalls || !(self.api.myPerson?.moderatedCommunities.isEmpty ?? false) || self.api.isAdmin {
+                    taskGroup.addTask {
+                        do {
+                            return try await self.api.repository.getReportCount(communityId: nil).unreadCountDictionary
+                        } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
+                            return [:]
+                        }
                     }
                 }
-            }
-            // Don't use `api.isAdmin` here; it falls back to `false` and we need to fallback to `true`
-            if alwaysMakeCalls || api.myInstance?.administrators.contains(where: { $0.id == api.myPerson?.id }) ?? true {
-                taskGroup.addTask {
-                    do {
-                        return try await [.registrationApplication: self.api.getRegistrationApplicationCount()]
-                    } catch let ApiClientError.response(response, _) where response.notAdmin {
-                        return [:]
+                // Don't use `api.isAdmin` here; it falls back to `false` and we need to fallback to `true`
+                if alwaysMakeCalls || api.myInstance?.administrators.contains(where: { $0.id == api.myPerson?.id }) ?? true {
+                    taskGroup.addTask {
+                        do {
+                            return try await [.registrationApplication: self.api.getRegistrationApplicationCount()]
+                        } catch let ApiClientError.response(response, _) where response.notAdmin {
+                            return [:]
+                        }
                     }
                 }
             }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -36,8 +36,8 @@ public extension LemmyConnection {
         case .searchLocalPeople, .moderatorsCanViewVotes, .hidePosts, .fullyFeaturedReports:
             version >= .v0_19_4
         case .searchLocalCommunities, .viewInstanceSettings, .viewInstanceCreationDate, .modlog,
-             .logIn, .signUp, .viewCommunityActiveUsers, .commentTreeSortedByDepth, .inbox,
-             .editAccountSettings:
+             .logIn, .signUp, .viewCommunityActiveUsers, .commentTreeSortedByDepth, .uploadImages,
+             .editAccountSettings, .privateMessaging, .viewReports:
             true
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -24,7 +24,6 @@ public extension PieFedConnection {
             unreadOnly: unreadOnly
         )
         let response = try await perform(request)
-        print(response)
         return try response.replies.map { try .init(from: $0) }
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -14,7 +14,18 @@ public extension PieFedConnection {
         limit: Int,
         unreadOnly: Bool = false
     ) async throws -> [Reply2Snapshot] {
-        throw ApiClientError.featureUnsupported
+        guard let sort = sort.piefedSortType else {
+            throw ApiClientError.featureUnsupported
+        }
+        let request = PieFedGetRepliesRequest(
+            sort: sort,
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
+        let response = try await perform(request)
+        print(response)
+        return try response.replies.map { try .init(from: $0) }
     }
     
     func getMentions(
@@ -23,7 +34,7 @@ public extension PieFedConnection {
         limit: Int,
         unreadOnly: Bool = false
     ) async throws -> [Reply2Snapshot] {
-        throw ApiClientError.featureUnsupported
+        []
     }
     
     func getMessages(
@@ -48,7 +59,8 @@ public extension PieFedConnection {
     }
     
     func markReplyAsRead(id: Int, read: Bool = true) async throws {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedMarkReplyAsReadRequest(commentReplyId: id, read: read)
+        try await perform(request)
     }
     
     func markMentionAsRead(id: Int, read: Bool = true) async throws {
@@ -60,7 +72,9 @@ public extension PieFedConnection {
     }
     
     func getPersonalUnreadCount() async throws -> PersonalUnreadCountSnapshot {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedGetUnreadCountRequest()
+        let response = try await perform(request)
+        return try .init(from: response)
     }
     
     func createMessage(personId: Int, content: String) async throws -> Message2Snapshot {


### PR DESCRIPTION
> [!note]
> Relies on [this MlemApiTypes PR](https://github.com/mlemgroup/MlemApiTypes/pull/24)

Due to API limitations, only the "replies" tab is available. It's also permanently in "unread only" mode; the button in the top-left does nothing. I've left the button in, despite it being broken - if they add support for it, it'll just start working without needing a TF update.

Closes #2104 

