### PR TITLE
iOS 26 style toolbars

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3399,7 +3399,7 @@
 			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.3;
+				minimumVersion = "1.4.0-beta.4";
 			};
 		};
 		03FA318A2C6FEC5400D47FA3 /* XCRemoteSwiftPackageReference "SwiftUI-Flow" */ = {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
-        "revision" : "807f73ce09a9b9723f12385e592b4e0aaebd3336",
-        "version" : "1.3.0"
+        "revision" : "9bedf1e79c7b7c34b35b74bef126f56d2400ef7f",
+        "version" : "1.4.0-beta.4"
       }
     },
     {

--- a/Mlem/App/Views/Pages/Community/AdvancedSortView.swift
+++ b/Mlem/App/Views/Pages/Community/AdvancedSortView.swift
@@ -37,9 +37,7 @@ struct AdvancedSortView: View {
         .presentationBackground(.themedGroupedBackground)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                CloseButtonView()
-            }
+            CloseButtonToolbarItem()
 //            Intentionally left commented out!
 //
 //            ToolbarItem(placement: .principal) {

--- a/Mlem/App/Views/Pages/DeleteAccountView.swift
+++ b/Mlem/App/Views/Pages/DeleteAccountView.swift
@@ -5,6 +5,7 @@
 //  Created by Eric Andrews on 2024-08-19.
 //
 
+import ComponentViews
 import Dependencies
 import Foundation
 import MlemMiddleware
@@ -45,9 +46,7 @@ struct DeleteAccountView: View {
             
             deleteConfirmation
             
-            Button("Cancel") {
-                dismiss()
-            }
+            CloseButtonView(ios18Label: .cancel)
         }
         .multilineTextAlignment(.center)
         .padding(Constants.main.doubleSpacing)

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/CommentEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/CommentEditorView.swift
@@ -77,9 +77,7 @@ struct CommentEditorView: View {
                     .navigationBarTitleDisplayMode(.inline)
                     .toolbar {
                         ToolbarItem(placement: .topBarLeading) {
-                            Button("Cancel") {
-                                dismiss()
-                            }
+                            CloseButtonView(ios18Label: .cancel)
                         }
                         ToolbarItem(placement: .principal) {
                             if AccountsTracker.main.userAccounts.count > 1, commentToEdit == nil {
@@ -100,13 +98,7 @@ struct CommentEditorView: View {
                             if sending {
                                 ProgressView()
                             } else {
-                                Button("Send", icon: .lemmy.send) {
-                                    sending = true
-                                    Task(priority: .userInitiated) {
-                                        await send()
-                                    }
-                                }
-                                .disabled(resolutionState != .success || textIsEmpty || slurMatch != nil)
+                                sendButton
                             }
                         }
                     }
@@ -281,5 +273,17 @@ struct CommentEditorView: View {
             .frame(maxWidth: .infinity)
             .background(.opacity(0.2), in: .capsule)
             .foregroundStyle(.themedCaution)
+    }
+    
+    @ViewBuilder
+    var sendButton: some View {
+        Button("Send", icon: .lemmy.send) {
+            sending = true
+            Task(priority: .userInitiated) {
+                await send()
+            }
+        }
+        .disabled(resolutionState != .success || textIsEmpty || slurMatch != nil)
+        .glassProminentButtonStyle()
     }
 }

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Toolbar.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Toolbar.swift
@@ -5,15 +5,14 @@
 //  Created by Sjmarf on 02/09/2024.
 //
 
+import ComponentViews
 import SwiftUI
 
 extension PostEditorView {
     @ToolbarContentBuilder
     var toolbar: some ToolbarContent {
         ToolbarItem(placement: .topBarLeading) {
-            Button("Cancel") {
-                dismiss()
-            }
+            CloseButtonView(ios18Label: .cancel)
         }
         ToolbarItemGroup(placement: .topBarTrailing) {
             Menu("Add", icon: .general.add) {
@@ -33,12 +32,18 @@ extension PostEditorView {
             if self.sending {
                 ProgressView()
             } else {
-                Button("Send", icon: .lemmy.send) {
-                    self.sending = true
-                    Task { await submit() }
-                }
-                .disabled(!canSubmit)
+                sendButton
             }
         }
+    }
+    
+    @ViewBuilder
+    var sendButton: some View {
+        Button("Send", icon: .lemmy.send) {
+            self.sending = true
+            Task { await submit() }
+        }
+        .disabled(!canSubmit)
+        .glassProminentButtonStyle()
     }
 }

--- a/Mlem/App/Views/Pages/Editors/ContentPurgeEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/ContentPurgeEditorView.swift
@@ -57,14 +57,13 @@ struct ContentPurgeEditorView: View {
                 .navigationTitle("Purge")
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
-                        Button("Cancel") { dismiss() }
+                        CloseButtonView(ios18Label: .cancel)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button("Send", icon: .lemmy.send) {
-                            Task {
-                                await send()
-                            }
+                            Task { await send() }
                         }
+                        .glassProminentButtonStyle()
                     }
                 }
             }

--- a/Mlem/App/Views/Pages/Editors/ContentRemovalEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/ContentRemovalEditorView.swift
@@ -56,12 +56,13 @@ struct ContentRemovalEditorView: View {
                 .navigationTitle(mode == .restore ? "Restore" : "Remove")
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
-                        Button("Cancel") { dismiss() }
+                        CloseButtonView(ios18Label: .cancel)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button("Send", icon: .lemmy.send) {
                             send()
                         }
+                        .glassProminentButtonStyle()
                     }
                 }
             }

--- a/Mlem/App/Views/Pages/Editors/PersonBanEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/PersonBanEditorView.swift
@@ -97,16 +97,13 @@ struct PersonBanEditorView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
-                        Button("Cancel") {
-                            dismiss()
-                        }
+                        CloseButtonView(ios18Label: .cancel)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button("Send", icon: .lemmy.send) {
-                            Task {
-                                await send()
-                            }
+                            Task { await send() }
                         }
+                        .glassProminentButtonStyle()
                     }
                 }
             }

