### PR TITLE
Action Sheet

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -337,6 +337,7 @@
 		03CBD1932C61369A00E870BC /* Interactable2Providing+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CBD1922C61369A00E870BC /* Interactable2Providing+Extensions.swift */; };
 		03CCDAA02BF2795300C0C851 /* LoginPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CCDA9F2BF2795300C0C851 /* LoginPage.swift */; };
 		03CCDAA42BF2852E00C0C851 /* LoginTotpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CCDAA32BF2852E00C0C851 /* LoginTotpView.swift */; };
+		03D001DD2EC53A97001BF97D /* NavigationPage+PresentationDetents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D001DC2EC53A97001BF97D /* NavigationPage+PresentationDetents.swift */; };
 		03D0273C2CD3BA5100984519 /* PersonContent+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D0273B2CD3BA5100984519 /* PersonContent+Extensions.swift */; };
 		03D283FA2D256E1E00A6659B /* VisitHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D283F92D256E1E00A6659B /* VisitHistory.swift */; };
 		03D283FC2D25A3F700A6659B /* VisitHistory+CodedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D283FB2D25A3F700A6659B /* VisitHistory+CodedData.swift */; };
@@ -895,6 +896,7 @@
 		03CBD1922C61369A00E870BC /* Interactable2Providing+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Interactable2Providing+Extensions.swift"; sourceTree = "<group>"; };
 		03CCDA9F2BF2795300C0C851 /* LoginPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPage.swift; sourceTree = "<group>"; };
 		03CCDAA32BF2852E00C0C851 /* LoginTotpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTotpView.swift; sourceTree = "<group>"; };
+		03D001DC2EC53A97001BF97D /* NavigationPage+PresentationDetents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationPage+PresentationDetents.swift"; sourceTree = "<group>"; };
 		03D0273B2CD3BA5100984519 /* PersonContent+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonContent+Extensions.swift"; sourceTree = "<group>"; };
 		03D283F92D256E1E00A6659B /* VisitHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitHistory.swift; sourceTree = "<group>"; };
 		03D283FB2D25A3F700A6659B /* VisitHistory+CodedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitHistory+CodedData.swift"; sourceTree = "<group>"; };
@@ -1418,6 +1420,7 @@
 				035BE08A2BDD903100F77D73 /* NavigationModel.swift */,
 				035BE08E2BDE911900F77D73 /* NavigationLayer.swift */,
 				035BE0882BDD901B00F77D73 /* NavigationPage.swift */,
+				03D001DC2EC53A97001BF97D /* NavigationPage+PresentationDetents.swift */,
 				0320B6642C91DBD500D38548 /* NavigationPage+View.swift */,
 				03531EF42C2DA610004A3464 /* NavigationSearchType.swift */,
 				035BE0902BDEA01E00F77D73 /* View+NavigationSheetModifiers.swift */,
@@ -3073,6 +3076,7 @@
 				CD9CFA302C2E22F600739BBC /* FeedDescription.swift in Sources */,
 				6363D5C527EE196700E34822 /* MlemApp.swift in Sources */,
 				03B0EB6F2C87827A00F79FDF /* ExpandedPostView.swift in Sources */,
+				03D001DD2EC53A97001BF97D /* NavigationPage+PresentationDetents.swift in Sources */,
 				039F58912C7B5C7A00C61658 /* ContentView+Logic.swift in Sources */,
 				032C320A2C34495D00595286 /* SelectTextView.swift in Sources */,
 				0377BE3B2DE8E70D00E38593 /* HapticLevel+Extensions.swift in Sources */,

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -20,7 +20,8 @@ struct ActionSheet: View {
             }
         }
         .presentationBackground(.themedGroupedBackground)
-        .presentationDetents([.medium])
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.hidden)
         .presentationBackgroundInteraction(.enabled)
     }
 

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -14,6 +14,7 @@ struct ActionSheet: View {
 
     let actions: [any Actions.Action]
 
+    @State var model: PopupAnchorModel = .init()
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
@@ -48,6 +49,7 @@ struct ActionSheet: View {
                 action.execute(environment: environment)
             }
             .disabled(label.visibility == .disabled)
+            .popupAnchor(model: model)
         }
     }
 }

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -26,10 +26,6 @@ struct ActionSheet: View {
             }
         }
         .presentationBackground(.themedGroupedBackground)
