### PR TITLE
Improve mark read on scroll reliability

### DIFF
--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+MarkReadOnScroll.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+MarkReadOnScroll.swift
@@ -30,7 +30,7 @@ private struct MarkReadOnScroll: ViewModifier {
     func ios18Body(content: Content) -> some View {
         content
             .onGeometryChange(for: Bool.self) { geometry in
-                geometry.frame(in: .global).maxY < 100
+                geometry.frame(in: .global).maxY < 90
             } action: { wasAboveTop, isAboveTop in
                 if markReadOnScroll, !wasAboveTop, isAboveTop {
                     post.updateRead(true, shouldQueue: true)

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+MarkReadOnScroll.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+MarkReadOnScroll.swift
@@ -30,7 +30,7 @@ private struct MarkReadOnScroll: ViewModifier {
     func ios18Body(content: Content) -> some View {
         content
             .onGeometryChange(for: Bool.self) { geometry in
-                geometry.frame(in: .global).maxY < 0
+                geometry.frame(in: .global).maxY < 100
             } action: { wasAboveTop, isAboveTop in
                 if markReadOnScroll, !wasAboveTop, isAboveTop {
                     post.updateRead(true, shouldQueue: true)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2169 

## Description

Root cause was the incredibly tight `.onGeometryChange` threshold. There was so little margin between the post crossing the threshold and it being derendered altogether that posts would sometimes drop even when scrolling very slowly.

This fixes that for all sane use cases by increasing the threshold to 90px. This causes the post to be marked read as it's sliding away under the header bar--the state change is still hidden from the user but the added space significantly improves detection reliability. Posts can still drop when scrolling extremely fast, but I believe that behavior is far enough outside of the expected usage profile to not warrant a more sophisticated fix.