### PR TITLE
fix double switcher behavior

### DIFF
--- a/Mlem/App/Views/Shared/CustomTabBarController.swift
+++ b/Mlem/App/Views/Shared/CustomTabBarController.swift
@@ -72,8 +72,9 @@ class CustomTabBarController: UITabBarController, UITabBarControllerDelegate {
     }
     
     @objc func swipeGestureTriggered(_ recognizer: UISwipeGestureRecognizer) {
-        print("DEBUG swipe gesture triggered")
-        swipeGestureCallback()
+        if !UIDevice.isIos26 {
+            swipeGestureCallback()
+        }
     }
     
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -6191,6 +6191,9 @@
         }
       }
     },
+    "Read %lld posts" : {
+
+    },
     "Read Indicator" : {
       "localizations" : {
         "fr" : {


### PR DESCRIPTION
Fixes an issue where the account switcher would open twice if the swipe up gesture was held when running on iOS 18