### PR TITLE
Theme fixes

### DIFF
--- a/Mlem/App/Configuration/Colors/Palette+Dracula.swift
+++ b/Mlem/App/Configuration/Colors/Palette+Dracula.swift
@@ -12,9 +12,9 @@ import Theming
 // source: https://draculatheme.com/contribute#color-palette
 private let _darkBackground: Color = .init(red: 0.07843137255, green: 0.07450980392, blue: 0.1215686275)
 private let _background: Color = .init(red: 0.1568627450980392, green: 0.16470588235294117, blue: 0.21176470588235294)
-private let _secondaryBackground: Color = .init(red: 0.26666666666666666, green: 0.2784313725490196, blue: 0.35294117647058826)
+private let _secondaryBackground: Color = .init(red: 53 / 255, green: 55 / 255, blue: 74 / 255) 
 private let _primary: Color = .init(red: 0.9725490196078431, green: 0.9725490196078431, blue: 0.9490196078431372)
-private let _secondary: Color = .init(red: 0.3843137254901961, green: 0.4470588235294118, blue: 0.6431372549019608)
+private let _secondary: Color = .init(red: 153 / 255, green: 178 / 255, blue: 255 / 255, opacity: 0.7) 
 private let _cyan: Color = .init(red: 0.5450980392156862, green: 0.9137254901960784, blue: 0.9921568627450981)
 private let _green: Color = .init(red: 0.3137254901960784, green: 0.9803921568627451, blue: 0.4823529411764706)
 private let _orange: Color = .init(red: 1.0, green: 0.7215686274509804, blue: 0.4235294117647059)

--- a/Mlem/App/Configuration/Colors/Palette+Dracula.swift
+++ b/Mlem/App/Configuration/Colors/Palette+Dracula.swift
@@ -66,6 +66,7 @@ extension Palette {
         savedFeed: _green,
         popularFeed: _cyan,
         suggestedFeed: _orange,
-        inbox: _purple
+        inbox: _purple,
+        fediseerEndorsement: _cyan
     )
 }

--- a/Mlem/App/Configuration/Colors/Palette+Monochrome.swift
+++ b/Mlem/App/Configuration/Colors/Palette+Monochrome.swift
@@ -59,6 +59,7 @@ extension Palette {
         savedFeed: Color(uiColor: .darkGray),
         popularFeed: Color(uiColor: .darkGray),
         suggestedFeed: Color(uiColor: .darkGray),
-        inbox: Color(uiColor: .darkGray)
+        inbox: Color(uiColor: .darkGray),
+        fediseerEndorsement: .gray
     )
 }

--- a/Mlem/App/Configuration/Colors/Palette+Solarized.swift
+++ b/Mlem/App/Configuration/Colors/Palette+Solarized.swift
@@ -72,6 +72,7 @@ extension Palette {
         savedFeed: cyan,
         popularFeed: magenta,
         suggestedFeed: orange,
-        inbox: violet
+        inbox: violet,
+        fediseerEndorsement: cyan
     )
 }

