### PR TITLE
Fix Loops embeds

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
@@ -70,6 +70,16 @@ public extension URL {
         return components.url!
     }
     
+    private struct LoopsVideoResponse: Codable {
+        let data: Body
+        internal struct Body: Codable {
+            let media: Media
+            internal struct Media: Codable {
+                let src_url: URL
+            }
+        }
+    }
+    
     /// Attempts to extract the underlying loops.video media URL from this URL
     /// - Returns: loops.video media URL if this is a loops.video url and the underlying URL was successfully parsed, nil otherwise
     func parseEmbeddedLoops() async -> URL? {
@@ -79,15 +89,20 @@ public extension URL {
         guard host() == "loops.video" else { return nil }
         
         do {
-            let urlRegex = /video-src="(?<url>.*)"/
-            let request: URLRequest = .init(url: self)
-            let (websiteContent, _) = try await URLSession.shared.data(for: request)
+            let (websiteContent, _) = try await URLSession.shared.data(from: self)
             
-            if let str = String(data: websiteContent, encoding: .utf8),
-               let match = str.firstMatch(of: urlRegex),
-               let loopUrl: URL = .init(string: .init(match.url)) {
-                return loopUrl
+            // parse video API ID from website content
+            let apiIdRegex = /<meta property="og:image" content="https:\/\/loopsusercontent\.com\/videos\/\d+\/((?<apiId>\d*))\/.*\/>/
+            guard let str: String = String(data: websiteContent, encoding: .utf8),
+                  let match = str.firstMatch(of: apiIdRegex),
+                  let apiUrl = URL(string: "https://loops.video/api/v1/video/\(match.apiId)") else {
+                return nil
             }
+            
+            // query API for video id
+            let (apiResponse, _) = try await URLSession.shared.data(from: apiUrl)
+            let decodedResponse = try JSONDecoder.defaultDecoder.decode(LoopsVideoResponse.self, from: apiResponse)
+            return decodedResponse.data.media.src_url
         } catch {
             Logger.universal.error("Failed to parse embedded loops: \(error.localizedDescription)")
         }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2421 

## Description

Loops recently changed how their webpage is displayed, so parsing the video source URL now requires two steps. First we have to fetch the page from the provided URL. This does not directly point us to the source URL; however, it _does_ contain some thumbnail information, which conveniently re-uses the API ID for the actual video (note that the original URL uses a one-way hash of the API ID, e.g., `https://loops.video/v/6DMa4tT2LZ` points to a video with API ID `119275713371843581`). With this information in hand we can then query the API directly and extract the source URL.
