### PR TITLE
Use `.alert` rather than `.confirmationDialog` on iOS 26

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		03EC83EE2E958A44004698BB /* OpenGraph in Frameworks */ = {isa = PBXBuildFile; productRef = 03EC83ED2E958A44004698BB /* OpenGraph */; };
 		03EC83F02E9590D3004698BB /* LinkHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC83EF2E9590D3004698BB /* LinkHostView.swift */; };
 		03EC84422E959AA5004698BB /* PostEditorWebsitePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC84412E959AA5004698BB /* PostEditorWebsitePreviewView.swift */; };
+		03EC86462E9E9D4D004698BB /* PopupAnchorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC86452E9E9D4C004698BB /* PopupAnchorModel.swift */; };
 		03ECD7192C81195000D48BF6 /* PostEditorView+LinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD7182C81195000D48BF6 /* PostEditorView+LinkView.swift */; };
 		03ECD71B2C811D6700D48BF6 /* PostEditorView+ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD71A2C811D6700D48BF6 /* PostEditorView+ImageView.swift */; };
 		03ECD71F2C864DB700D48BF6 /* ImageUploadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ECD71E2C864DB700D48BF6 /* ImageUploadManager.swift */; };
@@ -910,6 +911,7 @@
 		03EC83242E916C51004698BB /* View+SafeAreaBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+SafeAreaBar.swift"; sourceTree = "<group>"; };
 		03EC83EF2E9590D3004698BB /* LinkHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHostView.swift; sourceTree = "<group>"; };
 		03EC84412E959AA5004698BB /* PostEditorWebsitePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditorWebsitePreviewView.swift; sourceTree = "<group>"; };
+		03EC86452E9E9D4C004698BB /* PopupAnchorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupAnchorModel.swift; sourceTree = "<group>"; };
 		03ECD7182C81195000D48BF6 /* PostEditorView+LinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+LinkView.swift"; sourceTree = "<group>"; };
 		03ECD71A2C811D6700D48BF6 /* PostEditorView+ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+ImageView.swift"; sourceTree = "<group>"; };
 		03ECD71E2C864DB700D48BF6 /* ImageUploadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadManager.swift; sourceTree = "<group>"; };
@@ -2096,6 +2098,7 @@
 				CDFB8C682C7796020070845F /* View+DynamicBlur.swift */,
 				CD1B2E202C7F84160075C7EA /* View+MarkReadOnScroll.swift */,
 				03FD6CAF2C9B719100500FD6 /* View+PopupAnchor.swift */,
+				03EC86452E9E9D4C004698BB /* PopupAnchorModel.swift */,
 				037029A02D6B9A3900B749DF /* View+TabBarPreview.swift */,
 				034065C22D83742900637308 /* View+NavigtionStackPreview.swift */,
 				031CA5B62E599F7E00CF0C0F /* View+QuickSwipes.swift */,
@@ -2664,6 +2667,7 @@
 				032C32182C36F70300595286 /* ReplyBarConfiguration.swift in Sources */,
 				CDD4A0A02C8B985D0001AD1A /* ImportExportSettingsView.swift in Sources */,
 				03B431B62C454D49001A1EB5 /* UIImage+Extensions.swift in Sources */,
+				03EC86462E9E9D4D004698BB /* PopupAnchorModel.swift in Sources */,
 				CD93420B2DCD069800945333 /* InstanceUptimeView+Logic.swift in Sources */,
 				CD1446212A5B328E00610EF1 /* Privacy Policy.swift in Sources */,
 				03AFD0E32C3C0C540054B8AD /* InstanceView.swift in Sources */,

