### PR TITLE
PieFed API types update

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ListingType+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ListingType+PieFed.swift
@@ -13,7 +13,7 @@ public extension ListingType {
         case .all: .all
         case .local: .local
         case .subscribed: .subscribed
-        case .moderatorView: .moderated
+        case .moderatorView, .moderating: .moderated
         case .popular: .popular
         }
         if let value {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ReportSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ReportSnapshot+PieFed.swift
@@ -22,7 +22,7 @@ extension ReportSnapshot {
         
         self.updated = report.commentReport.updated
         self.resolved = report.commentReport.resolved
-        self.reason = report.commentReport.reason
+        self.reason = report.commentReport.reason ?? ""
         
         self.target = try .comment(.init(from: report))
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
@@ -216,6 +216,6 @@ public extension PieFedConnection {
     ) async throws -> [PersonVoteSnapshot] {
         let request = PieFedListCommentLikesRequest(commentId: id, page: page, limit: limit)
         let response = try await perform(request)
-        return try response.commentLikes?.map { try .init(from: $0) } ?? []
+        return try response.commentLikes.map { try .init(from: $0) }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
@@ -170,7 +170,7 @@ public extension PieFedConnection {
     
     @discardableResult
     func voteOnPost(id: Int, score: ScoringOperation) async throws -> Post2Snapshot {
-        let request = PieFedLikePostRequest(postId: id, score: score.rawValue)
+        let request = PieFedLikePostRequest(postId: id, score: score.rawValue, private: nil)
         async let response = perform(request)
         if !supports(.autoMarkPostReadOnInteract, defaultValue: false) {
             try await markPostAsRead(id: id, read: true)
@@ -319,6 +319,6 @@ public extension PieFedConnection {
     ) async throws -> [PersonVoteSnapshot] {
         let request = PieFedListPostLikesRequest(postId: id, page: page, limit: limit)
         let response = try await perform(request)
-        return try response.postLikes?.map { try .init(from: $0) } ?? []
+        return try response.postLikes.map { try .init(from: $0) }
     }
 }


### PR DESCRIPTION
> [!note]
> Relies on [this MlemApiTypes PR](https://github.com/mlemgroup/MlemApiTypes/pull/37).

Updated to latest PieFed API types. No breaking changes. Drafting until 2.3.1 is out; I don't want to risk breaking anything in the patch release