### PR TITLE
Visit history fixes

### DIFF
--- a/Mlem/App/Globals/Definitions/AccountsTracker.swift
+++ b/Mlem/App/Globals/Definitions/AccountsTracker.swift
@@ -99,8 +99,9 @@ class AccountsTracker {
         AppState.main.deactivate(account: account)
         do {
             try PersistenceRepository.liveValue.deleteAccountSettings(for: account)
+            try PersistenceRepository.liveValue.deleteVisitHistory(for: account)
         } catch {
-            handleError(error)
+            handleError(error, silent: true)
         }
         GuestAccountCache.main.clean()
     }

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -121,6 +121,10 @@ class PersistenceRepository {
         try FileManager.default.removeItem(at: PersistencePath.accountSettingsDirectory(for: account))
     }
     
+    func deleteVisitHistory(for account: any Account) throws {
+        try FileManager.default.removeItem(at: PersistencePath.visitHistory(for: account))
+    }
+    
     func loadUserAccounts() -> [UserAccount] {
         load([UserAccount].self, from: PersistencePath.userAccounts) ?? []
     }

--- a/Mlem/App/Models/Session/UserSession.swift
+++ b/Mlem/App/Models/Session/UserSession.swift
@@ -68,6 +68,7 @@ class UserSession: Session {
                     self.visitHistory = try await PersistenceRepository.liveValue.loadVisitHistory(for: account)
                 } catch {
                     self.visitHistory = .init()
+                    try? await saveVisitHistory()
                     handleError(error, silent: true)
                 }
             }


### PR DESCRIPTION
If the visit history fails to decode, it'll now reset the visit history and write that to the disk. This will stop the error from appearing next time the user switches to that account. The error will still be shown the first time the user switches to an account where the visit history fails to decode.

When you log out, the visit history file will now be deleted.

Maybe closes #2254. But it's more of a patch over the actual problem.