### PR TITLE
Use checkmark icon when editing posts and comments

### DIFF
--- a/Mlem/App/Views/Pages/Editors/CommentEditor/CommentEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/CommentEditorView.swift
@@ -277,7 +277,7 @@ struct CommentEditorView: View {
     
     @ViewBuilder
     var sendButton: some View {
-        Button("Send", icon: .lemmy.send) {
+        Button("Send", icon: commentToEdit != nil ? .general.success : .lemmy.send) {
             sending = true
             Task(priority: .userInitiated) {
                 await send()

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Toolbar.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Toolbar.swift
@@ -39,7 +39,7 @@ extension PostEditorView {
     
     @ViewBuilder
     var sendButton: some View {
-        Button("Send", icon: .lemmy.send) {
+        Button("Send", icon: postToEdit != nil ? .general.success : .lemmy.send) {
             self.sending = true
             Task { await submit() }
         }


### PR DESCRIPTION
## Issues

- closes #2269

## Description

Changes the paper plane icon to display a checkmark when editing posts and comments.

## Implementation Notes

Modified `CommentEditorView.swift` and `PostEditorView+Toolbar.swift` to conditionally render the submit icon.