### PR TITLE
Bare-bones `InboxNotification` type

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -363,6 +363,7 @@
 		03E614E42C0BCC7B00F692A4 /* Post1Providing+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E614E32C0BCC7B00F692A4 /* Post1Providing+Extensions.swift */; };
 		03E614E52C0BCCAA00F692A4 /* PostSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2EC7A2BFADA8B00DBC0EF /* PostSize.swift */; };
 		03E614E72C0BCDC200F692A4 /* FullyQualifiedLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E614E62C0BCDC200F692A4 /* FullyQualifiedLinkView.swift */; };
+		03EC82B72E8D8C97004698BB /* TestInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC82B62E8D8C97004698BB /* TestInboxView.swift */; };
 		03ECD7192C81195000D48BF6 /* PostEditorView+LinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD7182C81195000D48BF6 /* PostEditorView+LinkView.swift */; };
 		03ECD71B2C811D6700D48BF6 /* PostEditorView+ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD71A2C811D6700D48BF6 /* PostEditorView+ImageView.swift */; };
 		03ECD71F2C864DB700D48BF6 /* ImageUploadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD71E2C864DB700D48BF6 /* ImageUploadManager.swift */; };
@@ -901,6 +902,7 @@
 		03E46AD32D130728002589DB /* ScoringOperation+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScoringOperation+Extensions.swift"; sourceTree = "<group>"; };
 		03E614E32C0BCC7B00F692A4 /* Post1Providing+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post1Providing+Extensions.swift"; sourceTree = "<group>"; };
 		03E614E62C0BCDC200F692A4 /* FullyQualifiedLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullyQualifiedLinkView.swift; sourceTree = "<group>"; };
+		03EC82B62E8D8C97004698BB /* TestInboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestInboxView.swift; sourceTree = "<group>"; };
 		03ECD7182C81195000D48BF6 /* PostEditorView+LinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+LinkView.swift"; sourceTree = "<group>"; };
 		03ECD71A2C811D6700D48BF6 /* PostEditorView+ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+ImageView.swift"; sourceTree = "<group>"; };
 		03ECD71E2C864DB700D48BF6 /* ImageUploadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadManager.swift; sourceTree = "<group>"; };
@@ -1919,6 +1921,7 @@
 				CD635E1A2C94DACD00864F75 /* BypassProxyWarningSheet.swift */,
 				03AB484E2CBAE33500567FF9 /* MarkdownWithLinkList.swift */,
 				037DE0792CE108D9007F7B92 /* FooterLinkView.swift */,
+				03EC82B62E8D8C97004698BB /* TestInboxView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -2532,6 +2535,7 @@
 				81A179BF2DDE5BF300B17017 /* TabBarLongPressAction.swift in Sources */,
 				03B25B352CC4446400EB6DF5 /* FediseerOpinionListView.swift in Sources */,
 				CDB2EC7D2BFADAB300DBC0EF /* CompactPostView.swift in Sources */,
+				03EC82B72E8D8C97004698BB /* TestInboxView.swift in Sources */,
 				CD33CA522D3C18BF00106C8C /* ImageViewer+Views.swift in Sources */,
 				031CA5B52E590B0D00CF0C0F /* QuickSwipeAction+Extensions.swift in Sources */,
 				030056A42D7DB05A00EB0BA3 /* SharingLinksSettingsView.swift in Sources */,

