### PR TITLE
Fix SwiftUI previews

### DIFF
--- a/Mlem/App/Utility/Extensions/Views/PreviewModifier+SampleEnvironment.swift
+++ b/Mlem/App/Utility/Extensions/Views/PreviewModifier+SampleEnvironment.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 2025-02-02.
 //
 
+import Haptics
 import MlemMiddleware
 import SwiftUI
 
@@ -25,6 +26,8 @@ import SwiftUI
                 .environment(Mlem.AppState.mock(api: api))
                 .environment(FiltersTracker.main)
                 .environment(TabReselectTracker.main)
+                .environment(BackendClient.main)
+                .environment(HapticManager.main)
         }
     }
 

--- a/Mlem/App/Views/Root/ContentView+Tab.swift
+++ b/Mlem/App/Views/Root/ContentView+Tab.swift
@@ -43,7 +43,7 @@ extension ContentView {
             switch self {
             case .feeds: .lemmy.feed
             case .inbox: .lemmy.inbox
-            case .profile: .init("person.circle")
+            case .profile: .lemmy.personAvatar
             case .search: .general.search
             case .settings: .general.settings
             }


### PR DESCRIPTION
Previews were crashing, this fixes it.

Previews also currently return real data rather than mocked data as they should do - I'll fix this another time.