### PR TITLE
Fix changing account in post editor

### DIFF
--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorTargetView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorTargetView.swift
@@ -102,6 +102,11 @@ struct PostEditorTargetView: View {
                     .padding(.vertical, 6)
                     .padding(.horizontal, 8)
             }
+            .onChange(of: target.account) {
+                Task {
+                    await resolveCommunity()
+                }
+            }
             switch target.resolutionState {
             case .notFound, .error:
                 Image(icon: .general.warning)

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Logic.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Logic.swift
@@ -84,6 +84,10 @@ extension PostEditorView {
                     taskGroup.addTask { @MainActor in
                         let post: Post2?
                         do {
+                            guard community.api === target.account.api else {
+                                assertionFailure()
+                                throw PostEditorViewError.mismatchingTargetApi
+                            }
                             post = try await community.api.createPost(
                                 communityId: community.id,
                                 title: titleTextView.text,
@@ -186,4 +190,8 @@ extension PostEditorView {
         
         return newSlurMatches
     }
+}
+
+private enum PostEditorViewError: Error {
+    case mismatchingTargetApi
 }


### PR DESCRIPTION
`resolveCommunity` just wasn't being called anywhere.

Closes #2354

Do we want to put this in a patch? It's been broken for a while, so clearly no-one is using it, but it's quite a serious bug if someone _does_ use it.