-        .presentationDetents([.medium, .large], selection: Binding(
-            get: { navigation.actionSheetPresentationDetent },
-            set: { navigation.actionSheetPresentationDetent = $0 }
-        ))
         .presentationDragIndicator(.hidden)
         .presentationBackgroundInteraction(.enabled)
     }

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -1,0 +1,53 @@
+//
+//  ActionSheet.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-11-12.
+//
+
+import Actions
+import MlemMiddleware
+import SwiftUI
+
+struct ActionSheet: View {
+    let actions: [any Actions.Action]
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                content
+                    .padding(16)
+            }
+        }
+        .presentationBackground(.themedGroupedBackground)
+        .presentationDetents([.medium])
+        .presentationBackgroundInteraction(.enabled)
+    }
+
+    var content: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(actions.enumerated()), id: \.offset) { index, action in
+                if index != 0 {
+                    Divider()
+                }
+                ActionButton(action)
+            }
+        }
+        .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 25))
+        .labelStyle(ActionSheetLabelStyle())
+        .buttonStyle(.plain)
+    }
+}
+
+private struct ActionSheetLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            configuration.title
+            Spacer()
+            configuration.icon
+                .font(.title2)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+    }
+}

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -10,6 +10,8 @@ import MlemMiddleware
 import SwiftUI
 
 struct ActionSheet: View {
+    @Environment(\.self) var environment
+
     let actions: [any Actions.Action]
 
     var body: some View {
@@ -36,11 +38,17 @@ struct ActionSheet: View {
 
     @ViewBuilder
     func actionRow(_ index: Int, _ action: any Actions.Action) -> some View {
-        if ![actions.startIndex, actions.endIndex-1].contains(index) {
-            Divider()
-                .padding(.horizontal, 15)
+        let label = action.createLabel(environment: environment)
+        if label.visibility != .hidden {
+            if ![actions.startIndex, actions.endIndex-1].contains(index) {
+                Divider()
+                    .padding(.horizontal, 15)
+            }
+            Button(label) {
+                action.execute(environment: environment)
+            }
+            .disabled(label.visibility == .disabled)
         }
-        ActionButtonWithVisibilityControl(action)
     }
 }
 

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -28,7 +28,7 @@ struct ActionSheet: View {
     var content: some View {
         VStack(spacing: 0) {
             ForEach(Array(actions.enumerated()), id: \.offset) { index, action in
-                if index != 0 {
+                if ![actions.startIndex, actions.endIndex-1].contains(index) {
                     Divider()
                 }
                 ActionButton(action)

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -49,6 +49,9 @@ struct ActionSheet: View {
             }
             Button(label) {
                 action.execute(environment: environment)
+                if !navigation.rootChangePending, model.data == nil {
+                    dismiss()
+                }
             }
             .disabled(label.visibility == .disabled)
             .popupAnchor(model: model)

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -16,7 +16,7 @@ struct ActionSheet: View {
 
     let actions: [any Actions.Action]
 
-    @State var model: PopupAnchorModel = .init()
+    @State var popupAnchorModel: PopupAnchorModel = .init()
 
     var body: some View {
         ScrollView {
@@ -49,12 +49,12 @@ struct ActionSheet: View {
             }
             Button(label) {
                 action.execute(environment: environment)
-                if !navigation.rootChangePending, model.data == nil {
+                if !navigation.rootChangePending, popupAnchorModel.data == nil {
                     dismiss()
                 }
             }
             .disabled(label.visibility == .disabled)
-            .popupAnchor(model: model)
+            .popupAnchor(model: popupAnchorModel)
         }
     }
 }

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -30,6 +30,7 @@ struct ActionSheet: View {
             ForEach(Array(actions.enumerated()), id: \.offset) { index, action in
                 if ![actions.startIndex, actions.endIndex-1].contains(index) {
                     Divider()
+                        .padding(.horizontal, 15)
                 }
                 ActionButton(action)
             }

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -10,6 +10,7 @@ import MlemMiddleware
 import SwiftUI
 
 struct ActionSheet: View {
+    @Environment(\.dismiss) var dismiss
     @Environment(\.self) var environment
 
     let actions: [any Actions.Action]
@@ -35,6 +36,9 @@ struct ActionSheet: View {
         .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 25))
         .labelStyle(ActionSheetLabelStyle())
         .buttonStyle(ActionSheetButtonStyle())
+        .onChange(of: popupAnchorModel.outcome) { outcome in
+            if outcome == .confirmed { dismiss() }
+        }
     }
 
     @ViewBuilder

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -27,17 +27,20 @@ struct ActionSheet: View {
 
     var content: some View {
         VStack(spacing: 0) {
-            ForEach(Array(actions.enumerated()), id: \.offset) { index, action in
-                if ![actions.startIndex, actions.endIndex-1].contains(index) {
-                    Divider()
-                        .padding(.horizontal, 15)
-                }
-                ActionButtonWithVisibilityControl(action)
-            }
+            ForEach(Array(actions.enumerated()), id: \.offset, content: actionRow) 
         }
         .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 25))
         .labelStyle(ActionSheetLabelStyle())
         .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    func actionRow(_ index: Int, _ action: any Actions.Action) -> some View {
+        if ![actions.startIndex, actions.endIndex-1].contains(index) {
+            Divider()
+                .padding(.horizontal, 15)
+        }
+        ActionButtonWithVisibilityControl(action)
     }
 }
 

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -10,9 +10,7 @@ import MlemMiddleware
 import SwiftUI
 
 struct ActionSheet: View {
-    @Environment(\.dismiss) var dismiss
     @Environment(\.self) var environment
-    @Environment(NavigationLayer.self) var navigation
 
     let actions: [any Actions.Action]
 
@@ -46,16 +44,32 @@ struct ActionSheet: View {
             if ![actions.startIndex, actions.endIndex-1].contains(index) {
                 Divider()
                     .padding(.horizontal, 15)
+                ActionSheetButton(action: action, label: label)
+                    .popupAnchor(model: popupAnchorModel)
             }
-            Button(label) {
-                action.execute(environment: environment)
-                if !navigation.rootChangePending, popupAnchorModel.data == nil {
-                    dismiss()
-                }
-            }
-            .disabled(label.visibility == .disabled)
-            .popupAnchor(model: popupAnchorModel)
         }
+    }
+}
+
+private struct ActionSheetButton: View {
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.self) var environment
+    @Environment(NavigationLayer.self) var navigation
+    @Environment(PopupAnchorModel.self) var popupAnchorModel
+
+    let action: any Actions.Action
+
+    // Lable passed separately for performance reasons
+    let label: ActionLabel
+
+    var body: some View {
+        Button(label) {
+            action.execute(environment: environment)
+            if !navigation.rootChangePending, popupAnchorModel.data == nil {
+                dismiss()
+            }
+        }
+        .disabled(label.visibility == .disabled)
     }
 }
 

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -10,11 +10,14 @@ import MlemMiddleware
 import SwiftUI
 
 struct ActionSheet: View {
+    @Environment(\.dismiss) var dismiss
     @Environment(\.self) var environment
+    @Environment(NavigationLayer.self) var navigation
 
     let actions: [any Actions.Action]
 
     @State var model: PopupAnchorModel = .init()
+
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
@@ -23,7 +26,10 @@ struct ActionSheet: View {
             }
         }
         .presentationBackground(.themedGroupedBackground)
-        .presentationDetents([.medium, .large])
+        .presentationDetents([.medium, .large], selection: Binding(
+            get: { navigation.actionSheetPresentationDetent },
+            set: { navigation.actionSheetPresentationDetent = $0 }
+        ))
         .presentationDragIndicator(.hidden)
         .presentationBackgroundInteraction(.enabled)
     }

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -33,7 +33,7 @@ struct ActionSheet: View {
         }
         .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 25))
         .labelStyle(ActionSheetLabelStyle())
-        .buttonStyle(.plain)
+        .buttonStyle(ActionSheetButtonStyle())
     }
 
     @ViewBuilder
@@ -49,6 +49,13 @@ struct ActionSheet: View {
             }
             .disabled(label.visibility == .disabled)
         }
+    }
+}
+
+private struct ActionSheetButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundStyle(configuration.role == .destructive ? .themedWarning : .themedPrimary)
     }
 }
 

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -48,9 +48,9 @@ struct ActionSheet: View {
             if ![actions.startIndex, actions.endIndex-1].contains(index) {
                 Divider()
                     .padding(.horizontal, 15)
-                ActionSheetButton(action: action, label: label)
-                    .popupAnchor(model: popupAnchorModel)
             }
+            ActionSheetButton(action: action, label: label)
+                .popupAnchor(model: popupAnchorModel)
         }
     }
 }

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -41,6 +41,8 @@ struct ActionSheet: View {
 }
 
 private struct ActionSheetLabelStyle: LabelStyle {
+    @ScaledMetric(relativeTo: .body) var rowHeight = 40
+
     func makeBody(configuration: Configuration) -> some View {
         HStack {
             configuration.title
@@ -48,7 +50,9 @@ private struct ActionSheetLabelStyle: LabelStyle {
             configuration.icon
                 .font(.title2)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 25)
+        .frame(height: rowHeight)
+        .padding(.vertical, 8)
+        .contentShape(.rect)
     }
 }

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -32,7 +32,7 @@ struct ActionSheet: View {
                     Divider()
                         .padding(.horizontal, 15)
                 }
-                ActionButton(action)
+                ActionButtonWithVisibilityControl(action)
             }
         }
         .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: 25))

