### PR TITLE
Disable editing on text selector (iOS 26)

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3398,8 +3398,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.3;
+				kind = revision;
+				revision = 9bedf1e79c7b7c34b35b74bef126f56d2400ef7f;
 			};
 		};
 		03FA318A2C6FEC5400D47FA3 /* XCRemoteSwiftPackageReference "SwiftUI-Flow" */ = {

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3398,8 +3398,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect";
 			requirement = {
-				kind = revision;
-				revision = 9bedf1e79c7b7c34b35b74bef126f56d2400ef7f;
+				kind = upToNextMajorVersion;
+				minimumVersion = "1.4.0-beta.4";
 			};
 		};
 		03FA318A2C6FEC5400D47FA3 /* XCRemoteSwiftPackageReference "SwiftUI-Flow" */ = {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
-        "revision" : "807f73ce09a9b9723f12385e592b4e0aaebd3336",
-        "version" : "1.3.0"
+        "revision" : "9bedf1e79c7b7c34b35b74bef126f56d2400ef7f"
       }
     },
     {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,7 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
-        "revision" : "9bedf1e79c7b7c34b35b74bef126f56d2400ef7f"
+        "revision" : "9bedf1e79c7b7c34b35b74bef126f56d2400ef7f",
+        "version" : "1.4.0-beta.4"
       }
     },
     {

--- a/Mlem/App/Views/Shared/SelectTextView.swift
+++ b/Mlem/App/Views/Shared/SelectTextView.swift
@@ -41,7 +41,7 @@ struct SelectTextView: View {
             }
             .padding(.horizontal, 10)
             TextEditor(text: .constant(text))
-                .introspect(.textEditor, on: .iOS(.v17, .v18)) { textEditor in
+                .introspect(.textEditor, on: .iOS(.v17, .v18, .v26)) { textEditor in
                     textEditor.isEditable = false
                     textEditor.textContainerInset = .init(top: 0, left: 10, bottom: 10, right: 10)
                     textEditor.backgroundColor = UIColor(palette.background.primary)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2207 

## Description

Updates introspect and adds `.v26` to the `SelectTextView`'s introspection.

Note that introspect does not yet have a released version compatible with iOS 26, so I have pointed it at [1.4.0-beta.4](https://github.com/siteline/swiftui-introspect/tags).