### PR TITLE
Localization fixes

### DIFF
--- a/Mlem/App/Views/Root/Login/Onboarding/OnboardingRecommendInstanceView.swift
+++ b/Mlem/App/Views/Root/Login/Onboarding/OnboardingRecommendInstanceView.swift
@@ -82,10 +82,10 @@ struct OnboardingRecommendInstanceView: View {
     
     func numberText(_ value: Int) -> Text {
         if colorScheme == .dark {
-            Text("\(value)")
+            Text(String(value))
                 .foregroundStyle(.teal.gradient.shadow(.drop(color: .blue, radius: 10)))
         } else {
-            Text("\(value)")
+            Text(String(value))
                 .foregroundStyle(lightModeForeground)
         }
     }

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetyBlurNsfwSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetyBlurNsfwSettingsView.swift
@@ -15,7 +15,7 @@ struct SafetyBlurNsfwSettingsView: View {
             headerView
             Picker("Blur NSFW Content", selection: $blurNsfw) {
                 ForEach(NsfwBlurBehavior.allCases, id: \.self) { type in
-                    Label(type.label.key, icon: type.icon)
+                    Label(String(localized: type.label), icon: type.icon)
                         .symbolVariant(.circle)
                 }
             }

--- a/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRow.swift
@@ -61,7 +61,7 @@ struct AccountListRow: View {
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if (account as? GuestAccount)?.isSaved ?? true {
-                Button(signOutLabel) {
+                Button(String(localized: signOutLabel)) {
                     showingSignOutConfirmation = true
                 }
                 .buttonStyle(.automatic)
@@ -90,8 +90,8 @@ struct AccountListRow: View {
             }
         }
         .labelStyle(.titleAndIcon) // Override `.conditional` label style from parent view
-        .confirmationDialog(signOutPrompt, isPresented: $showingSignOutConfirmation) {
-            Button(signOutLabel, role: .destructive) {
+        .confirmationDialog(String(localized: signOutPrompt), isPresented: $showingSignOutConfirmation) {
+            Button(String(localized: signOutLabel), role: .destructive) {
                 if navigation.isInsideSheet, appState.activeSessions.contains(where: { $0.account === account }) {
                     dismiss()
                 }
@@ -115,11 +115,11 @@ struct AccountListRow: View {
         }
     }
     
-    var signOutLabel: String {
+    var signOutLabel: LocalizedStringResource {
         account is UserAccount ? "Sign Out" : "Remove"
     }
     
-    var signOutPrompt: String {
+    var signOutPrompt: LocalizedStringResource {
         if account is UserAccount {
             "Really sign out of \(account.nickname)?"
         } else {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -5744,7 +5744,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PiedFed"
+            "value" : "PieFed"
           }
         }
       }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -417,16 +417,6 @@
         }
       }
     },
-    "%lld" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
-          }
-        }
-      }
-    },
     "%lld Crossposts..." : {
       "localizations" : {
         "en" : {


### PR DESCRIPTION
Fix a couple of places where localizations weren't applied properly:
- The "sign out" button in context menus in the account switcher
- The "blur NSFW" settings page

The strings were already translated, but weren't rendered properly.

Also changed "PiedFed" -> "PieFed" in French. The PieFed website refers to itself as "PieFed" in French.

These fixes were also applied in the patch PR: #2243