### PR TITLE
Use native alphabet scroller for subscription list on iOS 26

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -28,12 +28,6 @@ struct SubscriptionListView: View {
     
     @Weak var form: UICollectionView?
     
-    var body: some View {
-        content
-            .listStyle(.sidebar)
-            .navigationTitle("Feeds")
-    }
-    
     var detailDisplayed: Bool {
         if UIDevice.isPad {
             noDetail ? false : navigation.path.isEmpty
@@ -42,32 +36,39 @@ struct SubscriptionListView: View {
         }
     }
     
+    var subscriptions: SubscriptionList? {
+        (appState.firstSession as? UserSession)?.subscriptions
+    }
+    
+    var sectionIndicesShown: Bool {
+        !UIDevice.isPad && sort == .alphabetical && (subscriptions?.communities.count ?? 0) > 10
+    }
+    
+    var body: some View {
+        Group {
+            // TODO: iOS 18 deprecation remove compatibility shim
+            if #available(iOS 26, *) {
+                content
+                    .listSectionIndexVisibility(sectionIndicesShown ? .visible : .hidden)
+            } else {
+                content
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationTitle("Feeds")
+    }
+    
     @ViewBuilder
     var content: some View {
         let sections = subscriptions?.visibleSections(sort: sort) ?? []
         
         Form {
-            Section {
-                ForEach(feedOptions, id: \.hashValue) { feedOption in
-                    SubscriptionListNavigationButton(.feeds(feedOption)) {
-                        HStack(spacing: 15) {
-                            FeedIconView(
-                                feedDescription: feedOption.description,
-                                size: appState.firstSession is GuestSession ? 36 : 28
-                            )
-                            VStack(alignment: .leading) {
-                                Text(feedOption.description.label)
-                                if appState.firstSession is GuestSession {
-                                    Text(feedOption.description.subtitle)
-                                        .font(.footnote)
-                                        .foregroundStyle(.themedSecondary)
-                                }
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(.rect)
-                    }
-                }
+            // TODO: iOS 18 deprecation remove compatibility shim
+            if #available(iOS 26, *) {
+                feeds
+                    .sectionIndexLabel("★")
+            } else {
+                feeds
             }
             
             if AccountsTracker.main.isEmpty {
@@ -98,7 +99,7 @@ struct SubscriptionListView: View {
         }
         .foregroundStyle(.themedPrimary)
         .overlay(alignment: .trailing) {
-            if sectionIndicesShown {
+            if !UIDevice.isIos26, sectionIndicesShown {
                 SectionIndexTitles(
                     sections: sections,
                     sectionScroller: $sectionScroller
@@ -146,6 +147,32 @@ struct SubscriptionListView: View {
     }
     
     @ViewBuilder
+    var feeds: some View {
+        Section {
+            ForEach(feedOptions, id: \.hashValue) { feedOption in
+                SubscriptionListNavigationButton(.feeds(feedOption)) {
+                    HStack(spacing: 15) {
+                        FeedIconView(
+                            feedDescription: feedOption.description,
+                            size: appState.firstSession is GuestSession ? 36 : 28
+                        )
+                        VStack(alignment: .leading) {
+                            Text(feedOption.description.label)
+                            if appState.firstSession is GuestSession {
+                                Text(feedOption.description.subtitle)
+                                    .font(.footnote)
+                                    .foregroundStyle(.themedSecondary)
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(.rect)
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder
     var signedOutInfoView: some View {
         VStack {
             Image(systemName: "list.bullet")
@@ -179,21 +206,23 @@ struct SubscriptionListView: View {
         .frame(maxWidth: .infinity)
         .foregroundStyle(.themedSecondary)
     }
-    
-    var subscriptions: SubscriptionList? {
-        (appState.firstSession as? UserSession)?.subscriptions
-    }
-    
-    var sectionIndicesShown: Bool {
-        !UIDevice.isPad && sort == .alphabetical && (subscriptions?.communities.count ?? 0) > 10
-    }
 }
 
 private struct SubscriptionListSectionView: View {
     let section: SubscriptionListSection
     let sectionIndicesShown: Bool
     
+    // TODO: iOS 18 deprecation remove compatibility shim
     var body: some View {
+        if #available(iOS 26, *), section.label != "Favorites" {
+            content
+                .sectionIndexLabel(section.label)
+        } else {
+            content
+        }
+    }
+    
+    var content: some View {
         Section(section.label) {
             ForEach(section.communities) { (community: Community2) in
                 SubscriptionListItemView(

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -214,7 +214,7 @@ private struct SubscriptionListSectionView: View {
     
     // TODO: iOS 18 deprecation remove compatibility shim
     var body: some View {
-        if #available(iOS 26, *), section.label != "Favorites" {
+        if #available(iOS 26, *), section.label != String(localized: "Favorites") {
             content
                 .sectionIndexLabel(section.label)
         } else {

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -214,9 +214,9 @@ private struct SubscriptionListSectionView: View {
     
     // TODO: iOS 18 deprecation remove compatibility shim
     var body: some View {
-        if #available(iOS 26, *), section.label != String(localized: "Favorites") {
+        if #available(iOS 26, *) {
             content
-                .sectionIndexLabel(section.label)
+                .sectionIndexLabel(section.showInScroller ? section.label : nil)
         } else {
             content
         }
@@ -258,6 +258,14 @@ struct SubscriptionListSection: Identifiable {
     let label: String
     var icon: Icon?
     let communities: [Community2]
+    let showInScroller: Bool
+    
+    init(label: String, icon: Icon? = nil, communities: [Community2], showInScroller: Bool = true) {
+        self.label = label
+        self.icon = icon
+        self.communities = communities
+        self.showInScroller = showInScroller
+    }
     
     var id: String { label }
 }
@@ -266,7 +274,11 @@ private extension SubscriptionList {
     func visibleSections(sort: SubscriptionListSort) -> [SubscriptionListSection] {
         var sections: [SubscriptionListSection] = .init()
         if !favorites.isEmpty {
-            sections.append(.init(label: String(localized: "Favorites"), icon: .lemmy.favorited, communities: favorites))
+            sections.append(.init(
+                label: String(localized: "Favorites"),
+                icon: .lemmy.favorited,
+                communities: favorites,
+                showInScroller: false))
         }
         switch sort {
         case .alphabetical:


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2286 
- progress towards #2191 

## Description

Uses the system alphabet scroller when iOS 26 is available.

This PR also includes one minor design change on iOS 26: the star label is now used to indicate favorites + defaults, allowing the user to scroll all the way to the top using the alphabet scroller.