--- a/Mlem/App/Views/Root/Tabs/Settings/DeveloperSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/DeveloperSettingsView.swift
@@ -84,6 +84,8 @@ struct DeveloperSettingsView: View {
                     Button(String("Create Silent Error")) {
                         handleError(ApiClientError.noEntityFound, silent: true)
                     }
+                    
+                    NavigationLink(String("New Inbox"), destination: .testInbox)
                 } header: {
                     Text(verbatim: "Debug Tools")
                 }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -44,6 +44,8 @@ extension NavigationPage {
             ProfileView()
         case .inbox:
             InboxView()
+        case .testInbox:
+            TestInboxView()
         case .search:
             SearchView()
         case let .externalApiInfo(api: api, actorId: actorId):

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -20,6 +20,7 @@ enum NavigationPage: Hashable {
     case upvotedFeed
     case topCommunities, topPeople, topInstances
     case profile, inbox, search
+    case testInbox
     case quickSwitcher
     case post(
         _ post: AnyPost,

--- a/Mlem/App/Views/Shared/TestInboxView.swift
+++ b/Mlem/App/Views/Shared/TestInboxView.swift
@@ -31,7 +31,7 @@ private struct TestInboxSectionView: View {
     
     let type: NotifType
     
-    @State var notifications: [MlemMiddleware.Notification]?
+    @State var notifications: [InboxNotification]?
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/Mlem/App/Views/Shared/TestInboxView.swift
+++ b/Mlem/App/Views/Shared/TestInboxView.swift
@@ -17,6 +17,7 @@ struct TestInboxView: View {
                     TestInboxSectionView(type: type)
                 }
             }
+            .padding(.horizontal, 10)
         }
         .themedGroupedBackground()
     }
@@ -38,11 +39,18 @@ private struct TestInboxSectionView: View {
             Text(type.rawValue)
             if let notifications {
                 ForEach(notifications) { notification in
-                    Text(String(notification.id))
-                        .lineLimit(3)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(10)
-                        .background(.themedSecondaryGroupedBackground, in: .capsule)
+                    HStack {
+                        Text(String(notification.id))
+                        Spacer()
+                        if notification.read {
+                            Image(icon: .general.success)
+                                .foregroundStyle(.blue)
+                        }
+                    }
+                    .lineLimit(3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(10)
+                    .background(.themedSecondaryGroupedBackground, in: .capsule)
                 }
             }
         }

--- a/Mlem/App/Views/Shared/TestInboxView.swift
+++ b/Mlem/App/Views/Shared/TestInboxView.swift
@@ -1,0 +1,66 @@
+//
+//  TestInboxView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-10-01.
+//
+
+import MlemMiddleware
+import SwiftUI
+
+// This view is for testing only and will be removed once the notification system is working
+struct TestInboxView: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 30) {
+                ForEach(NotifType.allCases, id: \.self) { type in
+                    TestInboxSectionView(type: type)
+                }
+            }
+        }
+        .themedGroupedBackground()
+    }
+}
+
+private enum NotifType: String, CaseIterable {
+    case reply, mention, message
+}
+
+private struct TestInboxSectionView: View {
+    @Environment(AppState.self) var appState
+    
+    let type: NotifType
+    
+    @State var notifications: [MlemMiddleware.Notification]?
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(type.rawValue)
+            if let notifications {
+                ForEach(notifications) { notification in
+                    Text(String(notification.id))
+                        .lineLimit(3)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                        .background(.themedSecondaryGroupedBackground, in: .capsule)
+                }
+            }
+        }
+        .task { await load() }
+    }
+    
+    func load() async {
+        do {
+            switch type {
+            case .reply:
+                notifications = try await appState.firstApi.getReplyNotifications()
+            case .mention:
+                notifications = try await appState.firstApi.getMentionNotifications()
+            case .message:
+                notifications = try await appState.firstApi.getMessageNotifications()
+            }
+        } catch {
+            handleError(error)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Caches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Caches.swift
@@ -54,6 +54,8 @@ extension ApiClient {
         var personVote: PersonVoteCache = .init()
         
         var registrationApplication: RegistrationApplicationCache = .init()
+
+        var notification: NotificationCache = .init()
         
         func clean() {
             community1.clean()
@@ -76,6 +78,7 @@ extension ApiClient {
             report.clean()
             personVote.clean()
             registrationApplication.clean()
+            notification.clean()
         }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -57,7 +57,22 @@ public extension ApiClient {
             myPersonId: myPersonId
         )
     }
+
+    func getReplyNotifications() async throws -> [Notification] {
+        let snapshots = try await repository.getReplyNotifications()
+        return await caches.notification.getModels(api: self, from: snapshots)
+    }
     
+    func getMentionNotifications() async throws -> [Notification] {
+        let snapshots = try await repository.getMentionNotifications()
+        return await caches.notification.getModels(api: self, from: snapshots)
+    }
+
+    func getMessageNotifications() async throws -> [Notification] {
+        let snapshots = try await repository.getMessageNotifications()
+        return await caches.notification.getModels(api: self, from: snapshots)
+    }
+
     func markAllAsRead() async throws {
         try await repository.markAllAsRead()
         for reply in caches.reply1.itemCache.value.values {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -58,17 +58,17 @@ public extension ApiClient {
         )
     }
 
-    func getReplyNotifications() async throws -> [Notification] {
+    func getReplyNotifications() async throws -> [InboxNotification] {
         let snapshots = try await repository.getReplyNotifications()
         return await caches.notification.getModels(api: self, from: snapshots)
     }
     
-    func getMentionNotifications() async throws -> [Notification] {
+    func getMentionNotifications() async throws -> [InboxNotification] {
         let snapshots = try await repository.getMentionNotifications()
         return await caches.notification.getModels(api: self, from: snapshots)
     }
 
-    func getMessageNotifications() async throws -> [Notification] {
+    func getMessageNotifications() async throws -> [InboxNotification] {
         let snapshots = try await repository.getMessageNotifications()
         return await caches.notification.getModels(api: self, from: snapshots)
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/NotificationCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/NotificationCaches.swift
@@ -1,0 +1,22 @@
+//
+//  NotificationCaches.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-01.
+//
+
+import Foundation
+
+class NotificationCache: ApiTypeBackedCache<InboxNotification, InboxNotificationSnapshot> {
+    override func performModelTranslation(api: ApiClient, from snapshot: InboxNotificationSnapshot) -> InboxNotification {
+        .init(
+            api: api,
+            id: snapshot.id,
+            read: snapshot.read
+        )
+    }
+    
+    override func updateModel(_ item: InboxNotification, with snapshot: InboxNotificationSnapshot, semaphore: UInt? = nil) {
+        // TODO: UpdateQueue move updateModel responsibilities fully out of the cache
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/InboxNotification+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/InboxNotification+CacheExtensions.swift
@@ -1,0 +1,10 @@
+//
+//  Notification+CacheExtensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2024-03-02.
+//
+
+extension InboxNotification: CacheIdentifiable {
+    public var cacheId: Int { id }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
@@ -54,19 +54,19 @@ extension ApiRepository {
         }
     }
 
-    func getReplyNotifications() async throws -> [NotificationSnapshot] {
+    func getReplyNotifications() async throws -> [InboxNotificationSnapshot] {
         try await performingForConnection { connection in
             try await connection.getReplyNotifications()
         }
     }
     
-    func getMentionNotifications() async throws -> [NotificationSnapshot] {
+    func getMentionNotifications() async throws -> [InboxNotificationSnapshot] {
         try await performingForConnection { connection in
             try await connection.getMentionNotifications()
         }
     }
 
-    func getMessageNotifications() async throws -> [NotificationSnapshot] {
+    func getMessageNotifications() async throws -> [InboxNotificationSnapshot] {
         try await performingForConnection { connection in
             try await connection.getMessageNotifications()
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
@@ -53,7 +53,25 @@ extension ApiRepository {
             )
         }
     }
+
+    func getReplyNotifications() async throws -> [NotificationSnapshot] {
+        try await performingForConnection { connection in
+            try await connection.getReplyNotifications()
+        }
+    }
     
+    func getMentionNotifications() async throws -> [NotificationSnapshot] {
+        try await performingForConnection { connection in
+            try await connection.getMentionNotifications()
+        }
+    }
+
+    func getMessageNotifications() async throws -> [NotificationSnapshot] {
+        try await performingForConnection { connection in
+            try await connection.getMessageNotifications()
+        }
+    }
+
     func markAllAsRead() async throws {
         try await performingForConnection { connection in
             try await connection.markAllAsRead()

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/InboxNotificationSnapshot+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/InboxNotificationSnapshot+Lemmy.swift
@@ -1,0 +1,45 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-07-14.
+//
+
+import Foundation
+
+extension InboxNotificationSnapshot {
+    init(from replyView: LemmyCommentReplyView) throws(ApiClientError) {
+        self.init(
+            id: LegacyNotificationIdWrapper(type: .reply, id: replyView.commentReply.id).hashValue,
+            read: replyView.commentReply.read
+        )
+    }
+
+    init(from mentionView: LemmyPersonCommentMentionView) throws(ApiClientError) {
+        self.init(
+            id: LegacyNotificationIdWrapper(type: .mention, id: mentionView.personMention.id).hashValue,
+            read: mentionView.personMention.read
+        )
+    }
+
+    init(from messageView: LemmyPrivateMessageView) throws(ApiClientError) {
+        guard let read = messageView.privateMessage.read else {
+            throw .responseMissingRequiredData("LemmyPrivateMessage read")
+        }
+
+        self.init(
+            id: LegacyNotificationIdWrapper(type: .message, id: messageView.privateMessage.id).hashValue,
+            read: read
+        )
+    }
+}
+
+// This can be removed once we drop support for < Lemmy 1.0
+private struct LegacyNotificationIdWrapper: Hashable {
+    enum NotificationType: Hashable {
+        case reply, mention, message
+    }
+
+    let type: NotificationType
+    let id: Int
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/InboxNotification.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/InboxNotification.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @Observable
-public class Notification: ContentModel, Identifiable {
+public class InboxNotification: ContentModel, Identifiable {
     public static var tierNumber: Int = 1
     public var api: ApiClient
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/Notification.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/Notification.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-10-01.
+//
+
+import Foundation
+
+@Observable
+public class Notification: ContentModel, Identifiable {
+    public static var tierNumber: Int = 1
+    public var api: ApiClient
+
+    public let id: Int
+    public var read: Bool
+
+    init(
+        api: ApiClient,
+        id: Int,
+        read: Bool
+    ) {
+        self.api = api
+        self.id = id
+        self.read = read
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -407,6 +407,10 @@ public protocol InstanceConnection {
         unreadOnly: Bool
     ) async throws -> [Message2Snapshot]
     
+    func getReplyNotifications() async throws -> [NotificationSnapshot]
+    func getMentionNotifications() async throws -> [NotificationSnapshot]
+    func getMessageNotifications() async throws -> [NotificationSnapshot]
+
     func markAllAsRead() async throws
     func markReplyAsRead(id: Int, read: Bool) async throws
     func markMentionAsRead(id: Int, read: Bool) async throws

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -407,9 +407,9 @@ public protocol InstanceConnection {
         unreadOnly: Bool
     ) async throws -> [Message2Snapshot]
     
-    func getReplyNotifications() async throws -> [NotificationSnapshot]
-    func getMentionNotifications() async throws -> [NotificationSnapshot]
-    func getMessageNotifications() async throws -> [NotificationSnapshot]
+    func getReplyNotifications() async throws -> [InboxNotificationSnapshot]
+    func getMentionNotifications() async throws -> [InboxNotificationSnapshot]
+    func getMessageNotifications() async throws -> [InboxNotificationSnapshot]
 
     func markAllAsRead() async throws
     func markReplyAsRead(id: Int, read: Bool) async throws

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -59,6 +59,42 @@ public extension LemmyConnection {
         return try response.privateMessages.map { try .init(from: $0) }
     }
     
+    func getReplyNotifications() async throws -> [NotificationSnapshot] {
+        let response = try await performingForEndpoint { _ in
+            LemmyListRepliesRequest(
+                sort: .new,
+                page: 1,
+                limit: 5,
+                unreadOnly: false
+            )
+        }
+        return try response.replies.map { try .init(from: $0) }
+    }
+
+    func getMentionNotifications() async throws -> [NotificationSnapshot] {
+        let response = try await performingForEndpoint { _ in
+            LemmyListMentionsRequest(
+                sort: .new,
+                page: 1,
+                limit: 5,
+                unreadOnly: false
+            )
+        }
+        return try response.mentions.map { try .init(from: $0) }
+    }
+
+    func getMessageNotifications() async throws -> [NotificationSnapshot] {
+        let response = try await performingForEndpoint { _ in
+            LemmyGetPrivateMessageRequest(
+                unreadOnly: false,
+                page: 1,
+                limit: 5,
+                creatorId: nil
+            )
+        }
+        return try response.privateMessages.map { try .init(from: $0) }
+    }
+    
     func markAllAsRead() async throws {
         _ = try await performingForEndpoint { endpoint in
             LemmyMarkAllNotificationsReadRequest(endpoint: endpoint)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -59,7 +59,7 @@ public extension LemmyConnection {
         return try response.privateMessages.map { try .init(from: $0) }
     }
     
-    func getReplyNotifications() async throws -> [NotificationSnapshot] {
+    func getReplyNotifications() async throws -> [InboxNotificationSnapshot] {
         let response = try await performingForEndpoint { _ in
             LemmyListRepliesRequest(
                 sort: .new,
@@ -71,7 +71,7 @@ public extension LemmyConnection {
         return try response.replies.map { try .init(from: $0) }
     }
 
-    func getMentionNotifications() async throws -> [NotificationSnapshot] {
+    func getMentionNotifications() async throws -> [InboxNotificationSnapshot] {
         let response = try await performingForEndpoint { _ in
             LemmyListMentionsRequest(
                 sort: .new,
@@ -83,7 +83,7 @@ public extension LemmyConnection {
         return try response.mentions.map { try .init(from: $0) }
     }
 
-    func getMessageNotifications() async throws -> [NotificationSnapshot] {
+    func getMessageNotifications() async throws -> [InboxNotificationSnapshot] {
         let response = try await performingForEndpoint { _ in
             LemmyGetPrivateMessageRequest(
                 unreadOnly: false,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -75,6 +75,18 @@ public extension PieFedConnection {
         }
     }
     
+    func getReplyNotifications() async throws -> [NotificationSnapshot] {
+        throw ApiClientError.featureUnsupported
+    }
+
+    func getMentionNotifications() async throws -> [NotificationSnapshot] {
+        throw ApiClientError.featureUnsupported
+    }
+
+    func getMessageNotifications() async throws -> [NotificationSnapshot] {
+        throw ApiClientError.featureUnsupported
+    }
+
     func markAllAsRead() async throws {
         let request = PieFedMarkAllRepliesReadRequest()
         try await perform(request)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -75,15 +75,15 @@ public extension PieFedConnection {
         }
     }
     
-    func getReplyNotifications() async throws -> [NotificationSnapshot] {
+    func getReplyNotifications() async throws -> [InboxNotificationSnapshot] {
         throw ApiClientError.featureUnsupported
     }
 
-    func getMentionNotifications() async throws -> [NotificationSnapshot] {
+    func getMentionNotifications() async throws -> [InboxNotificationSnapshot] {
         throw ApiClientError.featureUnsupported
     }
 
-    func getMessageNotifications() async throws -> [NotificationSnapshot] {
+    func getMessageNotifications() async throws -> [InboxNotificationSnapshot] {
         throw ApiClientError.featureUnsupported
     }
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Notification/InboxNotificationSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Notification/InboxNotificationSnapshot.swift
@@ -1,0 +1,26 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-05-06.
+//
+
+import Foundation
+
+public struct InboxNotificationSnapshot: CacheIdentifiable {
+    public let id: Int
+    public var read: Bool
+
+    public var cacheId: Int { id }
+
+    public init(id: Int, read: Bool) {
+        self.id = id
+        self.read = read
+    }
+}
+
+public enum InboxNotificationContentSnapshot {
+    case reply(Comment2Snapshot)
+    case mention(Comment2Snapshot)
+    case message(Message2Snapshot)
+}


### PR DESCRIPTION
Partially completes #2157. We need to have a new inbox system working before Lemmy 1.0.

Adds a new type called `InboxNotification`. It can't be called `Notification`, becauase there's a type called `Notification` in the `Foundation` libary.

In this initial implementation, `InboxNotification` only has `id` and `read` properties:

``` swift
public class InboxNotification: ContentModel, Identifiable {
    public static var tierNumber: Int = 1
    public var api: ApiClient

    public let id: Int
    public var read: Bool
    
    // ...
}
```

In future, it will also have a `content: InboxNotificationContent` property, with `InboxNotificationContent` defined as:

``` swift
public enum InboxNotificationContent {
    case reply(Comment2)
    case mention(Comment2)
    case message(Message2)
}
```

For testing purposes, I've added a page labelled "Test Inbox" under developer settings. It loads some notifications and displays the ID and read status of each.

I've created new issues for the work that needs to be done next:
- #2336
- #2337
- #2339
- #2340
- #2338