### PR TITLE
Backend V1

### DIFF
--- a/Mlem/App/Models/MlemStats/MlemStats.swift
+++ b/Mlem/App/Models/MlemStats/MlemStats.swift
@@ -66,7 +66,7 @@ class MlemStats {
         case .score:
             return filteredInstances
         case .users:
-            return filteredInstances.sorted { $0.userCount > $1.userCount }
+            return filteredInstances.sorted { $0.totalUsers > $1.totalUsers }
         case .alphabetical:
             return filteredInstances.sorted { $0.host < $1.host }
         case .version:

--- a/Mlem/App/Utility/Extensions/Content Models/Instance3+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Instance3+Extensions.swift
@@ -13,7 +13,7 @@ extension Instance3 {
         .init(
             displayName: displayName,
             name: name,
-            userCount: userCount,
+            totalUsers: userCount,
             avatar: avatar,
             software: software
         )

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -81,7 +81,8 @@ struct ContentView: View {
                 .quickSwipeMinimumDrag(20)
                 .quickSwipeCornerRadius(Constants.main.standardSpacing)
                 .quickSwipeIconSize(28)
-                .task {
+                .task(id: BackendClient.main.environment) {
+                    print("DEBUG loading instances")
                     do {
                         try await MlemStats.main.loadInstances()
                     } catch {

--- a/Mlem/App/Views/Root/Tabs/Settings/DeveloperSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/DeveloperSettingsView.swift
@@ -65,6 +65,10 @@ struct DeveloperSettingsView: View {
             
             #if DEBUG
                 Section {
+                    Toggle("Use QC Backend",
+                           isOn: .init(get: { BackendClient.main.environment == .qc },
+                                       set: { BackendClient.main.changeEnvironment(to: $0 ? .qc : .prod) }))
+                    
                     Button(String("Trigger Onboarding")) {
                         navigation.showFullScreenCover(.onboarding)
                     }
@@ -72,7 +76,7 @@ struct DeveloperSettingsView: View {
                     Button(String("Reset Feed Welcome Banner")) {
                         showFeedWelcomePrompt = true
                     }
-                
+                    
                     Button(String("Reset Feed TestFlight Banner")) {
                         lastTestFlightUpdate = nil
                     }

--- a/Mlem/App/Views/Root/Tabs/Settings/DeveloperSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/DeveloperSettingsView.swift
@@ -65,7 +65,7 @@ struct DeveloperSettingsView: View {
             
             #if DEBUG
                 Section {
-                    Toggle("Use QC Backend",
+                    Toggle(String("Use QC Backend"),
                            isOn: .init(get: { BackendClient.main.environment == .qc },
                                        set: { BackendClient.main.changeEnvironment(to: $0 ? .qc : .prod) }))
                     

--- a/Mlem/App/Views/Shared/Search/Results/InstanceListRowBody.swift
+++ b/Mlem/App/Views/Shared/Search/Results/InstanceListRowBody.swift
@@ -119,7 +119,7 @@ struct InstanceListRowBody<Content: View>: View {
     
     var userCountReadout: some View {
         HStack {
-            Text((instance?.userCount_ ?? summary?.userCount ?? 0).abbreviated)
+            Text((instance?.userCount_ ?? summary?.totalUsers ?? 0).abbreviated)
             Image(icon: .lemmy.person)
                 .symbolVariant(.fill)
                 .fontWeight(.semibold)

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -9250,6 +9250,9 @@
         }
       }
     },
+    "Use QC Backend" : {
+
+    },
     "User" : {
       "localizations" : {
         "fr" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -9250,9 +9250,6 @@
         }
       }
     },
-    "Use QC Backend" : {
-
-    },
     "User" : {
       "localizations" : {
         "fr" : {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Backend Client/BackendClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Backend Client/BackendClient.swift
@@ -55,11 +55,10 @@ public class BackendClient {
     
     public func getInstances() async throws -> [InstanceSummary] {
         let request: URLRequest = .init(url: baseUrl
-            .appendingPathComponent("/v0/stats/instances")
+            .appendingPathComponent("/v1/stats/instances")
             .appending(queryItems: [
-                .init(name: "minUsers", value: "20"),
-                .init(name: "minScore", value: "0"),
-                .init(name: "allowSus", value: "false")
+                .init(name: "minTotalUsers", value: "20"),
+                .init(name: "minMonthyUsers", value: "1"),
             ])
         )
         let (data, _) = try await URLSession.shared.data(for: request)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Backend Client/BackendClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Backend Client/BackendClient.swift
@@ -8,11 +8,22 @@
 import Foundation
 import SwiftUI
 
-private let backendAddress: String = "https://backend.mlemapp.org:8443/v0"
+public enum BackendEnvironment {
+    case qc, prod
+    
+    internal var address: URL {
+        switch self {
+        case .prod:
+            return .init(string: "https://backend.mlemapp.org:8443/")!
+        case .qc:
+            return .init(string: "https://backend.mlemapp.org:2096/")!
+        }
+    }
+}
 
 @Observable
 public class BackendClient {
-    private let baseUrl: URL
+    public private(set) var environment: BackendEnvironment = .prod
     private let jsonDecoder: JSONDecoder = {
         let decoder: JSONDecoder = .init()
         decoder.dateDecodingStrategy = .custom { decoder in
@@ -31,31 +42,20 @@ public class BackendClient {
     public private(set) var testflightUpdate: URL?
     
     public static var main: BackendClient = .init()
-
+    private var baseUrl: URL { environment.address }
+    
     private init() {
-        guard let url = URL(string: backendAddress) else {
-            fatalError("Could not form backend URL")
-        }
-        self.baseUrl = url
-        
-        Task {
-            do {
-                try await fetchFlairs()
-                try await fetchTestflightUpdate()
-            } catch {
-                print(error)
-            }
-        }
+        refresh()
     }
     
     public func healthCheck() async throws -> BackendHealthCheck {
-        let (data, _) = try await URLSession.shared.data(for: URLRequest(url: baseUrl.appendingPathComponent("/health")))
+        let (data, _) = try await URLSession.shared.data(for: URLRequest(url: baseUrl.appendingPathComponent("/v0/health")))
         return try jsonDecoder.decode(BackendHealthCheck.self, from: data)
     }
     
     public func getInstances() async throws -> [InstanceSummary] {
         let request: URLRequest = .init(url: baseUrl
-            .appendingPathComponent("/stats/instances")
+            .appendingPathComponent("/v0/stats/instances")
             .appending(queryItems: [
                 .init(name: "minUsers", value: "20"),
                 .init(name: "minScore", value: "0"),
@@ -66,14 +66,30 @@ public class BackendClient {
         return try jsonDecoder.decode([InstanceSummary].self, from: data)
     }
     
+    public func changeEnvironment(to environment: BackendEnvironment) {
+        self.environment = environment
+        refresh()
+    }
+    
+    private func refresh() {
+        Task {
+            do {
+                try await fetchFlairs()
+                try await fetchTestflightUpdate()
+            } catch {
+                print(error)
+            }
+        }
+    }
+    
     private func fetchTestflightUpdate() async throws {
-        let (data, _) = try await URLSession.shared.data(for: URLRequest(url: baseUrl.appendingPathComponent("/mlem/testflight")))
+        let (data, _) = try await URLSession.shared.data(for: URLRequest(url: baseUrl.appendingPathComponent("/v0/mlem/testflight")))
         testflightUpdate = try jsonDecoder.decode(TestflightUpdate.self, from: data).url
     }
     
     private func fetchFlairs(enabledOnly: Bool = true) async throws {
         let request: URLRequest = .init(url: baseUrl
-            .appendingPathComponent("/mlem/flairs")
+            .appendingPathComponent("/v0/mlem/flairs")
             .appending(queryItems: [
                 .init(name: "enabledOnly", value: enabledOnly.description)
             ])

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Backend Client/BackendClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Backend Client/BackendClient.swift
@@ -13,10 +13,8 @@ public enum BackendEnvironment {
     
     internal var address: URL {
         switch self {
-        case .prod:
-            return .init(string: "https://backend.mlemapp.org:8443/")!
-        case .qc:
-            return .init(string: "https://backend.mlemapp.org:2096/")!
+        case .prod: .init(string: "https://backend.mlemapp.org:8443/")!
+        case .qc: .init(string: "https://backend.mlemapp.org:2096/")!
         }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Backend Client/InstanceSummary.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Backend Client/InstanceSummary.swift
@@ -11,20 +11,20 @@ import Foundation
 public struct InstanceSummary: Codable, Hashable, Identifiable {
     public let displayName: String
     public let name: String
-    public let userCount: Int
+    public let totalUsers: Int
     public let avatar: URL?
     public let software: SiteSoftware
     
     public init(
         displayName: String,
         name: String,
-        userCount: Int,
+        totalUsers: Int,
         avatar: URL? = nil,
         software: SiteSoftware
     ) {
         self.displayName = displayName
         self.name = name
-        self.userCount = userCount
+        self.totalUsers = totalUsers
         self.avatar = avatar
         self.software = software
     }
@@ -32,9 +32,9 @@ public struct InstanceSummary: Codable, Hashable, Identifiable {
     enum CodingKeys: String, CodingKey {
         case displayName = "name"
         case name = "host"
-        case userCount
+        case userCount // Removed in Mlem 2.4
+        case totalUsers
         case avatar
-        case version // Removed in Mlem 2.2
         case software
     }
 
@@ -47,23 +47,24 @@ public struct InstanceSummary: Codable, Hashable, Identifiable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.displayName = try container.decode(String.self, forKey: .displayName)
         self.name = try container.decode(String.self, forKey: .name)
-        self.userCount = try container.decode(Int.self, forKey: .userCount)
-        self.avatar = try container.decode(URL?.self, forKey: .avatar)
         
-        if let software = try container.decodeIfPresent(SiteSoftware.self, forKey: .software) {
-            self.software = software
-        } else if let version = try container.decodeIfPresent(SiteVersion.self, forKey: .version) {
-            self.software = .init(type: .lemmy, version: version)
+        if let totalUsers = try container.decodeIfPresent(Int.self, forKey: .totalUsers) {
+            self.totalUsers = totalUsers
+        } else if let totalUsers = try container.decodeIfPresent(Int.self, forKey: .userCount) {
+            self.totalUsers = totalUsers
         } else {
-            throw DecodingError.dataCorruptedError(forKey: .software, in: container, debugDescription: "")
+            throw DecodingError.dataCorruptedError(forKey: .totalUsers, in: container, debugDescription: "")
         }
+        
+        self.avatar = try container.decode(URL?.self, forKey: .avatar)
+        self.software = try container.decode(SiteSoftware.self, forKey: .software)
     }
     
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(displayName, forKey: .displayName)
         try container.encode(name, forKey: .name)
-        try container.encode(userCount, forKey: .userCount)
+        try container.encode(totalUsers, forKey: .totalUsers)
         try container.encode(avatar, forKey: .avatar)
         try container.encode(software, forKey: .software)
     }


### PR DESCRIPTION
- Updates the `BackendClient` to use the new v1 endpoint for instances
- Removes `version` from `InstanceSummary`'s `CodingKeys` (this was removed in 2.2, so all our users should have the new coding by now)
- Adds a dev toggle to use the QC backend