--- a/Mlem/App/Actions/ContextMenu+InboxNotification.swift
+++ b/Mlem/App/Actions/ContextMenu+InboxNotification.swift
@@ -9,7 +9,13 @@ import Actions
 import MlemMiddleware
 import SwiftUI
 
-private let seeds: [ActionSeed] = [
+private let topLevelSeeds: [ActionSeed] = [
+    .reply,
+    .markRead,
+    .selectText
+]
+
+private let actionSheetSeeds: [ActionSeed] = [
     .upvote,
     .downvote,
     .save,
@@ -23,14 +29,33 @@ private let seeds: [ActionSeed] = [
     .delete
 ]
 
+private struct InboxNotificationContextMenuViewModifier: ViewModifier {
+    @Environment(NavigationLayer.self) var navigation
+
+    let notification: InboxNotification
+
+    func body(content: Content) -> some View {
+        content
+            .contextMenu {
+                ActionButtons { _ in
+                    topLevelSeeds.compactMap {
+                        $0.createAction(notification) ?? $0.createAction(notification.content.wrappedValue)
+                    }
+                }
+                Divider()
+                Button("More...", icon: .general.menu) {
+                    let actions = actionSheetSeeds.compactMap {
+                        $0.createAction(notification) ?? $0.createAction(notification.content.wrappedValue)
+                    }
+                    navigation.openSheet(.actionSheet(actions))
+                }
+                .symbolVariant(.circle)
+        }
+    }
+}
+
 extension View {
     func contextMenu(notification: InboxNotification) -> some View {
-        contextMenu {
-            ActionButtons { _ in
-                seeds.compactMap {
-                    $0.createAction(notification) ?? $0.createAction(notification.content.wrappedValue)
-                }
-            }
-        }
+        modifier(InboxNotificationContextMenuViewModifier(notification: notification))
     }
 }

--- a/Mlem/App/Actions/ContextMenu+InboxNotification.swift
+++ b/Mlem/App/Actions/ContextMenu+InboxNotification.swift
@@ -10,9 +10,10 @@ import MlemMiddleware
 import SwiftUI
 
 private let topLevelSeeds: [ActionSeed] = [
-    .reply,
     .markRead,
-    .share
+    .share,
+    .blockCreator,
+    .report
 ]
 
 private let actionSheetSeeds: [ActionSeed] = [

--- a/Mlem/App/Actions/ContextMenu+InboxNotification.swift
+++ b/Mlem/App/Actions/ContextMenu+InboxNotification.swift
@@ -12,7 +12,7 @@ import SwiftUI
 private let topLevelSeeds: [ActionSeed] = [
     .reply,
     .markRead,
-    .selectText
+    .share
 ]
 
 private let actionSheetSeeds: [ActionSeed] = [

--- a/Mlem/App/Actions/ContextMenu+InboxNotification.swift
+++ b/Mlem/App/Actions/ContextMenu+InboxNotification.swift
@@ -42,14 +42,15 @@ private struct InboxNotificationContextMenuViewModifier: ViewModifier {
                         $0.createAction(notification) ?? $0.createAction(notification.content.wrappedValue)
                     }
                 }
-                Divider()
-                Button("More...", icon: .general.menu) {
-                    let actions = actionSheetSeeds.compactMap {
-                        $0.createAction(notification) ?? $0.createAction(notification.content.wrappedValue)
+                Section {
+                    Button("More...", icon: .general.menu) {
+                        let actions = actionSheetSeeds.compactMap {
+                            $0.createAction(notification) ?? $0.createAction(notification.content.wrappedValue)
+                        }
+                        navigation.openSheet(.actionSheet(actions))
                     }
-                    navigation.openSheet(.actionSheet(actions))
+                    .symbolVariant(.circle)
                 }
-                .symbolVariant(.circle)
         }
     }
 }

--- a/Mlem/App/Actions/ShareAction.swift
+++ b/Mlem/App/Actions/ShareAction.swift
@@ -42,7 +42,14 @@ extension ShareAction {
         case .askEveryTime: nil
         }
         if let url, let navigation = environment.navigation {
-            navigation.model?.shareInfo = .init(url: url, actions: entity.shareSheetActions())
+            if case .actionSheet = navigation.root {
+                navigation.dismissSheet()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    NavigationModel.main.shareInfo = .init(url: url, actions: entity.shareSheetActions())
+                }
+            } else {
+                navigation.model?.shareInfo = .init(url: url, actions: entity.shareSheetActions())
+            }
         } else {
             environment.navigation?.openSheet(.shareInstancePicker(entity))
         }

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/PopupAnchorModel.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/PopupAnchorModel.swift
@@ -13,6 +13,10 @@ class PopupAnchorModel {
         var message: String
         var actions: [Action]?
     }
+
+    enum Outcome {
+        case cancelled, confirmed
+    }
     
     struct Action {
         let title: String
@@ -34,6 +38,7 @@ class PopupAnchorModel {
     }
     
     private(set) var data: PopupData?
+    var outcome: Outcome?
     
     func showPopup(message: LocalizedStringResource, _ actions: [Action]?) {
         showPopup(message: .init(localized: message), actions)

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PopupAnchor.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+PopupAnchor.swift
@@ -53,11 +53,15 @@ struct PopupAnchor: ViewModifier {
         ForEach(Array(actions.enumerated()), id: \.offset) { _, action in
             Button(
                 action.title,
-                role: action.isDestructive ? .destructive : nil,
-                action: action.callback
-            )
+                role: action.isDestructive ? .destructive : nil
+            ) {
+                action.callback()
+                model.outcome = .confirmed
+            }
         }
-        Button("Cancel", role: .cancel) {}
+        Button("Cancel", role: .cancel) {
+            model.outcome = .cancelled
+        }
     }
 }
 

--- a/Mlem/App/Views/Pages/ExternalApiInfoView.swift
+++ b/Mlem/App/Views/Pages/ExternalApiInfoView.swift
@@ -44,7 +44,6 @@ struct ExternalApiInfoView: View {
         .background(.themedGroupedBackground)
         .presentationBackground(.themedGroupedBackground)
         .task { await loadData() }
-        .presentationDetents([.medium])
         .presentationBackgroundInteraction(.enabled)
     }
     

--- a/Mlem/App/Views/Shared/Accounts/QuickSwitcherView.swift
+++ b/Mlem/App/Views/Shared/Accounts/QuickSwitcherView.swift
@@ -23,6 +23,5 @@ struct QuickSwitcherView: View {
             }
         }
         .presentationBackground(.themedGroupedBackground)
