### PR TITLE
Update queue for InboxNotification

### DIFF
--- a/Mlem/App/Views/Shared/HandleLemmyLinksModifier.swift
+++ b/Mlem/App/Views/Shared/HandleLemmyLinksModifier.swift
@@ -62,7 +62,7 @@ struct HandleLemmyLinksModifier: ViewModifier {
             // LemmyMarkdownUI parses the `/c/comm@example.com` and `!comm@example.com` link formats into regular links,
             // so those don't need to be handled in this method. However, it doesn't parse links written in the format
             // [Some text](/c/comm@example.com), which is a format that lemmy-ui supports. Those links are handled here.
-            // Later, it might  be better to move that into LemmyMarkdownUI, but I think we'd need to modify the core
+            // Later, it might be better to move that into LemmyMarkdownUI, but I think we'd need to modify the core
             // cmark code rather than just the extensions, which isn't ideal.
             
             if let newUrl = createLemmyUrlFromShortcut(parts: url.pathComponents), interpretLemmyUrlPath(url: newUrl) {

--- a/Mlem/App/Views/Shared/TestInboxView.swift
+++ b/Mlem/App/Views/Shared/TestInboxView.swift
@@ -52,6 +52,11 @@ private struct TestInboxSectionView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(10)
                     .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 10))
+                    .onTapGesture {
+                        Task {
+                            notification.toggleRead()
+                        }
+                    }
                 }
             }
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/NotificationCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/NotificationCaches.swift
@@ -31,6 +31,7 @@ class NotificationCache: CoreCache<InboxNotification> {
         let newItem: InboxNotification = .init(
             api: api,
             id: snapshot.id,
+            contentId: snapshot.contentId,
             read: snapshot.read,
             content: content
         )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
@@ -71,6 +71,22 @@ extension ApiRepository {
             try await connection.getMessageNotifications()
         }
     }
