### PR TITLE
Add code syntax highlighting support

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -3392,7 +3392,7 @@
 			repositoryURL = "https://github.com/mlemgroup/LemmyMarkdownUI";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.12.0;
+				minimumVersion = 0.13.0;
 			};
 		};
 		0392826E2BC84E480097F91A /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "highlightswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/appstefan/highlightswift.git",
+      "state" : {
+        "revision" : "784ca3ccfc8a2cf724fbb2f06cb6ec3329424da3",
+        "version" : "1.1.0"
+      }
+    },
+    {
       "identity" : "keychainaccess",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kishikawakatsumi/KeychainAccess.git",
@@ -32,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlemgroup/LemmyMarkdownUI",
       "state" : {
-        "revision" : "624644674e0466e83fbf0dcdf52af2c6e5e70c6c",
-        "version" : "0.12.0"
+        "revision" : "de46c794b45773da93b7296668e94785e44f40a4",
+        "version" : "0.13.0"
       }
     },
     {

--- a/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/MarkdownConfiguration+Extensions.swift
@@ -28,19 +28,25 @@ extension MarkdownConfiguration {
         }
     }
     
-    static func `default`(palette: Palette) -> MarkdownConfiguration { .init(
-        inlineImageLoader: loadInlineImage,
-        imageBlockView: { imageView($0, shouldBlur: false) },
-        wrapCodeBlockLines: Settings.get(\.markdown_wrapCodeBlockLines),
-        spoilerLabel: .init(localized: "Spoiler"),
-        tableLabel: .init(localized: "Table"),
-        censorLabel: .init(localized: "Censored"),
-        primaryColor: palette.label.primary,
-        secondaryColor: palette.label.secondary,
-        codeBackgroundColor: palette.groupedBackground.tertiary,
-        censorColor: palette.warning,
-        codeFontScaleFactor: 0.9
-    ) }
+    static func `default`(palette: Palette) -> MarkdownConfiguration {
+        let currentPaletteOption = Settings.get(\.appearance_palette)
+        let enableSyntaxHighlighting = ![.solarized, .monochrome].contains(currentPaletteOption)
+
+        return .init(
+            inlineImageLoader: loadInlineImage,
+            imageBlockView: { imageView($0, shouldBlur: false) },
+            wrapCodeBlockLines: Settings.get(\.markdown_wrapCodeBlockLines),
+            spoilerLabel: .init(localized: "Spoiler"),
+            tableLabel: .init(localized: "Table"),
+            censorLabel: .init(localized: "Censored"),
+            primaryColor: palette.label.primary,
+            secondaryColor: palette.label.secondary,
+            codeBackgroundColor: palette.groupedBackground.tertiary,
+            censorColor: palette.warning,
+            codeFontScaleFactor: 0.9,
+            enableSyntaxHighlighting: enableSyntaxHighlighting
+        )
+    }
     
     static func defaultBlurred(palette: Palette) -> MarkdownConfiguration {
         var config = Self.default(palette: palette)


### PR DESCRIPTION
## Issues

- closes #2119

## Description

Adds syntax highlighting for code blocks and conditionally enabling the feature based on the current color theme.

## Implementation Notes

- Upgrades LemmyMarkdownUI dependency from 0.12.0 to 0.13.0 which includes HighlightSwift for syntax highlighting.
- Syntax highlighting is automatically disabled for Solarized and Monochrome themes to maintain readability.