### PR TITLE
Profile editor tweaks

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Settings/ProfileSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ProfileSettingsView.swift
@@ -213,8 +213,9 @@ private struct CircleImageUploadButton: View {
                 Button {
                     url = nil
                 } label: {
-                    Image(icon: .general.close)
+                    Image(icon: .general.delete)
                         .resizable()
+                        .symbolVariant(.circle.fill)
                 }
             } else {
                 switch imageManager.state {
@@ -225,14 +226,14 @@ private struct CircleImageUploadButton: View {
                     ImageUploadMenu(imageManager: imageManager, imageUploadApi: api) {
                         Image(icon: .general.add)
                             .resizable()
+                            .symbolVariant(.circle.fill)
                     }
                 }
             }
         }
-        .symbolVariant(.circle.fill)
         .aspectRatio(contentMode: .fit)
-        .frame(height: 48)
+        .frame(height: 36)
         .symbolRenderingMode(.hierarchical)
-        .fontWeight(.thin)
+        .fontWeight(.regular)
     }
 }

--- a/Mlem/Packages/Media/Sources/Media/Core/CoreMediaView.swift
+++ b/Mlem/Packages/Media/Sources/Media/Core/CoreMediaView.swift
@@ -41,7 +41,7 @@ public struct CoreMediaView: View {
                     )
             }
         }
-        .aspectRatio(aspectRatio, contentMode: .fit)
+        .aspectRatio(aspectRatio, contentMode: contentMode)
         .allowsHitTesting(false)
     }
     


### PR DESCRIPTION
Made some tweaks to the avatar and banner sections of the profile editor. The "remove upload" button now uses a `trash` icon rather than an `xmark` and is slightly smaller. I also fixed a bug where the banner image wouldn't fill the frame correctly