### PR TITLE
Add "distinguish interaction bar" accessibility setting

### DIFF
--- a/Mlem/App/Configuration/User Settings/SettingsValues.swift
+++ b/Mlem/App/Configuration/User Settings/SettingsValues.swift
@@ -21,6 +21,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
     var a11y_showSettingsIcons: Bool
     var a11y_websiteThumbnailIcon: Bool
     var a11y_zoomSliderLocation: ZoomSliderLocation
+    var a11y_showInteractionBarButtonOutline: Bool
     var accounts_defaultId: Int?
     var accounts_grouped: Bool
     var accounts_sort: AccountSortMode
@@ -120,6 +121,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.a11y_showSettingsIcons = try container.decodeIfPresent(Bool.self, forKey: ._a11y_showSettingsIcons) ?? true
         self.a11y_websiteThumbnailIcon = try container.decodeIfPresent(Bool.self, forKey: ._a11y_websiteThumbnailIcon) ?? false
         self.a11y_zoomSliderLocation = try container.decodeIfPresent(ZoomSliderLocation.self, forKey: ._a11y_zoomSliderLocation) ?? .none
+        self.a11y_showInteractionBarButtonOutline = try container.decodeIfPresent(Bool.self, forKey: ._a11y_showInteractionBarButtonOutline) ?? false
         self.accounts_defaultId = try container.decodeIfPresent(Int?.self, forKey: ._accounts_defaultId) ?? nil
         self.accounts_grouped = try container.decodeIfPresent(Bool.self, forKey: ._accounts_grouped) ?? false
         self.accounts_sort = try container.decodeIfPresent(AccountSortMode.self, forKey: ._accounts_sort) ?? .name
@@ -342,6 +344,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         case _a11y_showSettingsIcons = "a11y_showSettingsIcons"
         case _a11y_websiteThumbnailIcon = "a11y_websiteThumbnailIcon"
         case _a11y_zoomSliderLocation = "a11y_zoomSliderLocation"
+        case _a11y_showInteractionBarButtonOutline = "a11y_showInteractionBarButtonOutline"
         case _accounts_defaultId = "accounts_defaultId"
         case _accounts_grouped = "accounts_grouped"
         case _accounts_sort = "accounts_sort"
@@ -440,6 +443,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.a11y_showSettingsIcons = settings.showSettingsIcons
         self.a11y_websiteThumbnailIcon = settings.websiteThumbnailIcon
         self.a11y_zoomSliderLocation = settings.zoomSliderLocation
+        self.a11y_showInteractionBarButtonOutline = false
         self.accounts_defaultId = nil // In 2.0, the last used account is now activated when the app is opened
         self.accounts_grouped = settings.groupAccountSort
         self.accounts_sort = settings.accountSort

--- a/Mlem/App/Configuration/User Settings/SettingsValues.swift
+++ b/Mlem/App/Configuration/User Settings/SettingsValues.swift
@@ -21,7 +21,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
     var a11y_showSettingsIcons: Bool
     var a11y_websiteThumbnailIcon: Bool
     var a11y_zoomSliderLocation: ZoomSliderLocation
-    var a11y_showInteractionBarButtonOutline: Bool
+    var a11y_showInteractionBarButtonBackground: Bool
     var accounts_defaultId: Int?
     var accounts_grouped: Bool
     var accounts_sort: AccountSortMode
@@ -121,7 +121,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.a11y_showSettingsIcons = try container.decodeIfPresent(Bool.self, forKey: ._a11y_showSettingsIcons) ?? true
         self.a11y_websiteThumbnailIcon = try container.decodeIfPresent(Bool.self, forKey: ._a11y_websiteThumbnailIcon) ?? false
         self.a11y_zoomSliderLocation = try container.decodeIfPresent(ZoomSliderLocation.self, forKey: ._a11y_zoomSliderLocation) ?? .none
-        self.a11y_showInteractionBarButtonOutline = try container.decodeIfPresent(Bool.self, forKey: ._a11y_showInteractionBarButtonOutline) ?? false
+        self.a11y_showInteractionBarButtonBackground = try container.decodeIfPresent(Bool.self, forKey: ._a11y_showInteractionBarButtonBackground) ?? false
         self.accounts_defaultId = try container.decodeIfPresent(Int?.self, forKey: ._accounts_defaultId) ?? nil
         self.accounts_grouped = try container.decodeIfPresent(Bool.self, forKey: ._accounts_grouped) ?? false
         self.accounts_sort = try container.decodeIfPresent(AccountSortMode.self, forKey: ._accounts_sort) ?? .name
@@ -344,7 +344,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         case _a11y_showSettingsIcons = "a11y_showSettingsIcons"
         case _a11y_websiteThumbnailIcon = "a11y_websiteThumbnailIcon"
         case _a11y_zoomSliderLocation = "a11y_zoomSliderLocation"
-        case _a11y_showInteractionBarButtonOutline = "a11y_showInteractionBarButtonOutline"
+        case _a11y_showInteractionBarButtonBackground = "a11y_showInteractionBarButtonBackground"
         case _accounts_defaultId = "accounts_defaultId"
         case _accounts_grouped = "accounts_grouped"
         case _accounts_sort = "accounts_sort"
@@ -443,7 +443,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.a11y_showSettingsIcons = settings.showSettingsIcons
         self.a11y_websiteThumbnailIcon = settings.websiteThumbnailIcon
         self.a11y_zoomSliderLocation = settings.zoomSliderLocation
