### PR TITLE
Fix markdown toolbar hitbox

### DIFF
--- a/Mlem/App/Views/Shared/MarkdownEditorToolbarView.swift
+++ b/Mlem/App/Views/Shared/MarkdownEditorToolbarView.swift
@@ -83,6 +83,7 @@ struct MarkdownEditorToolbarView: View {
         }
         .frame(maxWidth: .infinity)
         .frame(height: toolbarHeight, alignment: .bottom)
+        .padding(.top, UIDevice.isIos26 ? 12 : 0)
         .onChange(of: imageManager.state) {
             switch imageManager.state {
             case let .done(upload):

--- a/Mlem/App/Views/Shared/MarkdownTextEditor.swift
+++ b/Mlem/App/Views/Shared/MarkdownTextEditor.swift
@@ -75,7 +75,7 @@ struct MarkdownTextEditor<Content: View>: UIViewRepresentable {
         )
         let contentView = contentController.view!
         
-        let inputView = UIInputView(frame: CGRect(x: 0, y: 0, width: 0, height: 36), inputViewStyle: .keyboard)
+        let inputView = UIInputView(frame: CGRect(x: 0, y: 0, width: 0, height: UIDevice.isIos26 ? 48 : 36), inputViewStyle: .keyboard)
         inputView.addSubview(contentController.view)
         inputView.inputViewController?.addChild(contentController)
         contentView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
The top ~25% of the markdown toolbar was not registering taps. This fixes it. The top of the view was outside of the bounding box for the keyboard accessory.

Also fixed the dividers in the toolbar having uneven padding on iOS 26.