--- a/Mlem/App/Views/Pages/Instance/Fediseer.swift
+++ b/Mlem/App/Views/Pages/Instance/Fediseer.swift
@@ -112,7 +112,7 @@ struct FediseerEndorsement: Codable {
 
 extension FediseerEndorsement: FediseerOpinion, Equatable {
     static var icon: Icon = .fediseer.endorsement
-    static var color: ThemedColor { .themedColorfulAccent(7) }
+    static var color: ThemedColor { .themedFediseerEndorsement }
     
     var reason: String? { endorsementReasons?.first }
     var evidence: String? { nil }
@@ -126,7 +126,7 @@ struct FediseerHesitation: Codable {
 
 extension FediseerHesitation: FediseerOpinion, Equatable {
     static var icon: Icon = .fediseer.hesitation
-    static var color: ThemedColor { .themedCaution }
+    static var color: ThemedColor { .themedFediseerHesitation }
     
     var reason: String? { hesitationReasons?.first }
     var evidence: String? { hesitationEvidence?.first }
@@ -140,7 +140,7 @@ struct FediseerCensure: Codable {
 
 extension FediseerCensure: FediseerOpinion, Equatable {
     static var icon: Icon = .fediseer.censure
-    static var color: ThemedColor { .themedWarning }
+    static var color: ThemedColor { .themedFediseerCensure }
     
     var reason: String? { censureReasons?.first }
     var evidence: String? { censureEvidence?.first }

--- a/Mlem/App/Views/Pages/UploadConfirmationView.swift
+++ b/Mlem/App/Views/Pages/UploadConfirmationView.swift
@@ -103,5 +103,6 @@ struct UploadConfirmationView: View {
             .animation(.easeOut(duration: 0.1), value: isUploading)
         }
         .padding()
+        .presentationBackground(.themedBackground)
     }
 }

--- a/Mlem/Packages/Theming/Sources/Theming/Palette+Default.swift
+++ b/Mlem/Packages/Theming/Sources/Theming/Palette+Default.swift
@@ -64,6 +64,7 @@ public extension Palette {
         savedFeed: .green,
         popularFeed: .indigo,
         suggestedFeed: .orange,
-        inbox: .purple
+        inbox: .purple,
+        fediseerEndorsement: .cyan
     )
 }

--- a/Mlem/Packages/Theming/Sources/Theming/Palette.swift
+++ b/Mlem/Packages/Theming/Sources/Theming/Palette.swift
@@ -45,6 +45,10 @@ public struct Palette {
     public var popularFeed: Color
     public var suggestedFeed: Color
     public var inbox: Color
+
+    public var fediseerEndorsement: Color
+    public var fediseerHesitation: Color { caution }
+    public var fediseerCensure: Color { warning }
     
     public init(
         bordered: Bool,
@@ -76,7 +80,8 @@ public struct Palette {
         savedFeed: Color,
         popularFeed: Color,
         suggestedFeed: Color,
-        inbox: Color
+        inbox: Color,
+        fediseerEndorsement: Color
     ) {
         self.bordered = bordered
         self.label = label
@@ -108,6 +113,7 @@ public struct Palette {
         self.popularFeed = popularFeed
         self.suggestedFeed = suggestedFeed
         self.inbox = inbox
+        self.fediseerEndorsement = fediseerEndorsement
     }
 }
 

--- a/Mlem/Packages/Theming/Sources/Theming/ThemedColor.swift
+++ b/Mlem/Packages/Theming/Sources/Theming/ThemedColor.swift
@@ -185,6 +185,18 @@ public extension ShapeStyle where Self == ThemedColor {
         .init(hashString: "inbox", getColor: \.inbox)
     }
 
+    static var themedFediseerEndorsement: ThemedColor {
+        .init(hashString: "fediseerEndorsement", getColor: \.fediseerEndorsement)
+    }
+
+    static var themedFediseerHesitation: ThemedColor {
+        .init(hashString: "fediseerHesitation", getColor: \.fediseerHesitation)
+    }
+
+    static var themedFediseerCensure: ThemedColor {
+        .init(hashString: "fediseerCensure", getColor: \.fediseerCensure)
+    }
+
     static var themedCommentAccent: ThemedColor { themedColorfulAccent(0) }
     static var themedPostAccent: ThemedColor { themedColorfulAccent(1) }
     static var themedPersonAccent: ThemedColor { themedColorfulAccent(2) }


### PR DESCRIPTION
- Fixed the theme not applying to `UploadConfirmationView` background
- Fediseer Endorsement color now has its own value in `Palette` (rather than using a numbered accent)
- Fediseer Hesitations now use the `caution` color rather than a numbered accent
- Fediseer Censurse now use the `warning` color rather than a numbered accent
- Tweaked some dracula theme colors (see comparison below)
  - Turned up the brightness of `.secondary` slightly and made it slightly translucent
  - Reduced brightness of `.tertiaryGroupedBackground`
  
These color changes are technically a departure from the exact color values used by Dracula, but I think that's the lesser of two evils in this case.

| Old | New  |
| ------- | --- | 
| <img width="603" height="1311" alt="IMG_2178" src="https://github.com/user-attachments/assets/de6f3730-ebc0-42f5-9de6-4ffef37d69c2" /> | <img width="603" height="1311" alt="IMG_2177" src="https://github.com/user-attachments/assets/03743ad7-3115-497c-934f-8393db0a1948" /> |

Closes #2021