### PR TITLE
Fix removing content crashing app

### DIFF
--- a/Mlem/App/Views/Pages/Editors/ContentRemovalEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/ContentRemovalEditorView.swift
@@ -71,12 +71,14 @@ struct ContentRemovalEditorView: View {
     
     func send() {
         target.toggleRemoved(reason: reason) { status in
-            switch status {
-            case .success:
-                hapticManager.play(haptic: .success, tier: .low)
-                dismiss()
-            case let .failure(error):
-                handleError(error)
+            Task { @MainActor in
+                switch status {
+                case .success:
+                    hapticManager.play(haptic: .success, tier: .low)
+                    dismiss()
+                case let .failure(error):
+                    handleError(error)
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #2217. It does send the removal request correctly, it just crashes afterward.

---------

This was a `@MainActor` issue. I've fixed the issue in this specific case. What do you think about changing MlemMiddleware to run the callback on the main actor? That would be a more general fix that would avoid similar issues cropping up in future.