### PR TITLE
Better MlemStats error handling

### DIFF
--- a/Mlem/App/Models/ErrorDetails.swift
+++ b/Mlem/App/Models/ErrorDetails.swift
@@ -29,7 +29,7 @@ struct ErrorDetails: Hashable {
         location: String? = nil,
         icon: Icon? = nil,
         buttonText: String? = nil,
-        refresh: (() -> Bool)? = nil,
+        refresh: (() async -> Bool)? = nil,
         autoRefresh: Bool = false
     ) {
         self.title = title

--- a/Mlem/App/Models/MlemStats/MlemStats.swift
+++ b/Mlem/App/Models/MlemStats/MlemStats.swift
@@ -11,9 +11,10 @@ import MlemMiddleware
 /// Class exposing instance search functionality. Instance data is fetched from the Mlem backend.
 class MlemStats {
     enum MlemStatsApiClientError: Error { case failed }
-    private var loadingState: LoadingState = .idle
-    
     private(set) var instances: [InstanceSummary]?
+
+    private(set) var loadingState: LoadingState = .idle
+    private(set) var errorDetails: ErrorDetails?
     
     // This set is queried for use in link-handling.
     // Some of the largest instances are hard-coded just in-case the backend is down.
@@ -31,7 +32,7 @@ class MlemStats {
     static let main: MlemStats = .init()
     
     @MainActor
-    func loadInstances(forceRefresh: Bool = false) async throws {
+    func loadInstances(forceRefresh: Bool = false) async {
         guard forceRefresh || loadingState == .idle else { return }
         loadingState = .loading
         do {
@@ -41,9 +42,13 @@ class MlemStats {
             self.instances = instances
             hosts.formUnion(Set(instances.lazy.map(\.host)))
             loadingState = .done
+            errorDetails = nil
         } catch {
             loadingState = .idle
-            throw error
+            errorDetails = .init(error: error, refresh: {
+                await self.loadInstances()
+                return true
+            })
         }
     }
     

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -83,11 +83,7 @@ struct ContentView: View {
                 .quickSwipeCornerRadius(Constants.main.standardSpacing)
                 .quickSwipeIconSize(28)
                 .task(id: BackendClient.main.environment) {
-                    do {
-                        try await MlemStats.main.loadInstances(forceRefresh: true)
-                    } catch {
-                        handleError(error)
-                    }
+                    await MlemStats.main.loadInstances(forceRefresh: true)
                 }
                 .onChange(of: appState.firstPerson) {
                     // Observe AppState.main.firstPerson to update FiltersTracker as needed

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -173,6 +173,9 @@ extension NavigationPage {
                         .foregroundStyle(.themedCaution)
                         .padding(.horizontal, Constants.main.standardSpacing)
                         .padding(.bottom, Constants.main.halfSpacing)
+                } else if let errorDetails = MlemStats.main.errorDetails {
+                    ErrorView(errorDetails)
+                        .padding(.top, 40)
                 }
             }
         case let .languagePicker(selectedLanguages: selectedLanguages, callback: callback):

--- a/Mlem/App/Views/Shared/Search/Home/TopInstancesListView.swift
+++ b/Mlem/App/Views/Shared/Search/Home/TopInstancesListView.swift
@@ -13,19 +13,29 @@ struct TopInstancesListView: View {
     
     var body: some View {
         FancyScrollView {
-            LazyVStack(spacing: 0) {
-                SearchResultsView(results: MlemStats.main.instances ?? []) { instance in
-                    InstanceListRow(
-                        instance,
-                        readout: .users,
-                        visitContext: .other
-                    )
-                }
-                EndOfFeedView(loadingState: .done, viewType: .hobbit)
+            if let errorDetails = MlemStats.main.errorDetails {
+                ErrorView(errorDetails)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 40)
+            } else {
+                content
             }
-            .animation(.easeOut(duration: 0.1), value: MlemStats.main.instances?.isEmpty)
         }
         .background(.themedGroupedBackground)
         .navigationTitle("Instances")
+    }
+
+    var content: some View {
+        LazyVStack(spacing: 0) {
+            SearchResultsView(results: MlemStats.main.instances ?? []) { instance in
+                InstanceListRow(
+                    instance,
+                    readout: .users,
+                    visitContext: .other
+                )
+            }
+            EndOfFeedView(loadingState: .done, viewType: .hobbit)
+        }
+        .animation(.easeOut(duration: 0.1), value: MlemStats.main.instances?.isEmpty)
     }
 }


### PR DESCRIPTION
Cloudflare is currently down, which causes the Mlem backend to be unreachable. This would cause an error toast on startup.

In this PR, I've removed that error toast. Instead, an `ErrorView` is shown in the instance list.

<img width=40% src="https://github.com/user-attachments/assets/c84e4da9-003e-43b3-a700-51e086b36c21" />

<img width=40% src="https://github.com/user-attachments/assets/267b4465-fcf3-4e55-94a5-0ccbefc5443f" />

The `MlemStats` instance list is also used for `HandleThreadiverseLinksModifier`, but that code is capable of working fine without it. If the backend is offline, it'll just take a little longer to open some links while it contacts the instance directly.