### PR TITLE
fix subscription list tint

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -63,7 +63,7 @@ struct SubscriptionListView: View {
     var content: some View {
         let sections = subscriptions?.visibleSections(sort: sort) ?? []
         
-        Form {
+        Form(tint: .themedPrimary) {
             // TODO: iOS 18 deprecation remove compatibility shim
             if #available(iOS 26, *) {
                 feeds

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -54,6 +54,7 @@ struct SubscriptionListView: View {
                 content
             }
         }
+        .tint(.themedPrimary)
         .listStyle(.sidebar)
         .navigationTitle("Feeds")
     }

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListView.swift
@@ -54,7 +54,6 @@ struct SubscriptionListView: View {
                 content
             }
         }
-        .tint(.themedPrimary)
         .listStyle(.sidebar)
         .navigationTitle("Feeds")
     }

--- a/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
@@ -7,6 +7,7 @@
 
 import Media
 import SwiftUI
+import Theming
 
 extension MediaView {
     @ViewBuilder
@@ -27,6 +28,7 @@ extension MediaView {
     var fallbackImage: some View {
         if loader.loading == .loading {
             ProgressView()
+                .tint(.themedSecondary)
         } else if !showErrorOverlay {
             switch fallback.fallbackStyle {
             case .standard:

--- a/Mlem/App/Views/Shared/MenuButton.swift
+++ b/Mlem/App/Views/Shared/MenuButton.swift
@@ -31,6 +31,7 @@ struct MenuButton: View {
                     }
                 }
             )
+            .tint(action.appearance.isDestructive ? .themedNegative : nil)
             .disabled(action.disabled)
         } else if let action = action as? ActionGroup {
             switch action.displayMode {

--- a/Mlem/App/Views/Shared/Palette Components/Form.swift
+++ b/Mlem/App/Views/Shared/Palette Components/Form.swift
@@ -15,6 +15,13 @@ struct Form<Content: View>: View {
     
     @ViewBuilder let content: () -> Content
     
+    let tint: ThemedColor
+    
+    init(tint: ThemedColor = .themedAccent, @ViewBuilder content: @escaping () -> Content) {
+        self.tint = tint
+        self.content = content
+    }
+    
     var body: some View {
         SwiftUI.Form {
             content()
@@ -22,6 +29,7 @@ struct Form<Content: View>: View {
                 .listRowBackground(palette.groupedBackground.secondary)
                 .buttonStyle(PaletteButton())
         }
+        .tint(tint)
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
         .background(.themedGroupedBackground)

--- a/Mlem/App/Views/Shared/Palette Components/Form.swift
+++ b/Mlem/App/Views/Shared/Palette Components/Form.swift
@@ -22,7 +22,6 @@ struct Form<Content: View>: View {
                 .listRowBackground(palette.groupedBackground.secondary)
                 .buttonStyle(PaletteButton())
         }
-        .tint(.themedAccent)
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
         .background(.themedGroupedBackground)

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -5322,6 +5322,9 @@
         }
       }
     },
+    "No image" : {
+
+    },
     "No reason given" : {
       "localizations" : {
         "fr" : {

--- a/Mlem/Packages/Theming/Sources/Theming/View+Tint.swift
+++ b/Mlem/Packages/Theming/Sources/Theming/View+Tint.swift
@@ -19,8 +19,13 @@ private struct ThemedTintViewModifier: ViewModifier {
 }
 
 public extension View {
-    func tint(_ themedColor: ThemedColor) -> some View {
-        modifier(ThemedTintViewModifier(themedColor: themedColor))
+    @ViewBuilder
+    func tint(_ themedColor: ThemedColor?) -> some View {
+        if let themedColor {
+            modifier(ThemedTintViewModifier(themedColor: themedColor))
+        } else {
+            self
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2216 

## Description

- Removes the default tint from our custom `Form`--as far as I can tell it didn't actually do anything other than prevent the form tint from being locally overridden.
- Tint the subscription list `.themedPrimary`
- Force a `.themedSecondary` tint on the `MediaView` spinner so it always renders as gray rather than picking up parent tint (this is consistent with other spinners in the app)
