### PR TITLE
FeedLoadingState

### DIFF
--- a/Mlem/App/Views/Shared/EndOfFeedView.swift
+++ b/Mlem/App/Views/Shared/EndOfFeedView.swift
@@ -61,16 +61,21 @@ struct EndOfFeedView: View {
     
     @State var showLoadMore: Bool = false
     
-    let loadingState_: LoadingState?
+    let loadingState_: FeedLoadingState?
     let viewType: EndOfFeedViewType
     let feedLoader: (any FeedLoading)?
     
-    var loadingState: LoadingState {
+    var loadingState: FeedLoadingState {
         assert(loadingState_ != nil || feedLoader != nil, "either loadingState_ or feedLoader must be defined")
         return loadingState_ ?? feedLoader?.loadingState ?? .done
     }
     
+    @_disfavoredOverload
     init(loadingState: LoadingState, viewType: EndOfFeedViewType) {
+        self.init(loadingState: .init(from: loadingState), viewType: viewType)
+    }
+
+    init(loadingState: FeedLoadingState, viewType: EndOfFeedViewType) {
         self.loadingState_ = loadingState
         self.feedLoader = nil
         self.viewType = viewType
@@ -116,7 +121,7 @@ struct EndOfFeedView: View {
                         }
                     }
                 }
-            case .loading:
+            case .loading, .initial:
                 ProgressView()
             case .done:
                 HStack {

--- a/Mlem/App/Views/Shared/PersonContentGridView.swift
+++ b/Mlem/App/Views/Shared/PersonContentGridView.swift
@@ -32,7 +32,7 @@ struct PersonContentGridView: View {
         }
     }
     
-    var loadingState: LoadingState {
+    var loadingState: FeedLoadingState {
         switch contentType {
         case .all: feedLoader.loadingState
         case .posts: feedLoader.postLoadingState

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/CommentCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/CommentCaches.swift
@@ -28,7 +28,6 @@ class Comment1Cache: ApiTypeBackedCache<Comment1, Comment1Snapshot> {
     
     override func updateModel(_ item: Comment1, with snapshot: Comment1Snapshot, semaphore: UInt? = nil) {
         // TODO: UpdateQueue move updateModel responsibilities fully out of the cache
-        print("noop")
     }
 }
 
@@ -51,6 +50,5 @@ class Comment2Cache: ApiTypeBackedCache<Comment2, Comment2Snapshot> {
     
     override func updateModel(_ item: Comment2, with snapshot: Comment2Snapshot, semaphore: UInt? = nil) {
         // TODO: UpdateQueue move updateModel responsibilities fully out of the cache
-        print("noop")
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/PostCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/PostCaches.swift
@@ -35,7 +35,6 @@ class Post1Cache: ApiTypeBackedCache<Post1, Post1Snapshot> {
     
     override func updateModel(_ item: Post1, with snapshot: Post1Snapshot, semaphore: UInt? = nil) {
         // TODO: UpdateQueue move updateModel responsibilities fully out of the cache
-        print("noop")
     }
 }
 
@@ -60,7 +59,6 @@ class Post2Cache: ApiTypeBackedCache<Post2, Post2Snapshot> {
     
     override func updateModel(_ item: Post2, with snapshot: Post2Snapshot, semaphore: UInt? = nil) {
         // TODO: UpdateQueue move updateModel responsibilities fully out of the cache
-        print("noop")
     }
 }
 
@@ -76,6 +74,5 @@ class Post3Cache: ApiTypeBackedCache<Post3, Post3Snapshot> {
     
     override func updateModel(_ item: Post3, with snapshot: Post3Snapshot, semaphore: UInt? = nil) {
         // TODO: UpdateQueue move updateModel responsibilities fully out of the cache
-        print("noop")
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Report/ReportTarget.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Report/ReportTarget.swift
@@ -65,9 +65,9 @@ public enum ReportTarget {
         // TODO: UpdateQueue rework reports to integrate UpdateQueue
         switch (self, snapshot) {
         case (.post, .post):
-            print("noop") // print here to make the compiler happy
+            break
         case let (.comment(comment), .comment(updatedComment)):
-            print("noop") // print here to make the compiler happy
+            break
         case let (.message(message), .message(updatedMessage)):
             message.update(with: updatedMessage)
         default:

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoading.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoading.swift
@@ -11,7 +11,7 @@ public protocol FeedLoading<Item>: AnyObject {
     associatedtype Item: FeedLoadable
     
     var items: [Item] { get }
-    var loadingState: LoadingState { get }
+    var loadingState: FeedLoadingState { get }
     
     func loadMoreItems() async throws
     func loadIfThreshold(_ item: Item) throws

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoadingState.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoadingState.swift
@@ -13,3 +13,15 @@ import Foundation
 public enum LoadingState: Hashable {
     case idle, loading, done
 }
+
+public enum FeedLoadingState: Hashable {
+    case initial, idle, loading, done
+
+    public init(from loadingState: LoadingState) {
+        self = switch loadingState {
+        case .idle: .idle
+        case .loading: .loading
+        case .done: .done
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -12,7 +12,7 @@ import Semaphore
 @Observable
 public class StandardFeedLoader<Item: FeedLoadable>: FeedLoading {
     public internal(set) var items: [Item] = .init()
-    public internal(set) var loadingState: LoadingState = .loading
+    public internal(set) var loadingState: FeedLoadingState = .initial
     private(set) var thresholds: Thresholds<Item> = .init()
     
     let fetcher: Fetcher<Item>
@@ -27,7 +27,7 @@ public class StandardFeedLoader<Item: FeedLoadable>: FeedLoading {
     
     /// Updates the loading state
     @MainActor
-    func setLoading(_ newState: LoadingState) {
+    func setLoading(_ newState: FeedLoadingState) {
         loadingState = newState
         print("[\(Self.self)] set loading state to \(newState)")
     }
@@ -84,7 +84,7 @@ public class StandardFeedLoader<Item: FeedLoadable>: FeedLoading {
   
         try await loadingActor.load { response in
             var newItems: [Item]?
-            var newState: LoadingState
+            var newState: FeedLoadingState
             
             switch response {
             case let .success(items):

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
@@ -122,10 +122,10 @@ public class PersonContentFeedLoader: StandardFeedLoader<PersonContent> {
     
     // convenience accessors for child types
     public var posts: [PersonContent] { tempPostStream?.items ?? postStream.items }
-    public var postLoadingState: LoadingState { postStream.doneLoading ? .done : loadingState }
+    public var postLoadingState: FeedLoadingState { postStream.doneLoading ? .done : loadingState }
     
     public var comments: [PersonContent] { tempCommentStream?.items ?? commentStream.items }
-    public var commentLoadingState: LoadingState { commentStream.doneLoading ? .done : loadingState }
+    public var commentLoadingState: FeedLoadingState { commentStream.doneLoading ? .done : loadingState }
     
     public init(
         api: ApiClient,


### PR DESCRIPTION
Added a new type, `FeedLoadingState`, which is the same as `LoadingState` but has an extra case: `.initial`. We can't just add this case to `LoadingState` because `LoadingState` is used elsewhere.

No functional changes.