### PR TITLE
PieFed moderator tools

### DIFF
--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -92,14 +92,18 @@ extension Comment1Providing {
         showAllActions: Bool = true,
         report: Report? = nil
     ) -> [any Action] {
-        if api.isAdmin || (api.supportsOrNil(.moderatorsCanViewVotes) ?? true), showAllActions || Settings.get(\.menus_allModActions) {
+        let adminsCanViewVotes = api.supportsOrNil(.adminsCanViewVotes) ?? false
+        let moderatorsCanViewVotes = api.supportsOrNil(.moderatorsCanViewVotes) ?? false
+        let viewVotesIsPossible = (api.isAdmin && adminsCanViewVotes) || moderatorsCanViewVotes
+        
+        if viewVotesIsPossible, showAllActions || Settings.get(\.menus_allModActions) {
             viewVotesAction()
         }
         if let self2, !isOwnComment {
             self2.removeAction(appState: appState).disabled(!canModerate)
             self2.creator.banActions(appState: appState, community: self2.community, withUserLabel: true)
         }
-        if api.isAdmin {
+        if api.isAdmin, api.supportsOrNil(.purgeContent) ?? false {
             purgeAction(appState: appState)
             if !isOwnComment {
                 purgeCreatorAction(appState: appState)

--- a/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
@@ -131,8 +131,12 @@ extension Community1Providing {
         blockAction(appState: appState, feedback: feedback)
         if api.isAdmin {
             ActionGroup {
-                removeAction(appState: appState)
-                purgeAction(appState: appState)
+                if api.supportsOrNil(.removeCommunity) ?? false {
+                    removeAction(appState: appState)
+                }
+                if api.supportsOrNil(.purgeContent) ?? false {
+                    purgeAction(appState: appState)
+                }
             }
         }
     }

--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -114,10 +114,14 @@ extension Person1Providing {
             banActions(appState: appState, community: community)
             if api.isAdmin {
                 purgeAction(appState: appState)
+                if api.supportsOrNil(.purgeContent) ?? false {
+                    purgeAction(appState: appState)
+                }
             }
             
             if let community3 = community as? any Community3Providing,
                let myPerson = api.myPerson,
+               api.supportsOrNil(.editModeratorList) ?? false,
                myPerson.canModerate(self, in: community3) {
                 addModAction(community: community3, isOn: community3.moderators.contains(where: { $0.id == id }))
             }
@@ -149,19 +153,22 @@ extension Person1Providing {
     }
     
     func banActions(appState: AppState, community: (any Community)?, withUserLabel: Bool = false) -> [any Action] {
-        let isModerator: Bool
+        let canBanFromCommunity: Bool
         let showBoth: Bool
+        
+        let canBanFromInstance = api.isAdmin && (api.supportsOrNil(.banFromInstance) ?? false)
+        
         if let myPerson = api.myPerson, let community {
-            isModerator = myPerson.moderates(communityId: community.id)
-            showBoth = api.isAdmin && isBannedFromCommunity(community) != bannedFromInstance
+            canBanFromCommunity = myPerson.moderates(communityId: community.id) && (api.supportsOrNil(.banFromCommunity) ?? false)
+            showBoth = canBanFromInstance && isBannedFromCommunity(community) != bannedFromInstance
         } else {
-            isModerator = false
+            canBanFromCommunity = false
             showBoth = false
         }
         var output: [any Action] = .init()
         // admins should see separate 'ban' and 'unban' actions if ban statuses conflict; otherwise actions are grouped under a single entry (community or instance, depending on moderation status)
         // moderators see community ban action by default, regardless of admin status
-        if isModerator {
+        if canBanFromCommunity {
             if showBoth {
                 output.append(banFromInstanceAction(appState: appState))
             }
@@ -170,7 +177,7 @@ extension Person1Providing {
             }
         }
         // non-moderator admins see instance ban action by default
-        else if api.isAdmin {
+        else if canBanFromInstance {
             output.append(banFromInstanceAction(appState: appState))
             if showBoth, let community {
                 output.append(banFromCommunityAction(appState: appState, community: community, withUserLabel: withUserLabel))

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -184,7 +184,12 @@ extension Post1Providing {
                 pinToInstanceAction(appState: appState, feedback: feedback)
             }
             lockAction(appState: appState, feedback: feedback)
-            if let navigation, api.isAdmin || (api.supportsOrNil(.moderatorsCanViewVotes) ?? true) {
+            
+            let adminsCanViewVotes = api.supportsOrNil(.adminsCanViewVotes) ?? false
+            let moderatorsCanViewVotes = api.supportsOrNil(.moderatorsCanViewVotes) ?? false
+            let viewVotesIsPossible = (api.isAdmin && adminsCanViewVotes) || moderatorsCanViewVotes
+            
+            if let navigation, viewVotesIsPossible {
                 viewVotesAction(navigation: navigation)
             }
         }
@@ -192,7 +197,7 @@ extension Post1Providing {
             self2.removeAction(appState: appState).disabled(!canModerate)
             self2.creator.banActions(appState: appState, community: self2.community, withUserLabel: true)
         }
-        if api.isAdmin {
+        if api.isAdmin, api.supportsOrNil(.purgeContent) ?? false {
             purgeAction(appState: appState)
             if !isOwnPost {
                 purgeCreatorAction(appState: appState)

--- a/Mlem/App/Views/Pages/Community/CommunityView+Logic.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView+Logic.swift
@@ -9,6 +9,14 @@ import Foundation
 import MlemMiddleware
 
 extension CommunityView {
+    func canEditModeratorList(_ community: any Community) -> Bool {
+        guard let firstPerson = appState.firstPerson else { return false }
+        if !(firstPerson.api.supportsOrNil(.editModeratorList) ?? true) {
+            return false
+        }
+        return firstPerson.isAdmin || firstPerson.moderates(community: community)
+    }
+    
     func openAddModSheet() {
         navigation.openSheet(.personPicker { person in
             newMod = person
@@ -40,6 +48,7 @@ extension CommunityView {
     
     func moderatorQuickSwipes(community: any Community, person: any Person) -> SwipeConfiguration {
         guard let community = community as? any Community3Providing,
+              canEditModeratorList(community),
               let myPerson = appState.firstPerson,
               myPerson.canModerate(person, in: community) else {
             return .init()

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -203,8 +203,7 @@ struct CommunityView: View {
                 }
             }
             
-            if let firstPerson = appState.firstPerson,
-               firstPerson.isAdmin || firstPerson.moderates(community: community) {
+            if canEditModeratorList(community) {
                 Button("Add Moderator", icon: .general.add, action: openAddModSheet)
                     .buttonStyle(.capsule)
                     .confirmationDialog("Add Moderator", isPresented: $showingConfirmation) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
@@ -92,7 +92,7 @@ public extension ApiClient {
         removeContent: Bool,
         reason: String?,
         expires: Date? = nil
-    ) async throws -> Person2 {
+    ) async throws -> Person1 {
         let snapshot = try await repository.banPersonFromCommunity(
             personId: personId,
             communityId: communityId,
@@ -101,7 +101,7 @@ public extension ApiClient {
             reason: reason,
             expires: expires
         )
-        let person = await caches.person2.getModel(
+        let person = await caches.person1.getModel(
             api: self,
             from: snapshot
         )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiErrorResponse.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiErrorResponse.swift
@@ -36,7 +36,8 @@ private let possible2FAErrors: Set<String> = [
 
 private let couldntFindObjectErrors: Set<String> = [
     "couldnt_find_person",
-    "couldnt_find_object"
+    "couldnt_find_object",
+    "No object found."
 ]
 
 public extension ApiErrorResponse {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Person.swift
@@ -64,7 +64,7 @@ extension ApiRepository {
         removeContent: Bool,
         reason: String?,
         expires: Date? = nil
-    ) async throws -> Person2Snapshot {
+    ) async throws -> Person1Snapshot {
         try await performingForConnection { connection in
             try await connection.banPersonFromCommunity(
                 personId: personId,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -16,6 +16,7 @@ public enum Feature: Hashable {
     // On some earlier Lemmy versions, legacy report types are used
     case fullyFeaturedReports
     
+    case adminsCanViewVotes
     // On Lemmy, admins were able to view votes before moderators were able to
     case moderatorsCanViewVotes
     
@@ -36,6 +37,13 @@ public enum Feature: Hashable {
     
     case editAndDeletePrivateMessages
     case reportPrivateMessages
+    case purgeContent
+    case removeCommunity
+    case banFromInstance
+    case banFromCommunity
+    
+    // Add/remove moderators from a community
+    case editModeratorList
     
     case commentTreeSortedByDepth
     case uploadImages

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/PostFeatureType+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/PostFeatureType+Lemmy.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-07-20.
+//
+
+import Foundation
+
+extension PostFeatureType {
+    var apiType: LemmyPostFeatureType {
+        switch self {
+        case .community: .community
+        case .instance: .local
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Comment1Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Comment1Snapshot+PieFed.swift
@@ -25,7 +25,10 @@ public extension Comment1Snapshot {
         self.updated = comment.updated
         self.distinguished = comment.distinguished ?? false
         self.languageId = comment.languageId
-        self.deleted = comment.deleted
+        
+        // If a post is removed, deleted is true for some reason
+        self.deleted = comment.removed ? false : comment.deleted
+        
         self.removed = comment.removed
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Post1Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Post1Snapshot+PieFed.swift
@@ -18,7 +18,10 @@ public extension Post1Snapshot {
         self.title = post.title
         self.content = post.body
         self.linkUrl = post.url
-        self.deleted = post.deleted
+        
+        // If a post is removed, deleted is true for some reason
+        self.deleted = post.removed ? false : post.deleted
+        
         self.embed = nil
         self.pinnedCommunity = post.sticky
         self.pinnedInstance = false

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/PostFeatureType+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/PostFeatureType+PieFed.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-07-20.
+//
+
+import Foundation
+
+extension PostFeatureType {
+    var piefedPostFeatureType: PieFedPostFeatureType {
+        switch self {
+        case .community: .community
+        case .instance: .local
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostFeatureType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostFeatureType.swift
@@ -16,11 +16,4 @@ public enum PostFeatureType {
         case .local: .instance
         }
     }
-    
-    var apiType: LemmyPostFeatureType {
-        switch self {
-        case .community: .community
-        case .instance: .local
-        }
-    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -251,7 +251,7 @@ public protocol InstanceConnection {
         removeContent: Bool,
         reason: String?,
         expires: Date?
-    ) async throws -> Person2Snapshot
+    ) async throws -> Person1Snapshot
     
     @discardableResult
     func banPersonFromInstance(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -38,7 +38,8 @@ public extension LemmyConnection {
         case .searchLocalCommunities, .viewInstanceSettings, .viewInstanceCreationDate, .modlog,
              .logIn, .signUp, .viewCommunityActiveUsers, .commentTreeSortedByDepth, .uploadImages,
              .editAccountSettings, .viewMentionsAndPrivateMessages, .viewReports, .editAndDeletePrivateMessages,
-             .reportPrivateMessages:
+             .reportPrivateMessages, .adminsCanViewVotes, .purgeContent, .removeCommunity, .banFromInstance,
+             .banFromCommunity, .editModeratorList:
             true
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
@@ -111,10 +111,14 @@ public extension LemmyConnection {
     }
     
     func resolve(url: URL) async throws -> ResolvedContent {
-        let response = try await performingForEndpoint { endpoint in
-            LemmyResolveObjectRequest(endpoint: endpoint, q: url.absoluteString)
+        do {
+            let response = try await performingForEndpoint { endpoint in
+                LemmyResolveObjectRequest(endpoint: endpoint, q: url.absoluteString)
+            }
+            return try .init(from: response)
+        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
+            throw ApiClientError.noEntityFound
         }
-        return try .init(from: response)
     }
     
     func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [Instance1Snapshot]) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
@@ -117,7 +117,7 @@ public extension LemmyConnection {
         removeContent: Bool,
         reason: String?,
         expires: Date? = nil
-    ) async throws -> Person2Snapshot {
+    ) async throws -> Person1Snapshot {
         let expiryTimestamp: Int?
         if let expires {
             expiryTimestamp = Int(expires.timeIntervalSince1970)
@@ -138,7 +138,7 @@ public extension LemmyConnection {
             )
         }
         guard response.banned == ban else { throw ApiClientError.unsuccessful }
-        return try .init(from: response.personView)
+        return try .init(from: response.personView.person)
     }
     
     @discardableResult

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
@@ -183,7 +183,9 @@ public extension PieFedConnection {
         remove: Bool,
         reason: String?
     ) async throws -> Comment2Snapshot {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedRemoveCommentRequest(commentId: id, removed: remove, reason: reason)
+        let response = try await perform(request)
+        return try .init(from: response.commentView)
     }
     
     @discardableResult

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Community.swift
@@ -100,6 +100,17 @@ public extension PieFedConnection {
         personId: Int,
         added: Bool
     ) async throws -> (moderators: [Person1Snapshot], community: Community1Snapshot) {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedAddModToCommunityRequest(communityId: communityId, personId: personId, added: added)
+        let response = try await perform(request)
+        let moderators: [Person1Snapshot] = try response.moderators.map { try .init(from: $0.moderator) }
+        
+        guard let first = response.moderators.first else {
+            throw ApiClientError.unsuccessful
+        }
+        let community: Community1Snapshot = try .init(from: first.community)
+        return (
+            moderators: moderators,
+            community: community
+        )
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
@@ -94,8 +94,28 @@ public extension PieFedConnection {
         removeContent: Bool,
         reason: String?,
         expires: Date? = nil
-    ) async throws -> Person2Snapshot {
-        throw ApiClientError.featureUnsupported
+    ) async throws -> Person1Snapshot {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX") // ensure consistent formatting
+        formatter.timeZone = TimeZone(secondsFromGMT: 0) // optional, adjust if needed
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        if ban {
+            let request = PieFedModerateCommunityBanRequest(
+                communityId: communityId,
+                userId: personId,
+                reason: reason ?? "",
+                expiredAt: formatter.string(from: expires ?? .distantFuture)
+            )
+            let response = try await perform(request)
+            return try .init(from: response.bannedUser)
+        } else {
+            let request = PieFedModerateCommunityUnBanRequest(
+                communityId: communityId,
+                userId: personId
+            )
+            let response = try await perform(request)
+            return try .init(from: response.bannedUser)
+        }
     }
     
     @discardableResult

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
@@ -96,8 +96,8 @@ public extension PieFedConnection {
         expires: Date? = nil
     ) async throws -> Person1Snapshot {
         let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX") // ensure consistent formatting
-        formatter.timeZone = TimeZone(secondsFromGMT: 0) // optional, adjust if needed
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         if ban {
             let request = PieFedModerateCommunityBanRequest(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
@@ -264,7 +264,9 @@ public extension PieFedConnection {
         remove: Bool,
         reason: String?
     ) async throws -> Post2Snapshot {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedRemovePostRequest(postId: id, removed: remove, reason: reason)
+        let response = try await perform(request)
+        return try .init(from: response.postView)
     }
     
     @discardableResult
@@ -273,12 +275,20 @@ public extension PieFedConnection {
         pin: Bool,
         to target: PostFeatureType
     ) async throws -> Post2Snapshot {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedFeaturePostRequest(
+            postId: id,
+            featured: pin,
+            featureType: target.piefedPostFeatureType
+        )
+        let response = try await perform(request)
+        return try .init(from: response.postView)
     }
     
     @discardableResult
     func lockPost(id: Int, lock: Bool) async throws -> Post2Snapshot {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedLockPostRequest(postId: id, locked: lock)
+        let response = try await perform(request)
+        return try .init(from: response.postView)
     }
     
     @discardableResult


### PR DESCRIPTION
> [!note]
> Relies on [this MlemApiTypes PR](https://github.com/mlemgroup/MlemApiTypes/pull/30)

Closes #2107

Implemented all of the moderator tools that are currently possible to implement:
- Remove (both post & comment)
- Pin
- Lock

The following moderator tools are not possible to implement at this time, or their API endpoints are currently broken. So, I've hidden them from the UI.

Broken APIs:
- Ban from community (#2160)
- Add/remove moderators (#2161)

Unsupported:
- Ban from instance (#2162)
- View votes (#2163)
- Purge content (#2164)
- Remove communities (#2165)

This PR also fixes a minor bug in which the six-month active user count would always show 0.