-        self.a11y_showInteractionBarButtonOutline = false
+        self.a11y_showInteractionBarButtonBackground = false
         self.accounts_defaultId = nil // In 2.0, the last used account is now activated when the app is opened
         self.accounts_grouped = settings.groupAccountSort
         self.accounts_sort = settings.accountSort

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -16,7 +16,7 @@ struct AccessibilitySettingsView: View {
     @Setting(\.a11y_showSettingsIcons) var showSettingsIcons
     @Setting(\.a11y_zoomSliderLocation) var zoomSliderLocation
     @Setting(\.media_animatedAvatars) var animatedAvatars
-    @Setting(\.a11y_showInteractionBarButtonOutline) var showInteractionBarButtonOutline
+    @Setting(\.a11y_showInteractionBarButtonBackground) var showInteractionBarButtonBackground
     
     var body: some View {
         Form {
@@ -62,7 +62,7 @@ struct AccessibilitySettingsView: View {
             }
 
             Section {
-                Toggle("Button Outlines", icon: .general.circle, isOn: $showInteractionBarButtonOutline)
+                Toggle("Distinguish Interaction Bar", icon: .general.circle, isOn: $showInteractionBarButtonBackground)
             } header: {
                 Text("Contrast")
             }

--- a/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AccessibilitySettingsView.swift
@@ -16,6 +16,7 @@ struct AccessibilitySettingsView: View {
     @Setting(\.a11y_showSettingsIcons) var showSettingsIcons
     @Setting(\.a11y_zoomSliderLocation) var zoomSliderLocation
     @Setting(\.media_animatedAvatars) var animatedAvatars
+    @Setting(\.a11y_showInteractionBarButtonOutline) var showInteractionBarButtonOutline
     
     var body: some View {
         Form {
@@ -58,6 +59,12 @@ struct AccessibilitySettingsView: View {
                 } header: {
                     Text("Reduce Motion")
                 }
+            }
+
+            Section {
+                Toggle("Button Outlines", icon: .general.circle, isOn: $showInteractionBarButtonOutline)
+            } header: {
+                Text("Contrast")
             }
             
             Section {

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarActionLabelView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarActionLabelView.swift
@@ -34,6 +34,7 @@ struct InteractionBarActionLabelView: View {
                 if showOutline {
                     RoundedRectangle(cornerRadius: Constants.main.barIconCornerRadius)
                         .fill(.themedTertiaryGroupedBackground)
+                        .paletteBorder(cornerRadius: Constants.main.barIconCornerRadius)
                 }
             }
             .frame(width: Constants.main.barIconHitbox, height: Constants.main.barIconHitbox)

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarActionLabelView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarActionLabelView.swift
@@ -10,6 +10,8 @@ import Theming
 
 struct InteractionBarActionLabelView: View {
     static let unweightedSymbols: Set<String> = [Icons.upvote, Icons.downvote]
+
+    @Setting(\.a11y_showInteractionBarButtonOutline) var showInteractionBarButtonOutline
         
     let appearance: ActionAppearance
     
@@ -28,6 +30,12 @@ struct InteractionBarActionLabelView: View {
             .frame(width: Constants.main.barIconBackgroundSize, height: Constants.main.barIconBackgroundSize)
             .foregroundStyle(appearance.isOn ? .themedContrastingLabel : .themedPrimary)
             .background(appearance.isOn ? appearance.color : .clear, in: .rect(cornerRadius: Constants.main.barIconCornerRadius))
+            .background {
+                if showOutline {
+                    RoundedRectangle(cornerRadius: Constants.main.barIconCornerRadius)
+                        .fill(.themedTertiaryGroupedBackground)
+                }
+            }
             .frame(width: Constants.main.barIconHitbox, height: Constants.main.barIconHitbox)
             .contentShape(Rectangle())
             .opacity(appearance.isInProgress ? 0.5 : 1)
@@ -38,5 +46,9 @@ struct InteractionBarActionLabelView: View {
                 }
             }
             .transaction { $0.animation = nil }
+    }
+
+    var showOutline: Bool {
+        !appearance.isOn && showInteractionBarButtonOutline
     }
 }

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarActionLabelView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarActionLabelView.swift
@@ -11,7 +11,7 @@ import Theming
 struct InteractionBarActionLabelView: View {
     static let unweightedSymbols: Set<String> = [Icons.upvote, Icons.downvote]
 
-    @Setting(\.a11y_showInteractionBarButtonOutline) var showInteractionBarButtonOutline
+    @Setting(\.a11y_showInteractionBarButtonBackground) var showInteractionBarButtonBackground
         
     let appearance: ActionAppearance
     
@@ -49,6 +49,6 @@ struct InteractionBarActionLabelView: View {
     }
 
     var showOutline: Bool {
-        !appearance.isOn && showInteractionBarButtonOutline
+        !appearance.isOn && showInteractionBarButtonBackground
     }
 }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -5322,6 +5322,9 @@
         }
       }
     },
+    "No image" : {
+
+    },
     "No reason given" : {
       "localizations" : {
         "fr" : {


### PR DESCRIPTION
When enabled, interaction bar buttons always a subtle background, even when the buttons are in the "off" state.

Requested here: https://lemmy.ml/post/37498140/21661855