### PR TITLE
Lemmy 1.0: Rearrange bridging system

### DIFF
--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -167,7 +167,7 @@ class PersistenceRepository {
     }
     
     func savePinnedSortTypes(_ value: Set<PostSortType>) async throws {
-        try await save(value.compactMap(\.legacyApiSortType), to: PersistencePath.pinnedSortTypes)
+        try await save(value.compactMap(\.v3ApiType), to: PersistencePath.pinnedSortTypes)
     }
     
     /// Saves the given user settings

--- a/Mlem/App/Views/Root/Tabs/Settings/SortingSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SortingSettingsView.swift
@@ -15,17 +15,17 @@ struct SortingSettingsView: View {
     
     var defaultPostSort: PostSortType {
         get { .init(legacyDefaultPostSort) }
-        nonmutating set { legacyDefaultPostSort = newValue.legacyApiSortType ?? .hot }
+        nonmutating set { legacyDefaultPostSort = newValue.v3ApiType ?? .hot }
     }
     
     var fallbackPostSort: PostSortType {
         get { .init(legacyFallbackPostSort) }
-        nonmutating set { legacyFallbackPostSort = newValue.legacyApiSortType ?? .hot }
+        nonmutating set { legacyFallbackPostSort = newValue.v3ApiType ?? .hot }
     }
     
     var defaultCommentSort: CommentSortType {
         get { .init(legacyDefaultCommentSort) }
-        nonmutating set { legacyDefaultCommentSort = newValue.apiSortType }
+        nonmutating set { legacyDefaultCommentSort = newValue.v3CommentApiType }
     }
     
     var body: some View {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/CommentSortType+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/CommentSortType+Lemmy.swift
@@ -19,7 +19,14 @@ public extension CommentSortType {
         }
     }
     
-    var apiSortType: LemmyCommentSortType {
+    func apiType(for endpoint: SiteVersion.EndpointVersion) throws(ApiClientError) -> SearchSortTypeBridge {
+        switch endpoint {
+        case .v3: .old(v3PostApiType)
+        case .v4: try .newOrUnsupported(v4SearchApiType)
+        }
+    }
+    
+    var v3CommentApiType: LemmyCommentSortType {
         switch self {
         case .new: .new
         case .old: .old
@@ -29,7 +36,7 @@ public extension CommentSortType {
         }
     }
     
-    var legacyApiSortType: LemmySortType {
+    var v3PostApiType: LemmySortType {
         switch self {
         case .new: .new
         case .old: .old
@@ -39,8 +46,7 @@ public extension CommentSortType {
         }
     }
     
-    /// Returns `nil` if the `CommentSortType` is a value that cannot be converted to an `LemmySearchSortType`.
-    var apiSearchSortType: LemmySearchSortType? {
+    var v4SearchApiType: LemmySearchSortType? {
         switch self {
         case .new: .new
         case .old: .old

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/PostSortType+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/PostSortType+Lemmy.swift
@@ -29,8 +29,21 @@ public extension PostSortType {
         }
     }
     
-    /// Returns `nil` if the `PostSortType` is a value that cannot be converted to an `LemmySortType`.
-    var legacyApiSortType: LemmySortType? {
+    func apiType(for endpoint: SiteVersion.EndpointVersion) throws(ApiClientError) -> SearchSortTypeBridge {
+        switch endpoint {
+        case .v3: try .oldOrUnsupported(v3ApiType)
+        case .v4: try .newOrUnsupported(v4SearchApiType)
+        }
+    }
+    
+    func apiType(for endpoint: SiteVersion.EndpointVersion) throws(ApiClientError) -> PostSortTypeBridge {
+        switch endpoint {
+        case .v3: try .oldOrUnsupported(v3ApiType)
+        case .v4: .new(v4PostApiType)
+        }
+    }
+
+    var v3ApiType: LemmySortType? {
         switch self {
         case .active: .active
         case .hot: .hot
@@ -44,7 +57,7 @@ public extension PostSortType {
         }
     }
     
-    var apiSortType: LemmyPostSortType {
+    var v4PostApiType: LemmyPostSortType {
         switch self {
         case .active: .active
         case .hot: .hot
@@ -58,8 +71,7 @@ public extension PostSortType {
         }
     }
     
-    /// Returns `nil` if the `PostSortType` is a value that cannot be converted to an `LemmySearchSortType`.
-    var apiSearchSortType: LemmySearchSortType? {
+    var v4SearchApiType: LemmySearchSortType? {
         switch self {
         case .new: .new
         case .old: .old

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/SearchSortType+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/SearchSortType+Lemmy.swift
@@ -23,8 +23,14 @@ extension SearchSortType {
         }
     }
     
-    /// Returns `nil` if the `SearchSortType` is a value that cannot be converted to an `LemmySortType`.
-    var legacyApiSortType: LemmySortType? {
+    func apiType(for endpoint: SiteVersion.EndpointVersion) throws(ApiClientError) -> SearchSortTypeBridge {
+        try switch endpoint {
+        case .v3: try .oldOrUnsupported(v3ApiType)
+        case .v4: try .newOrUnsupported(v4ApiType)
+        }
+    }
+    
+    private var v3ApiType: LemmySortType? {
         switch self {
         case .new: .new
         case .old: .old
@@ -32,8 +38,7 @@ extension SearchSortType {
         }
     }
     
-    /// Returns `nil` if the `SearchSortType` is a value that cannot be converted to an `LemmySearchSortType`.
-    var apiSortType: LemmySearchSortType? {
+    private var v4ApiType: LemmySearchSortType? {
         switch self {
         case .new: .new
         case .old: .old

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SearchSortTypeBridge.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SearchSortTypeBridge.swift
@@ -13,23 +13,50 @@ import Rest
 // The type of that property is manually overriden with this type, which
 // can then be converted into either of those two types.
 
-public struct SearchSortTypeBridge: Codable, Hashable, Sendable, URLQueryItemEncodable {
+public typealias ApiBridgeable = Codable & Hashable & RawRepresentable<String> & Sendable
+
+public enum ApiBridge<OldType: ApiBridgeable, NewType: ApiBridgeable>: Codable, Hashable, Sendable, URLQueryItemEncodable {
+    case old(OldType)
+    case new(NewType)
+    
     public typealias RawValue = String
     
-    let oldSortType: LemmySortType?
-    let newSortType: LemmySearchSortType?
+    var value: any ApiBridgeable {
+        switch self {
+        case let .old(old): old
+        case let .new(new): new
+        }
+    }
     
-    public init(oldSortType: LemmySortType?, newSortType: LemmySearchSortType?) {
-        self.oldSortType = oldSortType
-        self.newSortType = newSortType
+    public static func oldOrUnsupported(_ value: OldType?) throws(ApiClientError) -> Self {
+        if let value {
+            return .old(value)
+        } else {
+            throw .featureUnsupported
+        }
+    }
+
+    public static func newOrUnsupported(_ value: NewType?) throws(ApiClientError) -> Self {
+        if let value {
+            return .new(value)
+        } else {
+            throw .featureUnsupported
+        }
     }
 }
 
-public extension SearchSortTypeBridge {
+public extension ApiBridge {
     init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.oldSortType = try? container.decode(LemmySortType.self)
-        self.newSortType = try? container.decode(LemmySearchSortType.self)
+        if let new = try? container.decode(NewType.self) {
+            self = .new(new)
+            return
+        }
+        if let old = try? container.decode(OldType.self) {
+            self = .old(old)
+            return
+        }
+        throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported value type"))
     }
     
     func encode(to encoder: any Encoder) throws {
@@ -37,13 +64,9 @@ public extension SearchSortTypeBridge {
         try container.encode(encodeInQueryItemFormat())
     }
     
-    func encodeInQueryItemFormat() -> String? {
-        if let oldSortType {
-            return oldSortType.rawValue
-        } else if let newSortType {
-            return newSortType.rawValue
-        } else {
-            return nil
-        }
-    }
+    func encodeInQueryItemFormat() -> String? { value.rawValue }
 }
+
+public typealias SearchSortTypeBridge = ApiBridge<LemmySortType, LemmySearchSortType>
+public typealias PostSortTypeBridge = ApiBridge<LemmySortType, LemmyPostSortType>
+public typealias CommunitySortTypeBridge = ApiBridge<LemmySortType, LemmyCommunitySortType>

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Comment.swift
@@ -52,7 +52,7 @@ public extension LemmyConnection {
                 savedOnly: filter == .saved,
                 likedOnly: filter == .upvoted,
                 dislikedOnly: filter == .downvoted,
-                timeRangeSeconds: nil,
+                timeRangeSeconds: sort.timeRangeSeconds,
                 pageCursor: nil,
                 pageBack: nil
             )
@@ -83,7 +83,7 @@ public extension LemmyConnection {
                 savedOnly: filter == .saved,
                 likedOnly: filter == .upvoted,
                 dislikedOnly: filter == .downvoted,
-                timeRangeSeconds: nil,
+                timeRangeSeconds: sort.timeRangeSeconds,
                 pageCursor: nil,
                 pageBack: nil
             )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Comment.swift
@@ -41,7 +41,7 @@ public extension LemmyConnection {
             LemmyListCommentsRequest(
                 endpoint: endpoint,
                 type_: .all,
-                sort: sort.apiSortType,
+                sort: sort.v3CommentApiType,
                 maxDepth: maxDepth,
                 page: page,
                 limit: limit,
@@ -72,7 +72,7 @@ public extension LemmyConnection {
             LemmyListCommentsRequest(
                 endpoint: endpoint,
                 type_: .all,
-                sort: sort.apiSortType,
+                sort: sort.v3CommentApiType,
                 maxDepth: maxDepth,
                 page: page,
                 limit: limit,
@@ -108,8 +108,7 @@ public extension LemmyConnection {
             communityId: communityId,
             creatorId: creatorId,
             filter: filter,
-            legacySort: sort.legacyApiSortType,
-            sort: sort.apiSearchSortType,
+            createSortType: { try sort.apiType(for: $0) },
             timeRangeSeconds: sort.timeRangeSeconds
         )
     }
@@ -130,8 +129,7 @@ public extension LemmyConnection {
             communityId: communityId,
             creatorId: creatorId,
             filter: filter,
-            legacySort: sort.legacyApiSortType,
-            sort: sort.apiSortType,
+            createSortType: { try sort.apiType(for: $0) },
             timeRangeSeconds: sort.timeRangeSeconds
         )
     }
@@ -143,19 +141,18 @@ public extension LemmyConnection {
         communityId: Int?,
         creatorId: Int?,
         filter: ListingType,
-        legacySort: LemmySortType?,
-        sort: LemmySearchSortType?,
+        createSortType: @escaping (SiteVersion.EndpointVersion) throws -> SearchSortTypeBridge,
         timeRangeSeconds: Int?
     ) async throws -> [Comment2Snapshot] {
         let response = try await performingForEndpoint { endpoint in
-            LemmySearchRequest(
+            try LemmySearchRequest(
                 endpoint: endpoint,
                 q: query,
                 communityId: communityId,
                 communityName: nil,
                 creatorId: creatorId,
                 type_: .comments,
-                sort: .init(oldSortType: endpoint == .v3 ? legacySort : nil, newSortType: endpoint == .v4 ? sort : nil),
+                sort: createSortType(endpoint),
                 listingType: filter.apiType,
                 page: page,
                 limit: limit,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Community.swift
@@ -42,17 +42,14 @@ public extension LemmyConnection {
         sort: SearchSortType = .top(.allTime)
     ) async throws -> [Community2Snapshot] {
         let response = try await performingForEndpoint { endpoint in
-            LemmySearchRequest(
+            try LemmySearchRequest(
                 endpoint: endpoint,
                 q: query,
                 communityId: nil,
                 communityName: nil,
                 creatorId: nil,
                 type_: .communities,
-                sort: .init(
-                    oldSortType: endpoint == .v3 ? sort.legacyApiSortType : nil,
-                    newSortType: endpoint == .v4 ? sort.apiSortType : nil
-                ),
+                sort: sort.apiType(for: endpoint),
                 listingType: filter.apiType,
                 page: page,
                 limit: limit,
@@ -76,7 +73,7 @@ public extension LemmyConnection {
             LemmyListCommunitiesRequest(
                 endpoint: endpoint,
                 type_: .subscribed,
-                sort: nil,
+                sort: endpoint == .v4 ? .new(.nameAsc) : .old(.new),
                 showNsfw: true,
                 page: page,
                 limit: limit,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -16,7 +16,7 @@ public extension LemmyConnection {
     ) async throws -> [Reply2Snapshot] {
         let response = try await performingForEndpoint { _ in
             LemmyListRepliesRequest(
-                sort: sort.apiSortType,
+                sort: sort.v3CommentApiType,
                 page: page,
                 limit: limit,
                 unreadOnly: unreadOnly
@@ -33,7 +33,7 @@ public extension LemmyConnection {
     ) async throws -> [Reply2Snapshot] {
         let response = try await performingForEndpoint { _ in
             LemmyListMentionsRequest(
-                sort: sort.apiSortType,
+                sort: sort.v3CommentApiType,
                 page: page,
                 limit: limit,
                 unreadOnly: unreadOnly

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
@@ -72,17 +72,14 @@ public extension LemmyConnection {
         sort: SearchSortType = .top(.allTime)
     ) async throws -> [Person2Snapshot] {
         let response = try await performingForEndpoint { endpoint in
-            LemmySearchRequest(
+            try LemmySearchRequest(
                 endpoint: endpoint,
                 q: query,
                 communityId: nil,
                 communityName: nil,
                 creatorId: nil,
                 type_: .users,
-                sort: .init(
-                    oldSortType: endpoint == .v3 ? sort.legacyApiSortType : nil,
-                    newSortType: endpoint == .v4 ? sort.apiSortType : nil
-                ),
+                sort: sort.apiType(for: endpoint),
                 listingType: filter.apiType,
                 page: page,
                 limit: limit,
@@ -190,7 +187,7 @@ public extension LemmyConnection {
                 endpoint: endpoint,
                 personId: id,
                 username: nil,
-                sort: sort.legacyApiSortType,
+                sort: sort.v3ApiType,
                 page: page,
                 limit: limit,
                 communityId: nil,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
@@ -33,7 +33,7 @@ public extension LemmyConnection {
                 showHidden: showHidden,
                 showRead: nil,
                 showNsfw: nil,
-                timeRangeSeconds: nil,
+                timeRangeSeconds: sort.timeRangeSeconds,
                 multiCommunityId: nil,
                 hideMedia: nil,
                 markAsRead: nil,
@@ -72,7 +72,7 @@ public extension LemmyConnection {
                 showHidden: showHidden,
                 showRead: nil,
                 showNsfw: nil,
-                timeRangeSeconds: nil,
+                timeRangeSeconds: sort.timeRangeSeconds,
                 multiCommunityId: nil,
                 hideMedia: nil,
                 markAsRead: nil,
@@ -155,7 +155,7 @@ public extension LemmyConnection {
             creatorId: creatorId,
             filter: filter,
             createSortType: { try sort.apiType(for: $0) },
-            timeRangeSeconds: nil
+            timeRangeSeconds: sort.timeRangeSeconds
         )
     }
     
@@ -191,14 +191,14 @@ public extension LemmyConnection {
         timeRangeSeconds: Int?
     ) async throws -> [Post2Snapshot] {
         let response = try await performingForEndpoint { endpoint in
-            LemmySearchRequest(
+            try LemmySearchRequest(
                 endpoint: endpoint,
                 q: query,
                 communityId: communityId,
                 communityName: nil,
                 creatorId: creatorId,
                 type_: .posts,
-                sort: try createSortType(endpoint),
+                sort: createSortType(endpoint),
                 listingType: filter.apiType,
                 page: page,
                 limit: limit,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
@@ -18,10 +18,10 @@ public extension LemmyConnection {
         showHidden: Bool = false
     ) async throws -> (posts: [Post2Snapshot], cursor: String?) {
         let response = try await performingForEndpoint { endpoint in
-            LemmyListPostsRequest(
+            try LemmyListPostsRequest(
                 endpoint: endpoint,
                 type_: .all,
-                sort: sort.legacyApiSortType,
+                sort: sort.apiType(for: endpoint),
                 page: cursor == nil ? page : nil,
                 limit: limit,
                 communityId: communityId,
@@ -57,10 +57,10 @@ public extension LemmyConnection {
         showHidden: Bool = false
     ) async throws -> (posts: [Post2Snapshot], cursor: String?) {
         let response = try await performingForEndpoint { endpoint in
-            LemmyListPostsRequest(
+            try LemmyListPostsRequest(
                 endpoint: endpoint,
                 type_: feed.apiType,
-                sort: sort.legacyApiSortType,
+                sort: sort.apiType(for: endpoint),
                 page: cursor == nil ? page : nil,
                 limit: limit,
                 communityId: nil,
@@ -99,7 +99,7 @@ public extension LemmyConnection {
                 endpoint: endpoint,
                 personId: personId,
                 username: nil,
-                sort: sort.legacyApiSortType,
+                sort: sort.v3ApiType,
                 page: page,
                 limit: limit,
                 communityId: communityId,
@@ -154,8 +154,7 @@ public extension LemmyConnection {
             communityId: communityId,
             creatorId: creatorId,
             filter: filter,
-            legacySort: sort.legacyApiSortType,
-            sort: sort.apiSearchSortType,
+            createSortType: { try sort.apiType(for: $0) },
             timeRangeSeconds: nil
         )
     }
@@ -176,8 +175,7 @@ public extension LemmyConnection {
             communityId: communityId,
             creatorId: creatorId,
             filter: filter,
-            legacySort: sort.legacyApiSortType,
-            sort: sort.apiSortType,
+            createSortType: { try sort.apiType(for: $0) },
             timeRangeSeconds: sort.timeRangeSeconds
         )
     }
@@ -189,8 +187,7 @@ public extension LemmyConnection {
         communityId: Int?,
         creatorId: Int?,
         filter: ListingType,
-        legacySort: LemmySortType?,
-        sort: LemmySearchSortType?,
+        createSortType: @escaping (SiteVersion.EndpointVersion) throws -> SearchSortTypeBridge,
         timeRangeSeconds: Int?
     ) async throws -> [Post2Snapshot] {
         let response = try await performingForEndpoint { endpoint in
@@ -201,7 +198,7 @@ public extension LemmyConnection {
                 communityName: nil,
                 creatorId: creatorId,
                 type_: .posts,
-                sort: .init(oldSortType: endpoint == .v3 ? legacySort : nil, newSortType: endpoint == .v4 ? sort : nil),
+                sort: try createSortType(endpoint),
                 listingType: filter.apiType,
                 page: page,
                 limit: limit,


### PR DESCRIPTION
> [!note]
> Relies on [this MlemApiTypes PR](https://github.com/mlemgroup/MlemApiTypes/pull/33)

This PR refactors parts of the system that bridges between v3 and v4 sort types in the Lemmy API.

One effect of this is that sorting by "top" now works correctly on Lemmy 1.0.