### PR TITLE
disable mark read call when on piefed >= 1.1

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -39,11 +39,14 @@ public enum Feature: Hashable {
     case banFromInstance
     case banFromCommunity
     
-    // Add/remove moderators from a community
+    /// Add/remove moderators from a community
     case editModeratorList
     
     case commentTreeSortedByDepth
     case uploadImages
     case editAccountSettings
     case commentSearch
+    
+    /// Server automatically marks posts as read when voted on or saved
+    case autoMarkPostReadOnInteract
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -40,10 +40,8 @@ public extension LemmyConnection {
              .editAccountSettings, .viewMentionsAndPrivateMessages, .viewReports, .editAndDeletePrivateMessages,
              .reportPrivateMessages, .viewVotes, .purgeContent, .removeCommunity, .banFromInstance,
              .banFromCommunity, .editModeratorList, .commentSearch, .undeletePrivateMessages, .searchLocalPeople,
-             .hidePosts:
+             .hidePosts, .autoMarkPostReadOnInteract:
             true
-        default:
-            false
         }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -42,6 +42,8 @@ public extension LemmyConnection {
              .banFromCommunity, .editModeratorList, .commentSearch, .undeletePrivateMessages, .searchLocalPeople,
              .hidePosts:
             true
+        default:
+            false
         }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
@@ -35,7 +35,7 @@ public extension PieFedConnection {
             version >= timeRange.minimumVersion
         case let .listingType(listingType):
             listingType.pieFedListingType != nil
-        case .viewCommunityActiveUsers, .viewMentionsAndPrivateMessages, .editAndDeletePrivateMessages:
+        case .viewCommunityActiveUsers, .viewMentionsAndPrivateMessages, .editAndDeletePrivateMessages, .autoMarkPostReadOnInteract:
             version >= .v1_1_0
         default: false
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
@@ -162,16 +162,22 @@ public extension PieFedConnection {
     func voteOnPost(id: Int, score: ScoringOperation) async throws -> Post2Snapshot {
         let request = PieFedCreatePostLikeRequest(postId: id, score: score.rawValue)
         async let response = perform(request)
-        try await markPostAsRead(id: id, read: true)
-        return try await .init(from: response.postView, overrideRead: true)
+        if !supports(.autoMarkPostReadOnInteract, defaultValue: false) {
+            try await markPostAsRead(id: id, read: true)
+            return try await .init(from: response.postView, overrideRead: true)
+        }
+        return try await .init(from: response.postView)
     }
     
     @discardableResult
     func savePost(id: Int, save: Bool) async throws -> Post2Snapshot {
         let request = PieFedSavePostRequest(postId: id, save: save)
         async let response = try await perform(request)
-        try await markPostAsRead(id: id, read: true)
-        return try await .init(from: response.postView, overrideRead: true)
+        if !supports(.autoMarkPostReadOnInteract, defaultValue: false) {
+            try await markPostAsRead(id: id, read: true)
+            return try await .init(from: response.postView, overrideRead: true)
+        }
+        return try await .init(from: response.postView)
     }
     
     @discardableResult


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2183 

## Description

- Adds `.autoMarkPostReadOnInteract` to `Feature` and logic to indicate it is supported on PieFed 1.1 and up
- Updates `PieFedConnection` to only manually mark read if `.autoMarkPostReadOnInteract` is not supported