--- a/Mlem/App/Views/Pages/Editors/RegistrationApplicationDenialEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/RegistrationApplicationDenialEditorView.swift
@@ -32,14 +32,13 @@ struct RegistrationApplicationDenialEditorView: View {
                 .navigationTitle("Deny Application")
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
-                        Button("Cancel") { dismiss() }
+                        CloseButtonView(ios18Label: .cancel)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button("Send", icon: .lemmy.send) {
-                            Task {
-                                await send()
-                            }
+                            Task { await send() }
                         }
+                        .glassProminentButtonStyle()
                     }
                 }
             }

--- a/Mlem/App/Views/Pages/Editors/ReportEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/ReportEditorView.swift
@@ -54,7 +54,7 @@ struct ReportEditorView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
-                        Button("Cancel") { dismiss() }
+                        CloseButtonView(ios18Label: .cancel)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button("Send", icon: .lemmy.send) {
@@ -62,6 +62,7 @@ struct ReportEditorView: View {
                                 await send()
                             }
                         }
+                        .glassProminentButtonStyle()
                         .disabled(reason.isEmpty)
                     }
                 }

--- a/Mlem/App/Views/Pages/Instance/FediseerInfoView.swift
+++ b/Mlem/App/Views/Pages/Instance/FediseerInfoView.swift
@@ -41,7 +41,7 @@ struct FediseerInfoView: View {
             .frame(maxWidth: .infinity)
         }
         .toolbar {
-            CloseButtonView()
+            CloseButtonToolbarItem()
         }
     }
     

--- a/Mlem/App/Views/Root/Login/LoginCredentialsView.swift
+++ b/Mlem/App/Views/Root/Login/LoginCredentialsView.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 11/05/2024.
 //
 
+import ComponentViews
 import MlemMiddleware
 import SwiftUI
 import Theming
