### PR TITLE
Rename `SiteVersion.EndpointVersion` -> `LemmyEndpointVersion`

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion+EndpointVersion.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion+EndpointVersion.swift
@@ -7,15 +7,13 @@
 
 import Foundation
 
-public extension SiteVersion {
-    enum EndpointVersion: Hashable, Sendable {
-        case v3, v4
-        
-        public var pathComponent: String {
-            switch self {
-            case .v3: "v3"
-            case .v4: "v4"
-            }
+enum LemmyEndpointVersion: Hashable, Sendable {
+    case v3, v4
+    
+    var pathComponent: String {
+        switch self {
+        case .v3: "v3"
+        case .v4: "v4"
         }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/CommentSortType+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/CommentSortType+Lemmy.swift
@@ -19,7 +19,7 @@ public extension CommentSortType {
         }
     }
     
-    func apiType(for endpoint: SiteVersion.EndpointVersion) throws(ApiClientError) -> SearchSortTypeBridge {
+    internal func apiType(for endpoint: LemmyEndpointVersion) throws(ApiClientError) -> SearchSortTypeBridge {
         switch endpoint {
         case .v3: .old(v3PostApiType)
         case .v4: try .newOrUnsupported(v4SearchApiType)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/PostSortType+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/PostSortType+Lemmy.swift
@@ -29,14 +29,14 @@ public extension PostSortType {
         }
     }
     
-    func apiType(for endpoint: SiteVersion.EndpointVersion) throws(ApiClientError) -> SearchSortTypeBridge {
+    internal func apiType(for endpoint: LemmyEndpointVersion) throws(ApiClientError) -> SearchSortTypeBridge {
         switch endpoint {
         case .v3: try .oldOrUnsupported(v3ApiType)
         case .v4: try .newOrUnsupported(v4SearchApiType)
         }
     }
     
-    func apiType(for endpoint: SiteVersion.EndpointVersion) throws(ApiClientError) -> PostSortTypeBridge {
+    internal func apiType(for endpoint: LemmyEndpointVersion) throws(ApiClientError) -> PostSortTypeBridge {
         switch endpoint {
         case .v3: try .oldOrUnsupported(v3ApiType)
         case .v4: .new(v4PostApiType)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/SearchSortType+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/SearchSortType+Lemmy.swift
@@ -23,7 +23,7 @@ extension SearchSortType {
         }
     }
     
-    func apiType(for endpoint: SiteVersion.EndpointVersion) throws(ApiClientError) -> SearchSortTypeBridge {
+    func apiType(for endpoint: LemmyEndpointVersion) throws(ApiClientError) -> SearchSortTypeBridge {
         try switch endpoint {
         case .v3: try .oldOrUnsupported(v3ApiType)
         case .v4: try .newOrUnsupported(v4ApiType)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Comment.swift
@@ -141,7 +141,7 @@ public extension LemmyConnection {
         communityId: Int?,
         creatorId: Int?,
         filter: ListingType,
-        createSortType: @escaping (SiteVersion.EndpointVersion) throws -> SearchSortTypeBridge,
+        createSortType: @escaping (LemmyEndpointVersion) throws -> SearchSortTypeBridge,
         timeRangeSeconds: Int?
     ) async throws -> [Comment2Snapshot] {
         let response = try await performingForEndpoint { endpoint in

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
@@ -187,7 +187,7 @@ public extension LemmyConnection {
         communityId: Int?,
         creatorId: Int?,
         filter: ListingType,
-        createSortType: @escaping (SiteVersion.EndpointVersion) throws -> SearchSortTypeBridge,
+        createSortType: @escaping (LemmyEndpointVersion) throws -> SearchSortTypeBridge,
         timeRangeSeconds: Int?
     ) async throws -> [Post2Snapshot] {
         let response = try await performingForEndpoint { endpoint in

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection.swift
@@ -30,7 +30,7 @@ public class LemmyConnection: InstanceConnection {
     public let baseUrl: URL
     public var token: String?
     
-    private var endpointMultiplexer: ConnectionMultiplexer<SiteVersion.EndpointVersion> = .init { [.v3, .v4] }
+    private var endpointMultiplexer: ConnectionMultiplexer<LemmyEndpointVersion> = .init { [.v3, .v4] }
     private(set) var contextDataManager: SharedTaskManager<Context, RawContext> = .init()
 
     public var fetchedVersion: SiteVersion? {
@@ -99,7 +99,7 @@ public class LemmyConnection: InstanceConnection {
     // When this function is called, the `requestGenerator` will be called at least once,
     // but may be called more than once.
     func performingForEndpoint<Request: RestRequest>(
-        _ requestGenerator: @escaping (SiteVersion.EndpointVersion) async throws -> Request
+        _ requestGenerator: @escaping (LemmyEndpointVersion) async throws -> Request
     ) async throws -> Request.Response {
         do {
             return try await endpointMultiplexer.perform { endpoint in
@@ -113,7 +113,7 @@ public class LemmyConnection: InstanceConnection {
     // When this function is called, the `callback` will be called at least once,
     // but may be called more than once.
     func processingForEndpoint<Response>(
-        _ callback: @escaping (SiteVersion.EndpointVersion) async throws -> Response
+        _ callback: @escaping (LemmyEndpointVersion) async throws -> Response
     ) async throws -> Response {
         do {
             return try await endpointMultiplexer.perform { endpoint in


### PR DESCRIPTION
> [!note]
> Relies on [this MlemApiTypes PR](https://github.com/mlemgroup/MlemApiTypes/pull/36)

Moved `EndpointVersion` out of `SiteVersion` and renamed it to `LemmyEndpointVersion`.

Justification: `SiteVersion` should simply represent a semantic version number without attachment to Lemmy or PieFed specifically