### PR TITLE
Refactor `RestClient` to avoid `ErrorType` generic argument

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
@@ -24,7 +24,7 @@ class ApiRepository {
     let username: String?
     private var connectionMultiplexer: ConnectionMultiplexer<ConnectionWrapper>!
     
-    var restClient: RestClient<ApiErrorResponse> = .init()
+    let restClient = RestClient(errorType: ApiErrorResponse.self)
     var token: String?
     
     var connection: (any InstanceConnection)? {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection.swift
@@ -11,7 +11,7 @@ import Rest
 public class LemmyConnection: InstanceConnection {
     public static let softwareType: SiteSoftwareType = .lemmy
     
-    let restClient = RestClient<ApiErrorResponse>()
+    let restClient = RestClient(errorType: ApiErrorResponse.self)
     
     enum LemmyConnectionError: Error {
         case invalidSession

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection.swift
@@ -11,7 +11,7 @@ import Rest
 public class PieFedConnection: InstanceConnection {
     public static let softwareType: SiteSoftwareType = .pieFed
     
-    let restClient = RestClient<ApiErrorResponse>()
+    let restClient = RestClient(errorType: ApiErrorResponse.self)
     
     enum PieFedConnectionError: Error {
         case invalidSession

--- a/Mlem/Packages/Rest/Package.swift
+++ b/Mlem/Packages/Rest/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
             dependencies: [],
             swiftSettings: [
                 .swiftLanguageMode(.v5),
+                .enableUpcomingFeature("FullTypedThrows"),
                 .enableUpcomingFeature("BareSlashRegexLiterals")
             ]
         )

--- a/Mlem/Packages/Rest/Sources/RestClient/RestClient.swift
+++ b/Mlem/Packages/Rest/Sources/RestClient/RestClient.swift
@@ -7,13 +7,36 @@
 
 import Foundation
 
-public class RestClient<ErrorType: Decodable & CustomStringConvertible> {
+public class RestClient {
+    public struct ErrorProcessorContext {
+        let decoder: JSONDecoder
+        let data: Data
+        let response: HTTPURLResponse
+    }
+
     private let decoder: JSONDecoder = .defaultDecoder
     
     // This should really be internal, but for now the image upload system needs to access this
     public let urlSession: URLSession = .init(configuration: .default)
+
+    public var errorProcessor: (ErrorProcessorContext) throws(RestError) -> Void
     
-    public init() {}
+    public init(errorProcessor: @escaping (ErrorProcessorContext) throws(RestError) -> Void = { _ in }) {
+        self.errorProcessor = errorProcessor
+    }
+
+    public init<ErrorType: Decodable & CustomStringConvertible>(errorType: ErrorType.Type) {
+        self.errorProcessor = { context throws(RestError) in
+            if let apiError = try? context.decoder.decode(ErrorType.self, from: context.data) {
+                // at present we have a single error model which appears to be used throughout
+                // the API, however we may way to consider adding the error model type as an
+                // associated value in the same was as the response to allow requests to define
+                // their own error models when necessary, or drop back to this as the default...
+                
+                throw .response(String(describing: apiError), statusCode: context.response.statusCode)
+            }
+        }
+    }
     
     public func perform<Request: RestRequest>(
         baseUrl: URL,
@@ -28,15 +51,14 @@ public class RestClient<ErrorType: Decodable & CustomStringConvertible> {
             if response.statusCode >= 500 || response.statusCode == 404 {
                 throw .serverError(statusCode: response.statusCode)
             }
-            
-            if let apiError = try? decoder.decode(ErrorType.self, from: data) {
-                // at present we have a single error model which appears to be used throughout
-                // the API, however we may way to consider adding the error model type as an
-                // associated value in the same was as the response to allow requests to define
-                // their own error models when necessary, or drop back to this as the default...
-                
-                throw .response(String(describing: apiError), statusCode: response.statusCode)
-            }
+
+            try errorProcessor(
+                .init(
+                    decoder: decoder,
+                    data: data,
+                    response: response
+                )
+            )
         }
         
         return try decode(Request.Response.self, from: data)


### PR DESCRIPTION
If `RestClient` is unable to decode the response of a request into the intended type, it attempts to decode it as an error type (`ApiErrorResponse`) instead. Previously, this error type was specified via a generic argument on `RestClient`, and the logic was hard-coded. In this PR, the logic is instead injected into the `RestClient`. So, `RestClient` doesn't need to be generic anymore.

This makes it easier to use `RestClient` in a context where we don't need to decode an error type at all. That scenario doesn't exist yet, but might do in future if we use `RestClient` for the Mlem backend, Fediseer, lemmy-status etc.