@@ -51,10 +52,8 @@ struct LoginCredentialsView: View {
             .toolbar {
                 if navigation.isInsideSheet, isRootView {
                     ToolbarItem(placement: .topBarLeading) {
-                        Button("Cancel") {
-                            dismiss()
-                        }
-                        .disabled(authenticating)
+                        CloseButtonView(ios18Label: .cancel)
+                            .disabled(authenticating)
                     }
                 }
             }

--- a/Mlem/App/Views/Root/Login/LoginInstancePickerView.swift
+++ b/Mlem/App/Views/Root/Login/LoginInstancePickerView.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 10/05/2024.
 //
 
+import ComponentViews
 import MlemMiddleware
 import SwiftUI
 import Theming
@@ -30,10 +31,8 @@ struct LoginInstancePickerView: View {
             .toolbar {
                 if navigation.isInsideSheet, isRootView {
                     ToolbarItem(placement: .topBarLeading) {
-                        Button("Cancel") {
-                            dismiss()
-                        }
-                        .disabled(connecting)
+                        CloseButtonView(ios18Label: .cancel)
+                            .disabled(connecting)
                     }
                 }
             }

--- a/Mlem/App/Views/Root/Login/SignUpView.swift
+++ b/Mlem/App/Views/Root/Login/SignUpView.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 05/09/2024.
 //
 
+import ComponentViews
 import MlemMiddleware
 import SwiftUI
 
@@ -95,7 +96,7 @@ struct SignUpView: View {
         .toolbar {
             if navigation.isInsideSheet, isRootView {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") {
+                    CloseButtonView(ios18Label: .cancel) {
                         navigation.dismissSheet()
                     }
                 }

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
@@ -120,14 +120,12 @@ extension InboxView {
     @ToolbarContentBuilder
     var toolbar: some ToolbarContent {
         ToolbarItem(placement: .topBarLeading) {
-            if UIDevice.isIos26 {
-                // This is a bit of a hack... the WWDC mentioned a `.glassProminent` button style
-                // that we should be using here, but it seems to be missing from the API
+            if #available(iOS 26, *) {
                 if showRead {
                     hideReadButton
                 } else {
                     hideReadButton
-                        .buttonStyle(.borderedProminent)
+                        .buttonStyle(.glassProminent)
                 }
             } else {
                 hideReadButton

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -34,9 +34,7 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
             }
         }
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                CloseButtonView()
-            }
+            CloseButtonToolbarItem()
         }
         .contentMargins(.top, 0)
     }

--- a/Mlem/App/Views/Root/Tabs/Settings/ProfileSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ProfileSettingsView.swift
@@ -181,8 +181,14 @@ struct ProfileSettingsView: View {
     
     @ViewBuilder
     var saveButtonView: some View {
-        Button("Save", icon: .general.success) {
+        Button {
             Task { @MainActor in await submit() }
+        } label: {
+            if #available(iOS 26, *) {
+                Label("Save", icon: .general.success)
+            } else {
+                Text("Save")
+            }
         }
         .glassProminentButtonStyle()
     }

--- a/Mlem/App/Views/Root/Tabs/Settings/ProfileSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ProfileSettingsView.swift
@@ -99,12 +99,18 @@ struct ProfileSettingsView: View {
         .toolbar {
             if showToolbarOptions {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") {
+                    Button {
                         displayName = person.displayName == person.name ? "" : person.displayName
                         bioTextView.text = person.description ?? ""
                         bioHasChanged = false
                         avatarUrl = person.avatar
                         bannerUrl = person.banner
+                    } label: {
+                        if #available(iOS 26, *) {
+                            Label("Discard", icon: .general.delete)
+                        } else {
+                            Text("Cancel")
+                        }
                     }
                     .disabled(isSubmitting)
                 }
@@ -112,17 +118,11 @@ struct ProfileSettingsView: View {
                     if isSubmitting {
                         ProgressView()
                     } else {
-                        Button("Save") {
-                            Task { @MainActor in
-                                await submit()
-                            }
-                        }
+                        saveButtonView
                     }
                 }
             } else if navigation.isInsideSheet {
-                ToolbarItem(placement: .topBarTrailing) {
-                    CloseButtonView()
-                }
+                CloseButtonToolbarItem()
             }
         }
     }
@@ -177,6 +177,14 @@ struct ProfileSettingsView: View {
             }
         }
         .listRowInsets(.init())
+    }
+    
+    @ViewBuilder
+    var saveButtonView: some View {
+        Button("Save", icon: .general.success) {
+            Task { @MainActor in await submit() }
+        }
+        .glassProminentButtonStyle()
     }
     
     @MainActor

