### PR TITLE
PieFed 1.2

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Person3Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Person3Snapshot+PieFed.swift
@@ -22,7 +22,7 @@ public extension Person3Snapshot {
         self.moderatedCommunities = moderatedCommunities
     }
     
-    init(from personDetails: PieFedGetPersonDetailsResponse) throws(ApiClientError) {
+    init(from personDetails: PieFedGetUserResponse) throws(ApiClientError) {
         self.person = try .init(from: personDetails.personView, allPropertiesPresent: true)
         
         if let site = personDetails.site {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/PersonalUnreadCountSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/PersonalUnreadCountSnapshot+PieFed.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public extension PersonalUnreadCountSnapshot {
-    init(from response: PieFedGetUnreadCountResponse) throws(ApiClientError) {
+    init(from response: PieFedUserUnreadCountsResponse) throws(ApiClientError) {
         self.replies = response.replies
         self.mentions = response.mentions
         self.messages = response.privateMessages

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
@@ -49,7 +49,8 @@ public extension PieFedConnection {
             parentId: nil,
             personId: nil,
             likedOnly: filter == .upvoted,
-            savedOnly: filter == .saved
+            savedOnly: filter == .saved,
+            depthFirst: false
         )
         let response = try await perform(request)
         return try response.comments.map { try .init(from: $0) }
@@ -77,7 +78,8 @@ public extension PieFedConnection {
             parentId: parentId,
             personId: nil,
             likedOnly: filter == .upvoted,
-            savedOnly: filter == .saved
+            savedOnly: filter == .saved,
+            depthFirst: false
         )
         let response = try await perform(request)
         return try response.comments.map { try .init(from: $0) }
@@ -124,7 +126,11 @@ public extension PieFedConnection {
     
     @discardableResult
     func voteOnComment(id: Int, score: ScoringOperation) async throws -> Comment2Snapshot {
-        let request = PieFedCreateCommentLikeRequest(commentId: id, score: score.rawValue)
+        let request = PieFedCreateCommentLikeRequest(
+            commentId: id,
+            score: score.rawValue,
+            private: false
+        )
         let response = try await perform(request)
         return try .init(from: response.commentView)
     }
@@ -149,7 +155,12 @@ public extension PieFedConnection {
         content: String,
         languageId: Int?
     ) async throws -> Comment2Snapshot {
-        let request = PieFedEditCommentRequest(commentId: id, body: content, languageId: languageId)
+        let request = PieFedEditCommentRequest(
+            commentId: id,
+            body: content,
+            languageId: languageId,
+            distinguished: false
+        )
         let response = try await perform(request)
         return try .init(from: response.commentView)
     }
@@ -172,7 +183,12 @@ public extension PieFedConnection {
     
     @discardableResult
     func reportComment(id: Int, reason: String) async throws -> ReportSnapshot {
-        let request = PieFedCreateCommentReportRequest(commentId: id, reason: reason)
+        let request = PieFedCreateCommentReportRequest(
+            commentId: id,
+            reason: reason,
+            description: nil,
+            reportRemote: nil
+        )
         let response = try await perform(request)
         return try .init(from: response.commentReportView)
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+General.swift
@@ -16,7 +16,7 @@ public extension PieFedConnection {
         if totpToken != nil {
             throw ApiClientError.featureUnsupported
         }
-        let request = PieFedLoginRequest(username: usernameOrEmail, password: password)
+        let request = PieFedUserLoginRequest(username: usernameOrEmail, password: password)
         let response = try await perform(request)
         guard let jwt = response.jwt else {
             throw ApiClientError.notLoggedIn

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
@@ -104,7 +104,9 @@ public extension PieFedConnection {
                 communityId: communityId,
                 userId: personId,
                 reason: reason ?? "",
-                expiredAt: formatter.string(from: expires ?? .distantFuture)
+                expiredAt: formatter.string(from: expires ?? .distantFuture),
+                expiresAt: expires,
+                permanent: expires == nil
             )
             let response = try await perform(request)
             return try .init(from: response.bannedUser)


### PR DESCRIPTION
> [!note]
> Relies on [this MlemApiTypes > PR](https://github.com/mlemgroup/MlemApiTypes/pull/34)

Updated to PieFed 1.2 API types. No functional changes - PieFed 1.2 hasn't broken anything (as far as I can tell); this is just adding the new API types.