### PR TITLE
Hide instance block button on PieFed

### DIFF
--- a/Mlem/App/Utility/Extensions/Content Models/InstanceStubProviding+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/InstanceStubProviding+Extensions.swift
@@ -87,7 +87,8 @@ extension InstanceStubProviding {
             openInBrowserAction()
             shareAction(navigation: navigation)
         }
-        if !local || (allowExternalBlocking && actorId != AppState.main.firstApi.actorId) {
+        
+        if blockingAvailable(allowExternalBlocking: allowExternalBlocking) {
             ActionGroup {
                 blockAction(
                     appState: appState,
@@ -96,6 +97,22 @@ extension InstanceStubProviding {
                 )
             }
         }
+    }
+    
+    private func blockingAvailable(allowExternalBlocking: Bool) -> Bool {
+        let apiToBlockWith: ApiClient
+        
+        if api.token == nil {
+            if !allowExternalBlocking { return false }
+            if actorId == AppState.main.firstApi.actorId { return false }
+            apiToBlockWith = AppState.main.firstApi
+        } else {
+            apiToBlockWith = api
+        }
+        
+        if !apiToBlockWith.supports(.blockInstances, defaultValue: false) { return false }
+        
+        return true
     }
     
     func shareAction(navigation: NavigationLayer?) -> BasicAction {

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -33,7 +33,7 @@ struct BlockListView: View {
     
     var body: some View {
         FancyScrollView {
-            BubblePicker(Tab.allCases, selected: $selectedTab, label: \.label, value: { tab in
+            BubblePicker(availableTabs, selected: $selectedTab, label: \.label, value: { tab in
                 guard let blockList = (appState.firstSession as? UserSession)?.blocks else { return 0 }
                 switch tab {
                 case .people:
@@ -73,5 +73,13 @@ struct BlockListView: View {
             }
         }
         .navigationTitle("Block List")
+    }
+    
+    var availableTabs: [Tab] {
+        var output: [Tab] = [.people, .communities]
+        if appState.firstApi.supports(.blockInstances, defaultValue: false) {
+            output.append(.instances)
+        }
+        return output
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -52,4 +52,6 @@ public enum Feature: Hashable {
     
     /// Server automatically marks posts as read when voted on or saved
     case autoMarkPostReadOnInteract
+    
+    case blockInstances
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/BlockListSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/BlockListSnapshot+PieFed.swift
@@ -19,7 +19,7 @@ public extension BlockListSnapshot {
         
         self.instances = myUserInfo.instanceBlocks.reduce(into: [:]) {
             let actorId: ActorIdentifier = .instance(host: $1.instance.domain)
-            $0[actorId] = $1.instance.id
+            $0[actorId] = actorId.url.absoluteString.hashValue
         }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -40,7 +40,7 @@ public extension LemmyConnection {
              .editAccountSettings, .viewMentionsAndPrivateMessages, .viewReports, .editAndDeletePrivateMessages,
              .reportPrivateMessages, .viewVotes, .purgeContent, .removeCommunity, .banFromInstance,
              .banFromCommunity, .editModeratorList, .commentSearch, .undeletePrivateMessages, .searchLocalPeople,
-             .hidePosts, .editDisplayName, .editProfile, .autoMarkPostReadOnInteract:
+             .hidePosts, .editDisplayName, .editProfile, .autoMarkPostReadOnInteract, .blockInstances:
             true
         }
     }


### PR DESCRIPTION
Hid the "block" button for instances and the "instances" tab in the block list on PieFed.