### PR TITLE
Basic iOS 26 account switcher implementation

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -527,6 +527,7 @@
 		CDE1F19C2C63E2EB008AF042 /* SettingPropertyWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE1F19B2C63E2EB008AF042 /* SettingPropertyWrapper.swift */; };
 		CDE1F19E2C63E306008AF042 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE1F19D2C63E306008AF042 /* Constants.swift */; };
 		CDE4AC472CA372B600981010 /* SDWebImageWebPCoder in Frameworks */ = {isa = PBXBuildFile; productRef = CDE4AC462CA372B600981010 /* SDWebImageWebPCoder */; };
+		CDE88C352E68938D00183AE5 /* View+AccountSwitcherGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE88C342E68938800183AE5 /* View+AccountSwitcherGesture.swift */; };
 		CDEE15522D22190600EB9D7B /* ErrorsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEE15512D22190000EB9D7B /* ErrorsTracker.swift */; };
 		CDEE15542D22364B00EB9D7B /* ErrorLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEE15532D22364500EB9D7B /* ErrorLogView.swift */; };
 		CDF8C1912D5D502400295CBA /* InteractionBarWidgetPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF8C1902D5D501E00295CBA /* InteractionBarWidgetPickerView.swift */; };
@@ -1062,6 +1063,7 @@
 		CDE1F1972C63DFC9008AF042 /* PadConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PadConstants.swift; sourceTree = "<group>"; };
 		CDE1F19B2C63E2EB008AF042 /* SettingPropertyWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingPropertyWrapper.swift; sourceTree = "<group>"; };
 		CDE1F19D2C63E306008AF042 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		CDE88C342E68938800183AE5 /* View+AccountSwitcherGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AccountSwitcherGesture.swift"; sourceTree = "<group>"; };
 		CDEE15512D22190000EB9D7B /* ErrorsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorsTracker.swift; sourceTree = "<group>"; };
 		CDEE15532D22364500EB9D7B /* ErrorLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorLogView.swift; sourceTree = "<group>"; };
 		CDF8C1902D5D501E00295CBA /* InteractionBarWidgetPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionBarWidgetPickerView.swift; sourceTree = "<group>"; };
@@ -2063,6 +2065,7 @@
 		CD4ED8482BF1112A00EFA0A2 /* View Modifiers */ = {
 			isa = PBXGroup;
 			children = (
+				CDE88C342E68938800183AE5 /* View+AccountSwitcherGesture.swift */,
 				CDB738282CB8A69D005B11BB /* View+PaletteBorder.swift */,
 				030EE3032D651A4100D58C2C /* View+Refreshable.swift */,
 				CD4ED8492BF1113800EFA0A2 /* View+TabReselectConsumer.swift */,
@@ -2647,6 +2650,7 @@
 				CD93420B2DCD069800945333 /* InstanceUptimeView+Logic.swift in Sources */,
 				CD1446212A5B328E00610EF1 /* Privacy Policy.swift in Sources */,
 				03AFD0E32C3C0C540054B8AD /* InstanceView.swift in Sources */,
+				CDE88C352E68938D00183AE5 /* View+AccountSwitcherGesture.swift in Sources */,
 				CDD4A09C2C8A122F0001AD1A /* Settings.swift in Sources */,
 				03AB906F2D418C200054D9E1 /* CommentJumpButtonSettingsView.swift in Sources */,
 				033819282D4424D9000AFC55 /* SafetyWarningsSettingsView.swift in Sources */,

--- a/Mlem/App/Globals/Definitions/TabReselectTracker.swift
+++ b/Mlem/App/Globals/Definitions/TabReselectTracker.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 @Observable
 class TabReselectTracker {
+    var blockTabSwitch: Bool = false
     private(set) var flag: Bool = false
 
     static var main: TabReselectTracker = .init()

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+AccountSwitcherGesture.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+AccountSwitcherGesture.swift
@@ -1,0 +1,53 @@
+//
+//  View+AccountSwitcherGesture.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2025-09-03.
+//
+
+import SwiftUI
+
+struct AccountSwitcherGesture: ViewModifier {
+    let tabReselectTracker: TabReselectTracker
+    let navigationModel: NavigationModel
+    
+    @GestureState private var dragGestureActive: Bool = false
+    @State var switcherOpened: Bool = false
+    @State var dragCompleted: Bool = false
+    
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .simultaneousGesture(DragGesture()
+                    .updating($dragGestureActive) { _, state, _ in
+                        state = true
+                    }
+                    .onChanged { value in
+                        if (UIScreen.main.bounds.height - value.startLocation.y) < 80,
+                           value.translation.height < -100,
+                           !switcherOpened {
+                            switcherOpened = true
+                            tabReselectTracker.blockTabSwitch = true
+                            navigationModel.openSheet(.quickSwitcher)
+                            
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                tabReselectTracker.blockTabSwitch = false
+                            }
+                        }
+                    })
+                .onChange(of: dragGestureActive) {
+                    if !dragGestureActive {
+                        switcherOpened = false
+                    }
+                }
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    func withAccountSwitcherGesture(tabReselectTracker: TabReselectTracker, navigationModel: NavigationModel) -> some View {
+        modifier(AccountSwitcherGesture(tabReselectTracker: tabReselectTracker, navigationModel: navigationModel))
+    }
+}

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+AccountSwitcherGesture.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+AccountSwitcherGesture.swift
@@ -16,7 +16,7 @@ struct AccountSwitcherGesture: ViewModifier {
     @State var dragCompleted: Bool = false
     
     func body(content: Content) -> some View {
-        if #available(iOS 26, *) {
+        if #available(iOS 26, *), !UIDevice.isPad {
             content
                 .simultaneousGesture(DragGesture()
                     .updating($dragGestureActive) { _, state, _ in

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -159,17 +159,7 @@ struct ContentView: View {
         ], onSwipeUp: {
             navigationModel.openSheet(.quickSwitcher)
         })
-        .simultaneousGesture(DragGesture()
-            .onChanged { value in
-                if (UIScreen.main.bounds.height - value.startLocation.y) < 80, value.translation.height < -100 {
-                    tabReselectTracker.blockTabSwitch = true
-                    navigationModel.openSheet(.quickSwitcher)
-                    
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        tabReselectTracker.blockTabSwitch = false
-                    }
-                }
-            })
+        .withAccountSwitcherGesture(tabReselectTracker: tabReselectTracker, navigationModel: navigationModel)
         .overlay(alignment: .bottom) {
             ToastOverlayView(
                 shouldDisplayNewToasts: shouldDisplayToasts,

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -164,11 +164,10 @@ struct ContentView: View {
                 if (UIScreen.main.bounds.height - value.startLocation.y) < 80, value.translation.height < -100 {
                     tabReselectTracker.blockTabSwitch = true
                     navigationModel.openSheet(.quickSwitcher)
-                }
-            }
-            .onEnded { _ in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    tabReselectTracker.blockTabSwitch = false
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        tabReselectTracker.blockTabSwitch = false
+                    }
                 }
             })
         .overlay(alignment: .bottom) {

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -159,6 +159,18 @@ struct ContentView: View {
         ], onSwipeUp: {
             navigationModel.openSheet(.quickSwitcher)
         })
+        .simultaneousGesture(DragGesture()
+            .onChanged { value in
+                if (UIScreen.main.bounds.height - value.startLocation.y) < 80, value.translation.height < -100 {
+                    tabReselectTracker.blockTabSwitch = true
+                    navigationModel.openSheet(.quickSwitcher)
+                }
+            }
+            .onEnded { _ in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    tabReselectTracker.blockTabSwitch = false
+                }
+            })
         .overlay(alignment: .bottom) {
             ToastOverlayView(
                 shouldDisplayNewToasts: shouldDisplayToasts,

--- a/Mlem/App/Views/Shared/CustomTabBarController.swift
+++ b/Mlem/App/Views/Shared/CustomTabBarController.swift
@@ -78,7 +78,6 @@ class CustomTabBarController: UITabBarController, UITabBarControllerDelegate {
     
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
         guard !TabReselectTracker.main.blockTabSwitch else {
-            print("DEBUG tab switch blocked")
             return false
         }
         

--- a/Mlem/App/Views/Shared/CustomTabBarController.swift
+++ b/Mlem/App/Views/Shared/CustomTabBarController.swift
@@ -77,6 +77,11 @@ class CustomTabBarController: UITabBarController, UITabBarControllerDelegate {
     }
     
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        guard !TabReselectTracker.main.blockTabSwitch else {
+            print("DEBUG tab switch blocked")
+            return false
+        }
+        
         TabReselectTracker.main.reset() // reset to prevent unconsumed actions from blocking the reselect flag
         if tabBarController.selectedViewController === viewController,
            let item = viewController as? CustomTabViewHostingController {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- progress towards #2198 

## Description

Simple implementation of an account switcher swipe gesture compatible with iOS 26. As discussed in Slack, this is a temporary workaround; a robust UIKit solution would likely perform better, but this restores the missing functionality without too much trouble. I've put almost all the logic in a view modifier so it can be easily removed later.