### PR TITLE
Allow moderators to toggle NSFW on PieFed

### DIFF
--- a/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/ActionAppearance+StaticValues.swift
@@ -216,6 +216,14 @@ extension ActionAppearance {
         )
     }
     
+    static func toggleNsfw(isOn: Bool) -> Self {
+        .init(
+            label: isOn ? "Remove NSFW Tag" : "Add NSFW Tag",
+            color: .themedNegative,
+            icon: Icons.blurNsfw
+        )
+    }
+    
     static func resolve(isOn: Bool) -> Self {
         .init(
             label: isOn ? "Unresolve" : "Resolve",

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -210,6 +210,10 @@ extension Post1Providing {
             }
             lockAction(appState: appState, feedback: feedback)
             
+            if setNsfwIsAvailable(appState: appState) {
+                setNsfwAction(appState: appState)
+            }
+            
             let viewVotesIsPossible = api.supports(.viewVotes, defaultValue: false)
             
             if let navigation, viewVotesIsPossible {
@@ -337,6 +341,9 @@ extension Post1Providing {
             return true
         }
         if pinnedInstancePending, !(barConfiguration?.all.contains(.action(.pin)) ?? false) {
+            return true
+        }
+        if nsfwPending {
             return true
         }
         return false
@@ -504,6 +511,33 @@ extension Post1Providing {
         )
     }
     
+    func setNsfwAction(appState: AppState) -> BasicAction {
+        .init(
+            id: "setNsfw\(uid)",
+            appearance: .toggleNsfw(isOn: nsfw),
+            callback: setNsfwIsAvailable(appState: appState) ? { @MainActor in
+                self.self2?.toggleNsfw { status in
+                    Task {
+                        await self.handleModerationActionCompletion(
+                            message: "Failed to set NSFW status",
+                            result: status,
+                            feedback: [.haptic]
+                        )
+                    }
+                }
+            } : nil
+        )
+    }
+    
+    func setNsfwIsAvailable(appState: AppState) -> Bool {
+        guard let self2 else { return false }
+        guard canModerate else { return false }
+        guard self2.community.apiIsLocal else { return false }
+        guard api.canInteract(appState: appState) else { return false }
+        guard api.supports(.moderatorSetNsfw, defaultValue: false) else { return false }
+        return true
+    }
+
     func viewVotesAction(navigation: NavigationLayer) -> BasicAction {
         let enabled = canModerate && api.supports(.viewVotes, defaultValue: true)
         return .init(

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -784,6 +784,9 @@
         }
       }
     },
+    "Add NSFW Tag" : {
+
+    },
     "Additional Read Indicator" : {
       "localizations" : {
         "fr" : {
@@ -3460,6 +3463,9 @@
           }
         }
       }
+    },
+    "Failed to set NSFW status" : {
+
     },
     "Failed to unlock post" : {
       "localizations" : {
@@ -6696,6 +6702,9 @@
           }
         }
       }