--- a/Mlem/App/Views/Shared/Search/SearchBar/View+WithSheetSearch.swift
+++ b/Mlem/App/Views/Shared/Search/SearchBar/View+WithSheetSearch.swift
@@ -5,12 +5,11 @@
 //  Created by Sjmarf on 2025-08-22.
 //
 
+import ComponentViews
 import SwiftUI
 
 private struct SearchSheetViewModifier: ViewModifier {
     @Environment(NavigationLayer.self) var navigation
-    
-    let closeButtonLabel: LocalizedStringResource
     
     @Binding var query: String
     @FocusState var focused: Bool
@@ -24,10 +23,8 @@ private struct SearchSheetViewModifier: ViewModifier {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button(String(localized: closeButtonLabel)) {
-                    navigation.dismissSheet()
-                }
+            CloseButtonToolbarItem(ios18Label: .cancel) {
+                navigation.dismissSheet()
             }
         }
         .onAppear {
@@ -66,10 +63,7 @@ private struct SearchSheetViewModifier: ViewModifier {
 }
 
 extension View {
-    func withSheetSearch(
-        closeButtonLabel: LocalizedStringResource = "Cancel",
-        query: Binding<String>
-    ) -> some View {
-        modifier(SearchSheetViewModifier(closeButtonLabel: closeButtonLabel, query: query))
+    func withSheetSearch(query: Binding<String>) -> some View {
+        modifier(SearchSheetViewModifier(query: query))
     }
 }

--- a/Mlem/App/Views/Shared/Search/SearchSheetView.swift
+++ b/Mlem/App/Views/Shared/Search/SearchSheetView.swift
@@ -13,22 +13,9 @@ struct SearchSheetView<Item: Searchable, Content: View>: View {
     @Environment(AppState.self) var appState
     @Environment(NavigationLayer.self) var navigation
     
-    enum CloseButtonLabel {
-        case cancel
-        case done
-        
-        var label: LocalizedStringResource {
-            switch self {
-            case .cancel: "Cancel"
-            case .done: "Done"
-            }
-        }
-    }
-    
     @ViewBuilder let content: ([Item], NavigationLayer) -> Content
     let api: ApiClient
     let filter: ListingType
-    let closeButtonLabel: CloseButtonLabel
     
     @State var query: String = ""
     @State var results: [Item] = []
@@ -37,13 +24,11 @@ struct SearchSheetView<Item: Searchable, Content: View>: View {
     init(
         api: ApiClient? = nil,
         filter: ListingType? = nil,
-        closeButtonLabel: CloseButtonLabel = .cancel,
         @ViewBuilder content: @escaping ([Item], NavigationLayer) -> Content
     ) {
         self.api = api ?? AppState.main.firstApi
         self.filter = filter ?? .all
         self.content = content
-        self.closeButtonLabel = closeButtonLabel
     }
     
     var body: some View {
@@ -55,7 +40,7 @@ struct SearchSheetView<Item: Searchable, Content: View>: View {
         .background(.themedGroupedBackground)
         .presentationBackground(.themedGroupedBackground)
         .navigationBarTitleDisplayMode(.inline)
-        .withSheetSearch(closeButtonLabel: closeButtonLabel.label, query: $query)
+        .withSheetSearch(query: $query)
         .task(id: query, priority: .userInitiated) {
             do {
                 if !query.isEmpty {
@@ -83,12 +68,10 @@ extension SearchSheetView {
     init<RowContent: View>(
         api: ApiClient? = nil,
         filter: ListingType? = nil,
-        closeButtonLabel: CloseButtonLabel = .cancel,
         @ViewBuilder content: @escaping (Item, NavigationLayer) -> RowContent
     ) where Content == SearchResultsView<Item, RowContent> {
         self.api = api ?? AppState.main.firstApi
         self.filter = filter ?? .all
-        self.closeButtonLabel = closeButtonLabel
         self.content = { (results: [Item], navigation: NavigationLayer) in
             SearchResultsView(results: results) { item in
                 content(item, navigation)
@@ -99,13 +82,11 @@ extension SearchSheetView {
     init<RowContent: View, HeaderContent: View>(
         api: ApiClient? = nil,
         filter: ListingType? = nil,
-        closeButtonLabel: CloseButtonLabel = .cancel,
         @ViewBuilder content: @escaping (Item, NavigationLayer) -> RowContent,
         @ViewBuilder header: @escaping () -> HeaderContent
     ) where Content == VStack<TupleView<(HeaderContent, SearchResultsView<Item, RowContent>)>> {
         self.api = api ?? AppState.main.firstApi
         self.filter = filter ?? .all
-        self.closeButtonLabel = closeButtonLabel
         self.content = { (results: [Item], dismiss: NavigationLayer) in
             VStack(alignment: .leading, spacing: 0) {
                 header()

--- a/Mlem/App/Views/Shared/SelectTextView.swift
+++ b/Mlem/App/Views/Shared/SelectTextView.swift
@@ -19,38 +19,81 @@ struct SelectTextView: View {
     let text: String
     
     var body: some View {
+        Group {
+            if #available(iOS 26, *) {
+                ios26Body
+            } else {
+                ios18Body
+            }
+        }
+        .presentationDetents([.medium])
+        .presentationBackgroundInteraction(.enabled)
+    }
+    
+    @ViewBuilder
+    var ios18Body: some View {
         VStack(spacing: 10) {
             HStack {
                 Spacer()
-                Button {
-                    let pasteboard = UIPasteboard.general
-                    pasteboard.string = text
-                    hapticManager.play(haptic: .lightSuccess, tier: .high)
-                    dismiss()
-                } label: {
-                    Label("Copy All", icon: .general.copy)
-                        .symbolVariant(.fill)
-                        .font(.footnote)
-                        .fontWeight(.semibold)
-                }
-                .foregroundStyle(.white)
-                .frame(height: 30)
-                .padding(.horizontal, 12)
-                .background(Capsule().fill(.themedAccent))
+                copyButton
+                    .foregroundStyle(.white)
+                    .frame(height: 30)
+                    .padding(.horizontal, 12)
+                    .background(Capsule().fill(.themedAccent))
                 CloseButtonView()
             }
             .padding(.horizontal, 10)
-            TextEditor(text: .constant(text))
-                .introspect(.textEditor, on: .iOS(.v17, .v18)) { textEditor in
-                    textEditor.isEditable = false
-                    textEditor.textContainerInset = .init(top: 0, left: 10, bottom: 10, right: 10)
-                    textEditor.backgroundColor = UIColor(palette.background.primary)
-                }
+            textEditor(withBackground: true)
         }
         .padding(.top, 10)
-        .presentationDetents([.medium])
-        .presentationBackgroundInteraction(.enabled)
         .presentationCornerRadius(20)
         .background(.themedBackground)
+    }
+    
+    @available(iOS 26, *)
+    @ViewBuilder
+    var ios26Body: some View {
+        NavigationStack {
+            textEditor(withBackground: false)
+                .padding(.horizontal, 20)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        CloseButtonView()
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        copyButton
+                    }
+                }
+        }
+    }
+    
+    @ViewBuilder
+    func textEditor(withBackground: Bool) -> some View {
+        TextEditor(text: .constant(text))
+            .scrollContentBackground(.hidden)
+            .introspect(.textEditor, on: .iOS(.v17, .v18, .v26)) { textEditor in
+                textEditor.isEditable = false
+                textEditor.textContainerInset = .init(top: 0, left: 10, bottom: 10, right: 10)
+                if withBackground {
+                    textEditor.backgroundColor = UIColor(palette.background.primary)
+                } else {
+                    textEditor.backgroundColor = .clear
+                }
+            }
+    }
+    
+    @ViewBuilder
+    var copyButton: some View {
+        Button {
+            let pasteboard = UIPasteboard.general
+            pasteboard.string = text
+            hapticManager.play(haptic: .lightSuccess, tier: .high)
+            dismiss()
+        } label: {
+            Label("Copy All", icon: .general.copy)
+                .symbolVariant(.fill)
+                .font(.footnote)
+                .fontWeight(.semibold)
+        }
     }
 }

--- a/Mlem/App/Views/Shared/ShareInstancePickerView.swift
+++ b/Mlem/App/Views/Shared/ShareInstancePickerView.swift
@@ -23,7 +23,7 @@ struct ShareInstancePickerView: View {
                     .foregroundStyle(.themedSecondary)
                     .padding(.leading, 8)
                 Spacer()
-                CloseButtonView()
+                closeButton
             }
             VStack(spacing: 0) {
                 instanceTargetRow(entity.api.host, label: "My Instance", url: entity.url())
@@ -41,6 +41,25 @@ struct ShareInstancePickerView: View {
         .padding(16)
         .presentationBackground(.themedGroupedBackground)
         .presentationDetentFitsContent()
+    }
+    
+    @ViewBuilder
+    var closeButton: some View {
+        if #available(iOS 26, *) {
+            Button {
+                dismiss()
+            } label: {
+                Label("Close", icon: .general.close)
+                    .padding(10)
+                    .background(.themedSecondaryGroupedBackground, in: .circle)
+                    .foregroundStyle(.themedSecondary)
+            }
+            .labelStyle(.iconOnly)
+            .font(.title)
+            .buttonStyle(.plain)
+        } else {
+            CloseButtonView()
+        }
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Shared/Toast/ToastView.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastView.swift
@@ -139,6 +139,7 @@ struct ToastView: View {
     }
     
     @ViewBuilder
+    // swiftlint:disable:next function_body_length
     func errorView(_ details: ErrorDetails) -> some View {
         Button {
             if details.error != nil {
@@ -160,9 +161,15 @@ struct ToastView: View {
                         .frame(maxWidth: isExpanded ? .infinity : nil)
                     
                     if isExpanded {
-                        CloseButtonView(size: 28, callback: {
+                        Button("Close", icon: .general.close) {
                             toast.kill()
-                        })
+                        }
+                        .labelStyle(.iconOnly)
+                        .symbolVariant(.circle.fill)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.themedSecondary)
+                        .foregroundStyle(.secondary)
+                        .font(.title)
                         .padding(.trailing, 10)
                     }
                 }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -2890,6 +2890,9 @@
         }
       }
     },
+    "Discard" : {
+
+    },
     "Disclosure Group" : {
       "localizations" : {
         "fr" : {

--- a/Mlem/Packages/ComponentViews/Sources/ComponentViews/CloseButtonToolbarItem.swift
+++ b/Mlem/Packages/ComponentViews/Sources/ComponentViews/CloseButtonToolbarItem.swift
@@ -1,0 +1,35 @@
+//
+//  File.swift
+//  ComponentViews
+//
+//  Created by Sjmarf on 2025-09-11.
+//
+
+import SwiftUI
+
+public struct CloseButtonToolbarItem: ToolbarContent {
+    var ios18Label: CloseButtonView.LabelType
+    var callback: (() -> Void)?
+    
+    public init(
+        ios18Label: CloseButtonView.LabelType = .xmark,
+        callback: (() -> Void)? = nil
+    ) {
+        self.ios18Label = ios18Label
+        self.callback = callback
+    }
+    
+    public var body: some ToolbarContent {
+        ToolbarItem(placement: placement) {
+            CloseButtonView(ios18Label: ios18Label, callback: callback)
+        }
+    }
+    
+    var placement: ToolbarItemPlacement {
+        if #available(iOS 26, *) {
+            return .topBarLeading
+        } else {
+            return .topBarTrailing
+        }
+    }
+}

--- a/Mlem/Packages/ComponentViews/Sources/ComponentViews/CloseButtonView.swift
+++ b/Mlem/Packages/ComponentViews/Sources/ComponentViews/CloseButtonView.swift
@@ -16,50 +16,49 @@ public struct CloseButtonView: View {
         case cancel, xmark
     }
     
-    var size: CGFloat = 30
     var ios18Label: LabelType
     var callback: (() -> Void)?
     
     public init(
-        size: CGFloat = 30,
         ios18Label: LabelType = .xmark,
         callback: (() -> Void)? = nil
     ) {
-        self.size = size
         self.ios18Label = ios18Label
         self.callback = callback
     }
     
     public var body: some View {
-        Button {
-            if let callback {
-                callback()
-            } else {
-                dismiss()
-            }
-        } label: {
-            if #available(iOS 26, *) {
-                Image(systemName: "xmark")
-            } else {
-                ios18LabelView
-            }
+        if #available(iOS 26, *) {
+            Button("Dismiss", systemImage: "xmark", action: submit)
+        } else {
+            ios18Body
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Dismiss")
     }
     
     @ViewBuilder
-    private var ios18LabelView: some View {
+    private var ios18Body: some View {
         switch ios18Label {
         case .cancel:
-            Text("Cancel")
+            Button("Cancel", action: submit)
         case .xmark:
-            Image(systemName: "xmark.circle.fill")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(height: size)
-                .symbolRenderingMode(.palette)
-                .foregroundStyle(.themedSecondary, .themedSecondary.opacity(0.2))
+            Button(action: submit) {
+                Image(systemName: "xmark.circle.fill")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 30)
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.themedSecondary, .themedSecondary.opacity(0.2))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
+        }
+    }
+    
+    func submit() {
+        if let callback {
+            callback()
+        } else {
+            dismiss()
         }
     }
 }

--- a/Mlem/Packages/ComponentViews/Sources/ComponentViews/CloseButtonView.swift
+++ b/Mlem/Packages/ComponentViews/Sources/ComponentViews/CloseButtonView.swift
@@ -12,11 +12,21 @@ import Theming
 public struct CloseButtonView: View {
     @Environment(\.dismiss) var dismiss
     
+    public enum LabelType {
+        case cancel, xmark
+    }
+    
     var size: CGFloat = 30
+    var ios18Label: LabelType
     var callback: (() -> Void)?
     
-    public init(size: CGFloat = 30, callback: (() -> Void)? = nil) {
+    public init(
+        size: CGFloat = 30,
+        ios18Label: LabelType = .xmark,
+        callback: (() -> Void)? = nil
+    ) {
         self.size = size
+        self.ios18Label = ios18Label
         self.callback = callback
     }
     
@@ -28,6 +38,22 @@ public struct CloseButtonView: View {
                 dismiss()
             }
         } label: {
+            if #available(iOS 26, *) {
+                Image(systemName: "xmark")
+            } else {
+                ios18LabelView
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Dismiss")
+    }
+    
+    @ViewBuilder
+    private var ios18LabelView: some View {
+        switch ios18Label {
+        case .cancel:
+            Text("Cancel")
+        case .xmark:
             Image(systemName: "xmark.circle.fill")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
@@ -35,7 +61,5 @@ public struct CloseButtonView: View {
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(.themedSecondary, .themedSecondary.opacity(0.2))
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Dismiss")
     }
 }

--- a/Mlem/Packages/ComponentViews/Sources/ComponentViews/View+GlassProminentButtonStyle.swift
+++ b/Mlem/Packages/ComponentViews/Sources/ComponentViews/View+GlassProminentButtonStyle.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//  ComponentViews
+//
+//  Created by Sjmarf on 2025-09-11.
+//
+
+import SwiftUI
+
+public extension View {
+    @ViewBuilder
+    func glassProminentButtonStyle() -> some View {
+        if #available(iOS 26, *) {
+            buttonStyle(.glassProminent)
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2261

- Close buttons are now on the left where possible (on iOS 26 only)
- Toolbar actions associated with confirming something now have a prominent (blue) background
- We now use icons rather than text for toolbar button labels
- Redesigned the "select text" sheet a little:

<img width=30% alt="IMG_2033" src="https://github.com/user-attachments/assets/f32e1467-177b-44cb-9307-e7cd7792e06c" />
