### PR TITLE
Remap PieFed "active" sort to "New Comments"

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/PostSortType+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/PostSortType+PieFed.swift
@@ -10,12 +10,12 @@ import Foundation
 public extension PostSortType {
     var pieFedSortType: PieFedSortType? {
         switch self {
-        case .active: .active
+        case .active: nil
         case .hot: .hot
         case .new: .new
         case .old: nil
         case .mostComments: nil
-        case .newComments: nil
+        case .newComments: .active // This is intentional
         case .controversial: nil
         case .scaled: .scaled
         case let .top(range):


### PR DESCRIPTION
The "Active" sort mode on PieFed isn't the same as the "Active" sort on Lemmy. Instead, it just sorts by newest comment date. I think it's best to rename it to "New Comments" in Mlem, which is what I've done here.