### PR TITLE
PieFed 1.2 support

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ImageUpload1Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ImageUpload1Snapshot+PieFed.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public extension ImageUpload1Snapshot {
-    init(from response: PieFedUploadResponse) {
+    init(from response: PieFedImageUploadResponse) {
         self.url = response.url
         self.alias = nil
         self.deleteToken = nil

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/PieFedPostAggregates+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/PieFedPostAggregates+Extensions.swift
@@ -16,7 +16,8 @@ extension PieFedPostAggregates: ApiContentAggregatesProtocol {
             upvotes: 0,
             downvotes: 0,
             published: .distantPast,
-            newestCommentTime: ""
+            newestCommentTime: "",
+            crossPosts: 0
         )
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
@@ -126,7 +126,7 @@ public extension PieFedConnection {
     
     @discardableResult
     func voteOnComment(id: Int, score: ScoringOperation) async throws -> Comment2Snapshot {
-        let request = PieFedCreateCommentLikeRequest(
+        let request = PieFedLikeCommentRequest(
             commentId: id,
             score: score.rawValue,
             private: false

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Community.swift
@@ -48,7 +48,9 @@ public extension PieFedConnection {
             sort: sort,
             listingType: filter.pieFedListingType,
             page: page,
-            limit: limit
+            limit: limit,
+            communityName: nil,
+            communityId: nil
         )
         let response = try await perform(request)
         return try response.communities.map { try .init(from: $0) }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Image.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Image.swift
@@ -38,7 +38,7 @@ public extension PieFedConnection {
         )
         
         do {
-            let response = try JSONDecoder.defaultDecoder.decode(PieFedUploadResponse.self, from: data)
+            let response = try JSONDecoder.defaultDecoder.decode(PieFedImageUploadResponse.self, from: data)
             return .init(from: response)
         } catch DecodingError.dataCorrupted {
             let text = String(decoding: data, as: UTF8.self)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -64,7 +64,7 @@ public extension PieFedConnection {
             let response = try await perform(request)
             return try response.privateMessages.map { try .init(from: $0) }
         } else {
-            let request = PieFedGetPrivateMessagesRequest(
+            let request = PieFedListPrivateMessagesRequest(
                 unreadOnly: unreadOnly,
                 page: page,
                 limit: limit,
@@ -121,7 +121,11 @@ public extension PieFedConnection {
     
     @discardableResult
     func deleteMessage(id: Int, delete: Bool) async throws -> Message2Snapshot {
-        let request = PieFedDeletePrivateMessageRequest(messageId: id, deleted: delete)
+        let request = PieFedDeletePrivateMessageRequest(
+            messageId: id,
+            deleted: delete,
+            privateMessageId: id
+        )
         let response = try await perform(request)
         return try .init(from: response.privateMessageView)
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
@@ -73,7 +73,9 @@ public extension PieFedConnection {
             sort: sort,
             listingType: filter.pieFedListingType,
             page: page,
-            limit: limit
+            limit: limit,
+            communityName: nil,
+            communityId: nil
         )
         let response = try await perform(request)
         return try response.users.map { try .init(from: $0) }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
@@ -29,7 +29,11 @@ public extension PieFedConnection {
             personId: nil,
             communityName: nil,
             likedOnly: filter == .upvoted,
-            savedOnly: filter == .saved
+            savedOnly: filter == .saved,
+            q: nil,
+            page: page,
+            feedId: nil,
+            topicId: nil
         )
         let response = try await perform(request)
         let posts: [Post2Snapshot] = try response.posts.map { try .init(from: $0) }
@@ -57,7 +61,11 @@ public extension PieFedConnection {
             personId: nil,
             communityName: nil,
             likedOnly: filter == .upvoted,
-            savedOnly: filter == .saved
+            savedOnly: filter == .saved,
+            q: nil,
+            page: page,
+            feedId: nil,
+            topicId: nil
         )
         let response = try await perform(request)
         let posts: [Post2Snapshot] = try response.posts.map { try .init(from: $0) }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
@@ -20,7 +20,7 @@ public extension PieFedConnection {
         if filter == .downvoted {
             throw ApiClientError.featureUnsupported
         }
-        let request = PieFedGetPostsRequest(
+        let request = PieFedListPostsRequest(
             type_: nil,
             sort: sort.pieFedSortType,
             pageCursor: page,
@@ -48,7 +48,7 @@ public extension PieFedConnection {
         if filter == .downvoted || showHidden {
             throw ApiClientError.featureUnsupported
         }
-        let request = PieFedGetPostsRequest(
+        let request = PieFedListPostsRequest(
             type_: feed.pieFedListingType,
             sort: sort.pieFedSortType,
             pageCursor: page,
@@ -116,7 +116,9 @@ public extension PieFedConnection {
             sort: sort,
             listingType: filter.pieFedListingType,
             page: page,
-            limit: limit
+            limit: limit,
+            communityName: nil,
+            communityId: communityId
         )
         let response = try await perform(request)
         return try response.posts.map { try .init(from: $0) }
@@ -160,7 +162,7 @@ public extension PieFedConnection {
     
     @discardableResult
     func voteOnPost(id: Int, score: ScoringOperation) async throws -> Post2Snapshot {
-        let request = PieFedCreatePostLikeRequest(postId: id, score: score.rawValue)
+        let request = PieFedLikePostRequest(postId: id, score: score.rawValue)
         async let response = perform(request)
         if !supports(.autoMarkPostReadOnInteract, defaultValue: false) {
             try await markPostAsRead(id: id, read: true)


### PR DESCRIPTION
> [!note]
> Relies on [this MlemApiTypes PR](https://github.com/mlemgroup/MlemApiTypes/pull/35)

Updates the PieFed API types. In PieFed 1.2, they made a breaking change to the private message deletion endpoint. PieFed 1.2 isn't out just yet but it will be shortly, so this needs to go in Mlem 2.3.

The `pageCursor` -> `page` change is non-breaking; PieFed 1.2 continues to support `pageCursor`