### PR TITLE
Use new action system for comments when using separate moderator menu

### DIFF
--- a/Mlem/App/Actions/ContextMenu+Comment.swift
+++ b/Mlem/App/Actions/ContextMenu+Comment.swift
@@ -45,28 +45,38 @@ extension EllipsisMenu {
     init(
         icon: Icon = .general.menu,
         size: CGFloat,
-        comment: any Comment1Providing
+        comment: any Comment1Providing,
+        type: Set<CommentEllipsisMenuContent.ActionListType> = [.basic, .moderator]
     ) where Content == CommentEllipsisMenuContent {
         self.icon = icon
         self.size = size
 
-        self.content = CommentEllipsisMenuContent(comment: comment)
+        self.content = CommentEllipsisMenuContent(comment: comment, type: type)
     }
 }
 
 struct CommentEllipsisMenuContent: View {
+    enum ActionListType {
+        case basic, moderator
+    }
+
     let comment: any Comment1Providing
+    let type: Set<ActionListType>
 
     var body: some View {
-        ControlGroup {
-            ActionButtons { _ in
-                seeds.compactMap { $0.createAction(comment) }
+        if type.contains(.basic) {
+            ControlGroup {
+                ActionButtons { _ in
+                    seeds.compactMap { $0.createAction(comment) }
+                }
             }
+            .controlGroupStyle(.compactMenu)
         }
-        .controlGroupStyle(.compactMenu)
-        Section {
-            ActionButtons { _ in
-                moderationSeeds.compactMap { $0.createAction(comment) }
+        if type.contains(.moderator) {
+            Section {
+                ActionButtons { _ in
+                    moderationSeeds.compactMap { $0.createAction(comment) }
+                }
             }
         }
     }

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -156,17 +156,9 @@ struct CommentView<EmbeddedContent: View>: View {
             switch moderatorActionGrouping {
             case .separateMenu:
                 if comment.canModerate {
-                    EllipsisMenu(icon: .lemmy.moderation, size: 24) {
-                        comment.moderatorMenuActions(appState: appState, showAllActions: !inFeed, report: reportContext)
-                    }
+                    EllipsisMenu(icon: .lemmy.moderation, size: 24, comment: comment, type: [.moderator])
                 }
-                EllipsisMenu(size: 24) {
-                    comment.basicMenuActions(
-                        appState: appState,
-                        navigation: navigation,
-                        commentTreeTracker: commentTreeTracker
-                    )
-                }
+                EllipsisMenu(size: 24, comment: comment, type: [.basic])
             case .disclosureGroup:
                 EllipsisMenu(size: 24) {
                     comment.allMenuActions(

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1855,7 +1855,7 @@
         }
       }
     },
-    "Choose action..." : {
+    "Choose an action..." : {
 
     },
     "Choose another instance..." : {
@@ -3086,6 +3086,9 @@
           }
         }
       }
+    },
+    "Downvoted" : {
+
     },
     "Downvotes" : {
       "localizations" : {


### PR DESCRIPTION
In #2390, I mentioned that the new action system was not yet used when using the separate moderator menu. This has now been implemented.