+    },
+    "Remove NSFW Tag" : {
+
     },
     "Remove Post" : {
       "localizations" : {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Post.swift
@@ -271,6 +271,12 @@ extension ApiRepository {
         }
     }
     
+    func setPostNsfw(id: Int, nsfw: Bool) async throws -> Post1Snapshot {
+        try await performingForConnection { connection in
+            try await connection.setPostNsfw(id: id, nsfw: nsfw)
+        }
+    }
+    
     func getPostVotes(
         id: Int,
         page: Int = 1,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -54,4 +54,5 @@ public enum Feature: Hashable {
     case autoMarkPostReadOnInteract
     
     case blockInstances
+    case moderatorSetNsfw
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1.swift
@@ -34,7 +34,6 @@ public final class Post1: Post1Providing {
     public var linkUrl: URL?
     public var embeddedMediaUrl: URL?
     public var embed: PostEmbed?
-    public var nsfw: Bool
     public var thumbnailUrl: URL?
     public let created: Date
     public var updated: Date?
@@ -57,6 +56,9 @@ public final class Post1: Post1Providing {
     public var pinnedInstance: Bool
     public var pinnedInstancePending: Bool = false
     
+    public var nsfw: Bool
+    public var nsfwPending: Bool = false
+
     init(
         api: ApiClient,
         actorId: ActorIdentifier,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1Providing+Snapshots.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1Providing+Snapshots.swift
@@ -5,8 +5,8 @@
 //  Created by Eric Andrews on 2025-07-22.
 //
 
-extension Post1Providing {
-    public func snapshotUpdate(with snapshot: any PostSnapshotProviding) async {
+public extension Post1Providing {
+    func snapshotUpdate(with snapshot: any PostSnapshotProviding) async {
         if let post3snapshot = snapshot as? Post3Snapshot {
             await snapshot1Update(with: post3snapshot.post.post)
         } else if let post2snapshot = snapshot as? Post2Snapshot {
@@ -38,13 +38,14 @@ extension Post1Providing {
         post1.setIfChanged(\.pinnedInstancePending, false)
         post1.setIfChanged(\.locked, snapshot.locked)
         post1.setIfChanged(\.lockedPending, false)
+        post1.setIfChanged(\.nsfwPending, false)
     }
     
-    public func takeSnapshot() -> any PostSnapshotProviding {
+    func takeSnapshot() -> any PostSnapshotProviding {
         takeSnapshot1()
     }
     
-    public func takeSnapshot1() -> Post1Snapshot {
+    func takeSnapshot1() -> Post1Snapshot {
         .init(
             actorId: actorId,
             id: id,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
@@ -72,6 +72,7 @@ public extension Post1Providing {
     var locked: Bool { post1.locked }
     var lockedPending: Bool { post1.lockedPending }
     var nsfw: Bool { post1.nsfw }
+    var nsfwPending: Bool { post1.nsfwPending }
     var created: Date { post1.created }
     var removed: Bool { post1.removed }
     var removedPending: Bool { post1.removedPending }
@@ -364,6 +365,27 @@ public extension Post1Providing {
         }
     }
     
+    func updateNsfw(_ newValue: Bool, callback: ((UpdateStatus) -> Void)?) {
+        post1.nsfw = newValue
+        post1.nsfwPending = true
+        Task {
+            await updateQueue.addItem {
+                do {
+                    let ret = try await self.api.repository.setPostNsfw(id: self.id, nsfw: newValue)
+                    callback?(.success)
+                    return ret
+                } catch {
+                    callback?(.failure(error))
+                    throw (error)
+                }
+            }
+        }
+    }
+    
+    func toggleNsfw(callback: ((UpdateStatus) -> Void)?) {
+        updateNsfw(!nsfw, callback: callback)
+    }
+
     func getVotes(page: Int, limit: Int) async throws -> [PersonVote] {
         try await api.getPostVotes(id: id, communityId: communityId, page: page, limit: limit)
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -139,6 +139,9 @@ public protocol InstanceConnection {
     func lockPost(id: Int, lock: Bool) async throws -> Post2Snapshot
     
     @discardableResult
+    func setPostNsfw(id: Int, nsfw: Bool) async throws -> Post1Snapshot
+    
+    @discardableResult
     func getPostVotes(
         id: Int,
         page: Int,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -42,6 +42,8 @@ public extension LemmyConnection {
              .banFromCommunity, .editModeratorList, .commentSearch, .undeletePrivateMessages, .searchLocalPeople,
              .hidePosts, .editDisplayName, .editProfile, .autoMarkPostReadOnInteract, .blockInstances:
             true
+        case .moderatorSetNsfw:
+            false
         }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
@@ -436,6 +436,19 @@ public extension LemmyConnection {
     }
     
     @discardableResult
+    func setPostNsfw(id: Int, nsfw: Bool) async throws -> Post1Snapshot {
+        let response = try await performingForEndpoint { endpoint in
+            switch endpoint {
+            case .v3:
+                throw ApiClientError.featureUnsupported
+            case .v4:
+                return LemmyModUpdatePostRequest(postId: id, nsfw: nsfw, tags: nil)
+            }
+        }
+        return try .init(from: response.postView.post)
+    }
+
+    @discardableResult
     func getPostVotes(
         id: Int,
         page: Int = 1,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
@@ -39,6 +39,7 @@ public extension PieFedConnection {
             version >= .v1_1_0
         case .editProfile, .viewVotes, .undeletePrivateMessages:
             version >= .v1_2_0
+        case .moderatorSetNsfw: true
         default: false
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
@@ -312,6 +312,13 @@ public extension PieFedConnection {
     }
     
     @discardableResult
+    func setPostNsfw(id: Int, nsfw: Bool) async throws -> Post1Snapshot {
+        let request = PieFedModerateCommunityPostNsfwRequest(postId: id, nsfwStatus: nsfw)
+        let response = try await perform(request)
+        return try .init(from: response.post)
+    }
+
+    @discardableResult
     func getPostVotes(
         id: Int,
         page: Int = 1,


### PR DESCRIPTION
Closes #2172. It only works for communities on your local instance. I haven't tested this on Lemmy 1.0 yet, so the feature is disabled on Lemmy 1.0 for now (#2350)