### PR TITLE
Enable `InstanceView` community list and searching local people on PieFed

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
@@ -41,6 +41,11 @@ public extension PieFedConnection {
             version >= .v1_2_0
         case .banFromCommunity:
             version >= .v1_3_0
+        case .searchLocalPeople, .searchLocalCommunities:
+            // These features were not necessarily added in 1.3.
+            // Rather, we have only tested them on 1.3 and so are
+            // restricting them to that version.
+            version >= .v1_3_0
         case .moderatorSetNsfw: true
         default: false
         }


### PR DESCRIPTION
- The "communities" tab is now shown on the instance page for PieFed instances running version 1.3 or later
- When searching for users, you can now filter for users from a specific PieFed instance

Closes #2226

