### PR TITLE
Gradients

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Header/FeedIconView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Header/FeedIconView.swift
@@ -21,7 +21,7 @@ struct FeedIconView: View {
     
     var body: some View {
         Circle()
-            .fill(feedDescription.color)
+            .fill(feedDescription.color.gradient)
             .frame(width: size, height: size)
             .overlay {
                 Image(icon: feedDescription.icon)

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Header/FeedIconView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Header/FeedIconView.swift
@@ -9,6 +9,8 @@ import Foundation
 import SwiftUI
 
 struct FeedIconView: View {
+    @Environment(\.palette) var palette
+    
     let feedDescription: FeedDescription
     let size: CGFloat
     let scaledSize: CGFloat
@@ -21,7 +23,7 @@ struct FeedIconView: View {
     
     var body: some View {
         Circle()
-            .fill(feedDescription.color.gradient)
+            .fill(feedDescription.color.gradient(palette: palette))
             .frame(width: size, height: size)
             .overlay {
                 Image(icon: feedDescription.icon)

--- a/Mlem/App/Views/Root/Tabs/Settings/AboutMlemView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AboutMlemView.swift
@@ -7,6 +7,7 @@
 
 import ComponentViews
 import SwiftUI
+import Theming
 
 struct AboutMlemView: View {
     @Environment(\.palette) var palette
@@ -25,30 +26,30 @@ struct AboutMlemView: View {
                     FormChevron { Label("Website", icon: .general.website) }
                         .foregroundStyle(.themedPrimary)
                 }
-                .tint(.themedColorfulAccent(2))
+                .tint(ThemedColor.themedColorfulAccent(2).gradient)
                 Link(destination: URL(string: "https://lemmy.ml/c/mlemapp")!) {
                     FormChevron { Label("Lemmy Community", icon: .lemmy.community) }
                         .foregroundStyle(.themedPrimary)
                 }
-                .tint(.themedColorfulAccent(3))
+                .tint(ThemedColor.themedColorfulAccent(3).gradient)
                 Link(destination: URL(string: "https://matrix.to/#/#mlemappspace:matrix.org")!) {
                     FormChevron { Label("Matrix Room", image: "matrix.logo") }
                         .foregroundStyle(.themedPrimary)
                 }
-                .tint(.black) // non-palette because white tint turns this into white square
+                .tint(Color.black.gradient) // not ThemedColor because white tint turns this into white square
                 Link(destination: URL(string: "https://github.com/mlemgroup/mlem")!) {
                     FormChevron { Label("GitHub Repository", image: "github.logo") }
                         .foregroundStyle(.themedPrimary)
                 }
-                .tint(.black) // non-palette because white tint turns this into white square
+                .tint(Color.black.gradient) // not ThemedColor because white tint turns this into white square
             }
             Section {
                 NavigationLink("Privacy Policy", icon: .settings.privacy, destination: .settings(.document(.privacyPolicy)))
-                    .tint(.themedColorfulAccent(2))
+                    .tint(ThemedColor.themedColorfulAccent(2).gradient)
                 NavigationLink("EULA", icon: .settings.eula, destination: .settings(.document(.eula)))
-                    .tint(.themedColorfulAccent(0))
+                    .tint(ThemedColor.themedColorfulAccent(0).gradient)
                 NavigationLink("Licenses", icon: .settings.licence, destination: .settings(.licences))
-                    .tint(.themedColorfulAccent(4))
+                    .tint(ThemedColor.themedColorfulAccent(4).gradient)
             }
         }
         .buttonStyle(.plain)

--- a/Mlem/App/Views/Root/Tabs/Settings/AboutMlemView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AboutMlemView.swift
@@ -26,12 +26,12 @@ struct AboutMlemView: View {
                     FormChevron { Label("Website", icon: .general.website) }
                         .foregroundStyle(.themedPrimary)
                 }
-                .gradientTint(ThemedColor.themedColorfulAccent(2))
+                .gradientTint(.themedColorfulAccent(2))
                 Link(destination: URL(string: "https://lemmy.ml/c/mlemapp")!) {
                     FormChevron { Label("Lemmy Community", icon: .lemmy.community) }
                         .foregroundStyle(.themedPrimary)
                 }
-                .gradientTint(ThemedColor.themedColorfulAccent(3))
+                .gradientTint(.themedColorfulAccent(3))
                 Link(destination: URL(string: "https://matrix.to/#/#mlemappspace:matrix.org")!) {
                     FormChevron { Label("Matrix Room", image: "matrix.logo") }
                         .foregroundStyle(.themedPrimary)
@@ -45,11 +45,11 @@ struct AboutMlemView: View {
             }
             Section {
                 NavigationLink("Privacy Policy", icon: .settings.privacy, destination: .settings(.document(.privacyPolicy)))
-                    .gradientTint(ThemedColor.themedColorfulAccent(2))
+                    .gradientTint(.themedColorfulAccent(2))
                 NavigationLink("EULA", icon: .settings.eula, destination: .settings(.document(.eula)))
-                    .gradientTint(ThemedColor.themedColorfulAccent(0))
+                    .gradientTint(.themedColorfulAccent(0))
                 NavigationLink("Licenses", icon: .settings.licence, destination: .settings(.licences))
-                    .gradientTint(ThemedColor.themedColorfulAccent(4))
+                    .gradientTint(.themedColorfulAccent(4))
             }
         }
         .buttonStyle(.plain)

--- a/Mlem/App/Views/Root/Tabs/Settings/AboutMlemView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AboutMlemView.swift
@@ -26,12 +26,12 @@ struct AboutMlemView: View {
                     FormChevron { Label("Website", icon: .general.website) }
                         .foregroundStyle(.themedPrimary)
                 }
-                .tint(ThemedColor.themedColorfulAccent(2).gradient)
+                .gradientTint(ThemedColor.themedColorfulAccent(2))
                 Link(destination: URL(string: "https://lemmy.ml/c/mlemapp")!) {
                     FormChevron { Label("Lemmy Community", icon: .lemmy.community) }
                         .foregroundStyle(.themedPrimary)
                 }
-                .tint(ThemedColor.themedColorfulAccent(3).gradient)
+                .gradientTint(ThemedColor.themedColorfulAccent(3))
                 Link(destination: URL(string: "https://matrix.to/#/#mlemappspace:matrix.org")!) {
                     FormChevron { Label("Matrix Room", image: "matrix.logo") }
                         .foregroundStyle(.themedPrimary)
@@ -45,11 +45,11 @@ struct AboutMlemView: View {
             }
             Section {
                 NavigationLink("Privacy Policy", icon: .settings.privacy, destination: .settings(.document(.privacyPolicy)))
-                    .tint(ThemedColor.themedColorfulAccent(2).gradient)
+                    .gradientTint(ThemedColor.themedColorfulAccent(2))
                 NavigationLink("EULA", icon: .settings.eula, destination: .settings(.document(.eula)))
-                    .tint(ThemedColor.themedColorfulAccent(0).gradient)
+                    .gradientTint(ThemedColor.themedColorfulAccent(0))
                 NavigationLink("Licenses", icon: .settings.licence, destination: .settings(.licences))
-                    .tint(ThemedColor.themedColorfulAccent(4).gradient)
+                    .gradientTint(ThemedColor.themedColorfulAccent(4))
             }
         }
         .buttonStyle(.plain)

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct AccessibilitySettingsView: View {
     @Environment(\.accessibilityDifferentiateWithoutColor) var differentiateWithoutColor: Bool
@@ -23,7 +24,7 @@ struct AccessibilitySettingsView: View {
                 description: "Customize Mlem to work best for you. Some features are tied to system-wide accessibility settings.",
                 icon: .settings.accessibility
             )
-            .tint(.themedColorfulAccent(2))
+            .tint(ThemedColor.themedColorfulAccent(2).gradient)
             if differentiateWithoutColor {
                 Section {
                     NavigationLink(

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -24,7 +24,7 @@ struct AccessibilitySettingsView: View {
                 description: "Customize Mlem to work best for you. Some features are tied to system-wide accessibility settings.",
                 icon: .settings.accessibility
             )
-            .gradientTint(ThemedColor.themedColorfulAccent(2))
+            .gradientTint(.themedColorfulAccent(2))
             if differentiateWithoutColor {
                 Section {
                     NavigationLink(

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -24,7 +24,7 @@ struct AccessibilitySettingsView: View {
                 description: "Customize Mlem to work best for you. Some features are tied to system-wide accessibility settings.",
                 icon: .settings.accessibility
             )
-            .tint(ThemedColor.themedColorfulAccent(2).gradient)
+            .gradientTint(ThemedColor.themedColorfulAccent(2))
             if differentiateWithoutColor {
                 Section {
                     NavigationLink(

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
@@ -39,25 +39,25 @@ struct AccountSettingsView: View {
                             icon: .lemmy.person,
                             destination: .settings(.profile)
                         )
-                        .tint(ThemedColor.themedColorfulAccent(5).gradient)
+                        .gradientTint(ThemedColor.themedColorfulAccent(5))
                         NavigationLink(
                             "Sign-In & Security",
                             icon: .general.security,
                             destination: .settings(.accountSignIn)
                         )
-                        .tint(ThemedColor.themedColorfulAccent(2).gradient)
+                        .gradientTint(ThemedColor.themedColorfulAccent(2))
                         NavigationLink(
                             "Content & Notifications",
                             icon: .lemmy.post,
                             destination: .settings(.accountContent)
                         )
-                        .tint(ThemedColor.themedColorfulAccent(0).gradient)
+                        .gradientTint(ThemedColor.themedColorfulAccent(0))
                         NavigationLink(
                             "Advanced",
                             icon: .settings.advanced,
                             destination: .settings(.accountAdvanced)
                         )
-                        .tint(ThemedColor.themedNeutralAccent.gradient)
+                        .gradientTint(ThemedColor.themedNeutralAccent)
                     }
                 }
                 Section {
@@ -66,7 +66,7 @@ struct AccountSettingsView: View {
                         icon: .lemmy.block,
                         destination: .blockList
                     )
-                    .tint(ThemedColor.themedNegative.gradient)
+                    .gradientTint(.themedNegative)
                 }
                 Section {
                     NavigationLink(
@@ -74,7 +74,7 @@ struct AccountSettingsView: View {
                         icon: .settings.localAccountOptions,
                         destination: .settings(.accountLocal)
                     )
-                    .tint(ThemedColor.themedColorfulAccent(2).gradient)
+                    .gradientTint(.themedColorfulAccent(2))
                 } footer: {
                     Text("These options are stored locally in Mlem and not on your Lemmy account.")
                 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
@@ -39,25 +39,25 @@ struct AccountSettingsView: View {
                             icon: .lemmy.person,
                             destination: .settings(.profile)
                         )
-                        .gradientTint(ThemedColor.themedColorfulAccent(5))
+                        .gradientTint(.themedColorfulAccent(5))
                         NavigationLink(
                             "Sign-In & Security",
                             icon: .general.security,
                             destination: .settings(.accountSignIn)
                         )
-                        .gradientTint(ThemedColor.themedColorfulAccent(2))
+                        .gradientTint(.themedColorfulAccent(2))
                         NavigationLink(
                             "Content & Notifications",
                             icon: .lemmy.post,
                             destination: .settings(.accountContent)
                         )
-                        .gradientTint(ThemedColor.themedColorfulAccent(0))
+                        .gradientTint(.themedColorfulAccent(0))
                         NavigationLink(
                             "Advanced",
                             icon: .settings.advanced,
                             destination: .settings(.accountAdvanced)
                         )
-                        .gradientTint(ThemedColor.themedNeutralAccent)
+                        .gradientTint(.themedNeutralAccent)
                     }
                 }
                 Section {

--- a/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccountSettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct AccountSettingsView: View {
     @Environment(AppState.self) var appState
@@ -38,25 +39,25 @@ struct AccountSettingsView: View {
                             icon: .lemmy.person,
                             destination: .settings(.profile)
                         )
-                        .tint(.themedColorfulAccent(5))
+                        .tint(ThemedColor.themedColorfulAccent(5).gradient)
                         NavigationLink(
                             "Sign-In & Security",
                             icon: .general.security,
                             destination: .settings(.accountSignIn)
                         )
-                        .tint(.themedColorfulAccent(2))
+                        .tint(ThemedColor.themedColorfulAccent(2).gradient)
                         NavigationLink(
                             "Content & Notifications",
                             icon: .lemmy.post,
                             destination: .settings(.accountContent)
                         )
-                        .tint(.themedColorfulAccent(0))
+                        .tint(ThemedColor.themedColorfulAccent(0).gradient)
                         NavigationLink(
                             "Advanced",
                             icon: .settings.advanced,
                             destination: .settings(.accountAdvanced)
                         )
-                        .tint(.themedNeutralAccent)
+                        .tint(ThemedColor.themedNeutralAccent.gradient)
                     }
                 }
                 Section {
@@ -65,7 +66,7 @@ struct AccountSettingsView: View {
                         icon: .lemmy.block,
                         destination: .blockList
                     )
-                    .tint(.themedNegative)
+                    .tint(ThemedColor.themedNegative.gradient)
                 }
                 Section {
                     NavigationLink(
@@ -73,7 +74,7 @@ struct AccountSettingsView: View {
                         icon: .settings.localAccountOptions,
                         destination: .settings(.accountLocal)
                     )
-                    .tint(.themedColorfulAccent(2))
+                    .tint(ThemedColor.themedColorfulAccent(2).gradient)
                 } footer: {
                     Text("These options are stored locally in Mlem and not on your Lemmy account.")
                 }

--- a/Mlem/App/Views/Root/Tabs/Settings/AnimatedAvatarSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AnimatedAvatarSettingsView.swift
@@ -18,7 +18,7 @@ struct AnimatedAvatarSettingsView: View {
                 description: "Some users set animated media as their avatar. Control whether these avatars should play their animations.",
                 icon: .general.playCircle
             )
-            .gradientTint(ThemedColor.themedColorfulAccent(4))
+            .gradientTint(.themedColorfulAccent(4))
             
             Picker("Animate Avatars...", selection: $animatedAvatars) {
                 ForEach(AnimatedAvatarBehavior.allCases, id: \.self) { location in

--- a/Mlem/App/Views/Root/Tabs/Settings/AnimatedAvatarSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AnimatedAvatarSettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct AnimatedAvatarSettingsView: View {
     @Setting(\.media_animatedAvatars) var animatedAvatars
@@ -17,7 +18,7 @@ struct AnimatedAvatarSettingsView: View {
                 description: "Some users set animated media as their avatar. Control whether these avatars should play their animations.",
                 icon: .general.playCircle
             )
-            .tint(.themedColorfulAccent(4))
+            .tint(ThemedColor.themedColorfulAccent(4).gradient)
             
             Picker("Animate Avatars...", selection: $animatedAvatars) {
                 ForEach(AnimatedAvatarBehavior.allCases, id: \.self) { location in

--- a/Mlem/App/Views/Root/Tabs/Settings/AnimatedAvatarSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AnimatedAvatarSettingsView.swift
@@ -18,7 +18,7 @@ struct AnimatedAvatarSettingsView: View {
                 description: "Some users set animated media as their avatar. Control whether these avatars should play their animations.",
                 icon: .general.playCircle
             )
-            .tint(ThemedColor.themedColorfulAccent(4).gradient)
+            .gradientTint(ThemedColor.themedColorfulAccent(4))
             
             Picker("Animate Avatars...", selection: $animatedAvatars) {
                 ForEach(AnimatedAvatarBehavior.allCases, id: \.self) { location in

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -7,6 +7,7 @@
 
 import Dependencies
 import SwiftUI
+import Theming
 
 struct GeneralSettingsView: View {
     // behavior
@@ -34,7 +35,7 @@ struct GeneralSettingsView: View {
                 description: "Manage your overall setup for Mlem.",
                 icon: .settings.general
             )
-            .tint(.themedNeutralAccent)
+            .tint(ThemedColor.themedNeutralAccent.gradient)
             Section {
                 NavigationLink(
                     "Default Feed",

--- a/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/GeneralSettingsView.swift
@@ -35,7 +35,7 @@ struct GeneralSettingsView: View {
                 description: "Manage your overall setup for Mlem.",
                 icon: .settings.general
             )
-            .tint(ThemedColor.themedNeutralAccent.gradient)
+            .gradientTint(.themedNeutralAccent)
             Section {
                 NavigationLink(
                     "Default Feed",

--- a/Mlem/App/Views/Root/Tabs/Settings/HapticSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/HapticSettingsView.swift
@@ -19,7 +19,7 @@ struct HapticSettingsView: View {
                 description: "Customize how often Mlem plays haptic feedback.",
                 icon: .general.haptics
             )
-            .tint(ThemedColor.themedColorfulAccent(1).gradient)
+            .gradientTint(.themedColorfulAccent(1))
             Picker("Haptic Level", selection: $hapticLevel) {
                 ForEach(HapticTier.allCases, id: \.self) { level in
                     Text(level.label)

--- a/Mlem/App/Views/Root/Tabs/Settings/HapticSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/HapticSettingsView.swift
@@ -7,6 +7,7 @@
 
 import Haptics
 import SwiftUI
+import Theming
 
 struct HapticSettingsView: View {
     @Setting(\.behavior_hapticLevel) var hapticLevel
@@ -18,7 +19,7 @@ struct HapticSettingsView: View {
                 description: "Customize how often Mlem plays haptic feedback.",
                 icon: .general.haptics
             )
-            .tint(.themedColorfulAccent(1))
+            .tint(ThemedColor.themedColorfulAccent(1).gradient)
             Picker("Haptic Level", selection: $hapticLevel) {
                 ForEach(HapticTier.allCases, id: \.self) { level in
                     Text(level.label)

--- a/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct InboxSettingsView: View {
     @Setting(\.tab_inbox_badgeIncludedTypes) var tabInboxBadgeIncludedTypes
@@ -19,7 +20,7 @@ struct InboxSettingsView: View {
                 description: "Customize the interaction bar for inbox items, and choose which types of notification are included in the tab bar badge.",
                 icon: .lemmy.inbox
             )
-            .tint(.themedInbox)
+            .tint(ThemedColor.themedInbox.gradient)
             Section {
                 NavigationLink(.settings(.interactionBar(.reply))) {
                     SettingsInteractionBarSummaryView(configuration: replyInteractionBar)

--- a/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
@@ -20,7 +20,7 @@ struct InboxSettingsView: View {
                 description: "Customize the interaction bar for inbox items, and choose which types of notification are included in the tab bar badge.",
                 icon: .lemmy.inbox
             )
-            .tint(ThemedColor.themedInbox.gradient)
+            .gradientTint(ThemedColor.themedInbox)
             Section {
                 NavigationLink(.settings(.interactionBar(.reply))) {
                     SettingsInteractionBarSummaryView(configuration: replyInteractionBar)

--- a/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
@@ -20,7 +20,7 @@ struct InboxSettingsView: View {
                 description: "Customize the interaction bar for inbox items, and choose which types of notification are included in the tab bar badge.",
                 icon: .lemmy.inbox
             )
-            .gradientTint(ThemedColor.themedInbox)
+            .gradientTint(.themedInbox)
             Section {
                 NavigationLink(.settings(.interactionBar(.reply))) {
                     SettingsInteractionBarSummaryView(configuration: replyInteractionBar)

--- a/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
@@ -25,7 +25,7 @@ struct LinkSettingsView: View {
                 description: "Manage how Mlem handles links and control how images and videos are displayed.",
                 icon: .general.image
             )
-            .gradientTint(ThemedColor.themedColorfulAccent(4))
+            .gradientTint(.themedColorfulAccent(4))
             Section {
                 NavigationLink(
                     "Open External Links",

--- a/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct LinkSettingsView: View {
     @Setting(\.links_openInBrowser) var openLinksInBrowser
@@ -24,7 +25,7 @@ struct LinkSettingsView: View {
                 description: "Manage how Mlem handles links and control how images and videos are displayed.",
                 icon: .general.image
             )
-            .tint(.themedColorfulAccent(4))
+            .tint(ThemedColor.themedColorfulAccent(4).gradient)
             Section {
                 NavigationLink(
                     "Open External Links",

--- a/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LinkSettingsView.swift
@@ -25,7 +25,7 @@ struct LinkSettingsView: View {
                 description: "Manage how Mlem handles links and control how images and videos are displayed.",
                 icon: .general.image
             )
-            .tint(ThemedColor.themedColorfulAccent(4).gradient)
+            .gradientTint(ThemedColor.themedColorfulAccent(4))
             Section {
                 NavigationLink(
                     "Open External Links",

--- a/Mlem/App/Views/Root/Tabs/Settings/LongPressActionSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LongPressActionSettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct LongPressActionSettingsView: View {
     @Setting(\.tab_gestures_longPressAction) private var longPressAction: TabBarLongPressAction
@@ -17,7 +18,7 @@ struct LongPressActionSettingsView: View {
                 description: "Choose which action to perform when you tap and hold the profile icon.",
                 icon: .settings.longPress
             )
-            .tint(.themedColorfulAccent(2))
+            .tint(ThemedColor.themedColorfulAccent(2).gradient)
             
             Section {
                 Picker("Long Press Action", selection: $longPressAction) {

--- a/Mlem/App/Views/Root/Tabs/Settings/LongPressActionSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/LongPressActionSettingsView.swift
@@ -10,6 +10,7 @@ import Theming
 
 struct LongPressActionSettingsView: View {
     @Setting(\.tab_gestures_longPressAction) private var longPressAction: TabBarLongPressAction
+    @Environment(\.palette) var palette
     
     var body: some View {
         Form {
@@ -18,7 +19,7 @@ struct LongPressActionSettingsView: View {
                 description: "Choose which action to perform when you tap and hold the profile icon.",
                 icon: .settings.longPress
             )
-            .tint(ThemedColor.themedColorfulAccent(2).gradient)
+            .tint(ThemedColor.themedColorfulAccent(2).gradient(palette: palette))
             
             Section {
                 Picker("Long Press Action", selection: $longPressAction) {

--- a/Mlem/App/Views/Root/Tabs/Settings/ModeratorSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ModeratorSettingsView.swift
@@ -7,6 +7,7 @@
 
 import Icons
 import SwiftUI
+import Theming
 
 struct ModeratorSettingsView: View {
     @Setting(\.menus_modActionGrouping) var moderatorActionGrouping
@@ -20,7 +21,7 @@ struct ModeratorSettingsView: View {
                 description: "Manage settings related to content moderation.",
                 icon: .lemmy.moderation
             )
-            .tint(.themedModeration)
+            .tint(ThemedColor.themedModeration.gradient)
             Section {
                 NavigationLink(
                     "Moderator Actions",

--- a/Mlem/App/Views/Root/Tabs/Settings/ModeratorSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ModeratorSettingsView.swift
@@ -21,7 +21,7 @@ struct ModeratorSettingsView: View {
                 description: "Manage settings related to content moderation.",
                 icon: .lemmy.moderation
             )
-            .tint(ThemedColor.themedModeration.gradient)
+            .gradientTint(ThemedColor.themedModeration)
             Section {
                 NavigationLink(
                     "Moderator Actions",

--- a/Mlem/App/Views/Root/Tabs/Settings/ModeratorSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ModeratorSettingsView.swift
@@ -21,7 +21,7 @@ struct ModeratorSettingsView: View {
                 description: "Manage settings related to content moderation.",
                 icon: .lemmy.moderation
             )
-            .gradientTint(ThemedColor.themedModeration)
+            .gradientTint(.themedModeration)
             Section {
                 NavigationLink(
                     "Moderator Actions",

--- a/Mlem/App/Views/Root/Tabs/Settings/PostReadIndicatorSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostReadIndicatorSettingsView.swift
@@ -8,6 +8,7 @@
 import ComponentViews
 import Haptics
 import SwiftUI
+import Theming
 
 struct PostReadIndicatorSettingsView: View {
     @Environment(HapticManager.self) var hapticManager
@@ -30,7 +31,7 @@ struct PostReadIndicatorSettingsView: View {
                 description: "Read posts are shown with dimmed title text. If you like, you can choose an additional way of indicating read status.",
                 icon: .settings.readIndicatorSetting
             )
-            .tint(.themedSecondary)
+            .tint(ThemedColor.themedSecondary.gradient)
             Section {
                 Toggle(
                     "Additional Read Indicator",

--- a/Mlem/App/Views/Root/Tabs/Settings/PostReadIndicatorSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostReadIndicatorSettingsView.swift
@@ -31,7 +31,7 @@ struct PostReadIndicatorSettingsView: View {
                 description: "Read posts are shown with dimmed title text. If you like, you can choose an additional way of indicating read status.",
                 icon: .settings.readIndicatorSetting
             )
-            .tint(ThemedColor.themedSecondary.gradient)
+            .gradientTint(ThemedColor.themedSecondary)
             Section {
                 Toggle(
                     "Additional Read Indicator",

--- a/Mlem/App/Views/Root/Tabs/Settings/PostReadIndicatorSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostReadIndicatorSettingsView.swift
@@ -31,7 +31,7 @@ struct PostReadIndicatorSettingsView: View {
                 description: "Read posts are shown with dimmed title text. If you like, you can choose an additional way of indicating read status.",
                 icon: .settings.readIndicatorSetting
             )
-            .gradientTint(ThemedColor.themedSecondary)
+            .gradientTint(.themedSecondary)
             Section {
                 Toggle(
                     "Additional Read Indicator",

--- a/Mlem/App/Views/Root/Tabs/Settings/PrivacyBypassImageProxySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PrivacyBypassImageProxySettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct PrivacyBypassImageProxySettingsView: View {
     @Setting(\.privacy_autoBypassImageProxy) var bypassImageProxy
@@ -18,7 +19,7 @@ struct PrivacyBypassImageProxySettingsView: View {
                 description: "Some instances proxy images to protect your privacy. In certain cases, this causes image loading to fail. You can bypass the image proxy and load directly, but this will expose your IP address to the image host.",
                 icon: .lemmy.imageProxy
             )
-            .tint(.themedColorfulAccent(4))
+            .tint(ThemedColor.themedColorfulAccent(4).gradient)
             Section("Bypass Image Proxy...") {
                 Picker("Bypass Image Proxy", selection: $bypassImageProxy) {
                     Label("Automatically", icon: .general.success)

--- a/Mlem/App/Views/Root/Tabs/Settings/PrivacyBypassImageProxySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PrivacyBypassImageProxySettingsView.swift
@@ -19,7 +19,7 @@ struct PrivacyBypassImageProxySettingsView: View {
                 description: "Some instances proxy images to protect your privacy. In certain cases, this causes image loading to fail. You can bypass the image proxy and load directly, but this will expose your IP address to the image host.",
                 icon: .lemmy.imageProxy
             )
-            .gradientTint(ThemedColor.themedColorfulAccent(4))
+            .gradientTint(.themedColorfulAccent(4))
             Section("Bypass Image Proxy...") {
                 Picker("Bypass Image Proxy", selection: $bypassImageProxy) {
                     Label("Automatically", icon: .general.success)

--- a/Mlem/App/Views/Root/Tabs/Settings/PrivacyBypassImageProxySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PrivacyBypassImageProxySettingsView.swift
@@ -19,7 +19,7 @@ struct PrivacyBypassImageProxySettingsView: View {
                 description: "Some instances proxy images to protect your privacy. In certain cases, this causes image loading to fail. You can bypass the image proxy and load directly, but this will expose your IP address to the image host.",
                 icon: .lemmy.imageProxy
             )
-            .tint(ThemedColor.themedColorfulAccent(4).gradient)
+            .gradientTint(ThemedColor.themedColorfulAccent(4))
             Section("Bypass Image Proxy...") {
                 Picker("Bypass Image Proxy", selection: $bypassImageProxy) {
                     Label("Automatically", icon: .general.success)

--- a/Mlem/App/Views/Root/Tabs/Settings/PrivacySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PrivacySettingsView.swift
@@ -20,7 +20,7 @@ struct PrivacySettingsView: View {
                 description: "Manage how Mlem interacts with Lemmy instances and other websites.",
                 icon: .settings.privacy
             )
-            .tint(ThemedColor.themedColorfulAccent(2).gradient)
+            .gradientTint(ThemedColor.themedColorfulAccent(2))
             Section {
                 Toggle("Confirm Image Uploads", icon: .settings.confirmImageUploads, isOn: $confirmImageUploads)
             } footer: {

--- a/Mlem/App/Views/Root/Tabs/Settings/PrivacySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PrivacySettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct PrivacySettingsView: View {
     @Setting(\.privacy_autoBypassImageProxy) var bypassImageProxy
@@ -19,7 +20,7 @@ struct PrivacySettingsView: View {
                 description: "Manage how Mlem interacts with Lemmy instances and other websites.",
                 icon: .settings.privacy
             )
-            .tint(.themedColorfulAccent(2))
+            .tint(ThemedColor.themedColorfulAccent(2).gradient)
             Section {
                 Toggle("Confirm Image Uploads", icon: .settings.confirmImageUploads, isOn: $confirmImageUploads)
             } footer: {

--- a/Mlem/App/Views/Root/Tabs/Settings/PrivacySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PrivacySettingsView.swift
@@ -20,7 +20,7 @@ struct PrivacySettingsView: View {
                 description: "Manage how Mlem interacts with Lemmy instances and other websites.",
                 icon: .settings.privacy
             )
-            .gradientTint(ThemedColor.themedColorfulAccent(2))
+            .gradientTint(.themedColorfulAccent(2))
             Section {
                 Toggle("Confirm Image Uploads", icon: .settings.confirmImageUploads, isOn: $confirmImageUploads)
             } footer: {

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetyBlurNsfwSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetyBlurNsfwSettingsView.swift
@@ -35,6 +35,6 @@ struct SafetyBlurNsfwSettingsView: View {
             description: "Choose when Not Safe For Work content should be blurred.",
             icon: .general.hide
         )
-        .tint(ThemedColor.themedWarning.gradient)
+        .gradientTint(ThemedColor.themedWarning)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetyBlurNsfwSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetyBlurNsfwSettingsView.swift
@@ -35,6 +35,6 @@ struct SafetyBlurNsfwSettingsView: View {
             description: "Choose when Not Safe For Work content should be blurred.",
             icon: .general.hide
         )
-        .gradientTint(ThemedColor.themedWarning)
+        .gradientTint(.themedWarning)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetyBlurNsfwSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetyBlurNsfwSettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct SafetyBlurNsfwSettingsView: View {
     @Setting(\.safety_blurNsfw) var blurNsfw
@@ -34,6 +35,6 @@ struct SafetyBlurNsfwSettingsView: View {
             description: "Choose when Not Safe For Work content should be blurred.",
             icon: .general.hide
         )
-        .tint(.themedWarning)
+        .tint(ThemedColor.themedWarning.gradient)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetySettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct SafetySettingsView: View {
     @Environment(FiltersTracker.self) var filtersTracker
@@ -23,7 +24,7 @@ struct SafetySettingsView: View {
                 description: "Customize how content is displayed in your feed. Choose which types of content are blurred, and apply filters to hide posts from the feed altogether.",
                 icon: .settings.safety
             )
-            .tint(.themedColorfulAccent(3))
+            .tint(ThemedColor.themedColorfulAccent(3).gradient)
             Section {
                 NavigationLink(
                     "Blur NSFW Content",

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetySettingsView.swift
@@ -24,7 +24,7 @@ struct SafetySettingsView: View {
                 description: "Customize how content is displayed in your feed. Choose which types of content are blurred, and apply filters to hide posts from the feed altogether.",
                 icon: .settings.safety
             )
-            .tint(ThemedColor.themedColorfulAccent(3).gradient)
+            .gradientTint(ThemedColor.themedColorfulAccent(3))
             Section {
                 NavigationLink(
                     "Blur NSFW Content",

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetySettingsView.swift
@@ -24,7 +24,7 @@ struct SafetySettingsView: View {
                 description: "Customize how content is displayed in your feed. Choose which types of content are blurred, and apply filters to hide posts from the feed altogether.",
                 icon: .settings.safety
             )
-            .gradientTint(ThemedColor.themedColorfulAccent(3))
+            .gradientTint(.themedColorfulAccent(3))
             Section {
                 NavigationLink(
                     "Blur NSFW Content",

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetyWarningsSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetyWarningsSettingsView.swift
@@ -19,7 +19,7 @@ struct SafetyWarningsSettingsView: View {
                 description: "Choose whether to show a warning when opening a page that is likely to contain sensitive content.",
                 icon: .general.warning
             )
-            .gradientTint(ThemedColor.themedWarning)
+            .gradientTint(.themedWarning)
             Section("Show warnings when opening...") {
                 Toggle("NSFW Communities", icon: .lemmy.community, isOn: $showNsfwCommunityWarning)
                 Toggle("Modlogs", icon: .lemmy.modlog, isOn: $showModlogWarning)

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetyWarningsSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetyWarningsSettingsView.swift
@@ -19,7 +19,7 @@ struct SafetyWarningsSettingsView: View {
                 description: "Choose whether to show a warning when opening a page that is likely to contain sensitive content.",
                 icon: .general.warning
             )
-            .tint(ThemedColor.themedWarning.gradient)
+            .gradientTint(ThemedColor.themedWarning)
             Section("Show warnings when opening...") {
                 Toggle("NSFW Communities", icon: .lemmy.community, isOn: $showNsfwCommunityWarning)
                 Toggle("Modlogs", icon: .lemmy.modlog, isOn: $showModlogWarning)

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetyWarningsSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetyWarningsSettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct SafetyWarningsSettingsView: View {
     @Setting(\.safety_enableNsfwCommunityWarning) var showNsfwCommunityWarning
@@ -18,7 +19,7 @@ struct SafetyWarningsSettingsView: View {
                 description: "Choose whether to show a warning when opening a page that is likely to contain sensitive content.",
                 icon: .general.warning
             )
-            .tint(.themedWarning)
+            .tint(ThemedColor.themedWarning.gradient)
             Section("Show warnings when opening...") {
                 Toggle("NSFW Communities", icon: .lemmy.community, isOn: $showNsfwCommunityWarning)
                 Toggle("Modlogs", icon: .lemmy.modlog, isOn: $showModlogWarning)

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -7,6 +7,7 @@
 
 import MlemMiddleware
 import SwiftUI
+import Theming
 
 struct SettingsView: View {
     @Environment(AppState.self) var appState
@@ -30,44 +31,44 @@ struct SettingsView: View {
                     icon: .settings.general,
                     destination: .settings(.general)
                 )
-                .tint(.themedNeutralAccent)
+                .tint(ThemedColor.themedNeutralAccent.gradient)
                 NavigationLink(
                     "Privacy",
                     icon: .settings.privacy,
                     destination: .settings(.privacy)
                 )
-                .tint(.themedColorfulAccent(2))
+                .tint(ThemedColor.themedColorfulAccent(2).gradient)
                 NavigationLink(
                     "Safety & Filtering",
                     icon: .settings.safety,
                     destination: .settings(.safety)
                 )
-                .tint(.themedColorfulAccent(3))
+                .tint(ThemedColor.themedColorfulAccent(3).gradient)
                 NavigationLink(
                     "Accessibility",
                     icon: .settings.accessibility,
                     destination: .settings(.accessibility)
                 )
-                .tint(.themedColorfulAccent(2))
+                .tint(ThemedColor.themedColorfulAccent(2).gradient)
                 NavigationLink(
                     "Media & Links",
                     icon: .general.image,
                     destination: .settings(.links)
                 )
-                .tint(.themedColorfulAccent(4))
+                .tint(ThemedColor.themedColorfulAccent(4).gradient)
                 NavigationLink(
                     "Sorting",
                     icon: .settings.sorting,
                     destination: .settings(.sorting)
                 )
-                .tint(.themedColorfulAccent(5))
+                .tint(ThemedColor.themedColorfulAccent(5).gradient)
                 if AccountsTracker.main.highestLevelAccountType >= .moderator {
                     NavigationLink(
                         "Moderation",
                         icon: .lemmy.moderation,
                         destination: .settings(.moderation)
                     )
-                    .tint(.themedModeration)
+                    .tint(ThemedColor.themedModeration.gradient)
                     .symbolVariant(.fill)
                 }
             }
@@ -82,22 +83,22 @@ struct SettingsView: View {
             
             Section {
                 NavigationLink("Posts", icon: .lemmy.post, destination: .settings(.post))
-                    .tint(.themedPostAccent)
+                    .tint(ThemedColor.themedPostAccent.gradient)
                 NavigationLink("Comments", icon: .lemmy.comment, destination: .settings(.comment))
-                    .tint(.themedCommentAccent)
+                    .tint(ThemedColor.themedCommentAccent.gradient)
                 NavigationLink("Inbox", icon: .lemmy.inbox, destination: .settings(.inbox))
-                    .tint(.themedInbox)
+                    .tint(ThemedColor.themedInbox.gradient)
                 NavigationLink("Subscription List", icon: .lemmy.subscriptionList, destination: .settings(.subscriptionList))
-                    .tint(.themedCommunityAccent)
+                    .tint(ThemedColor.themedCommunityAccent.gradient)
                 NavigationLink("Tab Bar", icon: .settings.tabBar, destination: .settings(.tabBar))
-                    .tint(.themedColorfulAccent(5))
+                    .tint(ThemedColor.themedColorfulAccent(5).gradient)
             }
             
             Section {
                 NavigationLink("About Mlem", icon: .general.info, destination: .settings(.about))
-                    .tint(.themedColorfulAccent(2))
+                    .tint(ThemedColor.themedColorfulAccent(2).gradient)
                 NavigationLink("Advanced", icon: .settings.advanced, destination: .settings(.advanced))
-                    .tint(.themedNeutralAccent)
+                    .tint(ThemedColor.themedNeutralAccent.gradient)
             }
         }
         .labelStyle(.squircle)

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -31,44 +31,44 @@ struct SettingsView: View {
                     icon: .settings.general,
                     destination: .settings(.general)
                 )
-                .tint(ThemedColor.themedNeutralAccent.gradient)
+                .gradientTint(ThemedColor.themedNeutralAccent)
                 NavigationLink(
                     "Privacy",
                     icon: .settings.privacy,
                     destination: .settings(.privacy)
                 )
-                .tint(ThemedColor.themedColorfulAccent(2).gradient)
+                .gradientTint(ThemedColor.themedColorfulAccent(2))
                 NavigationLink(
                     "Safety & Filtering",
                     icon: .settings.safety,
                     destination: .settings(.safety)
                 )
-                .tint(ThemedColor.themedColorfulAccent(3).gradient)
+                .gradientTint(ThemedColor.themedColorfulAccent(3))
                 NavigationLink(
                     "Accessibility",
                     icon: .settings.accessibility,
                     destination: .settings(.accessibility)
                 )
-                .tint(ThemedColor.themedColorfulAccent(2).gradient)
+                .gradientTint(ThemedColor.themedColorfulAccent(2))
                 NavigationLink(
                     "Media & Links",
                     icon: .general.image,
                     destination: .settings(.links)
                 )
-                .tint(ThemedColor.themedColorfulAccent(4).gradient)
+                .gradientTint(ThemedColor.themedColorfulAccent(4))
                 NavigationLink(
                     "Sorting",
                     icon: .settings.sorting,
                     destination: .settings(.sorting)
                 )
-                .tint(ThemedColor.themedColorfulAccent(5).gradient)
+                .gradientTint(ThemedColor.themedColorfulAccent(5))
                 if AccountsTracker.main.highestLevelAccountType >= .moderator {
                     NavigationLink(
                         "Moderation",
                         icon: .lemmy.moderation,
                         destination: .settings(.moderation)
                     )
-                    .tint(ThemedColor.themedModeration.gradient)
+                    .gradientTint(ThemedColor.themedModeration)
                     .symbolVariant(.fill)
                 }
             }
@@ -83,22 +83,22 @@ struct SettingsView: View {
             
             Section {
                 NavigationLink("Posts", icon: .lemmy.post, destination: .settings(.post))
-                    .tint(ThemedColor.themedPostAccent.gradient)
+                    .gradientTint(ThemedColor.themedPostAccent)
                 NavigationLink("Comments", icon: .lemmy.comment, destination: .settings(.comment))
-                    .tint(ThemedColor.themedCommentAccent.gradient)
+                    .gradientTint(ThemedColor.themedCommentAccent)
                 NavigationLink("Inbox", icon: .lemmy.inbox, destination: .settings(.inbox))
-                    .tint(ThemedColor.themedInbox.gradient)
+                    .gradientTint(ThemedColor.themedInbox)
                 NavigationLink("Subscription List", icon: .lemmy.subscriptionList, destination: .settings(.subscriptionList))
-                    .tint(ThemedColor.themedCommunityAccent.gradient)
+                    .gradientTint(ThemedColor.themedCommunityAccent)
                 NavigationLink("Tab Bar", icon: .settings.tabBar, destination: .settings(.tabBar))
-                    .tint(ThemedColor.themedColorfulAccent(5).gradient)
+                    .gradientTint(ThemedColor.themedColorfulAccent(5))
             }
             
             Section {
                 NavigationLink("About Mlem", icon: .general.info, destination: .settings(.about))
-                    .tint(ThemedColor.themedColorfulAccent(2).gradient)
+                    .gradientTint(ThemedColor.themedColorfulAccent(2))
                 NavigationLink("Advanced", icon: .settings.advanced, destination: .settings(.advanced))
-                    .tint(ThemedColor.themedNeutralAccent.gradient)
+                    .gradientTint(ThemedColor.themedNeutralAccent)
             }
         }
         .labelStyle(.squircle)

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -31,44 +31,44 @@ struct SettingsView: View {
                     icon: .settings.general,
                     destination: .settings(.general)
                 )
-                .gradientTint(ThemedColor.themedNeutralAccent)
+                .gradientTint(.themedNeutralAccent)
                 NavigationLink(
                     "Privacy",
                     icon: .settings.privacy,
                     destination: .settings(.privacy)
                 )
-                .gradientTint(ThemedColor.themedColorfulAccent(2))
+                .gradientTint(.themedColorfulAccent(2))
                 NavigationLink(
                     "Safety & Filtering",
                     icon: .settings.safety,
                     destination: .settings(.safety)
                 )
-                .gradientTint(ThemedColor.themedColorfulAccent(3))
+                .gradientTint(.themedColorfulAccent(3))
                 NavigationLink(
                     "Accessibility",
                     icon: .settings.accessibility,
                     destination: .settings(.accessibility)
                 )
-                .gradientTint(ThemedColor.themedColorfulAccent(2))
+                .gradientTint(.themedColorfulAccent(2))
                 NavigationLink(
                     "Media & Links",
                     icon: .general.image,
                     destination: .settings(.links)
                 )
-                .gradientTint(ThemedColor.themedColorfulAccent(4))
+                .gradientTint(.themedColorfulAccent(4))
                 NavigationLink(
                     "Sorting",
                     icon: .settings.sorting,
                     destination: .settings(.sorting)
                 )
-                .gradientTint(ThemedColor.themedColorfulAccent(5))
+                .gradientTint(.themedColorfulAccent(5))
                 if AccountsTracker.main.highestLevelAccountType >= .moderator {
                     NavigationLink(
                         "Moderation",
                         icon: .lemmy.moderation,
                         destination: .settings(.moderation)
                     )
-                    .gradientTint(ThemedColor.themedModeration)
+                    .gradientTint(.themedModeration)
                     .symbolVariant(.fill)
                 }
             }
@@ -83,22 +83,22 @@ struct SettingsView: View {
             
             Section {
                 NavigationLink("Posts", icon: .lemmy.post, destination: .settings(.post))
-                    .gradientTint(ThemedColor.themedPostAccent)
+                    .gradientTint(.themedPostAccent)
                 NavigationLink("Comments", icon: .lemmy.comment, destination: .settings(.comment))
-                    .gradientTint(ThemedColor.themedCommentAccent)
+                    .gradientTint(.themedCommentAccent)
                 NavigationLink("Inbox", icon: .lemmy.inbox, destination: .settings(.inbox))
-                    .gradientTint(ThemedColor.themedInbox)
+                    .gradientTint(.themedInbox)
                 NavigationLink("Subscription List", icon: .lemmy.subscriptionList, destination: .settings(.subscriptionList))
-                    .gradientTint(ThemedColor.themedCommunityAccent)
+                    .gradientTint(.themedCommunityAccent)
                 NavigationLink("Tab Bar", icon: .settings.tabBar, destination: .settings(.tabBar))
-                    .gradientTint(ThemedColor.themedColorfulAccent(5))
+                    .gradientTint(.themedColorfulAccent(5))
             }
             
             Section {
                 NavigationLink("About Mlem", icon: .general.info, destination: .settings(.about))
-                    .gradientTint(ThemedColor.themedColorfulAccent(2))
+                    .gradientTint(.themedColorfulAccent(2))
                 NavigationLink("Advanced", icon: .settings.advanced, destination: .settings(.advanced))
-                    .gradientTint(ThemedColor.themedNeutralAccent)
+                    .gradientTint(.themedNeutralAccent)
             }
         }
         .labelStyle(.squircle)

--- a/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
@@ -8,6 +8,7 @@
 import ComponentViews
 import Icons
 import SwiftUI
+import Theming
 
 struct SharingLinksSettingsView: View {
     @Setting(\.links_shareMode) var linkSharingMode
@@ -21,7 +22,7 @@ struct SharingLinksSettingsView: View {
                 description: "In the Fediverse, many different links can point to the same piece of content. Choose which site to use when sharing content.",
                 icon: .general.share
             )
-            .tint(.themedColorfulAccent(3))
+            .tint(ThemedColor.themedColorfulAccent(3).gradient)
             
             pickerItemView(
                 mode: .myInstance,

--- a/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
@@ -22,7 +22,7 @@ struct SharingLinksSettingsView: View {
                 description: "In the Fediverse, many different links can point to the same piece of content. Choose which site to use when sharing content.",
                 icon: .general.share
             )
-            .tint(ThemedColor.themedColorfulAccent(3).gradient)
+            .gradientTint(ThemedColor.themedColorfulAccent(3))
             
             pickerItemView(
                 mode: .myInstance,

--- a/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SharingLinksSettingsView.swift
@@ -22,7 +22,7 @@ struct SharingLinksSettingsView: View {
                 description: "In the Fediverse, many different links can point to the same piece of content. Choose which site to use when sharing content.",
                 icon: .general.share
             )
-            .gradientTint(ThemedColor.themedColorfulAccent(3))
+            .gradientTint(.themedColorfulAccent(3))
             
             pickerItemView(
                 mode: .myInstance,

--- a/Mlem/App/Views/Root/Tabs/Settings/SortingSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SortingSettingsView.swift
@@ -36,7 +36,7 @@ struct SortingSettingsView: View {
                 description: "Choose the default sort mode for posts and comments.",
                 icon: .settings.sorting
             )
-            .gradientTint(ThemedColor.themedColorfulAccent(5))
+            .gradientTint(.themedColorfulAccent(5))
             Section {
                 HStack {
                     Text("Posts")

--- a/Mlem/App/Views/Root/Tabs/Settings/SortingSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SortingSettingsView.swift
@@ -36,7 +36,7 @@ struct SortingSettingsView: View {
                 description: "Choose the default sort mode for posts and comments.",
                 icon: .settings.sorting
             )
-            .tint(ThemedColor.themedColorfulAccent(5).gradient)
+            .gradientTint(ThemedColor.themedColorfulAccent(5))
             Section {
                 HStack {
                     Text("Posts")

--- a/Mlem/App/Views/Root/Tabs/Settings/SortingSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SortingSettingsView.swift
@@ -7,6 +7,7 @@
 
 import MlemMiddleware
 import SwiftUI
+import Theming
 
 struct SortingSettingsView: View {
     @Setting(\.post_defaultSort) var legacyDefaultPostSort
@@ -35,7 +36,7 @@ struct SortingSettingsView: View {
                 description: "Choose the default sort mode for posts and comments.",
                 icon: .settings.sorting
             )
-            .tint(.themedColorfulAccent(5))
+            .tint(ThemedColor.themedColorfulAccent(5).gradient)
             Section {
                 HStack {
                     Text("Posts")

--- a/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
@@ -20,7 +20,7 @@ struct SubscriptionListSettingsView: View {
                 description: "Customize how your subscription list is sorted.",
                 icon: .lemmy.subscriptionList
             )
-            .gradientTint(ThemedColor.themedCommunityAccent)
+            .gradientTint(.themedCommunityAccent)
             Section("Sort by...") {
                 Picker("Sort by...", selection: $sort) {
                     ForEach(SubscriptionListSort.allCases, id: \.self) { item in

--- a/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theming
 
 struct SubscriptionListSettingsView: View {
     @Setting(\.subscriptions_sort) private var sort
@@ -19,7 +20,7 @@ struct SubscriptionListSettingsView: View {
                 description: "Customize how your subscription list is sorted.",
                 icon: .lemmy.subscriptionList
             )
-            .tint(.themedCommunityAccent)
+            .tint(ThemedColor.themedCommunityAccent.gradient)
             Section("Sort by...") {
                 Picker("Sort by...", selection: $sort) {
                     ForEach(SubscriptionListSort.allCases, id: \.self) { item in

--- a/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
@@ -20,7 +20,7 @@ struct SubscriptionListSettingsView: View {
                 description: "Customize how your subscription list is sorted.",
                 icon: .lemmy.subscriptionList
             )
-            .tint(ThemedColor.themedCommunityAccent.gradient)
+            .gradientTint(ThemedColor.themedCommunityAccent)
             Section("Sort by...") {
                 Picker("Sort by...", selection: $sort) {
                     ForEach(SubscriptionListSort.allCases, id: \.self) { item in

--- a/Mlem/App/Views/Root/Tabs/Settings/SwipeActionEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SwipeActionEditorView.swift
@@ -68,7 +68,7 @@ private struct ActionListView<ActionType: ActionTypeProviding>: View {
             ForEach(actions, id: \.hashValue) { action in
                 HStack {
                     Label(action.appearance.label, systemImage: action.appearance.swipeIcon2)
-                        .tint(action.appearance.color)
+                        .tint(action.appearance.color.gradient)
                     Spacer()
                 }
                 .tag(action)

--- a/Mlem/App/Views/Root/Tabs/Settings/SwipeActionEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SwipeActionEditorView.swift
@@ -68,7 +68,7 @@ private struct ActionListView<ActionType: ActionTypeProviding>: View {
             ForEach(actions, id: \.hashValue) { action in
                 HStack {
                     Label(action.appearance.label, systemImage: action.appearance.swipeIcon2)
-                        .tint(action.appearance.color.gradient)
+                        .gradientTint(action.appearance.color)
                     Spacer()
                 }
                 .tag(action)

--- a/Mlem/App/Views/Root/Tabs/Settings/TabBarSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/TabBarSettingsView.swift
@@ -28,7 +28,7 @@ struct TabBarSettingsView: View {
                 description: "Customize the appearance of the tab bar.",
                 icon: .settings.tabBar
             )
-            .gradientTint(ThemedColor.themedColorfulAccent(5))
+            .gradientTint(.themedColorfulAccent(5))
             Section("Profile Tab Label") {
                 Picker("Profile Tab Label", selection: $profileTabLabel) {
                     profileTabLabelItem("Name", value: account.nickname, icon: .lemmy.alphabeticalSort)

--- a/Mlem/App/Views/Root/Tabs/Settings/TabBarSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/TabBarSettingsView.swift
@@ -7,6 +7,7 @@
 
 import Icons
 import SwiftUI
+import Theming
 
 struct TabBarSettingsView: View {
     @Environment(AppState.self) var appState
@@ -27,7 +28,7 @@ struct TabBarSettingsView: View {
                 description: "Customize the appearance of the tab bar.",
                 icon: .settings.tabBar
             )
-            .tint(.themedColorfulAccent(5))
+            .tint(ThemedColor.themedColorfulAccent(5).gradient)
             Section("Profile Tab Label") {
                 Picker("Profile Tab Label", selection: $profileTabLabel) {
                     profileTabLabelItem("Name", value: account.nickname, icon: .lemmy.alphabeticalSort)

--- a/Mlem/App/Views/Root/Tabs/Settings/TabBarSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/TabBarSettingsView.swift
@@ -28,7 +28,7 @@ struct TabBarSettingsView: View {
                 description: "Customize the appearance of the tab bar.",
                 icon: .settings.tabBar
             )
-            .tint(ThemedColor.themedColorfulAccent(5).gradient)
+            .gradientTint(ThemedColor.themedColorfulAccent(5))
             Section("Profile Tab Label") {
                 Picker("Profile Tab Label", selection: $profileTabLabel) {
                     profileTabLabelItem("Name", value: account.nickname, icon: .lemmy.alphabeticalSort)

--- a/Mlem/App/Views/Shared/Palette Components/Form.swift
+++ b/Mlem/App/Views/Shared/Palette Components/Form.swift
@@ -20,7 +20,6 @@ struct Form<Content: View>: View {
             content()
                 .foregroundStyle(.themedPrimary)
                 .listRowBackground(palette.groupedBackground.secondary)
-                // .tint(.themedAccent)
                 .buttonStyle(PaletteButton())
         }
         .tint(.themedAccent)

--- a/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
+++ b/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
@@ -25,6 +25,7 @@ struct SearchHomeView: View {
                 .padding(.top, 30)
                 .padding(.bottom, -4)
             browseList
+                .padding(.top, 20)
         }
         .padding(.horizontal, 16)
     }
@@ -44,26 +45,41 @@ struct SearchHomeView: View {
     
     @ViewBuilder
     var browseList: some View {
-        VStack(spacing: 16) {
+        HStack(alignment: .center, spacing: UIDevice.isPad ? 30 : 0) {
             ListRowButton(
                 title: "Communities",
                 icon: .lemmy.community,
-                destination: .topCommunities
+                destination: .topCommunities,
+                color: .green
             )
-            .tint(.themedCommunityAccent)
+            
+            if !UIDevice.isPad {
+                Spacer()
+            }
+            
             ListRowButton(
                 title: "Users",
                 icon: .lemmy.person,
-                destination: .topPeople
+                destination: .topPeople,
+                color: .blue
             )
-            .tint(.themedPersonAccent)
+            
+            if !UIDevice.isPad {
+                Spacer()
+            }
+            
             ListRowButton(
                 title: "Instances",
                 icon: .lemmy.instance,
-                destination: .topInstances
+                destination: .topInstances,
+                color: .red
             )
-            .tint(.themedColorfulAccent(1))
+            
+            if UIDevice.isPad {
+                Spacer()
+            }
         }
+        .padding(.horizontal, 20)
     }
     
     @ViewBuilder
@@ -85,23 +101,37 @@ private struct ListRowButton: View {
     let title: LocalizedStringResource
     let icon: Icon
     let destination: NavigationPage
+    let color: Color
     
     var body: some View {
         Button {
             navigation?.push(destination)
         } label: {
-            FormChevron {
-                HStack {
-                    Image(icon: icon)
-                        .symbolVariant(.fill)
-                        .foregroundStyle(.tint)
-                        .frame(minWidth: 30)
-                    Text(title)
-                }
+            VStack {
+                Image(icon: icon)
+                    .resizable()
+                    .foregroundStyle(.white)
+                    .symbolVariant(.fill)
+                    .scaledToFit()
+                    .padding(20)
+                    .background(color.gradient, in: .circle)
+                    .frame(width: 80, height: 80)
+                Text(title)
+                    .fontWeight(.semibold)
+                    .font(.subheadline)
             }
-            .padding(16)
-            .frame(maxWidth: .infinity)
-            .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 24))
+//            FormChevron {
+//                HStack {
+//                    Image(icon: icon)
+//                        .symbolVariant(.fill)
+//                        .foregroundStyle(.tint)
+//                        .frame(minWidth: 30)
+//                    Text(title)
+//                }
+//            }
+//            .padding(16)
+//            .frame(maxWidth: .infinity)
+//            .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 24))
         }
         .buttonStyle(.plain)
     }

--- a/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
+++ b/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
@@ -50,7 +50,7 @@ struct SearchHomeView: View {
                 title: "Communities",
                 icon: .lemmy.community,
                 destination: .topCommunities,
-                color: .green
+                color: .themedCommunityAccent
             )
             
             if !UIDevice.isPad {
@@ -61,7 +61,7 @@ struct SearchHomeView: View {
                 title: "Users",
                 icon: .lemmy.person,
                 destination: .topPeople,
-                color: .blue
+                color: .themedPersonAccent
             )
             
             if !UIDevice.isPad {
@@ -72,7 +72,7 @@ struct SearchHomeView: View {
                 title: "Instances",
                 icon: .lemmy.instance,
                 destination: .topInstances,
-                color: .red
+                color: .themedColorfulAccent(1)
             )
             
             if UIDevice.isPad {
@@ -101,7 +101,7 @@ private struct ListRowButton: View {
     let title: LocalizedStringResource
     let icon: Icon
     let destination: NavigationPage
-    let color: Color
+    let color: ThemedColor
     
     var body: some View {
         Button {
@@ -112,7 +112,6 @@ private struct ListRowButton: View {
                     .resizable()
                     .foregroundStyle(.white)
                     .symbolVariant(.fill)
-                    .scaledToFit()
                     .padding(20)
                     .background(color.gradient, in: .circle)
                     .frame(width: 80, height: 80)
@@ -120,18 +119,6 @@ private struct ListRowButton: View {
                     .fontWeight(.semibold)
                     .font(.subheadline)
             }
-//            FormChevron {
-//                HStack {
-//                    Image(icon: icon)
-//                        .symbolVariant(.fill)
-//                        .foregroundStyle(.tint)
-//                        .frame(minWidth: 30)
-//                    Text(title)
-//                }
-//            }
-//            .padding(16)
-//            .frame(maxWidth: .infinity)
-//            .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 24))
         }
         .buttonStyle(.plain)
     }

--- a/Mlem/Packages/Theming/Sources/Theming/ThemedColor.swift
+++ b/Mlem/Packages/Theming/Sources/Theming/ThemedColor.swift
@@ -19,6 +19,10 @@ public struct ThemedColor: ShapeStyle, Hashable, View, Sendable {
     public var body: some View {
         resolve(with: palette)
     }
+    
+    public var gradient: AnyGradient {
+        resolve(with: palette).gradient
+    }
 
     public func resolve(in environment: EnvironmentValues) -> Color {
         resolve(with: environment.palette)

--- a/Mlem/Packages/Theming/Sources/Theming/View+Tint.swift
+++ b/Mlem/Packages/Theming/Sources/Theming/View+Tint.swift
@@ -23,3 +23,20 @@ public extension View {
         modifier(ThemedTintViewModifier(themedColor: themedColor))
     }
 }
+
+private struct ThemedGradientTintModifier: ViewModifier {
+    @Environment(\.palette) private var palette
+    
+    let themedColor: ThemedColor
+    
+    func body(content: Content) -> some View {
+        content
+            .tint(themedColor.gradient(palette: palette))
+    }
+}
+
+public extension View {
+    func gradientTint(_ themedColor: ThemedColor) -> some View {
+        modifier(ThemedGradientTintModifier(themedColor: themedColor))
+    }
+}


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Description

Applies gradients to "icon on solid color backdrop" views.

## Implementation Notes

For convenience, I have defined `.gradientTint`. There were three alternatives to this implementation that I considered; of the four choices, I believe this to be the cleanest. The other options are:
- Add `isGradient` flag to the existing `.tint`. This both breaks from the system API pattern and requires defining two completely separate bodies for the actual modifier; at that point, it seems more direct to simply define a separate modifier.
- Call the system `.tint` but pass in the contextually resolved output of `ThemedColor.gradient`. This is extremely verbose and also requires adding a ton of `@Environment(\.palette)`s.
- Create a separate modifier also named `.tint` that takes in a `Palette -> AnyGradient` function, then resolves it to a gradient in the modifier itself. This is the closest to the system behavior, since you can just pass in `ThemedColor.gradient`, but has the annoying quirk that you have to explicitly namespace `ThemedColor` in the invocation (e.g., `.tint(ThemedColor.upvote.gradient)` instead of simply `.tint(.upvote.gradient)`), which makes the simple `.gradientTint` a little more concise.