--- a/Mlem/App/Models/Action/BasicAction.swift
+++ b/Mlem/App/Models/Action/BasicAction.swift
@@ -49,7 +49,13 @@ struct BasicAction: Action {
                     children: {
                         BasicAction(
                             id: "",
-                            appearance: .init(label: "Yes", isOn: false, color: .themedWarning, icon: ""),
+                            appearance: .init(
+                                label: "Yes",
+                                isOn: false,
+                                isDestructive: true,
+                                color: .themedWarning,
+                                icon: ""
+                            ),
                             callback: callback
                         )
                     }

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/PopupAnchorModel.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/PopupAnchorModel.swift
@@ -1,0 +1,60 @@
+//
+//  PopupAnchorModel.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-10-14.
+//
+
+import Foundation
+
+@Observable
+class PopupAnchorModel {
+    struct PopupData {
+        var title: String
+        var message: String?
+        var actions: [Action]?
+    }
+    
+    struct Action {
+        let title: String
+        let isDestructive: Bool
+        let callback: @MainActor () -> Void
+    }
+    
+    private(set) var data: PopupData?
+    
+    func showPopup(title: String, message: String?, _ actions: [Action]?) {
+        let newData = PopupData(title: title, message: message, actions: actions)
+        if data == nil {
+            data = newData
+        } else {
+            data = nil
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                self.data = newData
+            }
+        }
+    }
+        
+    func dismissPopup() {
+        data = nil
+    }
+}
+
+extension PopupAnchorModel {
+    func showPopup(_ actionGroup: ActionGroup) {
+        let children: [PopupAnchorModel.Action] = actionGroup.children.map { child in
+            .init(title: child.appearance.label, isDestructive: child.appearance.isDestructive) { @MainActor in
+                if let child = child as? BasicAction {
+                    child.callbackWithConfirmation(popupModel: self)
+                } else {
+                    assertionFailure("Not implemented")
+                }
+            }
+        }
+        showPopup(
+            title: actionGroup.appearance.label,
+            message: actionGroup.prompt,
+            children
+        )
+    }
+}

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/PopupAnchorModel.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/PopupAnchorModel.swift
@@ -10,8 +10,7 @@ import Foundation
 @Observable
 class PopupAnchorModel {
     struct PopupData {
-        var title: String
-        var message: String?
+        var message: String
         var actions: [Action]?
     }
     
@@ -23,8 +22,8 @@ class PopupAnchorModel {
     
     private(set) var data: PopupData?
     
-    func showPopup(title: String, message: String?, _ actions: [Action]?) {
-        let newData = PopupData(title: title, message: message, actions: actions)
+    func showPopup(message: String, _ actions: [Action]?) {
+        let newData = PopupData(message: message, actions: actions)
         if data == nil {
             data = newData
         } else {
@@ -52,8 +51,7 @@ extension PopupAnchorModel {
             }
         }
         showPopup(
-            title: actionGroup.appearance.label,
-            message: actionGroup.prompt,
+            message: actionGroup.prompt ?? actionGroup.appearance.label,
             children
         )
     }

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PopupAnchor.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PopupAnchor.swift
@@ -15,29 +15,49 @@ struct PopupAnchor: ViewModifier {
         model.data?.actions ?? []
     }
     
-    func body(content: Content) -> some View {
-        content
-            .confirmationDialog(
-                model.data?.title ?? "",
-                isPresented: Binding(
-                    get: { model.data != nil },
-                    set: {
-                        if !$0 { model.dismissPopup() }
-                    }
-                )
-            ) {
-                ForEach(Array(actions.enumerated()), id: \.offset) { _, action in
-                    Button(
-                        action.title,
-                        role: action.isDestructive ? .destructive : nil,
-                        action: action.callback
-                    )
-                }
-                Button("Cancel", role: .cancel) {}
-            } message: {
-                Text(model.data?.message ?? "")
+    var isPresented: Binding<Bool> {
+        Binding(
+            get: { model.data != nil },
+            set: {
+                if !$0 { model.dismissPopup() }
             }
-            .environment(model)
+        )
+    }
+    
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .alert(
+                    model.data?.message ?? "",
+                    isPresented: isPresented
+                ) {
+                    buttonsView
+                }
+                .environment(model)
+        } else {
+            content
+                .confirmationDialog(
+                    model.data?.message ?? "",
+                    isPresented: isPresented
+                ) {
+                    buttonsView
+                } message: {
+                    Text(model.data?.message ?? "")
+                }
+                .environment(model)
+        }
+    }
+    
+    @ViewBuilder
+    var buttonsView: some View {
+        ForEach(Array(actions.enumerated()), id: \.offset) { _, action in
+            Button(
+                action.title,
+                role: action.isDestructive ? .destructive : nil,
+                action: action.callback
+            )
+        }
+        Button("Cancel", role: .cancel) {}
     }
 }
 

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PopupAnchor.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PopupAnchor.swift
@@ -5,28 +5,37 @@
 //  Created by Sjmarf on 18/09/2024.
 //
 
+import Icons
 import SwiftUI
 
 struct PopupAnchor: ViewModifier {
     @State var model: PopupAnchorModel
     
+    var actions: [PopupAnchorModel.Action] {
+        model.data?.actions ?? []
+    }
+    
     func body(content: Content) -> some View {
         content
             .confirmationDialog(
-                model.popup?.appearance.label ?? "",
+                model.data?.title ?? "",
                 isPresented: Binding(
-                    get: { model.popup != nil },
+                    get: { model.data != nil },
                     set: {
                         if !$0 { model.dismissPopup() }
                     }
                 )
             ) {
-                ForEach(model.popup?.children ?? [], id: \.id) { action in
-                    MenuButton(action: action)
+                ForEach(Array(actions.enumerated()), id: \.offset) { _, action in
+                    Button(
+                        action.title,
+                        role: action.isDestructive ? .destructive : nil,
+                        action: action.callback
+                    )
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text(model.popup?.prompt ?? "")
+                Text(model.data?.message ?? "")
             }
             .environment(model)
     }
@@ -36,25 +45,5 @@ extension View {
     @ViewBuilder
     func popupAnchor(model: PopupAnchorModel = .init()) -> some View {
         modifier(PopupAnchor(model: model))
-    }
-}
-
-@Observable
-class PopupAnchorModel {
-    private(set) var popup: ActionGroup?
-    
-    func showPopup(_ actionGroup: ActionGroup) {
-        if popup == nil {
-            popup = actionGroup
-        } else {
-            popup = nil
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                self.popup = actionGroup
-            }
-        }
-    }
-        
-    func dismissPopup() {
-        popup = nil
     }
 }


### PR DESCRIPTION
Closes #2215

Also decoupled `PopoverAnchorModel` from the action system. This will make it easier to rewrite the action system in future.