### PR TITLE
Show website preview in post editor

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 		03EC83252E916C51004698BB /* View+SafeAreaBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC83242E916C51004698BB /* View+SafeAreaBar.swift */; };
 		03EC83EE2E958A44004698BB /* OpenGraph in Frameworks */ = {isa = PBXBuildFile; productRef = 03EC83ED2E958A44004698BB /* OpenGraph */; };
 		03EC83F02E9590D3004698BB /* LinkHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC83EF2E9590D3004698BB /* LinkHostView.swift */; };
+		03EC84422E959AA5004698BB /* PostEditorWebsitePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC84412E959AA5004698BB /* PostEditorWebsitePreviewView.swift */; };
 		03ECD7192C81195000D48BF6 /* PostEditorView+LinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD7182C81195000D48BF6 /* PostEditorView+LinkView.swift */; };
 		03ECD71B2C811D6700D48BF6 /* PostEditorView+ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD71A2C811D6700D48BF6 /* PostEditorView+ImageView.swift */; };
 		03ECD71F2C864DB700D48BF6 /* ImageUploadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD71E2C864DB700D48BF6 /* ImageUploadManager.swift */; };
@@ -908,6 +909,7 @@
 		03EC82B62E8D8C97004698BB /* TestInboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestInboxView.swift; sourceTree = "<group>"; };
 		03EC83242E916C51004698BB /* View+SafeAreaBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+SafeAreaBar.swift"; sourceTree = "<group>"; };
 		03EC83EF2E9590D3004698BB /* LinkHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHostView.swift; sourceTree = "<group>"; };
+		03EC84412E959AA5004698BB /* PostEditorWebsitePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditorWebsitePreviewView.swift; sourceTree = "<group>"; };
 		03ECD7182C81195000D48BF6 /* PostEditorView+LinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+LinkView.swift"; sourceTree = "<group>"; };
 		03ECD71A2C811D6700D48BF6 /* PostEditorView+ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+ImageView.swift"; sourceTree = "<group>"; };
 		03ECD71E2C864DB700D48BF6 /* ImageUploadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadManager.swift; sourceTree = "<group>"; };
@@ -1493,6 +1495,7 @@
 				03ECD7182C81195000D48BF6 /* PostEditorView+LinkView.swift */,
 				03ECD71A2C811D6700D48BF6 /* PostEditorView+ImageView.swift */,
 				0397D4922C6CE87E002C6CDC /* PostEditorTargetView.swift */,
+				03EC84412E959AA5004698BB /* PostEditorWebsitePreviewView.swift */,
 			);
 			path = PostEditor;
 			sourceTree = "<group>";
@@ -2710,6 +2713,7 @@
 				038028F82CB097A10091A8A2 /* SearchView+InstancePicker.swift in Sources */,
 				CD5C197D2D97096F0089614C /* ZoomCurves.swift in Sources */,
 				034147FD2D8F5844005503AF /* ExpandedPostHistoryTracker.swift in Sources */,
+				03EC84422E959AA5004698BB /* PostEditorWebsitePreviewView.swift in Sources */,
 				CD9CFA2C2C2E1EF300739BBC /* FeedIconView.swift in Sources */,
 				038188992D43E0F30073E88D /* SafetySettingsView.swift in Sources */,
 				CD1446252A5B357900610EF1 /* Document.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -365,6 +365,8 @@
 		03E614E72C0BCDC200F692A4 /* FullyQualifiedLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E614E62C0BCDC200F692A4 /* FullyQualifiedLinkView.swift */; };
 		03EC82B72E8D8C97004698BB /* TestInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC82B62E8D8C97004698BB /* TestInboxView.swift */; };
 		03EC83252E916C51004698BB /* View+SafeAreaBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC83242E916C51004698BB /* View+SafeAreaBar.swift */; };
+		03EC83EE2E958A44004698BB /* OpenGraph in Frameworks */ = {isa = PBXBuildFile; productRef = 03EC83ED2E958A44004698BB /* OpenGraph */; };
+		03EC83F02E9590D3004698BB /* LinkHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC83EF2E9590D3004698BB /* LinkHostView.swift */; };
 		03ECD7192C81195000D48BF6 /* PostEditorView+LinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD7182C81195000D48BF6 /* PostEditorView+LinkView.swift */; };
 		03ECD71B2C811D6700D48BF6 /* PostEditorView+ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD71A2C811D6700D48BF6 /* PostEditorView+ImageView.swift */; };
 		03ECD71F2C864DB700D48BF6 /* ImageUploadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD71E2C864DB700D48BF6 /* ImageUploadManager.swift */; };
