### PR TITLE
Remove "swipe anywhere to navigate" setting on iOS 26

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -71,19 +71,21 @@ struct GeneralSettingsView: View {
                         }
                     )
                 )
-                Toggle(
-                    "Swipe Anywhere to Navigate",
-                    icon: .settings.swipeAnywhere,
-                    isOn: .init(
-                        get: { swipeAnywhereToNavigate },
-                        set: {
-                            swipeAnywhereToNavigate = $0
-                            if $0 {
-                                swipeActionsEnabled = false
+                if !UIDevice.isIos26 {
+                    Toggle(
+                        "Swipe Anywhere to Navigate",
+                        icon: .settings.swipeAnywhere,
+                        isOn: .init(
+                            get: { swipeAnywhereToNavigate },
+                            set: {
+                                swipeAnywhereToNavigate = $0
+                                if $0 {
+                                    swipeActionsEnabled = false
+                                }
                             }
-                        }
+                        )
                     )
-                )
+                }
             }
             
             Section {

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
@@ -97,7 +97,7 @@ private class FullWidthGestureRecognizerDelegate: NSObject, UIGestureRecognizerD
     var navigationController: UINavigationController?
 
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        if !Settings.get(\.navigation_swipeAnywhere) { return false }
+        guard Settings.get(\.navigation_swipeAnywhere), !UIDevice.isIos26 else { return false }
         let isSystemSwipeToBackEnabled = navigationController?.interactivePopGestureRecognizer?.isEnabled == true
         let isThereStackedViewControllers = (navigationController?.viewControllers.count ?? 0) > 1
         return isSystemSwipeToBackEnabled && isThereStackedViewControllers


### PR DESCRIPTION
Closes #2196