### PR TITLE
Circle-based Search Design

### DIFF
--- a/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
+++ b/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
@@ -97,6 +97,7 @@ struct SearchHomeView: View {
 
 private struct ListRowButton: View {
     @Environment(\.navigation) var navigation
+    @Environment(\.palette) var palette
     
     let title: LocalizedStringResource
     let icon: Icon
@@ -113,7 +114,7 @@ private struct ListRowButton: View {
                     .foregroundStyle(.white)
                     .symbolVariant(.fill)
                     .padding(20)
-                    .background(color.gradient, in: .circle)
+                    .background(color.gradient(palette: palette), in: .circle)
                     .frame(width: 80, height: 80)
                 Text(title)
                     .fontWeight(.semibold)

--- a/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
+++ b/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
@@ -25,6 +25,7 @@ struct SearchHomeView: View {
                 .padding(.top, 30)
                 .padding(.bottom, -4)
             browseList
+                .padding(.top, 20)
         }
         .padding(.horizontal, 16)
     }
@@ -44,26 +45,41 @@ struct SearchHomeView: View {
     
     @ViewBuilder
     var browseList: some View {
-        VStack(spacing: 16) {
+        HStack(alignment: .center, spacing: UIDevice.isPad ? 30 : 0) {
             ListRowButton(
                 title: "Communities",
                 icon: .lemmy.community,
-                destination: .topCommunities
+                destination: .topCommunities,
+                color: .green
             )
-            .tint(.themedCommunityAccent)
+            
+            if !UIDevice.isPad {
+                Spacer()
+            }
+            
             ListRowButton(
                 title: "Users",
                 icon: .lemmy.person,
-                destination: .topPeople
+                destination: .topPeople,
+                color: .blue
             )
-            .tint(.themedPersonAccent)
+            
+            if !UIDevice.isPad {
+                Spacer()
+            }
+            
             ListRowButton(
                 title: "Instances",
                 icon: .lemmy.instance,
-                destination: .topInstances
+                destination: .topInstances,
+                color: .red
             )
-            .tint(.themedColorfulAccent(1))
+            
+            if UIDevice.isPad {
+                Spacer()
+            }
         }
+        .padding(.horizontal, 20)
     }
     
     @ViewBuilder
@@ -85,23 +101,37 @@ private struct ListRowButton: View {
     let title: LocalizedStringResource
     let icon: Icon
     let destination: NavigationPage
+    let color: Color
     
     var body: some View {
         Button {
             navigation?.push(destination)
         } label: {
-            FormChevron {
-                HStack {
-                    Image(icon: icon)
-                        .symbolVariant(.fill)
-                        .foregroundStyle(.tint)
-                        .frame(minWidth: 30)
-                    Text(title)
-                }
+            VStack {
+                Image(icon: icon)
+                    .resizable()
+                    .foregroundStyle(.white)
+                    .symbolVariant(.fill)
+                    .scaledToFit()
+                    .padding(20)
+                    .background(color.gradient, in: .circle)
+                    .frame(width: 80, height: 80)
+                Text(title)
+                    .fontWeight(.semibold)
+                    .font(.subheadline)
             }
-            .padding(16)
-            .frame(maxWidth: .infinity)
-            .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 24))
+//            FormChevron {
+//                HStack {
+//                    Image(icon: icon)
+//                        .symbolVariant(.fill)
+//                        .foregroundStyle(.tint)
+//                        .frame(minWidth: 30)
+//                    Text(title)
+//                }
+//            }
+//            .padding(16)
+//            .frame(maxWidth: .infinity)
+//            .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 24))
         }
         .buttonStyle(.plain)
     }

--- a/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
+++ b/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
@@ -50,7 +50,7 @@ struct SearchHomeView: View {
                 title: "Communities",
                 icon: .lemmy.community,
                 destination: .topCommunities,
-                color: .green
+                color: .themedCommunityAccent
             )
             
             if !UIDevice.isPad {
@@ -61,7 +61,7 @@ struct SearchHomeView: View {
                 title: "Users",
                 icon: .lemmy.person,
                 destination: .topPeople,
-                color: .blue
+                color: .themedPersonAccent
             )
             
             if !UIDevice.isPad {
@@ -72,7 +72,7 @@ struct SearchHomeView: View {
                 title: "Instances",
                 icon: .lemmy.instance,
                 destination: .topInstances,
-                color: .red
+                color: .themedColorfulAccent(1)
             )
             
             if UIDevice.isPad {
@@ -101,7 +101,7 @@ private struct ListRowButton: View {
     let title: LocalizedStringResource
     let icon: Icon
     let destination: NavigationPage
-    let color: Color
+    let color: ThemedColor
     
     var body: some View {
         Button {
@@ -112,7 +112,6 @@ private struct ListRowButton: View {
                     .resizable()
                     .foregroundStyle(.white)
                     .symbolVariant(.fill)
-                    .scaledToFit()
                     .padding(20)
                     .background(color.gradient, in: .circle)
                     .frame(width: 80, height: 80)
@@ -120,18 +119,6 @@ private struct ListRowButton: View {
                     .fontWeight(.semibold)
                     .font(.subheadline)
             }
-//            FormChevron {
-//                HStack {
-//                    Image(icon: icon)
-//                        .symbolVariant(.fill)
-//                        .foregroundStyle(.tint)
-//                        .frame(minWidth: 30)
-//                    Text(title)
-//                }
-//            }
-//            .padding(16)
-//            .frame(maxWidth: .infinity)
-//            .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 24))
         }
         .buttonStyle(.plain)
     }

--- a/Mlem/Packages/Theming/Sources/Theming/ThemedColor.swift
+++ b/Mlem/Packages/Theming/Sources/Theming/ThemedColor.swift
@@ -9,18 +9,16 @@ import Foundation
 import SwiftUI
 
 public struct ThemedColor: ShapeStyle, Hashable, View, Sendable {
-    @Environment(\.palette) private var palette
-    
     fileprivate let hashString: String
     
     let getColor: @Sendable (Palette) -> Color
     var opacity: CGFloat = 1
     
-    public var body: some View {
+    public func body(palette: Palette) -> some View {
         resolve(with: palette)
     }
     
-    public var gradient: AnyGradient {
+    public func gradient(palette: Palette) -> AnyGradient {
         resolve(with: palette).gradient
     }
 

--- a/Mlem/Packages/Theming/Sources/Theming/ThemedColor.swift
+++ b/Mlem/Packages/Theming/Sources/Theming/ThemedColor.swift
@@ -19,6 +19,10 @@ public struct ThemedColor: ShapeStyle, Hashable, View, Sendable {
     public var body: some View {
         resolve(with: palette)
     }
+    
+    public var gradient: AnyGradient {
+        resolve(with: palette).gradient
+    }
 
     public func resolve(in environment: EnvironmentValues) -> Color {
         resolve(with: environment.palette)


### PR DESCRIPTION
Redesigns the search homepage to use circles, plus adds `.gradient` to `Theming`:

<img width="250" height="543" alt="image" src="https://github.com/user-attachments/assets/593d9df5-02d4-4ceb-8d9f-c07cb7f61685" />

Also includes a minor rework of `ThemedColor`, removing the `@Environment(\.palette)` declaration and replacing all instances (i.e., the unused `body` var) with functions that take in the palette instead. This is because the `@Environment` declaration in `ThemedColor` was never considered to be installed on a view, and therefore simply read the default value.