@@ -905,6 +907,7 @@
 		03E614E62C0BCDC200F692A4 /* FullyQualifiedLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullyQualifiedLinkView.swift; sourceTree = "<group>"; };
 		03EC82B62E8D8C97004698BB /* TestInboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestInboxView.swift; sourceTree = "<group>"; };
 		03EC83242E916C51004698BB /* View+SafeAreaBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+SafeAreaBar.swift"; sourceTree = "<group>"; };
+		03EC83EF2E9590D3004698BB /* LinkHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHostView.swift; sourceTree = "<group>"; };
 		03ECD7182C81195000D48BF6 /* PostEditorView+LinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+LinkView.swift"; sourceTree = "<group>"; };
 		03ECD71A2C811D6700D48BF6 /* PostEditorView+ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+ImageView.swift"; sourceTree = "<group>"; };
 		03ECD71E2C864DB700D48BF6 /* ImageUploadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadManager.swift; sourceTree = "<group>"; };
@@ -1919,6 +1922,7 @@
 				CDD99C3D2C73F4380010367F /* WarningView.swift */,
 				034CC02F2D22C5BE00C557D3 /* WarningOverlayView.swift */,
 				CD13CC582C583C7A001AF428 /* WebsitePreviewView.swift */,
+				03EC83EF2E9590D3004698BB /* LinkHostView.swift */,
 				CD13CC5A2C588B34001AF428 /* WebView.swift */,
 				CD635E1A2C94DACD00864F75 /* BypassProxyWarningSheet.swift */,
 				03AB484E2CBAE33500567FF9 /* MarkdownWithLinkList.swift */,
@@ -2959,6 +2963,7 @@
 				CD03742A2D1DBFD2001E85FA /* ReadCheck.swift in Sources */,
 				035394932CA1AE2C00795AA5 /* UptimeData.swift in Sources */,
 				036ED6832D0C483B0018E5EA /* Profile2Providing+Extensions.swift in Sources */,
+				03EC83F02E9590D3004698BB /* LinkHostView.swift in Sources */,
 				033FCB2A2C5E3933007B7CD1 /* AlternateIconCell.swift in Sources */,
 				0389DDC72C389F840005B808 /* UnreadCount+Extensions.swift in Sources */,
 				03500C242BF55D0E00CAA076 /* Toast.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -1098,6 +1098,7 @@
 				037386472BDAFE81007492B5 /* LemmyMarkdownUI in Frameworks */,
 				CDA711FB2DB5CAC3008BC3ED /* Media in Frameworks */,
 				B104A6D82A59BF3C00B3E725 /* Nuke in Frameworks */,
+				03EC83EE2E958A44004698BB /* OpenGraph in Frameworks */,
 				50C99B562A61D792005D57DD /* Dependencies in Frameworks */,
 				636250DC2A18111400FC59B4 /* KeychainAccess in Frameworks */,
 				CD4368C12AE23FD400BD8BD1 /* Semaphore in Frameworks */,
@@ -2365,6 +2366,7 @@
 				0377BF9A2DF0E0E000E38593 /* Rest */,
 				0377BE282DE7A2DE00E38593 /* Haptics */,
 				031CA5762E5900E900CF0C0F /* QuickSwipes */,
+				03EC83ED2E958A44004698BB /* OpenGraph */,
 			);
 			productName = Mlem;
 			productReference = 6363D5C127EE196700E34822 /* Mlem.app */;
@@ -2451,6 +2453,7 @@
 				037386452BDAFE81007492B5 /* XCRemoteSwiftPackageReference "LemmyMarkdownUI" */,
 				03FA318A2C6FEC5400D47FA3 /* XCRemoteSwiftPackageReference "SwiftUI-Flow" */,
 				CDE4AC412CA3706F00981010 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
+				03EC83EC2E958A44004698BB /* XCRemoteSwiftPackageReference "OpenGraph" */,
 			);
 			productRefGroup = 6363D5C227EE196700E34822 /* Products */;
 			projectDirPath = "";
@@ -3416,6 +3419,14 @@
 				minimumVersion = "1.4.0-beta.4";
 			};
 		};
+		03EC83EC2E958A44004698BB /* XCRemoteSwiftPackageReference "OpenGraph" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/satoshi-takano/OpenGraph";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.6.0;
+			};
+		};
 		03FA318A2C6FEC5400D47FA3 /* XCRemoteSwiftPackageReference "SwiftUI-Flow" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tevelee/SwiftUI-Flow";
@@ -3504,6 +3515,11 @@
 		03D8BF422DA55B6900506687 /* Icons */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Icons;
