### PR TITLE
Short term tint fix

### DIFF
--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -65,7 +65,7 @@ struct ContentView: View {
                     shareInfo: .init(get: { navigationModel.shareInfo }, set: { navigationModel.shareInfo = $0 }),
                     contentPickerTracker: navigationModel.contentPickerTracker
                 )
-                .tint(.themedAccent)
+                .accentColor(ThemedColor.themedAccent.resolve(with: colorPalette.palette)) // deprecated, but .tint colors menu buttons
                 .palette(colorPalette.palette)
                 .environment(tabReselectTracker)
                 .environment(appState)

--- a/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
+++ b/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
@@ -6,8 +6,11 @@
 //
 
 import SwiftUI
+import Theming
 
 private struct NavigationSheetModifier: ViewModifier {
+    @Setting(\.appearance_palette) var colorPalette
+    
     let nextLayer: NavigationLayer?
     let contentPickerTracker_: () -> NavigationModel.ContentPickerTracker?
     let isTopSheet: Bool
@@ -82,6 +85,7 @@ private struct NavigationSheetModifier: ViewModifier {
                     }
                 }
             )
+            .accentColor(ThemedColor.themedAccent.resolve(with: colorPalette.palette)) // deprecated, but .tint colors menu buttons
     }
     
     var activityViewController: UIActivityViewController {

--- a/Mlem/App/Views/Shared/Palette Components/Form.swift
+++ b/Mlem/App/Views/Shared/Palette Components/Form.swift
@@ -20,9 +20,10 @@ struct Form<Content: View>: View {
             content()
                 .foregroundStyle(.themedPrimary)
                 .listRowBackground(palette.groupedBackground.secondary)
-                .tint(.themedAccent)
+                // .tint(.themedAccent)
                 .buttonStyle(PaletteButton())
         }
+        .tint(.themedAccent)
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
         .background(.themedGroupedBackground)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- progress towards #2016 

## Description

Not sure if this is a bug in SwiftUI or the intended behavior, but `.tint` colors the menu buttons when building with XCode 16.4. I don't love using the deprecated API here but it does work.
