### PR TITLE
PieFed: Better inbox

### DIFF
--- a/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
@@ -66,13 +66,17 @@ extension Message1Providing {
             selectTextAction()
         }
         if isOwnMessage {
-            if let editCallback {
-                editAction(appState: appState, callback: editCallback)
+            if api.supportsOrNil(.editAndDeletePrivateMessages) ?? true {
+                if let editCallback {
+                    editAction(appState: appState, callback: editCallback)
+                }
+                deleteAction(appState: appState, feedback: feedback)
             }
-            deleteAction(appState: appState, feedback: feedback)
         } else {
-            if report == nil {
-                reportAction(appState: appState)
+            if api.supportsOrNil(.reportPrivateMessages) ?? true {
+                if report == nil {
+                    reportAction(appState: appState)
+                }
             }
             if !isInMessageFeed {
                 blockCreatorAction(appState: appState, feedback: feedback)

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
@@ -34,13 +34,13 @@ extension InboxView {
                 
                 EndOfFeedView(feedLoader: feedLoader, viewType: .cartoon)
             } header: {
-                if appState.firstApi.supportsOrNil(.privateMessaging) ?? false {
+                if appState.firstApi.supportsOrNil(.viewMentionsAndPrivateMessages) ?? false {
                     sectionHeader
                 }
             }
         }
         .animation(.easeOut(duration: 0.1), value: feedLoader.items.isEmpty)
-        .padding(.top, (appState.firstApi.supportsOrNil(.privateMessaging) ?? false) ? 0 : Constants.main.standardSpacing)
+        .padding(.top, (appState.firstApi.supportsOrNil(.viewMentionsAndPrivateMessages) ?? false) ? 0 : Constants.main.standardSpacing)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
@@ -69,7 +69,7 @@ struct InboxView: View {
     }
     
     var feedLoader: StandardFeedLoader<InboxItem> {
-        if appState.firstApi.supportsOrNil(.privateMessaging) ?? false {
+        if appState.firstApi.supportsOrNil(.viewMentionsAndPrivateMessages) ?? false {
             switch selectedTab {
             case .all:
                 inboxFeedLoader

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -32,7 +32,11 @@ public enum Feature: Hashable {
     case signUp
     
     case viewReports
-    case privateMessaging
+    case viewMentionsAndPrivateMessages
+    
+    case editAndDeletePrivateMessages
+    case reportPrivateMessages
+    
     case commentTreeSortedByDepth
     case uploadImages
     case editAccountSettings

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Reply1Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Reply1Snapshot+PieFed.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 public extension Reply1Snapshot {
-    init(from commentReply: PieFedCommentReply) throws(ApiClientError) {
+    init(from commentReply: PieFedCommentReply, isMention: Bool) throws(ApiClientError) {
         self.id = commentReply.id
         self.recipientId = commentReply.recipientId
         self.commentId = commentReply.commentId
         self.read = commentReply.read
         self.created = commentReply.published
-        self.isMention = false
+        self.isMention = isMention
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Reply2Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Reply2Snapshot+PieFed.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 public extension Reply2Snapshot {
-    init(from commentReply: PieFedCommentReplyView) throws(ApiClientError) {
-        self.reply = try .init(from: commentReply.commentReply)
+    init(from commentReply: PieFedCommentReplyView, isMention: Bool) throws(ApiClientError) {
+        self.reply = try .init(from: commentReply.commentReply, isMention: isMention)
         self.comment = try .init(from: commentReply.comment)
         self.creator = try .init(from: commentReply.creator)
         self.post = try .init(from: commentReply.post)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -37,7 +37,8 @@ public extension LemmyConnection {
             version >= .v0_19_4
         case .searchLocalCommunities, .viewInstanceSettings, .viewInstanceCreationDate, .modlog,
              .logIn, .signUp, .viewCommunityActiveUsers, .commentTreeSortedByDepth, .uploadImages,
-             .editAccountSettings, .privateMessaging, .viewReports:
+             .editAccountSettings, .viewMentionsAndPrivateMessages, .viewReports, .editAndDeletePrivateMessages,
+             .reportPrivateMessages:
             true
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
@@ -33,6 +33,8 @@ public extension PieFedConnection {
             version >= sort.minimumVersion
         case let .sortTimeRange(timeRange):
             version >= timeRange.minimumVersion
+        case .viewMentionsAndPrivateMessages:
+            version >= .v1_0_1
         default: false
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -24,7 +24,7 @@ public extension PieFedConnection {
             unreadOnly: unreadOnly
         )
         let response = try await perform(request)
-        return try response.replies.map { try .init(from: $0) }
+        return try response.replies.map { try .init(from: $0, isMention: false) }
     }
     
     func getMentions(
@@ -33,7 +33,17 @@ public extension PieFedConnection {
         limit: Int,
         unreadOnly: Bool = false
     ) async throws -> [Reply2Snapshot] {
-        []
+        guard let sort = sort.piefedSortType else {
+            throw ApiClientError.featureUnsupported
+        }
+        let request = PieFedGetMentionsRequest(
+            sort: sort,
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
+        let response = try await perform(request)
+        return try response.replies.map { try .init(from: $0, isMention: true) }
     }
     
     func getMessages(
@@ -42,17 +52,27 @@ public extension PieFedConnection {
         limit: Int,
         unreadOnly: Bool = false
     ) async throws -> [Message2Snapshot] {
-        guard creatorId == nil else {
-            throw ApiClientError.featureUnsupported
+        if let creatorId {
+            if unreadOnly {
+                throw ApiClientError.featureUnsupported
+            }
+            let request = PieFedGetPrivateMessagesConversationRequest(
+                page: page,
+                limit: limit,
+                personId: creatorId
+            )
+            let response = try await perform(request)
+            return try response.privateMessages.map { try .init(from: $0) }
+        } else {
+            let request = PieFedGetPrivateMessagesRequest(
+                unreadOnly: unreadOnly,
+                page: page,
+                limit: limit,
+                creatorId: nil
+            )
+            let response = try await perform(request)
+            return try response.privateMessages.map { try .init(from: $0) }
         }
-        let request = PieFedGetPrivateMessagesRequest(
-            unreadOnly: unreadOnly,
-            page: page,
-            limit: limit,
-            creatorId: nil
-        )
-        let response = try await perform(request)
-        return try response.privateMessages.map { try .init(from: $0) }
     }
     
     func markAllAsRead() async throws {
@@ -66,11 +86,13 @@ public extension PieFedConnection {
     }
     
     func markMentionAsRead(id: Int, read: Bool = true) async throws {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedMarkReplyAsReadRequest(commentReplyId: id, read: read)
+        try await perform(request)
     }
     
     func markMessageAsRead(id: Int, read: Bool = true) async throws {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedMarkPrivateMessageAsReadRequest(privateMessageId: id, read: read)
+        try await perform(request)
     }
     
     func getPersonalUnreadCount() async throws -> PersonalUnreadCountSnapshot {
@@ -80,7 +102,9 @@ public extension PieFedConnection {
     }
     
     func createMessage(personId: Int, content: String) async throws -> Message2Snapshot {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedCreatePrivateMessageRequest(content: content, recipientId: personId)
+        let response = try await perform(request)
+        return try .init(from: response.privateMessageView)
     }
     
     @discardableResult


### PR DESCRIPTION
> [!note]
> Relies on [this MlemApiTypes PR](https://github.com/mlemgroup/MlemApiTypes/pull/28)

- Closes #2137
- Closes #2138

On PieFed instances running 1.0.1 or later, you can now access the mentions tab and the private messages tab. Remaining limitations:
- #2151