### PR TITLE
Fix "description" field of post editor being blank when editing post

### DIFF
--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -384,6 +384,7 @@ extension Post1Providing {
                 NavigationModel.main.openSheet(.createPost(
                     community: nil as AnyCommunity?,
                     title: self.title,
+                    content: self.content,
                     type: self.type,
                     nsfw: self.nsfw,
                     feedLoader: .init(wrappedValue: nil)

--- a/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView.swift
+++ b/Mlem/App/Views/Pages/Editors/CommentEditor/PostEditor/PostEditorView.swift
@@ -61,6 +61,7 @@ struct PostEditorView: View {
         self.init(
             community: community,
             title: postToEdit.title,
+            content: postToEdit.content,
             type: postToEdit.type,
             nsfw: postToEdit.nsfw,
             feedLoader: nil
@@ -72,6 +73,7 @@ struct PostEditorView: View {
     init?(
         community: AnyCommunity?,
         title: String = "",
+        content: String? = nil,
         type: PostType? = nil,
         nsfw: Bool = false,
         feedLoader: (any FeedLoading)?
@@ -88,19 +90,18 @@ struct PostEditorView: View {
         contentTextView.tag = 1
         
         titleTextView.text = title
+        contentTextView.text = content ?? ""
         self._titleIsEmpty = .init(wrappedValue: title.isEmpty)
         self._hasNsfwTag = .init(wrappedValue: nsfw)
         
         switch type {
-        case let .text(content):
-            contentTextView.text = content
         case let .media(url):
             self._imageUrl = .init(wrappedValue: url)
         case let .embedded(_, url):
             self._link = .init(wrappedValue: .value(.init(content: url, thumbnail: nil, label: "")))
         case let .link(url):
             self._link = .init(wrappedValue: .value(url))
-        case .titleOnly, nil:
+        case .titleOnly, .text, nil:
             break
         }
     }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -100,6 +100,7 @@ extension NavigationPage {
         case let .createPost(
             community: community,
             title: title,
+            content: content,
             type: type,
             nsfw: nsfw,
             feedLoader: feedLoader
@@ -107,6 +108,7 @@ extension NavigationPage {
             if let view = PostEditorView(
                 community: community,
                 title: title,
+                content: content,
                 type: type,
                 nsfw: nsfw,
                 feedLoader: feedLoader.wrappedValue

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -55,6 +55,7 @@ enum NavigationPage: Hashable {
     case createPost(
         community: AnyCommunity?,
         title: String,
+        content: String?,
         type: PostType?,
         nsfw: Bool,
         feedLoader: HashWrapper<(any FeedLoading)?>
@@ -267,6 +268,7 @@ enum NavigationPage: Hashable {
     static func createPost(
         community: (any CommunityStubProviding)?,
         title: String = "",
+        content: String? = nil,
         type: PostType?,
         nsfw: Bool = false,
         feedLoader: (any FeedLoading)?
@@ -280,6 +282,7 @@ enum NavigationPage: Hashable {
         return createPost(
             community: anyCommunity,
             title: title,
+            content: content,
             type: type,
             nsfw: nsfw,
             feedLoader: .init(wrappedValue: feedLoader)


### PR DESCRIPTION
If a post has an image, the "description" field would be blank when you edit the post. This bug was introduced in #2356.