+    
+    func markNotificationAsRead(
+        type: InboxNotificationContentType,
+        id: Int,
+        contentId: Int,
+        read: Bool
+    ) async throws {
+        try await performingForConnection { connection in
+            try await connection.markNotificationAsRead(
+                type: type,
+                id: id,
+                contentId: contentId,
+                read: read
+            )
+        }
+    }
 
     func markAllAsRead() async throws {
         try await performingForConnection { connection in

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2Providing+Snapshots.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment2Providing+Snapshots.swift
@@ -22,4 +22,23 @@ extension Comment2Providing {
         comment2.setIfChanged(\.creatorIsAdmin, snapshot.creatorIsAdmin)
         comment1.snapshot1Update(with: snapshot.comment)
     }
+    
+    public func takeSnapshot() -> any CommentSnapshotProviding {
+        takeSnapshot2()
+    }
+    
+    func takeSnapshot2() -> Comment2Snapshot {
+        .init(
+            comment: comment1.takeSnapshot1(),
+            creator: creator.takeSnapshot1(),
+            post: post.takeSnapshot1(),
+            community: community.takeSnapshot1(),
+            commentCount: commentCount,
+            creatorIsModerator: creatorIsModerator,
+            creatorIsAdmin: creatorIsAdmin,
+            creatorBannedFromCommunity: creatorBannedFromCommunity,
+            votes: votes,
+            saved: saved
+        )
+    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/InboxNotificationSnapshot+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/InboxNotificationSnapshot+Lemmy.swift
@@ -11,6 +11,7 @@ extension InboxNotificationSnapshot {
     init(from replyView: LemmyCommentReplyView) throws(ApiClientError) {
         try self.init(
             id: LegacyNotificationIdWrapper(type: .reply, id: replyView.commentReply.id).hashValue,
+            contentId: replyView.commentReply.id,
             read: replyView.commentReply.read,
             content: .reply(.init(from: replyView))
         )
@@ -19,6 +20,7 @@ extension InboxNotificationSnapshot {
     init(from mentionView: LemmyPersonCommentMentionView) throws(ApiClientError) {
         try self.init(
             id: LegacyNotificationIdWrapper(type: .mention, id: mentionView.personMention.id).hashValue,
+            contentId: mentionView.personMention.id,
             read: mentionView.personMention.read,
             content: .mention(.init(from: mentionView))
         )
@@ -31,6 +33,7 @@ extension InboxNotificationSnapshot {
 
         try self.init(
             id: LegacyNotificationIdWrapper(type: .message, id: messageView.privateMessage.id).hashValue,
+            contentId: messageView.privateMessage.id,
             read: read,
             content: .message(.init(from: messageView))
         )
@@ -39,10 +42,6 @@ extension InboxNotificationSnapshot {
 
 // This can be removed once we drop support for < Lemmy 1.0
 private struct LegacyNotificationIdWrapper: Hashable {
-    enum NotificationType: Hashable {
-        case reply, mention, message
-    }
-
-    let type: NotificationType
+    let type: InboxNotificationContentType
     let id: Int
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1Providing+Snapshots.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1Providing+Snapshots.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-10-12.
+//
+
+import Foundation
+
+extension Message1Providing {
+    func takeSnapshot1() -> Message1Snapshot {
+        .init(
+            actorId: actorId,
+            id: id,
+            creatorId: creatorId,
+            recipientId: recipientId,
+            created: created,
+            content: content,
+            updated: updated,
+            read: read,
+            deleted: deleted
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message2Providing+Snapshots.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message2Providing+Snapshots.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-10-12.
+//
+
+import Foundation
+
+extension Message2Providing {
+    func takeSnapshot2() -> Message2Snapshot {
+        .init(
+            message: message1.takeSnapshot1(),
+            creator: creator.takeSnapshot1(),
+            recipient: recipient.takeSnapshot1()
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/InboxNotification+Snapshots.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/InboxNotification+Snapshots.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-10-12.
+//
+
+import Foundation
+
+extension InboxNotification {
+    @MainActor
+    func snapshotUpdate(with snapshot: InboxNotificationSnapshot) {
+        setIfChanged(\.read, snapshot.read)
+    }
+    
+    func takeSnapshot() -> InboxNotificationSnapshot {
+        .init(
+            id: id,
+            contentId: contentId,
+            read: read,
+            content: content.takeSnapshot()
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/InboxNotification.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/InboxNotification.swift
@@ -9,28 +9,54 @@ import Foundation
 
 @Observable
 public class InboxNotification: ContentModel, Identifiable {
+    public var updateQueue: InboxNotificationUpdateQueue = .init()
+    
     public static var tierNumber: Int = 1
     public var api: ApiClient
 
     public let id: Int
+    // This can be removed when we drop support for < Lemmy 1.0
+    public let contentId: Int
+    
     public var read: Bool
     public let content: InboxNotificationContent
 
     init(
         api: ApiClient,
         id: Int,
+        contentId: Int,
         read: Bool,
         content: InboxNotificationContent
     ) {
         self.api = api
         self.id = id
+        self.contentId = contentId
         self.read = read
         self.content = content
+        
+        Task {
+            await updateQueue.setParent(self)
+        }
     }
-}
-
-public enum InboxNotificationContent {
-    case reply(Comment2)
-    case mention(Comment2)
-    case message(Message2)
+    
+    public func updateRead(_ newValue: Bool) {
+        read = newValue
+        Task {
+            await updateQueue.addItem {
+                try await self.api.repository.markNotificationAsRead(
+                    type: self.content.type,
+                    id: self.id,
+                    contentId: self.contentId,
+                    read: newValue
+                )
+                var snapshot = self.takeSnapshot()
+                snapshot.read = newValue
+                return snapshot
+            }
+        }
+    }
+    
+    public func toggleRead() {
+        updateRead(!read)
+    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/InboxNotificationContent.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/InboxNotificationContent.swift
@@ -1,0 +1,34 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-10-12.
+//
+
+import Foundation
+
+public enum InboxNotificationContent {
+    case reply(Comment2)
+    case mention(Comment2)
+    case message(Message2)
+    
+    public var type: InboxNotificationContentType {
+        switch self {
+        case .reply: .reply
+        case .mention: .mention
+        case .message: .message
+        }
+    }
+    
+    func takeSnapshot() -> InboxNotificationContentSnapshot {
+        switch self {
+        case let .reply(comment): .reply(comment.takeSnapshot2())
+        case let .mention(comment): .mention(comment.takeSnapshot2())
+        case let .message(message): .message(message.takeSnapshot2())
+        }
+    }
+}
+
+public enum InboxNotificationContentType: Hashable {
+    case reply, mention, message
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UpdateQueues/InboxNotificationUpdateQueue.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UpdateQueues/InboxNotificationUpdateQueue.swift
@@ -1,0 +1,107 @@
+//
+//  PostUpdateQueue.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-07-04.
+//
+
+import Semaphore
+
+/// This actor synchronizes state updates for a particular post.
+///
+/// Calls are queued using `addItem`, and each call must return a `PostSnapshotProviding`. When each call returns, `lastVerifiedSnapshot` is updated
+/// with the returned snapshot. Each call will only execute when the previous one finishes, ensuring that `lastVerifiedSnapshot` always accurately reflects
+/// the most recently queried server state.
+///
+/// When the queue finishes executing altogether, it updates its parent model with the most recent snapshot. State faking is performed by the model
+/// before the work item is queued.
+///
+/// - Note: some care must be taken to ensure that `parent` always points to a valid model. When a model is initialized, it updates `parent` to be itself;
+/// likewise, when a model is deinitialized, it updates `parent` to be the next lower-tier model contained within itself (e.g., `Post3`'s deinit updates parent
+/// to be `post2`). If this update is not performed, `parent` may become nil and the queue will refuse to execute. In debug mode this will throw an error,
+/// while in production the queue will simply not run until an item is added when the parent is present.
+public actor InboxNotificationUpdateQueue {
+    weak var parent: InboxNotification?
+    
+    private var lastVerifiedSnapshot: InboxNotificationSnapshot?
+    
+    private var semaphore: AsyncSemaphore = .init(value: 1)
+    private var queue: Queue<InboxNotificationUpdateTask> = .init()
+
+    func setParent(_ newParent: InboxNotification) {
+        parent = newParent
+        lastVerifiedSnapshot = newParent.takeSnapshot()
+    }
+    
+    /// Add a task to the queue for a repository call that returns a complete snapshot.
+    /// - Note: prefer this method over the snapshot-modifying variant below
+    func addItem(item: @escaping () async throws -> InboxNotificationSnapshot) {
+        addItem(.createsSnapshot(item))
+    }
+    
+    /// Add a task to the queue for a repository call that **does not** return a complete snapshot. The queue will provide the latest verified
+    /// snapshot to the task, which should then modify and return the snapshot according to the repository call result.
+    /// - Note: **only** use this method when absolutely necessary; if the repository returns a complete snapshot, use the variant above.
+    func addItem(item: @escaping (InboxNotificationSnapshot) async throws -> InboxNotificationSnapshot) {
+        addItem(.modifiesSnapshot(item))
+    }
+    
+    private func addItem(_ item: InboxNotificationUpdateTask) {
+        queue.enqueue(item)
+        if queue.numItems == 1 {
+            Task {
+                await executeQueue()
+            }
+        }
+    }
+    
+    private func executeQueue() async {
+        await semaphore.wait()
+        defer {
+            semaphore.signal()
+            print("DEBUG finished executing queue")
+        }
+        print("DEBUG executing queue")
+        
+        // assigning this here ensures parent stays in scope for the duration of the queue. For operations that remove the post
+        // (e.g., hide), if the call is slow, the parent might go out of scope before it returns; this in turn breaks the undo behavior
+        guard let parent else {
+            assertionFailure("Cannot execute queue with no parent!")
+            return
+        }
+        // this shouldn't be possible, since lastVerifiedSnapshot is set when the parent is set
+        guard var lastVerifiedSnapshot else {
+            assertionFailure("Cannot execute queue with no lastVerifiedSnapshot!")
+            return
+        }
+        while let task = queue.next() {
+            print("DEBUG found next task")
+            do {
+                let snapshot: InboxNotificationSnapshot
+                switch task {
+                case let .createsSnapshot(callback):
+                    snapshot = try await callback()
+                case let .modifiesSnapshot(callback):
+                    snapshot = try await callback(lastVerifiedSnapshot)
+                }
+                
+                self.lastVerifiedSnapshot = snapshot
+                lastVerifiedSnapshot = snapshot // also need to update scoped lastVerifiedSnapshot so updateParent gets the correct value\
+            } catch {
+                print(error)
+            }
+            queue.dequeue()
+        }
+        
+        await updateParent(parent, with: lastVerifiedSnapshot)
+    }
+    
+    private func updateParent(_ parent: InboxNotification, with snapshot: InboxNotificationSnapshot) async {
+        await parent.snapshotUpdate(with: snapshot)
+    }
+}
+
+enum InboxNotificationUpdateTask {
+    case createsSnapshot(() async throws -> InboxNotificationSnapshot)
+    case modifiesSnapshot((InboxNotificationSnapshot) async throws -> InboxNotificationSnapshot)
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UpdateQueues/InboxNotificationUpdateQueue.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UpdateQueues/InboxNotificationUpdateQueue.swift
@@ -1,5 +1,5 @@
 //
-//  PostUpdateQueue.swift
+//  InboxNotificationUpdateQueue.swift
 //  MlemMiddleware
 //
 //  Created by Eric Andrews on 2025-07-04.
@@ -7,19 +7,15 @@
 
 import Semaphore
 
-/// This actor synchronizes state updates for a particular post.
+/// This actor synchronizes state updates for a particular inbox notification.
 ///
-/// Calls are queued using `addItem`, and each call must return a `PostSnapshotProviding`. When each call returns, `lastVerifiedSnapshot` is updated
+/// Calls are queued using `addItem`, and each call must return an `InboxNotificationSnapshot`. When each call returns, `lastVerifiedSnapshot` is updated
 /// with the returned snapshot. Each call will only execute when the previous one finishes, ensuring that `lastVerifiedSnapshot` always accurately reflects
 /// the most recently queried server state.
 ///
 /// When the queue finishes executing altogether, it updates its parent model with the most recent snapshot. State faking is performed by the model
 /// before the work item is queued.
 ///
-/// - Note: some care must be taken to ensure that `parent` always points to a valid model. When a model is initialized, it updates `parent` to be itself;
-/// likewise, when a model is deinitialized, it updates `parent` to be the next lower-tier model contained within itself (e.g., `Post3`'s deinit updates parent
-/// to be `post2`). If this update is not performed, `parent` may become nil and the queue will refuse to execute. In debug mode this will throw an error,
-/// while in production the queue will simply not run until an item is added when the parent is present.
 public actor InboxNotificationUpdateQueue {
     weak var parent: InboxNotification?
     
@@ -63,8 +59,6 @@ public actor InboxNotificationUpdateQueue {
         }
         print("DEBUG executing queue")
         
-        // assigning this here ensures parent stays in scope for the duration of the queue. For operations that remove the post
-        // (e.g., hide), if the call is slow, the parent might go out of scope before it returns; this in turn breaks the undo behavior
         guard let parent else {
             assertionFailure("Cannot execute queue with no parent!")
             return

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -416,6 +416,13 @@ public protocol InstanceConnection {
     func getMentionNotifications() async throws -> [InboxNotificationSnapshot]
     func getMessageNotifications() async throws -> [InboxNotificationSnapshot]
 
+    func markNotificationAsRead(
+        type: InboxNotificationContentType,
+        id: Int,
+        contentId: Int,
+        read: Bool
+    ) async throws
+        
     func markAllAsRead() async throws
     func markReplyAsRead(id: Int, read: Bool) async throws
     func markMentionAsRead(id: Int, read: Bool) async throws

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -95,6 +95,25 @@ public extension LemmyConnection {
         return try response.privateMessages.map { try .init(from: $0) }
     }
     
+    func markNotificationAsRead(
+        type: InboxNotificationContentType,
+        id: Int,
+        contentId: Int,
+        read: Bool = true
+    ) async throws {
+        try await processingForEndpoint { endpoint in
+            guard endpoint == .v3 else { throw ApiClientError.featureUnsupported }
+            switch type {
+            case .reply:
+                try await self.markReplyAsRead(id: contentId, read: read)
+            case .mention:
+                try await self.markMentionAsRead(id: contentId, read: read)
+            case .message:
+                try await self.markMessageAsRead(id: contentId, read: read)
+            }
+        }
+    }
+    
     func markAllAsRead() async throws {
         _ = try await performingForEndpoint { endpoint in
             LemmyMarkAllNotificationsReadRequest(endpoint: endpoint)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -86,6 +86,15 @@ public extension PieFedConnection {
     func getMessageNotifications() async throws -> [InboxNotificationSnapshot] {
         throw ApiClientError.featureUnsupported
     }
+    
+    func markNotificationAsRead(
+        type: InboxNotificationContentType,
+        id: Int,
+        contentId: Int,
+        read: Bool
+    ) async throws {
+        throw ApiClientError.featureUnsupported
+    }
 
     func markAllAsRead() async throws {
         let request = PieFedMarkAllRepliesReadRequest()

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Notification/InboxNotificationSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Notification/InboxNotificationSnapshot.swift
@@ -9,13 +9,20 @@ import Foundation
 
 public struct InboxNotificationSnapshot: CacheIdentifiable {
     public let id: Int
+    public let contentId: Int
     public var read: Bool
     public var content: InboxNotificationContentSnapshot
 
     public var cacheId: Int { id }
 
-    public init(id: Int, read: Bool, content: InboxNotificationContentSnapshot) {
+    public init(
+        id: Int,
+        contentId: Int,
+        read: Bool,
+        content: InboxNotificationContentSnapshot
+    ) {
         self.id = id
+        self.contentId = contentId
         self.read = read
         self.content = content
     }


### PR DESCRIPTION
Added an update queue system for the new `InboxNotification`. In the "test inbox" view, you can now tap on an item to toggle its read status.

Closes #2336