+		};
+		03EC83ED2E958A44004698BB /* OpenGraph */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03EC83EC2E958A44004698BB /* XCRemoteSwiftPackageReference "OpenGraph" */;
+			productName = OpenGraph;
 		};
 		03FA318B2C6FECAE00D47FA3 /* Flow */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -64,6 +64,15 @@
       }
     },
     {
+      "identity" : "opengraph",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/satoshi-takano/OpenGraph",
+      "state" : {
+        "revision" : "15fa71b31cf85695cf7035a077aaa624f679f53a",
+        "version" : "1.6.0"
+      }
+    },
+    {
       "identity" : "sdwebimage",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage.git",

--- a/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
@@ -23,7 +23,7 @@ extension Community1Providing {
     
     @MainActor
     func showNewPostSheet(feedLoader: CommunityPostFeedLoader? = nil) {
-        NavigationModel.main.openSheet(.createPost(community: self, feedLoader: feedLoader))
+        NavigationModel.main.openSheet(.createPost(community: self, type: nil, feedLoader: feedLoader))
     }
     
     func toggleSubscribe(feedback: Set<FeedbackType>) {

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -363,8 +363,7 @@ extension Post1Providing {
                 NavigationModel.main.openSheet(.createPost(
                     community: nil as AnyCommunity?,
                     title: self.title,
-                    content: crossPostContent,
-                    url: self.linkUrl,
+                    type: self.type,
                     nsfw: self.nsfw,
                     feedLoader: .init(wrappedValue: nil)
                 ))

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+LinkView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+LinkView.swift
@@ -51,6 +51,9 @@ extension PostEditorView {
     }
     
     private func generatePostLink(url: URL) async throws -> PostLink {
+        if let api = targets.first?.account.api, try await api.supports(.fetchLinkMetadata) {
+            return try await api.getPostLink(url: url)
+        }
         let metadata = try await OpenGraph.fetch(url: url)
         let thumbnailUrl = metadata[.image].map { URL(string: $0) } ?? nil
         return .init(content: url, thumbnail: thumbnailUrl, label: metadata[.title] ?? url.absoluteString)

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+LinkView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+LinkView.swift
@@ -51,14 +51,14 @@ extension PostEditorView {
             return
         }
         if let url {
-            link = .value(url)
+            link = .value(.init(content: url, thumbnail: nil, label: ""))
         }
     }
     
     private var linkLabel: String {
         switch link {
-        case let .value(url):
-            url.absoluteString
+        case let .value(link):
+            link.content.absoluteString
         default:
             .init(localized: "Add Link")
         }

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+LinkView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+LinkView.swift
@@ -11,25 +11,7 @@ import SwiftUI
 
 extension PostEditorView {
     @ViewBuilder
-    var linkView: some View {
-        HStack {
-            switch link {
-            case let .value(link):
-                Text(link.label)
-            default:
-                addLinkButton()
-            }
-        }
-        .padding(8)
-        .background(.themedAccent.opacity(0.2))
-        // This second background is to prevent the view from being partially see-through, which makes the animations cleaner
-        .background(.themedGroupedBackground)
-        .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
-        .onTapGesture { pasteLink() }
-    }
-    
-    @ViewBuilder
-    private func addLinkButton() -> some View {
+    func addLinkButton() -> some View {
         Label("Add Link", icon: .general.link)
             .lineLimit(1)
             .fontWeight(.semibold)
@@ -39,6 +21,12 @@ extension PostEditorView {
                 maxWidth: .infinity,
                 alignment: link == .none ? .center : .leading
             )
+            .padding(8)
+            .background(.themedAccent.opacity(0.2))
+            // This second background is to prevent the view from being partially see-through, which makes the animations cleaner
+            .background(.themedGroupedBackground)
+            .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
+            .onTapGesture { pasteLink() }
     }
     
     private func pasteLink() {

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+LinkView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+LinkView.swift
@@ -13,25 +13,11 @@ extension PostEditorView {
     @ViewBuilder
     var linkView: some View {
         HStack {
-            Label(linkLabel, icon: .general.link)
-                .lineLimit(1)
-                .fontWeight(.semibold)
-                .foregroundStyle(.themedAccent)
-                .padding(.leading, 8)
-                .frame(
-                    maxWidth: .infinity,
-                    alignment: link == .none ? .center : .leading
-                )
-            if link != .none {
-                Button("Remove", icon: .general.close) {
-                    link = .none
-                }
-                .font(.title2)
-                .symbolVariant(.circle.fill)
-                .labelStyle(.iconOnly)
-                .symbolRenderingMode(.hierarchical)
-                .foregroundStyle(.themedAccent)
-                .fontWeight(.semibold)
+            switch link {
+            case let .value(link):
+                Text(link.label)
+            default:
+                addLinkButton()
             }
         }
         .padding(8)
@@ -40,6 +26,19 @@ extension PostEditorView {
         .background(.themedGroupedBackground)
         .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
         .onTapGesture { pasteLink() }
+    }
+    
+    @ViewBuilder
+    private func addLinkButton() -> some View {
+        Label("Add Link", icon: .general.link)
+            .lineLimit(1)
+            .fontWeight(.semibold)
+            .foregroundStyle(.themedAccent)
+            .padding(.leading, 8)
+            .frame(
+                maxWidth: .infinity,
+                alignment: link == .none ? .center : .leading
+            )
     }
     
     private func pasteLink() {
@@ -60,15 +59,6 @@ extension PostEditorView {
                     handleError(error)
                 }
             }
-        }
-    }
-    
-    private var linkLabel: String {
-        switch link {
-        case let .value(link):
-            link.content.absoluteString
-        default:
-            .init(localized: "Add Link")
         }
     }
     

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+LinkView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+LinkView.swift
@@ -5,6 +5,8 @@
 //  Created by Sjmarf on 29/08/2024.
 //
 
+import MlemMiddleware
+import OpenGraph
 import SwiftUI
 
 extension PostEditorView {
@@ -51,7 +53,13 @@ extension PostEditorView {
             return
         }
         if let url {
-            link = .value(.init(content: url, thumbnail: nil, label: ""))
+            Task {
+                do {
+                    link = try await .value(generatePostLink(url: url))
+                } catch {
+                    handleError(error)
+                }
+            }
         }
     }
     
@@ -62,5 +70,11 @@ extension PostEditorView {
         default:
             .init(localized: "Add Link")
         }
+    }
+    
+    private func generatePostLink(url: URL) async throws -> PostLink {
+        let metadata = try await OpenGraph.fetch(url: url)
+        let thumbnailUrl = metadata[.image].map { URL(string: $0) } ?? nil
+        return .init(content: url, thumbnail: thumbnailUrl, label: metadata[.title] ?? url.absoluteString)
     }
 }

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Views.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Views.swift
@@ -9,6 +9,36 @@ import SwiftUI
 
 extension PostEditorView {
     @ViewBuilder
+    var attachmentPickerView: some View {
+        switch link {
+        case let .value(link):
+            PostEditorWebsitePreviewView(
+                link: .init(
+                    get: { link },
+                    set: { self.link = .value($0) }
+                ),
+                removeCallback: {
+                    self.link = .none
+                },
+                shouldBlur: false
+            )
+            .transition(.scale.combined(with: .opacity))
+        default:
+            HStack(spacing: 10) {
+                if imageManager == nil, imageUrl == nil {
+                    addLinkButton()
+                        .transition(.move(edge: .leading).combined(with: .opacity))
+                }
+                if link == .none {
+                    imageView
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                }
+            }
+            .transition(.scale.combined(with: .opacity))
+        }
+    }
+    
+    @ViewBuilder
     var targetSelectionView: some View {
         let showWarning = !targets.allSatisfy { $0.sendState != .failed }
         VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView.swift
@@ -14,11 +14,11 @@ import SwiftUI
 struct PostEditorView: View {
     enum Field { case title, content }
     enum LinkState: Hashable {
-        case none, waiting, value(URL)
+        case none, waiting, value(PostLink)
         
         var url: URL? {
             switch self {
-            case let .value(url): url
+            case let .value(link): link.content
             default: nil
             }
         }
@@ -60,8 +60,7 @@ struct PostEditorView: View {
         self.init(
             community: community,
             title: postToEdit.title,
-            content: postToEdit.content ?? "",
-            url: postToEdit.linkUrl,
+            type: postToEdit.type,
             nsfw: postToEdit.nsfw,
             feedLoader: nil
         )
@@ -72,8 +71,7 @@ struct PostEditorView: View {
     init?(
         community: AnyCommunity?,
         title: String = "",
-        content: String = "",
-        url: URL? = nil,
+        type: PostType? = nil,
         nsfw: Bool = false,
         feedLoader: (any FeedLoading)?
     ) {
@@ -89,15 +87,20 @@ struct PostEditorView: View {
         contentTextView.tag = 1
         
         titleTextView.text = title
-        contentTextView.text = content
         self._titleIsEmpty = .init(wrappedValue: title.isEmpty)
         self._hasNsfwTag = .init(wrappedValue: nsfw)
-        if let url {
-            if url.isMedia {
-                self._imageUrl = .init(wrappedValue: url)
-            } else {
-                self._link = .init(wrappedValue: .value(url))
-            }
+        
+        switch type {
+        case let .text(content):
+            contentTextView.text = content
+        case let .media(url):
+            self._imageUrl = .init(wrappedValue: url)
+        case let .embedded(_, url):
+            self._link = .init(wrappedValue: .value(.init(content: url, thumbnail: nil, label: "")))
+        case let .link(url):
+            self._link = .init(wrappedValue: .value(url))
+        case .titleOnly, nil:
+            break
         }
     }
     

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView.swift
@@ -221,17 +221,8 @@ struct PostEditorView: View {
                             .padding(.leading, 10)
                             .transition(attachmentTransition)
                     }
-
-                    HStack(spacing: 10) {
-                        if imageManager == nil, imageUrl == nil {
-                            linkView
-                                .transition(.move(edge: .leading).combined(with: .opacity))
-                        }
-                        if link == .none {
-                            imageView
-                                .transition(.move(edge: .trailing).combined(with: .opacity))
-                        }
-                    }
+                    
+                    attachmentPickerView
                     
                     VStack {
                         MarkdownTextEditor(

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorWebsitePreviewView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorWebsitePreviewView.swift
@@ -28,8 +28,8 @@ struct PostEditorWebsitePreviewView: View {
     
     @ViewBuilder
     var content: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            if let thumbnailUrl = link.effectiveThumbnail {
+        if let thumbnailUrl = link.effectiveThumbnail {
+            VStack(alignment: .leading, spacing: 0) {
                 MediaView(
                     url: thumbnailUrl,
                     controlState: .constant(.init(
@@ -45,13 +45,19 @@ struct PostEditorWebsitePreviewView: View {
                     LinkHostView(link: link, withCapsule: true)
                         .padding(Constants.main.halfSpacing)
                 }
-            } else {
-                LinkHostView(link: link, withCapsule: false)
-                    .padding([.horizontal, .top], Constants.main.standardSpacing)
-            }
-            
-            HStack {
+                .overlay(alignment: .topTrailing) {
+                    removeButton
+                        .padding(10)
+                }
                 titleView
+            }
+        } else {
+            HStack {
+                VStack(alignment: .leading, spacing: 0) {
+                    LinkHostView(link: link, withCapsule: false)
+                        .padding([.horizontal, .top], Constants.main.standardSpacing)
+                    titleView
+                }
                 Spacer()
                 removeButton
                     .padding(.trailing, 10)
@@ -76,7 +82,7 @@ struct PostEditorWebsitePreviewView: View {
             action: removeCallback
         )
         .buttonStyle(.plain)
-        .font(.title2)
+        .font(.title)
         .fontWeight(.semibold)
         .imageScale(.large)
         .labelStyle(.iconOnly)

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorWebsitePreviewView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorWebsitePreviewView.swift
@@ -1,0 +1,85 @@
+//
+//  PostEditorWebsitePreviewView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-10-07.
+//
+
+import MlemMiddleware
+import SwiftUI
+
+struct PostEditorWebsitePreviewView: View {
+    @Setting(\.post_webPreview_showIcon) var showFavicons
+    @Setting(\.behavior_muteVideos) var muteVideos
+    
+    @Binding var link: PostLink
+    let removeCallback: () -> Void
+    let shouldBlur: Bool
+    
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.themedTertiaryGroupedBackground)
+            .clipShape(RoundedRectangle(cornerRadius: Constants.main.mediumItemCornerRadius))
+            .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.mediumItemCornerRadius))
+            .paletteBorder(cornerRadius: Constants.main.mediumItemCornerRadius)
+            .contentShape(.rect)
+    }
+    
+    @ViewBuilder
+    var content: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let thumbnailUrl = link.effectiveThumbnail {
+                MediaView(
+                    url: thumbnailUrl,
+                    controlState: .constant(.init(
+                        blurred: shouldBlur,
+                        animating: false,
+                        muted: muteVideos
+                    )),
+                    aspectRatioBounds: .bounded(vertical: .init(width: 1, height: 1), horizontal: nil),
+                    contentMode: .fill,
+                    overlays: shouldBlur ? [.controls, .nsfw, .error] : [.controls, .error]
+                )
+                .overlay(alignment: .bottomLeading) {
+                    LinkHostView(link: link, withCapsule: true)
+                        .padding(Constants.main.halfSpacing)
+                }
+            } else {
+                LinkHostView(link: link, withCapsule: false)
+                    .padding([.horizontal, .top], Constants.main.standardSpacing)
+            }
+            
+            HStack {
+                titleView
+                Spacer()
+                removeButton
+                    .padding(.trailing, 10)
+            }
+        }
+    }
+
+    @ViewBuilder
+    var titleView: some View {
+        Text(link.label)
+            .font(.subheadline)
+            .fontWeight(.semibold)
+            .padding(Constants.main.standardSpacing)
+            .foregroundStyle(.themedPrimary)
+    }
+
+    @ViewBuilder
+    var removeButton: some View {
+        Button(
+            "Remove",
+            systemImage: Icons.closeCircleFill,
+            action: removeCallback
+        )
+        .buttonStyle(.plain)
+        .font(.title2)
+        .fontWeight(.semibold)
+        .imageScale(.large)
+        .labelStyle(.iconOnly)
+        .symbolRenderingMode(.hierarchical)
+    }
+}

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -271,7 +271,7 @@ struct PersonView: View {
                 if let feedLoader {
                     if isProfileTab, selectedTab == .overview || selectedTab == .posts {
                         Button("New Post", icon: .general.add) {
-                            navigation.openSheet(.createPost(community: nil, feedLoader: feedLoader))
+                            navigation.openSheet(.createPost(community: nil, type: nil, feedLoader: feedLoader))
                         }
                         .buttonStyle(.capsule)
                         .padding([.horizontal, .bottom], Constants.main.standardSpacing)

--- a/Mlem/App/Views/Shared/LinkHostView.swift
+++ b/Mlem/App/Views/Shared/LinkHostView.swift
@@ -12,8 +12,24 @@ struct LinkHostView: View {
     @Setting(\.post_webPreview_showIcon) var showFavicons
     
     let link: PostLink
-
+    let withCapsule: Bool
+    
     var body: some View {
+        if withCapsule {
+            content
+                .padding(Constants.main.halfSpacing)
+                .padding(showFavicons ? .trailing : .horizontal, 3)
+                .background {
+                    Capsule()
+                        .fill(.regularMaterial)
+                        .overlay(Capsule().fill(.themedBackground.opacity(0.25)))
+                }
+        } else {
+            content
+        }
+    }
+    
+    var content: some View {
         HStack(spacing: Constants.main.halfSpacing) {
             if showFavicons {
                 CircleCroppedImageView(url: link.favicon, frame: Constants.main.smallAvatarSize, fallback: .favicon)

--- a/Mlem/App/Views/Shared/LinkHostView.swift
+++ b/Mlem/App/Views/Shared/LinkHostView.swift
@@ -1,0 +1,27 @@
+//
+//  LinkHostView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-10-07.
+//
+
+import MlemMiddleware
+import SwiftUI
+
+struct LinkHostView: View {
+    @Setting(\.post_webPreview_showIcon) var showFavicons
+    
+    let link: PostLink
+
+    var body: some View {
+        HStack(spacing: Constants.main.halfSpacing) {
+            if showFavicons {
+                CircleCroppedImageView(url: link.favicon, frame: Constants.main.smallAvatarSize, fallback: .favicon)
+            }
+            
+            Text(link.host)
+                .foregroundStyle(.themedSecondary)
+        }
+        .font(.footnote)
+    }
+}

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -98,16 +98,14 @@ extension NavigationPage {
         case let .createPost(
             community: community,
             title: title,
-            content: content,
-            url: url,
+            type: type,
             nsfw: nsfw,
             feedLoader: feedLoader
         ):
             if let view = PostEditorView(
                 community: community,
                 title: title,
-                content: content,
-                url: url,
+                type: type,
                 nsfw: nsfw,
                 feedLoader: feedLoader.wrappedValue
             ) {

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -54,8 +54,7 @@ enum NavigationPage: Hashable {
     case createPost(
         community: AnyCommunity?,
         title: String,
-        content: String,
-        url: URL?,
+        type: PostType?,
         nsfw: Bool,
         feedLoader: HashWrapper<(any FeedLoading)?>
     )
@@ -266,8 +265,7 @@ enum NavigationPage: Hashable {
     static func createPost(
         community: (any CommunityStubProviding)?,
         title: String = "",
-        content: String = "",
-        url: URL? = nil,
+        type: PostType?,
         nsfw: Bool = false,
         feedLoader: (any FeedLoading)?
     ) -> NavigationPage {
@@ -280,8 +278,7 @@ enum NavigationPage: Hashable {
         return createPost(
             community: anyCommunity,
             title: title,
-            content: content,
-            url: url,
+            type: type,
             nsfw: nsfw,
             feedLoader: .init(wrappedValue: feedLoader)
         )

--- a/Mlem/App/Views/Shared/WebsitePreviewView.swift
+++ b/Mlem/App/Views/Shared/WebsitePreviewView.swift
@@ -71,18 +71,11 @@ struct WebsitePreviewView: View {
                     overlays: shouldBlur ? [.controls, .nsfw, .error] : [.controls, .error]
                 )
                 .overlay(alignment: .bottomLeading) {
-                    LinkHostView(link: link)
-                        .padding(Constants.main.halfSpacing)
-                        .padding(showFavicons ? .trailing : .horizontal, 3)
-                        .background {
-                            Capsule()
-                                .fill(.regularMaterial)
-                                .overlay(Capsule().fill(.themedBackground.opacity(0.25)))
-                        }
+                    LinkHostView(link: link, withCapsule: true)
                         .padding(Constants.main.halfSpacing)
                 }
             } else {
-                LinkHostView(link: link)
+                LinkHostView(link: link, withCapsule: false)
                     .padding([.horizontal, .top], Constants.main.standardSpacing)
             }
             

--- a/Mlem/App/Views/Shared/WebsitePreviewView.swift
+++ b/Mlem/App/Views/Shared/WebsitePreviewView.swift
@@ -13,7 +13,7 @@ struct WebsitePreviewView: View {
     @Environment(\.openURL) private var openURL
     
     @Setting(\.post_webPreview_showIcon) var showFavicons
-
+    
     let shouldBlur: Bool
     
     let link: PostLink
@@ -53,6 +53,7 @@ struct WebsitePreviewView: View {
             .clipShape(RoundedRectangle(cornerRadius: Constants.main.mediumItemCornerRadius))
             .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.mediumItemCornerRadius))
             .paletteBorder(cornerRadius: Constants.main.mediumItemCornerRadius)
+            .contentShape(.rect)
     }
     
     var complex: some View {
@@ -70,7 +71,7 @@ struct WebsitePreviewView: View {
                     overlays: shouldBlur ? [.controls, .nsfw, .error] : [.controls, .error]
                 )
                 .overlay(alignment: .bottomLeading) {
-                    linkHost
+                    LinkHostView(link: link)
                         .padding(Constants.main.halfSpacing)
                         .padding(showFavicons ? .trailing : .horizontal, 3)
                         .background {
@@ -81,7 +82,7 @@ struct WebsitePreviewView: View {
                         .padding(Constants.main.halfSpacing)
                 }
             } else {
-                linkHost
+                LinkHostView(link: link)
                     .padding([.horizontal, .top], Constants.main.standardSpacing)
             }
             
@@ -91,17 +92,5 @@ struct WebsitePreviewView: View {
                 .padding(Constants.main.standardSpacing)
                 .foregroundStyle(.themedPrimary)
         }
-    }
-    
-    var linkHost: some View {
-        HStack(spacing: Constants.main.halfSpacing) {
-            if showFavicons {
-                CircleCroppedImageView(url: link.favicon, frame: Constants.main.smallAvatarSize, fallback: .favicon)
-            }
-            
-            Text(link.host)
-                .foregroundStyle(.themedSecondary)
-        }
-        .font(.footnote)
     }
 }

--- a/Mlem/App/Views/Shared/WebsitePreviewView.swift
+++ b/Mlem/App/Views/Shared/WebsitePreviewView.swift
@@ -13,7 +13,8 @@ struct WebsitePreviewView: View {
     @Environment(\.openURL) private var openURL
     
     @Setting(\.post_webPreview_showIcon) var showFavicons
-    
+    @Setting(\.behavior_muteVideos) var muteVideos
+
     let shouldBlur: Bool
     
     let link: PostLink
@@ -64,7 +65,7 @@ struct WebsitePreviewView: View {
                     controlState: .constant(.init(
                         blurred: shouldBlur,
                         animating: false,
-                        muted: Settings.get(\.behavior_muteVideos)
+                        muted: muteVideos
                     )),
                     aspectRatioBounds: .bounded(vertical: .init(width: 1, height: 1), horizontal: nil),
                     contentMode: .fill,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -32,7 +32,7 @@ public extension ApiClient {
     }
     
     func login(password: String, totpToken: String?) async throws {
-        guard let username = username else { throw ApiClientError.notLoggedIn }
+        guard let username else { throw ApiClientError.notLoggedIn }
         let token = try await getAccountToken(usernameOrEmail: username, password: password, totpToken: totpToken)
         updateToken(token)
     }
@@ -159,5 +159,9 @@ public extension ApiClient {
                 type: .init(from: entry.type, api: self)
             )
         }
+    }
+    
+    func getPostLink(url: URL) async throws -> PostLink {
+        try await repository.getPostLink(url: url)
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+General.swift
@@ -103,4 +103,10 @@ extension ApiRepository {
             )
         }
     }
+    
+    func getPostLink(url: URL) async throws -> PostLink {
+        try await performingForConnection { connection in
+            try await connection.getPostLink(url: url)
+        }
+    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -55,4 +55,6 @@ public enum Feature: Hashable {
     
     case blockInstances
     case moderatorSetNsfw
+    
+    case fetchLinkMetadata
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostLink.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostLink.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct PostLink: Equatable {
+public struct PostLink: Hashable {
     public let content: URL
     public let thumbnail: URL?
     public let label: String
@@ -28,7 +28,7 @@ public struct PostLink: Equatable {
     }
     
     public var effectiveThumbnail: URL? {
-        return thumbnail ?? content.youTubeThumbnailUrl
+        thumbnail ?? content.youTubeThumbnailUrl
     }
     
     public init(content: URL, thumbnail: URL?, label: String) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PostType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum PostType: Equatable {
+public enum PostType: Hashable {
     /// Post containing both a title and text
     case text(String)
     /// Post containing only media

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -387,6 +387,8 @@ public protocol InstanceConnection {
         type: ModlogEntryType?
     ) async throws -> [ModlogEntrySnapshot]
     
+    func getPostLink(url: URL) async throws -> PostLink
+
     // MARK: - Inbox
     
     func getReplies(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -40,7 +40,8 @@ public extension LemmyConnection {
              .editAccountSettings, .viewMentionsAndPrivateMessages, .viewReports, .editAndDeletePrivateMessages,
              .reportPrivateMessages, .viewVotes, .purgeContent, .removeCommunity, .banFromInstance,
              .banFromCommunity, .editModeratorList, .commentSearch, .undeletePrivateMessages, .searchLocalPeople,
-             .hidePosts, .editDisplayName, .editProfile, .autoMarkPostReadOnInteract, .blockInstances:
+             .hidePosts, .editDisplayName, .editProfile, .autoMarkPostReadOnInteract, .blockInstances,
+             .fetchLinkMetadata:
             true
         case .moderatorSetNsfw:
             false

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
@@ -199,4 +199,15 @@ public extension LemmyConnection {
         }
         return try response.toSnapshots()
     }
+    
+    func getPostLink(url: URL) async throws -> PostLink {
+        let response = try await performingForEndpoint { endpoint in
+            LemmyGetLinkMetadataRequest(endpoint: endpoint, url: url)
+        }
+        return .init(
+            content: url,
+            thumbnail: response.metadata.image,
+            label: response.metadata.title ?? url.absoluteString
+        )
+    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+General.swift
@@ -89,4 +89,8 @@ public extension PieFedConnection {
     ) async throws -> [ModlogEntrySnapshot] {
         throw ApiClientError.featureUnsupported
     }
+    
+    func getPostLink(url: URL) async throws -> PostLink {
+        throw ApiClientError.featureUnsupported
+    }
 }

--- a/Mlem/Packages/Rest/Sources/RestClient/URLQueryItemEncoder.swift
+++ b/Mlem/Packages/Rest/Sources/RestClient/URLQueryItemEncoder.swift
@@ -88,6 +88,8 @@ private class KeyedContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
             String(value)
         } else if let value = value as? Bool {
             value ? "true" : "false"
+        } else if let value = value as? URL {
+            value.absoluteString
         } else if let value = value as? any RawRepresentable<String> {
             value.rawValue
         } else if let value = value as? any RawRepresentable<Int> {


### PR DESCRIPTION
When you add a link to a post in the post editor, it now shows the link's image and title like you see in the feed.

<img width=30% alt="Screenshot 2025-10-07 at 21 14 37" src="https://github.com/user-attachments/assets/da61a505-b65a-42c4-80f9-223e3f9ca576" />

On Lemmy, the image URL is fetched using `LemmyGetLinkMetadataRequest`. PieFed doesn't have an equivalent yet (I've opened [an issue](https://codeberg.org/rimu/pyfedi/issues/1382) asking for it), so on PieFed we're extracting the metadata from the website directly. This requires a new package dependency.
