### PR TITLE
View votes on PieFed

### DIFF
--- a/Mlem/App/Views/Pages/VotesListView.swift
+++ b/Mlem/App/Views/Pages/VotesListView.swift
@@ -52,28 +52,7 @@ struct VotesListView: View {
     var body: some View {
         FancyScrollView {
             LazyVStack(spacing: Constants.main.halfSpacing) {
-                ForEach(votes, id: \.creator.id) { (vote: PersonVote) in
-                    NavigationLink(.person(vote.creator)) {
-                        HStack {
-                            FullyQualifiedLinkView(vote.creator, labelStyle: .medium)
-                            Spacer()
-                            Image(systemName: vote.vote.systemImage)
-                                .imageScale(.large)
-                                .symbolVariant(.fill)
-                                .symbolRenderingMode(.palette)
-                                .foregroundStyle(.themedContrastingLabel, vote.vote.color)
-                        }
-                    }
-                    .padding([.vertical, .trailing], Constants.main.halfSpacing)
-                    .padding(.leading, Constants.main.standardSpacing)
-                    .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
-                    .paletteBorder(cornerRadius: Constants.main.standardSpacing)
-                    .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
-                    .contextMenu {
-                        vote.creator.menuActions(appState: appState, navigation: navigation, community: target.model.community_)
-                    }
-                    .padding(.horizontal, Constants.main.standardSpacing)
-                }
+                ForEach(votes, id: \.creator.id, content: rowView)
                 EndOfFeedView(loadingState: loadingState, viewType: .turtle)
                     .onAppear {
                         loadNextPage()
@@ -83,6 +62,35 @@ struct VotesListView: View {
         .environment(\.communityContext, target.model.community_)
         .themedGroupedBackground()
         .navigationTitle("Votes")
+    }
+    
+    @ViewBuilder
+    func rowView(_ vote: PersonVote) -> some View {
+        NavigationLink(.person(vote.creator)) {
+            rowViewLabel(vote)
+        }
+        .padding([.vertical, .trailing], Constants.main.halfSpacing)
+        .padding(.leading, Constants.main.standardSpacing)
+        .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
+        .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
+        .contextMenu {
+            vote.creator.menuActions(appState: appState, navigation: navigation, community: target.model.community_)
+        }
+        .padding(.horizontal, Constants.main.standardSpacing)
+    }
+    
+    @ViewBuilder
+    func rowViewLabel(_ vote: PersonVote) -> some View {
+        HStack {
+            FullyQualifiedLinkView(vote.creator, labelStyle: .medium)
+            Spacer()
+            Image(systemName: vote.vote.systemImage)
+                .imageScale(.large)
+                .symbolVariant(.fill)
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.themedContrastingLabel, vote.vote.color)
+        }
     }
     
     func loadNextPage() {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
@@ -156,7 +156,6 @@ public extension ApiClient {
     ) async throws -> [PersonVote] {
         let snapshot = try await repository.getCommentVotes(
             id: id,
-            communityId: communityId,
             page: page,
             limit: limit
         )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -225,7 +225,6 @@ public extension ApiClient {
     ) async throws -> [PersonVote] {
         let snapshot = try await repository.getPostVotes(
             id: id,
-            communityId: communityId,
             page: page,
             limit: limit
         )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Comment.swift
@@ -174,14 +174,12 @@ extension ApiRepository {
     
     func getCommentVotes(
         id: Int,
-        communityId: Int,
         page: Int = 1,
         limit: Int = 20
     ) async throws -> [PersonVoteSnapshot] {
         try await performingForConnection { connection in
             try await connection.getCommentVotes(
                 id: id,
-                communityId: communityId,
                 page: page,
                 limit: limit
             )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Post.swift
@@ -266,21 +266,19 @@ extension ApiRepository {
         id: Int,
         lock: Bool
     ) async throws -> Post2Snapshot {
-        return try await performingForConnection { connection in
+        try await performingForConnection { connection in
             try await connection.lockPost(id: id, lock: lock)
         }
     }
     
     func getPostVotes(
         id: Int,
-        communityId: Int,
         page: Int = 1,
         limit: Int = 20
     ) async throws -> [PersonVoteSnapshot] {
         try await performingForConnection { connection in
             try await connection.getPostVotes(
                 id: id,
-                communityId: communityId,
                 page: page,
                 limit: limit
             )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/PersonVoteSnapshot+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/PersonVoteSnapshot+Lemmy.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-09-18.
+//
+
+import Foundation
+
+extension PersonVoteSnapshot {
+    init(from vote: LemmyVoteView) throws(ApiClientError) {
+        self.creator = try .init(from: vote.creator)
+        self.score = vote.score
+        self.creatorBannedFromCommunity = vote.creatorBannedFromCommunity
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/PersonVoteSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/PersonVoteSnapshot+PieFed.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-09-18.
+//
+
+import Foundation
+
+extension PersonVoteSnapshot {
+    init(from vote: PieFedPostLikeView) throws(ApiClientError) {
+        self.creator = try .init(from: vote.creator)
+        self.score = vote.score
+        self.creatorBannedFromCommunity = vote.creatorBannedFromCommunity
+    }
+    
+    init(from vote: PieFedCommentLikeView) throws(ApiClientError) {
+        self.creator = try .init(from: vote.creator)
+        self.score = vote.score
+        self.creatorBannedFromCommunity = vote.creatorBannedFromCommunity
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -141,7 +141,6 @@ public protocol InstanceConnection {
     @discardableResult
     func getPostVotes(
         id: Int,
-        communityId: Int,
         page: Int,
         limit: Int
     ) async throws -> [PersonVoteSnapshot]
@@ -220,7 +219,6 @@ public protocol InstanceConnection {
     @discardableResult
     func getCommentVotes(
         id: Int,
-        communityId: Int,
         page: Int,
         limit: Int
     ) async throws -> [PersonVoteSnapshot]

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Comment.swift
@@ -264,7 +264,6 @@ public extension LemmyConnection {
     @discardableResult
     func getCommentVotes(
         id: Int,
-        communityId: Int,
         page: Int = 1,
         limit: Int = 20
     ) async throws -> [PersonVoteSnapshot] {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
@@ -438,7 +438,6 @@ public extension LemmyConnection {
     @discardableResult
     func getPostVotes(
         id: Int,
-        communityId: Int,
         page: Int = 1,
         limit: Int = 20
     ) async throws -> [PersonVoteSnapshot] {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
@@ -215,6 +215,8 @@ public extension PieFedConnection {
         page: Int = 1,
         limit: Int = 20
     ) async throws -> [PersonVoteSnapshot] {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedListCommentLikesRequest(commentId: id, page: page, limit: limit)
+        let response = try await perform(request)
+        return try response.commentLikes?.map { try .init(from: $0) } ?? []
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
@@ -211,7 +211,6 @@ public extension PieFedConnection {
     @discardableResult
     func getCommentVotes(
         id: Int,
-        communityId: Int,
         page: Int = 1,
         limit: Int = 20
     ) async throws -> [PersonVoteSnapshot] {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
@@ -37,7 +37,7 @@ public extension PieFedConnection {
             listingType.pieFedListingType != nil
         case .viewCommunityActiveUsers, .viewMentionsAndPrivateMessages, .editAndDeletePrivateMessages, .autoMarkPostReadOnInteract:
             version >= .v1_1_0
-        case .editProfile:
+        case .editProfile, .viewVotes:
             version >= .v1_2_0
         default: false
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
@@ -318,6 +318,8 @@ public extension PieFedConnection {
         page: Int = 1,
         limit: Int = 20
     ) async throws -> [PersonVoteSnapshot] {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedListPostLikesRequest(postId: id, page: page, limit: limit)
+        let response = try await perform(request)
+        return try response.postLikes?.map { try .init(from: $0) } ?? []
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
@@ -314,7 +314,6 @@ public extension PieFedConnection {
     @discardableResult
     func getPostVotes(
         id: Int,
-        communityId: Int,
         page: Int = 1,
         limit: Int = 20
     ) async throws -> [PersonVoteSnapshot] {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/PersonVote/PersonVoteSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/PersonVote/PersonVoteSnapshot.swift
@@ -13,10 +13,4 @@ public struct PersonVoteSnapshot: CacheIdentifiable {
     public let creatorBannedFromCommunity: Bool?
     
     public var cacheId: Int { creator.id }
-    
-    public init(from vote: LemmyVoteView) throws(ApiClientError) {
-        self.creator = try .init(from: vote.creator)
-        self.score = vote.score
-        self.creatorBannedFromCommunity = vote.creatorBannedFromCommunity
-    }
 }


### PR DESCRIPTION
Enabled the "view votes" feature on PieFed 1.2 and up.

Closes #2163

The PieFed API sorts upvotes first, unlike the Lemmy equivalent which sorts downvotes first. I've opened [an issue](https://codeberg.org/rimu/pyfedi/issues/1315) on the PieFed repo for this.