### PR TITLE
PieFed: Mark posts as read

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
@@ -148,13 +148,14 @@ public extension PieFedConnection {
         throw ApiClientError.featureUnsupported
     }
     
-    // Marking many posts as *unread* was possible in 0.19.0, but that capability was removed in 1.0.0
     func markPostsAsRead(ids: Set<Int>) async throws {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedMarkPostAsReadRequest(postIds: Array(ids), postId: nil, read: true)
+        try await perform(request)
     }
     
     func markPostAsRead(id: Int, read: Bool) async throws {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedMarkPostAsReadRequest(postIds: nil, postId: id, read: read)
+        try await perform(request)
     }
     
     @discardableResult


### PR DESCRIPTION
Closes #2117. Only available on version 1.0.1 and later, but doesn't throw any user-visible errors on 1.0.0 so I haven't implemented a version check