### PR TITLE
Undelete private messages on PieFed

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
@@ -37,7 +37,7 @@ public extension PieFedConnection {
             listingType.pieFedListingType != nil
         case .viewCommunityActiveUsers, .viewMentionsAndPrivateMessages, .editAndDeletePrivateMessages, .autoMarkPostReadOnInteract:
             version >= .v1_1_0
-        case .editProfile, .viewVotes:
+        case .editProfile, .viewVotes, .undeletePrivateMessages:
             version >= .v1_2_0
         default: false
         }


### PR DESCRIPTION
Closes #2203

You're only able to undelete messages that you deleted _after_ they introduced undeleting private messages (in PieFed 1.2). I haven't bothered adding a check for this.