### PR TITLE
PieFed: Edit & Delete Private messages

### DIFF
--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tevelee/SwiftUI-Flow",
       "state" : {
-        "revision" : "b528bd06ae70fbd2936d9561a456fb6ea65bc7ff",
-        "version" : "2.5.0"
+        "revision" : "c8e85a78385b221387efeca125ee51e36898873b",
+        "version" : "2.6.0"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tevelee/SwiftUI-Flow",
       "state" : {
-        "revision" : "c8e85a78385b221387efeca125ee51e36898873b",
-        "version" : "2.6.0"
+        "revision" : "b528bd06ae70fbd2936d9561a456fb6ea65bc7ff",
+        "version" : "2.5.0"
       }
     },
     {

--- a/Mlem/App/Utility/Extensions/Content Models/DeletableProviding+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/DeletableProviding+Extensions.swift
@@ -13,14 +13,24 @@ extension DeletableProviding {
             toggleDeleted { status in
                 switch status {
                 case .success:
-                    ToastModel.main.add(
-                        .undoable(
-                            "Deleted",
-                            icon: .general.delete,
-                            callback: { self.updateDeleted(false, callback: nil) },
-                            color: .themedNegative
+                    if self is any Message1Providing, !(self.api.supportsOrNil(.undeletePrivateMessages) ?? true) {
+                        ToastModel.main.add(
+                            .basic(
+                                "Deleted",
+                                icon: .general.delete,
+                                color: .themedNegative
+                            )
                         )
-                    )
+                    } else {
+                        ToastModel.main.add(
+                            .undoable(
+                                "Deleted",
+                                icon: .general.delete,
+                                callback: { self.updateDeleted(false, callback: nil) },
+                                color: .themedNegative
+                            )
+                        )
+                    }
                 case .failure:
                     ToastModel.main.add(.failure("Failed to delete post!"))
                 }

--- a/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
@@ -70,7 +70,9 @@ extension Message1Providing {
                 if let editCallback {
                     editAction(appState: appState, callback: editCallback)
                 }
-                deleteAction(appState: appState, feedback: feedback)
+                if (api.supportsOrNil(.undeletePrivateMessages) ?? true) || !deleted {
+                    deleteAction(appState: appState, feedback: feedback)
+                }
             }
         } else {
             if api.supportsOrNil(.reportPrivateMessages) ?? true {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -36,6 +36,7 @@ public enum Feature: Hashable {
     case viewMentionsAndPrivateMessages
     
     case editAndDeletePrivateMessages
+    case undeletePrivateMessages
     case reportPrivateMessages
     case purgeContent
     case removeCommunity

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Instance1Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Instance1Snapshot+PieFed.swift
@@ -20,7 +20,7 @@ public extension Instance1Snapshot {
         self.publicKey = ""
         
         self.displayName = site.name
-        self.description = site.sidebar
+        self.description = site.sidebarMd ?? site.sidebar
         self.shortDescription = site.description
         self.avatar = site.icon
         self.banner = nil

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Message1Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Message1Snapshot+PieFed.swift
@@ -18,6 +18,13 @@ public extension Message1Snapshot {
         self.content = message.content
         self.updated = message.updated
         self.read = message.read
-        self.deleted = message.deleted
+        
+        var deleted = message.deleted
+        // This is required on PieFed 1.1. It *should* no longer be necessary
+        // from PieFed 1.2 onwards. Check to be sure though
+        if message.content == "Message Deleted" {
+            deleted = true
+        }
+        self.deleted = deleted
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -39,7 +39,7 @@ public extension LemmyConnection {
              .logIn, .signUp, .viewCommunityActiveUsers, .commentTreeSortedByDepth, .uploadImages,
              .editAccountSettings, .viewMentionsAndPrivateMessages, .viewReports, .editAndDeletePrivateMessages,
              .reportPrivateMessages, .adminsCanViewVotes, .purgeContent, .removeCommunity, .banFromInstance,
-             .banFromCommunity, .editModeratorList, .commentSearch:
+             .banFromCommunity, .editModeratorList, .commentSearch, .undeletePrivateMessages:
             true
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
@@ -33,10 +33,8 @@ public extension PieFedConnection {
             version >= sort.minimumVersion
         case let .sortTimeRange(timeRange):
             version >= timeRange.minimumVersion
-        case .viewCommunityActiveUsers:
-            version >= .v1_0_1
-        case .viewMentionsAndPrivateMessages:
-            version >= .v1_0_1
+        case .viewCommunityActiveUsers, .viewMentionsAndPrivateMessages, .editAndDeletePrivateMessages:
+            version >= .v1_1_0
         default: false
         }
     }
@@ -44,7 +42,7 @@ public extension PieFedConnection {
 
 private extension SiteVersion {
     static let v1_0_0: Self = .init("1.0.0")
-    static let v1_0_1: Self = .init("1.0.1")
+    static let v1_1_0: Self = .init("1.1.0")
 }
 
 private extension PostSortType {
@@ -88,7 +86,7 @@ private extension SearchSortType {
 private extension SortTimeRange {
     var minimumVersion: SiteVersion {
         switch self {
-        case .allTime: .v1_0_1
+        case .allTime: .v1_1_0
         case let .limited(timeInterval): LegacySortTimeRangeLimit(timeInterval)?.minimumVersion ?? .infinity
         }
     }
@@ -97,7 +95,7 @@ private extension SortTimeRange {
 private extension LegacySortTimeRangeLimit {
     var minimumVersion: SiteVersion {
         switch self {
-        case .threeMonth, .sixMonth, .nineMonth, .year: .v1_0_1
+        case .threeMonth, .sixMonth, .nineMonth, .year: .v1_1_0
         default: .zero
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -121,7 +121,7 @@ public extension PieFedConnection {
     
     @discardableResult
     func deleteMessage(id: Int, delete: Bool) async throws -> Message2Snapshot {
-        let request = PieFedDeletePrivateMessageRequest(privateMessageId: id, deleted: delete)
+        let request = PieFedDeletePrivateMessageRequest(messageId: id, deleted: delete)
         let response = try await perform(request)
         return try .init(from: response.privateMessageView)
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -109,7 +109,9 @@ public extension PieFedConnection {
     
     @discardableResult
     func editMessage(id: Int, content: String) async throws -> Message2Snapshot {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedEditPrivateMessageRequest(privateMessageId: id, content: content)
+        let response = try await perform(request)
+        return try .init(from: response.privateMessageView)
     }
     
     @discardableResult
@@ -119,6 +121,8 @@ public extension PieFedConnection {
     
     @discardableResult
     func deleteMessage(id: Int, delete: Bool) async throws -> Message2Snapshot {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedDeletePrivateMessageRequest(privateMessageId: id, deleted: delete)
+        let response = try await perform(request)
+        return try .init(from: response.privateMessageView)
     }
 }


### PR DESCRIPTION
> [!note]
> Relies on [this MlemApiTypes PR](https://github.com/mlemgroup/MlemApiTypes/pull/32)

Closes #2151. Once a message is deleted it is not yet possible to undelete it.

Also fixed the PieFed `InstanceView` showing HTML in the about page (closes #2186)