### PR TITLE
Disable ban option for non-local communities on PieFed

### DIFF
--- a/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Person1Providing+Extensions.swift
@@ -159,7 +159,10 @@ extension Person1Providing {
         let canBanFromInstance = api.isAdmin && api.supports(.banFromInstance, defaultValue: false)
         
         if let myPerson = api.myPerson, let community {
-            canBanFromCommunity = myPerson.moderates(communityId: community.id) && api.supports(.banFromCommunity, defaultValue: false)
+            let supportedByApi = api.supports(.banFromCommunity, defaultValue: false) && (
+                apiIsLocal || api.supports(.banFromNonLocalCommunity, defaultValue: false)
+            )
+            canBanFromCommunity = myPerson.moderates(communityId: community.id) && supportedByApi
             showBoth = canBanFromInstance && isBannedFromCommunity(community) != bannedFromInstance
         } else {
             canBanFromCommunity = false

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -37,7 +37,10 @@ public enum Feature: Hashable {
     case purgeContent
     case removeCommunity
     case banFromInstance
+    
     case banFromCommunity
+    case banFromNonLocalCommunity
+    
     case unbanWithReason
     
     /// Add/remove moderators from a community

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -41,7 +41,7 @@ public extension LemmyConnection {
              .reportPrivateMessages, .viewVotes, .purgeContent, .removeCommunity, .banFromInstance,
              .banFromCommunity, .editModeratorList, .commentSearch, .undeletePrivateMessages, .searchLocalPeople,
              .hidePosts, .editDisplayName, .editProfile, .autoMarkPostReadOnInteract, .blockInstances,
-             .fetchLinkMetadata, .unbanWithReason:
+             .fetchLinkMetadata, .unbanWithReason, .banFromNonLocalCommunity:
             true
         case .moderatorSetNsfw:
             false


### PR DESCRIPTION
PieFed only supports banning users if the community is on your local instance.

Relevant PieFed code: https://codeberg.org/rimu/pyfedi/src/branch/main/app/api/alpha/utils/community.py#L348