### PR TITLE
Upload custom thumbnail in PostEditorView

### DIFF
--- a/Mlem/App/Models/ImageUploadManager.swift
+++ b/Mlem/App/Models/ImageUploadManager.swift
@@ -120,6 +120,15 @@ class ImageUploadManager: Hashable {
         state = .idle
     }
     
+    func delete() async throws {
+        var imageToDelete: ImageUpload1?
+        if let image {
+            imageToDelete = image
+        }
+        await clear()
+        try await imageToDelete?.delete()
+    }
+    
     static func == (lhs: ImageUploadManager, rhs: ImageUploadManager) -> Bool {
         lhs.hashValue == rhs.hashValue
     }

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Logic.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Logic.swift
@@ -61,7 +61,7 @@ extension PostEditorView {
                 content: contentTextView.text,
                 linkUrl: imageManager?.image?.url ?? link.url ?? imageUrl,
                 altText: post.altText,
-                thumbnail: nil,
+                thumbnail: thumbnailManager.image?.url,
                 nsfw: hasNsfwTag,
                 languageId: nil
             )
@@ -93,6 +93,7 @@ extension PostEditorView {
                                 title: titleTextView.text,
                                 content: contentTextView.text,
                                 linkUrl: imageManager?.image?.url ?? link.url ?? imageUrl,
+                                thumbnail: thumbnailManager.image?.url,
                                 nsfw: hasNsfwTag
                             )
                         } catch {

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Views.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView+Views.swift
@@ -17,6 +17,8 @@ extension PostEditorView {
                     get: { link },
                     set: { self.link = .value($0) }
                 ),
+                imageManager: $thumbnailManager,
+                primaryApi: primaryApi,
                 removeCallback: {
                     self.link = .none
                 },

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView.swift
@@ -41,6 +41,7 @@ struct PostEditorView: View {
     @State var link: LinkState = .none
     @State var imageUrl: URL?
     @State var imageManager: ImageUploadManager?
+    @State var thumbnailManager: ImageUploadManager = .init()
     @State var uploadHistory: ImageUploadHistoryManager = .init()
     @State var markdownToolbarEditorModel: MarkdownEditorToolbarModel = .init()
     @State var sending: Bool = false
@@ -154,6 +155,7 @@ struct PostEditorView: View {
                 Task {
                     do {
                         try await imageManager?.image?.delete()
+                        try await thumbnailManager.image?.delete()
                     } catch {
                         handleError(error, silent: true)
                     }

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorWebsitePreviewView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorWebsitePreviewView.swift
@@ -7,19 +7,25 @@
 
 import MlemMiddleware
 import SwiftUI
+import Theming
 
 struct PostEditorWebsitePreviewView: View {
+    @Environment(\.palette) var palette
+
     @Setting(\.post_webPreview_showIcon) var showFavicons
     @Setting(\.behavior_muteVideos) var muteVideos
     
     @Binding var link: PostLink
+    @Binding var imageManager: ImageUploadManager
+
+    let primaryApi: ApiClient
     let removeCallback: () -> Void
     let shouldBlur: Bool
     
     var body: some View {
         content
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(.themedTertiaryGroupedBackground)
+            .background(.themedSecondaryGroupedBackground)
             .clipShape(RoundedRectangle(cornerRadius: Constants.main.mediumItemCornerRadius))
             .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.mediumItemCornerRadius))
             .paletteBorder(cornerRadius: Constants.main.mediumItemCornerRadius)
@@ -28,40 +34,15 @@ struct PostEditorWebsitePreviewView: View {
     
     @ViewBuilder
     var content: some View {
-        if let thumbnailUrl = link.effectiveThumbnail {
-            VStack(alignment: .leading, spacing: 0) {
-                MediaView(
-                    url: thumbnailUrl,
-                    controlState: .constant(.init(
-                        blurred: shouldBlur,
-                        animating: false,
-                        muted: muteVideos
-                    )),
-                    aspectRatioBounds: .bounded(vertical: .init(width: 1, height: 1), horizontal: nil),
-                    contentMode: .fill,
-                    overlays: shouldBlur ? [.controls, .nsfw, .error] : [.controls, .error]
-                )
-                .overlay(alignment: .bottomLeading) {
-                    LinkHostView(link: link, withCapsule: true)
-                        .padding(Constants.main.halfSpacing)
-                }
-                .overlay(alignment: .topTrailing) {
-                    removeButton
-                        .padding(10)
-                }
-                titleView
+        VStack(alignment: .leading, spacing: 0) {
+            if let thumbnailUrl = imageManager.image?.url ?? link.effectiveThumbnail {
+                imageView(thumbnailUrl)
+            } else {
+                imagePlaceholderView
+                LinkHostView(link: link, withCapsule: false)
+                    .padding([.horizontal, .top], Constants.main.standardSpacing)
             }
-        } else {
-            HStack {
-                VStack(alignment: .leading, spacing: 0) {
-                    LinkHostView(link: link, withCapsule: false)
-                        .padding([.horizontal, .top], Constants.main.standardSpacing)
-                    titleView
-                }
-                Spacer()
-                removeButton
-                    .padding(.trailing, 10)
-            }
+            titleView
         }
     }
 
@@ -73,19 +54,119 @@ struct PostEditorWebsitePreviewView: View {
             .padding(Constants.main.standardSpacing)
             .foregroundStyle(.themedPrimary)
     }
+    
+    @ViewBuilder
+    func imageView(_ thumbnailUrl: URL) -> some View {
+        MediaView(
+            url: thumbnailUrl,
+            controlState: .constant(.init(
+                blurred: shouldBlur,
+                animating: false,
+                muted: muteVideos
+            )),
+            aspectRatioBounds: .bounded(vertical: .init(width: 1, height: 1), horizontal: nil),
+            contentMode: .fill,
+            overlays: shouldBlur ? [.controls, .nsfw, .error] : [.controls, .error]
+        )
+        .overlay(alignment: .bottomLeading) {
+            LinkHostView(link: link, withCapsule: true)
+                .padding(Constants.main.halfSpacing)
+        }
+        .overlay(alignment: .topLeading) {
+            thumbnailUploadButton
+                .padding(10)
+        }
+        .overlay(alignment: .topTrailing) {
+            removeButton
+                .padding(10)
+                .foregroundStyle(.secondary, .thinMaterial)
+        }
+    }
+
+    @ViewBuilder
+    var imagePlaceholderView: some View {
+        ZStack {
+            ThemedColor.themedAccent.resolve(with: palette).opacity(0.2)
+                .frame(maxWidth: .infinity)
+                .aspectRatio(5 / 3, contentMode: .fit)
+            VStack {
+                Image(icon: .general.photoLibary)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .foregroundStyle(.themedAccent.opacity(0.2))
+                    .frame(width: 80)
+                Text("No image")
+                    .foregroundStyle(.themedAccent.opacity(0.5))
+                    .fontWeight(.semibold)
+                ImageUploadMenu(imageManager: imageManager, imageUploadApi: primaryApi) {
+                    Text("Upload")
+                }
+                .font(.footnote)
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 10)
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            removeButton
+                .padding(10)
+                .foregroundStyle(.themedAccent, .themedAccent.opacity(0.2))
+        }
+    }
 
     @ViewBuilder
     var removeButton: some View {
         Button(
             "Remove",
-            systemImage: Icons.closeCircleFill,
-            action: removeCallback
-        )
-        .buttonStyle(.plain)
-        .font(.title)
-        .fontWeight(.semibold)
-        .imageScale(.large)
-        .labelStyle(.iconOnly)
-        .symbolRenderingMode(.hierarchical)
+            icon: .general.close
+        ) {
+            Task {
+                do {
+                    try await imageManager.image?.delete()
+                    removeCallback()
+                } catch {
+                    handleError(error)
+                }
+            }
+        }
+        .buttonStyle(OverlayButtonStyle())
+    }
+
+    @ViewBuilder
+    var thumbnailUploadButton: some View {
+        if imageManager.image != nil {
+            Button("Custom Thumbnail", icon: .general.close) {
+                Task {
+                    do {
+                        try await imageManager.delete()
+                    } catch {
+                        handleError(error)
+                    }
+                }
+            }
+            .fontWeight(.semibold)
+            .padding(.vertical, 2)
+            .padding(.horizontal, 8)
+            .background(.thinMaterial, in: .capsule)
+            .foregroundStyle(.secondary)
+            .padding(5)
+        } else {
+            ImageUploadMenu(imageManager: imageManager, imageUploadApi: primaryApi) {
+                Label("Change Thumbnail", icon: .general.chooseImage)
+            }
+            .buttonStyle(OverlayButtonStyle())
+            .foregroundStyle(.secondary, .thinMaterial)
+        }
+    }
+}
+
+private struct OverlayButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.title)
+            .fontWeight(.semibold)
+            .imageScale(.large)
+            .labelStyle(.iconOnly)
+            .symbolVariant(.circle.fill)
+            .symbolRenderingMode(.palette)
     }
 }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1809,6 +1809,9 @@
         }
       }
     },
+    "Change Thumbnail" : {
+
+    },
     "Checkmark" : {
       "localizations" : {
         "fr" : {
@@ -2605,6 +2608,9 @@
           }
         }
       }
+    },
+    "Custom Thumbnail" : {
+
     },
     "Customize how content is displayed in your feed. Choose which types of content are blurred, and apply filters to hide posts from the feed altogether." : {
       "localizations" : {


### PR DESCRIPTION
When you attach a link to a post, you can now change the image used for that link.

If the link already has a default image (obtained using OpenGraph), the "change thumbnail" button is overlaid in the top-left.

<img src="https://github.com/user-attachments/assets/80300a0c-b53b-45b9-9a2a-6f28566dc137" width=30%/>

If the link does not have a default image, it shows like this:

<img width=30% src="https://github.com/user-attachments/assets/9c8d58a8-85a5-424a-a660-b54fbbb74c59" />