-        .presentationDetents([.medium, .large])
     }
 }

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -22,7 +22,7 @@ class NavigationLayer: Identifiable {
     var isFullScreenCover: Bool
     var canDisplayToasts: Bool
 
-    var actionSheetPresentationDetent: PresentationDetent = .medium
+    var rootViewPresentationDetent: PresentationDetent 
 
     // Used by ActionSheet
     var rootChangePending: Bool = false
@@ -43,6 +43,7 @@ class NavigationLayer: Identifiable {
         self.hasNavigationStack = hasNavigationStack
         self.isFullScreenCover = isFullScreenCover
         self.canDisplayToasts = canDisplayToasts
+        self.rootViewPresentationDetent = root.presentationDetentConfiguration?.default.presentationDetent() ?? .large
     }
     
     @MainActor
@@ -99,8 +100,8 @@ class NavigationLayer: Identifiable {
         rootChangePending = true
         if case .actionSheet = root {
             withAnimation {
-                if !page.presentationDetents.contains(.medium) {
-                    actionSheetPresentationDetent = .large
+                if !(page.presentationDetentConfiguration?.detents.contains(.medium) ?? false) {
+                    rootViewPresentationDetent = .large
                 }
             } completion: {
                 withAnimation(.easeOut(duration: 0.3)) {

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -100,8 +100,12 @@ class NavigationLayer: Identifiable {
         rootChangePending = true
         if case .actionSheet = root {
             withAnimation {
-                if !(page.presentationDetentConfiguration?.detents.contains(.medium) ?? false) {
-                    rootViewPresentationDetent = .large
+                if let detentsConfiguration = page.presentationDetentConfiguration {
+                    if detentsConfiguration.detents.contains(.large), self.rootViewPresentationDetent != .large {
+                        rootViewPresentationDetent = .large
+                    } else if detentsConfiguration.detents.contains(.medium), self.rootViewPresentationDetent != .medium {
+                        rootViewPresentationDetent = .medium
+                    }
                 }
             } completion: {
                 withAnimation(.easeOut(duration: 0.3)) {

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -23,6 +23,9 @@ class NavigationLayer: Identifiable {
     var canDisplayToasts: Bool
 
     var actionSheetPresentationDetent: PresentationDetent = .medium
+
+    // Used by ActionSheet
+    var rootChangePending: Bool = false
     
     init(
         root: NavigationPage,
@@ -93,6 +96,7 @@ class NavigationLayer: Identifiable {
             assertionFailure()
             return
         }
+        rootChangePending = true
         if case .actionSheet = root {
             withAnimation {
                 if !page.presentationDetents.contains(.medium) {

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -21,6 +21,8 @@ class NavigationLayer: Identifiable {
     var hasNavigationStack: Bool
     var isFullScreenCover: Bool
     var canDisplayToasts: Bool
+
+    var actionSheetPresentationDetent: PresentationDetent = .medium
     
     init(
         root: NavigationPage,
@@ -87,10 +89,24 @@ class NavigationLayer: Identifiable {
     /// Open a new sheet, optionally with navigation enabled. If `nil` is specified for `hasNavigationStack`, the value of `page.hasNavigationStack` will be used.
     @MainActor
     func openSheet(_ page: NavigationPage, hasNavigationStack: Bool? = nil) {
-        model?.openSheet(
-            page,
-            hasNavigationStack: hasNavigationStack ?? page.hasNavigationStack
-        )
+        guard let model else {
+            assertionFailure()
+            return
+        }
+        if case .actionSheet = root {
+            withAnimation {
+                actionSheetPresentationDetent = .large
+            } completion: {
+                withAnimation {
+                    self.root = page
+                }
+            }
+        } else {
+            model.openSheet(
+                page,
+                hasNavigationStack: hasNavigationStack ?? page.hasNavigationStack
+            )
+        }
     }
     
     /// Convenience proxy for showFullScreenCover. Opens the image viewer with the given URL and disables animations on the fullScreenCover.

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -95,9 +95,11 @@ class NavigationLayer: Identifiable {
         }
         if case .actionSheet = root {
             withAnimation {
-                actionSheetPresentationDetent = .large
+                if !page.presentationDetents.contains(.medium) {
+                    actionSheetPresentationDetent = .large
+                }
             } completion: {
-                withAnimation {
+                withAnimation(.easeOut(duration: 0.3)) {
                     self.root = page
                 }
             }

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -106,6 +106,8 @@ class NavigationLayer: Identifiable {
                     } else if detentsConfiguration.detents.contains(.medium), self.rootViewPresentationDetent != .medium {
                         rootViewPresentationDetent = .medium
                     }
+                } else {
+                    rootViewPresentationDetent = .large
                 }
             } completion: {
                 withAnimation(.easeOut(duration: 0.3)) {

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
@@ -13,7 +13,9 @@ struct NavigationLayerView: View {
     @Setting(\.appearance_interfaceStyle) var interfaceStyle
 
     @State var layer: NavigationLayer
+
     let hasSheetModifiers: Bool
+    var selectedDetent: Binding<PresentationDetent>?
     
     private let fullWidthGestureRecognizerDelegate: FullWidthGestureRecognizerDelegate = .init()
     
@@ -73,7 +75,16 @@ struct NavigationLayerView: View {
     @ViewBuilder
     private func rootView() -> some View {
         if hasSheetModifiers {
-            layer.root.view().navigationSheetModifiers(for: layer)
+            innerRootView().navigationSheetModifiers(for: layer)
+        } else {
+            innerRootView()
+        }
+    }
+
+    @ViewBuilder
+    private func innerRootView() -> some View {
+        if let selectedDetent {
+            layer.root.sheetView(selectedDetent: selectedDetent)
         } else {
             layer.root.view()
         }

--- a/Mlem/App/Views/Shared/Navigation/NavigationModel.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationModel.swift
@@ -73,11 +73,6 @@ class NavigationModel {
         )
     }
     
-    @MainActor
-    func addLayer(_ navigationLayer: NavigationLayer) {
-        layers.append(navigationLayer)
-    }
-    
     // Closes all sheets above and including the given index
     @MainActor
     func closeSheets(aboveIndex index: Int) {

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+PresentationDetents.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+PresentationDetents.swift
@@ -5,18 +5,23 @@
 //  Created by Sjmarf on 27/04/2024.
 //
 
+import ComponentViews
 import SwiftUI
 
 extension NavigationPage {
-    var presentationDetents: Set<PresentationDetent> {
+    // Return `nil` if you want the view itself to handle detents, rather than
+    // that it being handled by the navigation system. 
+    var presentationDetentConfiguration: NavigationDetentConfiguration? {
         switch self {
-        case .selectText: [.medium]
-        case .actionSheet: [.medium, .large]
-        case .externalApiInfo: [.medium]
-        case .rulesList: [.medium, .large]
-        case .quickSwitcher: [.medium, .large]
-        case .shareInstancePicker: []
-        default: [.large]
+        case .selectText: .only(.medium)
+        case .actionSheet: .init([.medium, .large], default: .medium)
+        case .externalApiInfo: .only(.medium)
+        case .rulesList: .init([.medium, .large], default: .medium)
+        case .quickSwitcher: .init([.medium, .large], default: .medium)
+        case .shareInstancePicker: .only(.fit)
+        case .remove, .denyApplication, .purge, .report, .editCommunity,
+            .createComment, .createPost, .ban: nil
+        default: .only(.large)
         }
     }
 
@@ -25,5 +30,52 @@ extension NavigationPage {
         case .shareInstancePicker: true
         default: false
         }
+    }
+}
+
+struct NavigationDetentConfiguration {
+    enum Detent {
+        case medium, large, fit
+
+        func presentationDetent() -> PresentationDetent? {
+            switch self {
+            case .medium: .medium
+            case .large: .large
+            case .fit: nil
+            }
+        }
+    }
+
+    let detents: Set<Detent>
+    let `default`: Detent
+
+    init(_ detents: Set<Detent>, default default_: Detent) {
+        self.detents = detents
+        self.default = default_
+        assert(detents.contains(default_))
+    }
+
+    static func only(_ detent: Detent) -> Self {
+        .init([detent], default: detent)
+    }
+}
+
+private extension Set<NavigationDetentConfiguration.Detent> {
+    func presentationDetents() -> Set<PresentationDetent> {
+        .init(lazy.compactMap { $0.presentationDetent() })
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func presentationDetents(
+        configuration: NavigationDetentConfiguration,
+        selection: Binding<PresentationDetent>
+    ) -> some View {
+        presentationDetentFitsContent(
+            fitDetentEnabled: configuration.detents.contains(.fit),
+            configuration.detents.presentationDetents(),
+            selection: selection
+        )
     }
 }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+PresentationDetents.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+PresentationDetents.swift
@@ -1,0 +1,29 @@
+//
+//  NavigationPage.swift
+//  Mlem
+//
+//  Created by Sjmarf on 27/04/2024.
+//
+
+import SwiftUI
+
+extension NavigationPage {
+    var presentationDetents: Set<PresentationDetent> {
+        switch self {
+        case .selectText: [.medium]
+        case .actionSheet: [.medium, .large]
+        case .externalApiInfo: [.medium]
+        case .rulesList: [.medium, .large]
+        case .quickSwitcher: [.medium, .large]
+        case .shareInstancePicker: []
+        default: [.large]
+        }
+    }
+
+    var fitDetentEnabled: Bool {
+        switch self {
+        case .shareInstancePicker: true
+        default: false
+        }
+    }
+}

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -206,6 +206,8 @@ extension NavigationPage {
             RegistrationApplicationDenialEditorView(application: application)
         case let .exportPostImage(post):
             ExportablePostEditorView(post: post.wrappedValue)
+        case let .actionSheet(actions):
+            ActionSheet(actions: actions.wrappedValue)
         }
     }
 }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -5,10 +5,22 @@
 //  Created by Sjmarf on 28/04/2024.
 //
 
+import ComponentViews
 import MlemMiddleware
 import SwiftUI
 
 extension NavigationPage {
+
+    @ViewBuilder
+    func sheetView(selectedDetent: Binding<PresentationDetent>) -> some View {
+        view()
+            .presentationDetentFitsContent(
+                fitDetentEnabled: true,
+                presentationDetents,
+                selection: selectedDetent
+            )
+    }
+
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     @ViewBuilder func view() -> some View {
         switch self {
@@ -186,7 +198,6 @@ extension NavigationPage {
             )
         case let .rulesList(model, callback):
             RulesPickerView(model: model.wrappedValue, callback: callback.wrappedValue)
-                .presentationDetents([.medium, .large])
         case .blockList:
             BlockListView()
         case let .advancedSorting(sort):

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -13,12 +13,12 @@ extension NavigationPage {
 
     @ViewBuilder
     func sheetView(selectedDetent: Binding<PresentationDetent>) -> some View {
-        view()
-            .presentationDetentFitsContent(
-                fitDetentEnabled: true,
-                presentationDetents,
-                selection: selectedDetent
-            )
+        if let presentationDetentConfiguration {
+            view()
+                .presentationDetents(configuration: presentationDetentConfiguration, selection: selectedDetent)
+        } else {
+            view()
+        }
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -364,6 +364,25 @@ enum NavigationPage: Hashable {
             true
         }
     }
+
+    var presentationDetents: Set<PresentationDetent> {
+        switch self {
+        case .selectText: [.medium]
+        case .actionSheet: [.medium, .large]
+        case .externalApiInfo: [.medium]
+        case .rulesList: [.medium, .large]
+        case .quickSwitcher: [.medium, .large]
+        case .shareInstancePicker: []
+        default: [.large]
+        }
+    }
+
+    var fitDetentEnabled: Bool {
+        switch self {
+        case .shareInstancePicker: true
+        default: false
+        }
+    }
 }
 
 struct HashWrapper<Value>: Hashable, Identifiable {

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -364,25 +364,6 @@ enum NavigationPage: Hashable {
             true
         }
     }
-
-    var presentationDetents: Set<PresentationDetent> {
-        switch self {
-        case .selectText: [.medium]
-        case .actionSheet: [.medium, .large]
-        case .externalApiInfo: [.medium]
-        case .rulesList: [.medium, .large]
-        case .quickSwitcher: [.medium, .large]
-        case .shareInstancePicker: []
-        default: [.large]
-        }
-    }
-
-    var fitDetentEnabled: Bool {
-        switch self {
-        case .shareInstancePicker: true
-        default: false
-        }
-    }
 }
 
 struct HashWrapper<Value>: Hashable, Identifiable {

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 27/04/2024.
 //
 
+import Actions
 import MlemMiddleware
 import SwiftUI
 
@@ -71,6 +72,7 @@ enum NavigationPage: Hashable {
     case modlog(ModlogView.InitialTarget)
     case denyApplication(RegistrationApplication)
     case exportPostImage(_ post: HashWrapper<any Post>)
+    case actionSheet(_ actions: HashWrapper<[any Actions.Action]>)
     
     static func post(_ post: any PostStubProviding, scrollTargetedComment: (any CommentStubProviding)? = nil) -> NavigationPage {
         if let scrollTargetedComment {
@@ -339,11 +341,15 @@ enum NavigationPage: Hashable {
     static func createPostImage(_ post: any Post) -> NavigationPage {
         exportPostImage(.init(wrappedValue: post))
     }
+
+    static func actionSheet(_ actions: [any Actions.Action]) -> NavigationPage {
+        actionSheet(.init(wrappedValue: actions))
+    }
     
     var hasNavigationStack: Bool {
         switch self {
         case .quickSwitcher, .report, .externalApiInfo, .selectText, .createComment,
-             .editComment, .createPost, .editPost, .denyApplication:
+             .editComment, .createPost, .editPost, .denyApplication, .actionSheet:
             false
         default:
             true

--- a/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
+++ b/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
@@ -42,21 +42,21 @@ private struct NavigationSheetModifier: ViewModifier {
                 isPresenting: Binding(get: { shareInfo != nil && isTopSheet }, set: { if !$0 { shareInfo = nil }})
             ) { activityViewController }
             )
-            .sheet(isPresented: Binding(
-                get: { !(nextLayer?.isFullScreenCover ?? true) },
-                set: { if !$0 { closeSheet() } }
-            )) {
-                if let nextLayer {
-                    NavigationLayerView(layer: nextLayer, hasSheetModifiers: true)
-                }
+            .sheet(item: Binding(
+                get: {
+                    if let nextLayer, !nextLayer.isFullScreenCover { nextLayer } else { nil }
+                },
+                set: { if $0 == nil { closeSheet() } }
+            )) { layer in
+                NavigationLayerView(layer: layer, hasSheetModifiers: true)
             }
-            .fullScreenCover(isPresented: Binding(
-                get: { nextLayer?.isFullScreenCover ?? false },
-                set: { if !$0 { closeSheet() } }
-            )) {
-                if let nextLayer {
-                    NavigationLayerView(layer: nextLayer, hasSheetModifiers: true)
-                }
+            .fullScreenCover(item: Binding(
+                get: {
+                    if let nextLayer, nextLayer.isFullScreenCover { nextLayer } else { nil }
+                },
+                set: { if $0 == nil { closeSheet() } }
+            )) { layer in
+                NavigationLayerView(layer: layer, hasSheetModifiers: true)
             }
             .photosPicker(
                 isPresented: .init(

--- a/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
+++ b/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
@@ -35,6 +35,7 @@ private struct NavigationSheetModifier: ViewModifier {
         contentPickerTracker_()
     }
     
+    // swiftlint:disable:next function_body_length
     func body(content: Content) -> some View {
         content
             // https://stackoverflow.com/questions/69693871/how-to-open-share-sheet-from-presented-sheet
@@ -48,7 +49,14 @@ private struct NavigationSheetModifier: ViewModifier {
                 },
                 set: { if $0 == nil { closeSheet() } }
             )) { layer in
-                NavigationLayerView(layer: layer, hasSheetModifiers: true)
+                NavigationLayerView(
+                    layer: layer,
+                    hasSheetModifiers: true,
+                    selectedDetent: Binding(
+                        get: { layer.actionSheetPresentationDetent },
+                        set: { layer.actionSheetPresentationDetent = $0 }
+                    )
+                )
             }
             .fullScreenCover(item: Binding(
                 get: {

--- a/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
+++ b/Mlem/App/Views/Shared/Navigation/View+NavigationSheetModifiers.swift
@@ -53,8 +53,8 @@ private struct NavigationSheetModifier: ViewModifier {
                     layer: layer,
                     hasSheetModifiers: true,
                     selectedDetent: Binding(
-                        get: { layer.actionSheetPresentationDetent },
-                        set: { layer.actionSheetPresentationDetent = $0 }
+                        get: { layer.rootViewPresentationDetent },
+                        set: { layer.rootViewPresentationDetent = $0 }
                     )
                 )
             }

--- a/Mlem/App/Views/Shared/SelectTextView.swift
+++ b/Mlem/App/Views/Shared/SelectTextView.swift
@@ -26,7 +26,6 @@ struct SelectTextView: View {
                 ios18Body
             }
         }
-        .presentationDetents([.medium])
         .presentationBackgroundInteraction(.enabled)
     }
     

--- a/Mlem/App/Views/Shared/ShareInstancePickerView.swift
+++ b/Mlem/App/Views/Shared/ShareInstancePickerView.swift
@@ -40,7 +40,6 @@ struct ShareInstancePickerView: View {
         }
         .padding(16)
         .presentationBackground(.themedGroupedBackground)
-        .presentationDetentFitsContent()
     }
     
     @ViewBuilder

--- a/Mlem/Packages/Actions/Sources/Actions/Views/ActionButton.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/ActionButton.swift
@@ -19,10 +19,8 @@ public struct ActionButton: View {
     public var body: some View {
         let label = action.createLabel(environment: environment)
         if label.visibility != .hidden {
-            Button(role: label.isDestructive ? .destructive : nil) {
+            Button(label) {
                 action.execute(environment: environment)
-            } label: {
-                Label(label)
             }
             .disabled(label.visibility == .disabled)
         }

--- a/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtonWithVisibilityControl.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtonWithVisibilityControl.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public struct ActionButton: View {
+public struct ActionButtonWithVisibilityControl: View {
     @Environment(\.self) private var environment
     
     private let action: any Action

--- a/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtons.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtons.swift
@@ -21,7 +21,7 @@ public struct ActionButtons: View {
 
     public var body: some View {
         ForEach(Array(actions(environment).enumerated()), id: \.offset) { _, action in
-            ActionButton(action)
+            ActionButtonWithVisibilityControl(action)
         }
     }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/Views/Button+Extensions.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/Button+Extensions.swift
@@ -1,0 +1,20 @@
+//
+//  Button+Extensions.swift
+//  Actions
+//
+//  Created by Sjmarf on 2025-11-12.
+//
+
+import SwiftUI
+
+public extension Button {
+    // Remeber to handle ActionLabel visibility when you use this
+    init(
+        _ label: ActionLabel,
+        callback: @escaping () -> Void
+    ) where Label == SwiftUI.Label<Text, Image> {
+        self.init(role: label.isDestructive ? .destructive : nil, action: callback) {
+            Label(label)
+        }
+    }
+}

--- a/Mlem/Packages/ComponentViews/Sources/ComponentViews/FitContentPresentationDetentViewModifier.swift
+++ b/Mlem/Packages/ComponentViews/Sources/ComponentViews/FitContentPresentationDetentViewModifier.swift
@@ -9,10 +9,24 @@ import SwiftUI
 
 private struct FitContentPresentationDetentViewModifier: ViewModifier {
     let otherDetents: Set<PresentationDetent>
+    var selection: Binding<PresentationDetent>?
     
     @State private var sheetContentHeight: CGFloat = SheetHeightKey.defaultValue
     
     func body(content: Content) -> some View {
+        if let selection {
+            innerBody(content: content)
+                .presentationDetents(
+                    otherDetents.union([.height(sheetContentHeight)]),
+                    selection: selection
+                )
+        } else {
+            innerBody(content: content)
+                .presentationDetents(otherDetents.union([.height(sheetContentHeight)]))
+        }
+    }
+
+    func innerBody(content: Content) -> some View {
         content
             .overlay {
                 GeometryReader { proxy in
@@ -23,15 +37,33 @@ private struct FitContentPresentationDetentViewModifier: ViewModifier {
                 }
             }
             .onPreferenceChange(SheetHeightKey.self) { sheetContentHeight = $0 }
-            .presentationDetents(otherDetents.union([.height(sheetContentHeight)]))
     }
 }
 
 public extension View {
+    @ViewBuilder
     func presentationDetentFitsContent(
+        fitDetentEnabled: Bool = true,
         _ otherDetents: Set<PresentationDetent> = []
     ) -> some View {
-        modifier(FitContentPresentationDetentViewModifier(otherDetents: otherDetents))
+        if fitDetentEnabled {
+            modifier(FitContentPresentationDetentViewModifier(otherDetents: otherDetents))
+        } else {
+            presentationDetents(otherDetents)
+        }
+    }
+
+    @ViewBuilder
+    func presentationDetentFitsContent(
+        fitDetentEnabled: Bool = true,
+        _ otherDetents: Set<PresentationDetent> = [],
+        selection: Binding<PresentationDetent>
+    ) -> some View {
+        if fitDetentEnabled {
+            modifier(FitContentPresentationDetentViewModifier(otherDetents: otherDetents, selection: selection))
+        } else {
+            presentationDetents(otherDetents, selection: selection)
+        }
     }
 }
 

--- a/Mlem/Packages/ComponentViews/Sources/ComponentViews/FitContentPresentationDetentViewModifier.swift
+++ b/Mlem/Packages/ComponentViews/Sources/ComponentViews/FitContentPresentationDetentViewModifier.swift
@@ -14,7 +14,7 @@ private struct FitContentPresentationDetentViewModifier: ViewModifier {
     @State private var sheetContentHeight: CGFloat = SheetHeightKey.defaultValue
     
     func body(content: Content) -> some View {
-        if let selection {
+        if let selection, !otherDetents.isEmpty {
             innerBody(content: content)
                 .presentationDetents(
                     otherDetents.union([.height(sheetContentHeight)]),


### PR DESCRIPTION
This is only used in the test inbox for now, but I think we should adopt this everywhere down the line.

Partially implements #1642

The context menu of a notification now only shows a few items, and the others are hidden within a sheet. IMO the actions shown in the image below are sensible ones to make available all the time. upvote/downvote/save/reply aren't shown here because they are available in the interaction bar.

<img width=30% src="https://github.com/user-attachments/assets/f14a0a4b-e19c-4f52-a97d-9d1c4991aa1c">

In future, we can make which actions appear here customizable.

The full sheet looks like this:

<img width=30% src="https://github.com/user-attachments/assets/df723ab9-2aea-4e69-bc7b-2f68241a23d9" />

When you tap on an item that opens a sheet (e.g. Reply), the `NavigationPage` being opened _replaces_ the action sheet, re-using the same sheet. This makes the transition nice and fast, which I think is better than closing the action sheet and opening a new one. This change required updates to the navigation system.