### PR TITLE
Lemmy 1.0 fixes

### DIFF
--- a/Mlem/App/Models/MlemStats/MlemStats.swift
+++ b/Mlem/App/Models/MlemStats/MlemStats.swift
@@ -45,10 +45,13 @@ class MlemStats {
             errorDetails = nil
         } catch {
             loadingState = .idle
-            errorDetails = .init(error: error, refresh: {
-                await self.loadInstances()
-                return true
-            })
+            if var errorDetails = handleErrorWithDetails(error) {
+                errorDetails.refresh = {
+                    await self.loadInstances()
+                    return true
+                }
+                self.errorDetails = errorDetails
+            }
         }
     }
     

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+LoadFeed.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+LoadFeed.swift
@@ -14,6 +14,7 @@ private struct LoadFeed: ViewModifier {
     
     let feedLoader: (any FeedLoading)?
     let shouldLoad: Bool
+    let errorDetails: Binding<ErrorDetails?>?
     
     func body(content: Content) -> some View {
         content
@@ -23,8 +24,9 @@ private struct LoadFeed: ViewModifier {
                     Task {
                         do {
                             try await feedLoader.loadMoreItems()
+                            errorDetails?.wrappedValue = nil
                         } catch {
-                            handleError(error)
+                            handleLoadFailure(error)
                         }
                     }
                 }
@@ -32,6 +34,24 @@ private struct LoadFeed: ViewModifier {
             .onChange(of: postSize) {
                 (feedLoader as? CorePostFeedLoader)?.setPrefetchingConfiguration(.forPostSize(postSize))
             }
+    }
+
+    func handleLoadFailure(_ error: any Error) {
+        if let errorDetailsBinding = self.errorDetails {
+            if var details = handleErrorWithDetails(error) {
+                details.refresh = {
+                    do {
+                        try await feedLoader?.loadMoreItems()
+                        return true
+                    } catch {
+                        return false
+                    }
+                }
+                errorDetailsBinding.wrappedValue = details
+            }
+        } else {
+            handleError(error)
+        }
     }
     
     var onChangeHash: Int {
@@ -44,7 +64,15 @@ private struct LoadFeed: ViewModifier {
 
 extension View {
     /// Convenience modifier. Attach to a view to load items from the given FeedLoading on appear if the given FeedLoading has no items
-    func loadFeed(_ feedLoader: (any FeedLoading)?, shouldLoad: Bool = true) -> some View {
-        modifier(LoadFeed(feedLoader: feedLoader, shouldLoad: shouldLoad))
+    func loadFeed(
+        _ feedLoader: (any FeedLoading)?,
+        shouldLoad: Bool = true,
+        errorDetails: Binding<ErrorDetails?>? = nil
+    ) -> some View {
+        modifier(LoadFeed(
+            feedLoader: feedLoader,
+            shouldLoad: shouldLoad,
+            errorDetails: errorDetails
+        ))
     }
 }

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -62,7 +62,7 @@ struct CommunityView: View {
     var body: some View {
         ContentLoader(model: community) { proxy in
             if let community = proxy.entity {
-                content(community: community)
+                content(community: community, contentLoaderError: proxy.error)
                     .externalApiWarning(entity: community, isLoading: proxy.isLoading)
                     .onChange(of: (community as? any Community2Providing)?.community2 == nil, initial: true) {
                         if let community2 = (community as? any Community2Providing)?.community2 {
@@ -88,7 +88,7 @@ struct CommunityView: View {
         
     @ViewBuilder
     // swiftlint:disable:next function_body_length
-    func content(community: any Community) -> some View {
+    func content(community: any Community, contentLoaderError: (any Error)?) -> some View {
         FancyScrollView {
             HStack {
                 FeedHeaderView(
@@ -118,6 +118,8 @@ struct CommunityView: View {
                         if let postFeedLoader {
                             postsTab(community: community, postFeedLoader: postFeedLoader)
                                 .padding(.bottom, -4)
+                        } else if let error = contentLoaderError {
+                            ErrorView(.init(error: contentLoaderError))
                         }
                     }
                     .toolbar {

--- a/Mlem/App/Views/Pages/Person/PersonView+Logic.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView+Logic.swift
@@ -16,7 +16,9 @@ extension PersonView {
                     try await feedLoader.loadMoreItems()
                 }
             } catch {
-                handleError(error)
+                // This is OK to silence because the feed loader will fail when
+                // it appears if this fails, and will show an ErrorView.
+                handleError(error, silent: true)
             }
         }
     }

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -44,6 +44,7 @@ struct PersonView: View {
     @State var feedLoader: SingleSourceMixedFeedLoader?
     @State var isAdmin: Bool
     @State var upgraded: Bool = false
+
     let isProfileTab: Bool
     
     init(
@@ -93,7 +94,7 @@ struct PersonView: View {
     var content: some View {
         ContentLoader(model: person) { proxy in
             if let person = proxy.entity {
-                content(person: person)
+                content(person: person, contentLoaderError: proxy.error)
                     .externalApiWarning(entity: person, isLoading: proxy.isLoading)
                     .onChange(of: (person as? any Person2Providing)?.person2 == nil, initial: true) {
                         if let person2 = (person as? any Person2Providing)?.person2 {
@@ -158,7 +159,7 @@ struct PersonView: View {
     }
     
     @ViewBuilder
-    func content(person: any Person) -> some View {
+    func content(person: any Person, contentLoaderError: (any Error)?) -> some View {
         FancyScrollView {
             VStack(spacing: 0) {
                 VStack(spacing: Constants.main.standardSpacing) {
@@ -173,6 +174,9 @@ struct PersonView: View {
                         personContent(person: person)
                     }
                     .transition(.opacity)
+                    
+                } else if let error = contentLoaderError {
+                    ErrorView(.init(error: error))
                 } else {
                     VStack(spacing: 0) {
                         ProgressView()

--- a/Mlem/App/Views/Shared/PersonContentGridView.swift
+++ b/Mlem/App/Views/Shared/PersonContentGridView.swift
@@ -30,12 +30,13 @@ struct PersonContentGridView: View {
     
     @State var columns: [GridItem] = [GridItem(.flexible())]
     @State var frameWidth: CGFloat = .zero
+    @State var errorDetails: ErrorDetails?
     
     var feedLoader: FeedLoaderType
     
     var body: some View {
         content
-            .loadFeed(feedLoader.feedLoading)
+            .loadFeed(feedLoader.feedLoading, errorDetails: $errorDetails)
             .widthReader(width: $frameWidth)
             .environment(\.parentFrameWidth, frameWidth)
             .onChange(of: postSize, initial: true) { _, newValue in
@@ -79,7 +80,11 @@ struct PersonContentGridView: View {
             .quickSwipeIconSize(postSize.quickSwipeIconSize)
             .quickSwipeThresholds(postSize.quickSwipeThresholds)
             .animation(.easeOut(duration: 0.1), value: items.isEmpty)
-            EndOfFeedView(loadingState: feedLoader.loadingState, viewType: .hobbit)
+            if let errorDetails {
+                ErrorView(errorDetails)
+            } else {
+                EndOfFeedView(loadingState: feedLoader.loadingState, viewType: .hobbit)
+            }
         }
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/Comment2Snapshot+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/Comment2Snapshot+Lemmy.swift
@@ -14,12 +14,10 @@ extension Comment2Snapshot {
         }
 
         let saved: Bool
-        if let actions = comment.commentActions {
-            saved = actions.savedAt != nil
-        } else if let saved_ = comment.saved {
+        if let saved_ = comment.saved {
             saved = saved_
         } else {
-            throw .responseMissingRequiredData("LemmyCommentView saved")
+            saved = comment.commentActions?.savedAt != nil
         }
         
         let votes: VotesModel
@@ -55,12 +53,10 @@ extension Comment2Snapshot {
         }
 
         let saved: Bool
-        if let actions = report.commentActions {
-            saved = actions.savedAt != nil
-        } else if let saved_ = report.saved {
+        if let saved_ = report.saved {
             saved = saved_
         } else {
-            throw .responseMissingRequiredData("LemmyCommentReportView saved")
+            saved = report.commentActions?.savedAt != nil
         }
         
         let votes: VotesModel

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/Community2Snapshot+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/Community2Snapshot+Lemmy.swift
@@ -10,10 +10,16 @@ import Foundation
 extension Community2Snapshot {
     init(from community: LemmyCommunityView) throws(ApiClientError) {
         guard let totalSubscribers = community.community.subscribers ?? community.counts?.subscribers,
-              let subscribed = community.communityActions?.followState?.isSubscribed ?? community.subscribed?.isSubscribed,
               let localSubscribers = community.community.subscribersLocal ?? community.counts?.subscribersLocal
         else {
-            throw .responseMissingRequiredData("LemmyCommunityView subscribed")
+            throw .responseMissingRequiredData("LemmyCommunityView subscriber count")
+        }
+
+        let subscribed: Bool
+        if let subscribed_ = community.subscribed?.isSubscribed {
+            subscribed = subscribed_
+        } else {
+            subscribed = community.communityActions?.followState?.isSubscribed ?? false
         }
 
         let subscription = SubscriptionModel(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/Post2Snapshot+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/Post2Snapshot+Lemmy.swift
@@ -39,9 +39,9 @@ extension Post2Snapshot {
 
         let commentCount: Int
         let unreadCommentCount: Int
-        if let actions = post.postActions, let comments = post.post.comments {
+        if let comments = post.post.comments {
             commentCount = comments
-            unreadCommentCount = comments - (actions.readCommentsAmount ?? 0)
+            unreadCommentCount = comments - (post.postActions?.readCommentsAmount ?? 0)
         } else if let counts = post.counts, let unreadComments = post.unreadComments {
             commentCount = counts.comments
             unreadCommentCount = unreadComments
@@ -52,16 +52,15 @@ extension Post2Snapshot {
         let saved: Bool
         let read: Bool
         let hidden: Bool
-        if let actions = post.postActions {
-            saved = actions.savedAt != nil
-            read = overrideRead ?? (actions.readAt != nil)
-            hidden = actions.hiddenAt != nil
-        } else if let saved_ = post.saved, let read_ = post.read, let hidden_ = post.hidden {
+        if let saved_ = post.saved, let read_ = post.read, let hidden_ = post.hidden {
             saved = saved_
             read = overrideRead ?? read_
             hidden = hidden_
         } else {
-            throw .responseMissingRequiredData("LemmyPostView actions")
+            let actions = post.postActions
+            saved = actions?.savedAt != nil
+            read = overrideRead ?? (actions?.readAt != nil)
+            hidden = actions?.hiddenAt != nil
         }
 
         try self.init(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
@@ -187,7 +187,11 @@ public extension LemmyConnection {
         communityId: Int? = nil
     ) async throws -> (person: Person3Snapshot, posts: [Post2Snapshot], comments: [Comment2Snapshot]) {
         let response = try await performingForEndpoint { endpoint in
-            LemmyReadPersonRequest(
+            if endpoint == .v4 {
+                // TODO: Use LemmyListPersonContentRequest here
+                throw ApiClientError.featureUnsupported
+            }
+            return LemmyReadPersonRequest(
                 endpoint: endpoint,
                 personId: id,
                 username: nil,


### PR DESCRIPTION
I have started testing against `voyager.lemmy.ml`, which runs Lemmy 1.0. This PR makes a few simple fixes. The feed now loads on Lemmy 1.0.

Also added an `ErrorView` to:
- `CommunityView`, if an upgrade fails
- `PersonView`, if an upgrade fails
- `PersonContentGridView`

The aforementioned `ErrorView` cases all appear when using Lemmy 1.0, because the associated requests currently fail.