### PR TITLE
Literal Filtering

### DIFF
--- a/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mlem.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4e7ddea06d169d00bec1196aa69c727650998a2799238c3531191510e8b3bd88",
+  "originHash" : "43861231e026337081f61ca6333efab477d3c9df1a0a55714b320ca479720f9b",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/libwebp-Xcode.git",
       "state" : {
-        "revision" : "b2b1d20a90b14d11f6ef4241da6b81c1d3f171e4",
-        "version" : "1.3.2"
+        "revision" : "0d60654eeefd5d7d2bef3835804892c40225e8b2",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Mlem/App/Configuration/User Settings/SettingsValues.swift
+++ b/Mlem/App/Configuration/User Settings/SettingsValues.swift
@@ -100,6 +100,8 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
     var navigation_swipeAnywhere: Bool
     var filters_keywordFilterEnabled: Bool
     var filters_keywords: Set<String>
+    var filters_literalFilterEnabled: Bool
+    var filters_literals: Set<String>
     
     var interactionBar_post: PostBarConfiguration
     var interactionBar_comment: CommentBarConfiguration
@@ -235,6 +237,8 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.navigation_swipeAnywhere = try container.decodeIfPresent(Bool.self, forKey: ._navigation_swipeAnywhere) ?? false
         self.filters_keywordFilterEnabled = try container.decodeIfPresent(Bool.self, forKey: ._filters_keywordFilterEnabled) ?? true
         self.filters_keywords = try container.decodeIfPresent(Set<String>.self, forKey: ._filters_keywords) ?? .init()
+        self.filters_literalFilterEnabled = try container.decodeIfPresent(Bool.self, forKey: ._filters_literalFilterEnabled) ?? true
+        self.filters_literals = try container.decodeIfPresent(Set<String>.self, forKey: ._filters_literals) ?? .init()
         self.interactionBar_post = try container.decodeIfPresent(PostBarConfiguration.self, forKey: ._interactionBar_post) ?? .default
         self.interactionBar_comment = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: ._interactionBar_comment) ?? .default
         self.interactionBar_reply = try container.decodeIfPresent(ReplyBarConfiguration.self, forKey: ._interactionBar_reply) ?? .default
@@ -326,6 +330,8 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         navigation_swipeAnywhere = otherValues.navigation_swipeAnywhere
         filters_keywordFilterEnabled = otherValues.filters_keywordFilterEnabled
         filters_keywords = otherValues.filters_keywords
+        filters_literalFilterEnabled = otherValues.filters_literalFilterEnabled
+        filters_literals = otherValues.filters_literals
         interactionBar_post = otherValues.interactionBar_post
         interactionBar_comment = otherValues.interactionBar_comment
         interactionBar_reply = otherValues.interactionBar_reply
@@ -423,6 +429,8 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         case _navigation_swipeAnywhere = "navigation_swipeAnywhere"
         case _filters_keywordFilterEnabled = "filters_keywordFilterEnabled"
         case _filters_keywords = "filters_keywords"
+        case _filters_literalFilterEnabled = "filters_literalFilterEnabled"
+        case _filters_literals = "filters_literals"
         case _interactionBar_post = "interactionBar_post"
         case _interactionBar_comment = "interactionBar_comment"
         case _interactionBar_reply = "interactionBar_reply"
@@ -522,6 +530,8 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.navigation_swipeAnywhere = settings.swipeAnywhereToNavigate
         self.filters_keywordFilterEnabled = settings.keywordFilterEnabled
         self.filters_keywords = filteredKeywords
+        self.filters_literalFilterEnabled = true // Added in 2.4
+        self.filters_literals = .init() // Added in 2.4
         self.interactionBar_alternateReportLayout = settings.alternateInteractionBarLayoutForReports
         
         let interactionBarConfigurations = persistenceRepository.loadInteractionBarConfigurations()

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -81,7 +81,7 @@ class FiltersTracker {
         rawKeywords = filteredKeywords
     }
     
-    func resetFilteredLiterals(to filteredLiterals: Set<String>) async {
+    func resetFilteredLiterals(to filteredLiterals: Set<String>) {
         literals = filteredLiterals
     }
     

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -81,6 +81,10 @@ class FiltersTracker {
         rawKeywords = filteredKeywords
     }
     
+    func resetFilteredLiterals(to filteredLiterals: Set<String>) async {
+        literals = filteredLiterals
+    }
+    
     func postWouldBeFiltered(_ post: any Post) -> Bool {
         (keywordFilterEnabled && post.title.failsKeywordFilter(keywords: keywords, phrases: phrases)) ||
         (literalFilterEnabled && post.title.failsLiteralFilter(literals: literals))

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -18,6 +18,8 @@ class FiltersTracker {
             (self.keywords, self.phrases) = parseKeywordsAndPhrases(from: rawKeywords)
         }
     }
+    @ObservationIgnored @Setting(\.filters_literalFilterEnabled) var literalFilterEnabled
+    @ObservationIgnored @Setting(\.filters_literals) var literals
     
     var isAdmin: Bool
     var moderatedCommunityActorIds: Set<ActorIdentifier>
@@ -33,7 +35,8 @@ class FiltersTracker {
             isAdmin: isAdmin,
             moderatedCommunityActorIds: moderatedCommunityActorIds,
             filteredKeywords: keywordFilterEnabled ? keywords : .init(),
-            filteredPhrases: keywordFilterEnabled ? phrases : .init()
+            filteredPhrases: keywordFilterEnabled ? phrases : .init(),
+            filteredLiterals: literalFilterEnabled ? literals : .init()
         )
     }
     

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -60,7 +60,7 @@ class FiltersTracker {
     }
     
     func addFilteredKeyword(_ keyword: String) async {
-        rawKeywords = rawKeywords.union([keyword])
+        rawKeywords.insert(keyword)
     }
     
     func removeFilteredKeyword(_ keyword: String) async {
@@ -69,7 +69,7 @@ class FiltersTracker {
     }
     
     func addFilteredLiteral(_ literal: String) async {
-        literals = literals.union([literal])
+        literals.insert(literal)
     }
     
     func removeFilteredLiteral(_ literal: String) async {

--- a/Mlem/App/Globals/Definitions/FiltersTracker.swift
+++ b/Mlem/App/Globals/Definitions/FiltersTracker.swift
@@ -45,6 +45,8 @@ class FiltersTracker {
         hasher.combine(moderatedCommunityActorIds)
         hasher.combine(rawKeywords)
         hasher.combine(keywordFilterEnabled)
+        hasher.combine(literals)
+        hasher.combine(literalFilterEnabled)
         return hasher.finalize()
     }
     
@@ -66,12 +68,22 @@ class FiltersTracker {
         rawKeywords = rawKeywords.subtracting([keyword])
     }
     
+    func addFilteredLiteral(_ literal: String) async {
+        literals = literals.union([literal])
+    }
+    
+    func removeFilteredLiteral(_ literal: String) async {
+        assert(literals.contains(literal), "Filtered literals do not contain \(literal)")
+        literals.remove(literal)
+    }
+    
     func resetFilteredKeywords(to filteredKeywords: Set<String>) async {
         rawKeywords = filteredKeywords
     }
     
     func postWouldBeFiltered(_ post: any Post) -> Bool {
-        keywordFilterEnabled && post.title.failsKeywordFilter(keywords: keywords, phrases: phrases)
+        (keywordFilterEnabled && post.title.failsKeywordFilter(keywords: keywords, phrases: phrases)) ||
+        (literalFilterEnabled && post.title.failsLiteralFilter(literals: literals))
     }
     
     static var main: FiltersTracker = .init()

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
@@ -108,7 +108,7 @@ struct FeedPostView<EmbeddedContent: View>: View {
     
     @ViewBuilder
     var obscuredContent: some View {
-        Text("Hidden by keyword filters")
+        Text("Hidden by filters")
             .italic()
             .foregroundStyle(.themedSecondary)
             .padding(Constants.main.standardSpacing)

--- a/Mlem/App/Views/Root/Tabs/Settings/Components/SettingsHeaderView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/Components/SettingsHeaderView.swift
@@ -63,6 +63,8 @@ struct SettingsHeaderIconView: View {
     }
 }
 
+// - MARK: Alternative Initializers
+
 extension SettingsHeaderView {
     init(
         title: LocalizedStringResource,
@@ -72,5 +74,15 @@ extension SettingsHeaderView {
         self.init(title: title, description: description) {
             SettingsHeaderIconView(icon: icon)
         }
+    }
+    
+    init(
+        title: LocalizedStringResource,
+        description: String,
+        icon: Icon
+    ) where IconView == SettingsHeaderIconView {
+        self.title = .init(localized: title)
+        self.description = description
+        self.icon = SettingsHeaderIconView(icon: icon)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -43,7 +43,7 @@ struct FiltersSettingsView: View {
             Section("Literals") {
                 literalSection
             } footer: {
-                Text("Hide posts with titles containing containing these precise character sequences")
+                Text("Hide posts with titles containing containing these precise character sequences.")
             }
         }
         .withConditionalLabelStyle()

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -20,6 +20,13 @@ struct FiltersSettingsView: View {
     @State var newKeyword: String = ""
     @State var newLiteral: String = ""
     
+    var descriptionDetail: String {
+        AccountsTracker.main.highestLevelAccountType >= .moderator ?
+        // swiftlint:disable:next line_length
+        " If you are a moderator or administrator of a filtered post, it will appear in your feed but require you to tap to view its content." :
+        ""
+    }
+    
     init() {
         @Dependency(\.persistenceRepository) var persistenceRepository
     }
@@ -28,8 +35,7 @@ struct FiltersSettingsView: View {
         Form {
             SettingsHeaderView(
                 title: "Filters",
-                // swiftlint:disable:next line_length
-                description: "Hide posts containing certain words, phrases, or character sequences from your feed. If you are a moderator or administrator of a filtered post, it will appear in your feed but require you to tap to view its content.",
+                description: "Hide posts containing certain words, phrases, or character sequences from your feed.\(descriptionDetail)",
                 icon: .settings.keywordFilter
             )
             

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -46,6 +46,7 @@ struct FiltersSettingsView: View {
                 Text("Hide posts with titles containing containing these precise character sequences.")
             }
         }
+        .scrollDismissesKeyboard(.interactively)
         .withConditionalLabelStyle()
         .navigationTitle("Filters")
         .toolbar {

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -21,18 +21,21 @@ struct FiltersSettingsView: View {
     
     @State var legacyWarningDisplayed: Bool = false
     
-    var descriptionDetail: String {
-        AccountsTracker.main.highestLevelAccountType >= .moderator ?
-        // swiftlint:disable:next line_length
-        " If you are a moderator or administrator of a filtered post, it will appear in your feed but require you to tap to view its content." :
-        ""
+    var headerDescription: String {
+        var output = String(localized: "Hide posts containing certain words, phrases, or character sequences from your feed.")
+        if AccountsTracker.main.highestLevelAccountType >= .moderator {
+            output += " "
+            // swiftlint:disable:next line_length
+            output += String(localized: "If you are a moderator or administrator of a filtered post, it will appear in your feed but require you to tap to view its content.")
+        }
+        return output
     }
     
     var body: some View {
         Form {
             SettingsHeaderView(
                 title: "Filters",
-                description: "Hide posts containing certain words, phrases, or character sequences from your feed.\(descriptionDetail)",
+                description: headerDescription,
                 icon: .settings.keywordFilter
             )
             

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -7,10 +7,9 @@
 
 import Dependencies
 import SwiftUI
+import os
 
 struct FiltersSettingsView: View {
-    @Dependency(\.persistenceRepository) var persistenceRepository
-    
     @Setting(\.filters_keywordFilterEnabled) var keywordFilterEnabled
     @Setting(\.filters_literalFilterEnabled) var literalFilterEnabled
     
@@ -20,15 +19,13 @@ struct FiltersSettingsView: View {
     @State var newKeyword: String = ""
     @State var newLiteral: String = ""
     
+    @State var legacyWarningDisplayed: Bool = false
+    
     var descriptionDetail: String {
         AccountsTracker.main.highestLevelAccountType >= .moderator ?
         // swiftlint:disable:next line_length
         " If you are a moderator or administrator of a filtered post, it will appear in your feed but require you to tap to view its content." :
         ""
-    }
-    
-    init() {
-        @Dependency(\.persistenceRepository) var persistenceRepository
     }
     
     var body: some View {
@@ -55,27 +52,33 @@ struct FiltersSettingsView: View {
         .scrollDismissesKeyboard(.interactively)
         .withConditionalLabelStyle()
         .navigationTitle("Filters")
+        .versionAwareDialog("Deprecated Format", isPresented: $legacyWarningDisplayed) {
+            Button("Re-Export") { export() }
+            Button("Close", role: .cancel) {}
+        } message: {
+            // swiftlint:disable:next line_length
+            Text("These filters were saved by an older version of Mlem, and will not be compatible with future versions. To preserve compatibility, re-export your filters.")
+        }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Menu("More...", icon: .general.toolbarMenu) {
-                    Button("Export...", icon: .general.export) {
-                        Task {
-                            if let url = await downloadTextToFileSystem(
-                                fileName: "keywords.txt",
-                                text: filtersTracker.rawKeywords.joined(separator: "\n")
-                            ) {
-                                navigation.model?.shareInfo = .init(url: url)
-                            } else {
-                                ToastModel.main.add(.failure())
-                            }
-                        }
-                    }
+                    Button("Export...", icon: .general.export) { export() }
                     Button("Import...", icon: .general.import) {
-                        navigation.showFilePicker(types: [.plainText]) { data in
-                            let text = String(data: data, encoding: .utf8) ?? ""
-                            await filtersTracker.resetFilteredKeywords(
-                                to: Set(text.split(separator: "\n").map(String.init))
-                            )
+                        navigation.showFilePicker(types: [.plainText, .json]) { data in
+                            do {
+                                let jsonData = try JSONDecoder().decode(ExportableFilters.self, from: data)
+                                Task { @MainActor in
+                                    await filtersTracker.resetFilteredKeywords(to: jsonData.rawKeywords)
+                                    await filtersTracker.resetFilteredLiterals(to: jsonData.literals)
+                                }
+                            } catch {
+                                // TODO: Mlem 2.5 remove legacy compatibility
+                                let text = String(data: data, encoding: .utf8) ?? ""
+                                await filtersTracker.resetFilteredKeywords(
+                                    to: Set(text.split(separator: "\n").map(String.init))
+                                )
+                                legacyWarningDisplayed = true
+                            }
                         }
                     }
                 }
@@ -178,4 +181,29 @@ struct FiltersSettingsView: View {
             await filtersTracker.removeFilteredLiteral(literal)
         }
     }
+    
+    func export() {
+        do {
+            let jsonData = try JSONEncoder().encode(ExportableFilters(
+                rawKeywords: filtersTracker.rawKeywords,
+                literals: filtersTracker.literals))
+            
+            Task {
+                if let jsonString = String(data: jsonData, encoding: .utf8), let url = await downloadTextToFileSystem(
+                    fileName: "filters.json",
+                    text: jsonString) {
+                    navigation.model?.shareInfo = .init(url: url)
+                } else {
+                    ToastModel.main.add(.failure())
+                }
+            }
+        } catch {
+            handleError(error)
+        }
+    }
+}
+
+private struct ExportableFilters: Codable {
+    let rawKeywords: Set<String>
+    let literals: Set<String>
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -26,23 +26,24 @@ struct FiltersSettingsView: View {
     
     var body: some View {
         Form {
-            Section {
-                Toggle("Enable Keyword Filters", icon: .settings.keywordFilter, isOn: $keywordFilterEnabled)
-                Toggle("Enable Literal Filters", icon: .settings.keywordFilter, isOn: $literalFilterEnabled)
-            }
+            SettingsHeaderView(
+                title: "Filters",
+                // swiftlint:disable:next line_length
+                description: "Hide posts containing certain words, phrases, or character sequences from your feed. If you are a moderator or administrator of a filtered post, it will appear in your feed but require you to tap to view its content.",
+                icon: .settings.keywordFilter
+            )
             
-            Section {
+            Section("Keywords") {
                 keywordSection
             } footer: {
                 // swiftlint:disable:next line_length
-                Text("Posts with these keywords in their titles will be hidden. If you are a moderator or administrator of a matching post, it will appear in your feed but require you to tap to view its content.")
+                Text("Hide posts with titles containing these whole words or phrases. Ignores case and punctuation (e.g., the keyword \"john\" will also filter \"John's\").")
             }
             
-            Section {
+            Section("Literals") {
                 literalSection
             } footer: {
-                // swiftlint:disable:next line_length
-                Text("Posts with these literal strings in their titles will be hidden. If you are a moderator or administrator of a matching post, it will appear in your feed but require you to tap to view its content.")
+                Text("Hide posts with titles containing containing these precise character sequences")
             }
         }
         .withConditionalLabelStyle()
@@ -77,6 +78,8 @@ struct FiltersSettingsView: View {
     
     @ViewBuilder
     var keywordSection: some View {
+        Toggle("Enable", icon: .settings.keywordFilter, isOn: $keywordFilterEnabled)
+        
         TextField("New Keyword...", text: $newKeyword)
             .textCase(.lowercase)
             .textInputAutocapitalization(.never)
@@ -124,6 +127,8 @@ struct FiltersSettingsView: View {
     
     @ViewBuilder
     var literalSection: some View {
+        Toggle("Enable", icon: .settings.keywordFilter, isOn: $literalFilterEnabled)
+        
         TextField("New Literal...", text: $newLiteral)
             .textCase(.lowercase)
             .textInputAutocapitalization(.never)

--- a/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/FiltersSettingsView.swift
@@ -12,11 +12,13 @@ struct FiltersSettingsView: View {
     @Dependency(\.persistenceRepository) var persistenceRepository
     
     @Setting(\.filters_keywordFilterEnabled) var keywordFilterEnabled
+    @Setting(\.filters_literalFilterEnabled) var literalFilterEnabled
     
     @Environment(FiltersTracker.self) var filtersTracker
     @Environment(NavigationLayer.self) var navigation
     
     @State var newKeyword: String = ""
+    @State var newLiteral: String = ""
     
     init() {
         @Dependency(\.persistenceRepository) var persistenceRepository
@@ -26,6 +28,7 @@ struct FiltersSettingsView: View {
         Form {
             Section {
                 Toggle("Enable Keyword Filters", icon: .settings.keywordFilter, isOn: $keywordFilterEnabled)
+                Toggle("Enable Literal Filters", icon: .settings.keywordFilter, isOn: $literalFilterEnabled)
             }
             
             Section {
@@ -33,6 +36,13 @@ struct FiltersSettingsView: View {
             } footer: {
                 // swiftlint:disable:next line_length
                 Text("Posts with these keywords in their titles will be hidden. If you are a moderator or administrator of a matching post, it will appear in your feed but require you to tap to view its content.")
+            }
+            
+            Section {
+                literalSection
+            } footer: {
+                // swiftlint:disable:next line_length
+                Text("Posts with these literal strings in their titles will be hidden. If you are a moderator or administrator of a matching post, it will appear in your feed but require you to tap to view its content.")
             }
         }
         .withConditionalLabelStyle()
@@ -75,9 +85,9 @@ struct FiltersSettingsView: View {
                 saveNewKeyword()
             }
         
-        ForEach(filtersTracker.rawKeywords.sorted(by: <), id: \.self) { filter in
+        ForEach(filtersTracker.rawKeywords.sorted(by: <), id: \.self) { keyword in
             HStack {
-                Text(filter)
+                Text(keyword)
                 
                 Spacer()
                 
@@ -85,7 +95,7 @@ struct FiltersSettingsView: View {
                 Image(icon: .general.delete)
                     .foregroundStyle(.themedWarning)
                     .onTapGesture {
-                        deleteKeyword(filter)
+                        deleteKeyword(keyword)
                     }
             }
         }
@@ -109,6 +119,51 @@ struct FiltersSettingsView: View {
         
         Task {
             await filtersTracker.removeFilteredKeyword(keyword)
+        }
+    }
+    
+    @ViewBuilder
+    var literalSection: some View {
+        TextField("New Literal...", text: $newLiteral)
+            .textCase(.lowercase)
+            .textInputAutocapitalization(.never)
+            .submitLabel(.done)
+            .onSubmit {
+                saveNewLiteral()
+            }
+        
+        ForEach(filtersTracker.literals.sorted(by: <), id: \.self) { literal in
+            HStack {
+                Text(literal)
+                
+                Spacer()
+                
+                // using a Button to do this makes the whole row register tap gestures :/
+                Image(icon: .general.delete)
+                    .foregroundStyle(.themedWarning)
+                    .onTapGesture {
+                        deleteLiteral(literal)
+                    }
+            }
+        }
+    }
+    
+    func saveNewLiteral() {
+        guard !newLiteral.isEmpty else { return }
+        
+        Task {
+            await filtersTracker.addFilteredLiteral(newLiteral)
+            newLiteral = ""
+        }
+    }
+    
+    func deleteLiteral(_ literal: String) {
+        guard filtersTracker.literals.contains(literal) else {
+            return
+        }
+        
+        Task {
+            await filtersTracker.removeFilteredLiteral(literal)
         }
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/SafetySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SafetySettingsView.swift
@@ -43,8 +43,8 @@ struct SafetySettingsView: View {
             }
             Section {
                 NavigationLink(
-                    "Keyword Filters",
-                    value: .init(localized: keywordFiltersNavigationLinkValue),
+                    "Filters",
+                    value: .init(localized: filtersNavigationLinkValue),
                     fallbackValue: "",
                     icon: .settings.keywordFilter,
                     destination: .settings(.filters)
@@ -65,8 +65,10 @@ struct SafetySettingsView: View {
         }
     }
     
-    var keywordFiltersNavigationLinkValue: LocalizedStringResource {
-        if filtersTracker.rawKeywords.isEmpty { return "None" }
-        return keywordFilterEnabled ? "On" : "Off"
+    var filtersNavigationLinkValue: LocalizedStringResource {
+        var sum = 0
+        if filtersTracker.keywordFilterEnabled && !filtersTracker.rawKeywords.isEmpty { sum += 1 }
+        if filtersTracker.literalFilterEnabled && !filtersTracker.literals.isEmpty { sum += 1 }
+        return sum > 0 ? "\(sum) Active" : "None"
     }
 }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -417,6 +417,9 @@
         }
       }
     },
+    "%lld Active" : {
+
+    },
     "%lld Crossposts..." : {
       "localizations" : {
         "en" : {
@@ -4014,7 +4017,7 @@
     "Hide posts containing certain words, phrases, or character sequences from your feed. If you are a moderator or administrator of a filtered post, it will appear in your feed but require you to tap to view its content." : {
 
     },
-    "Hide posts with titles containing containing these precise character sequences" : {
+    "Hide posts with titles containing containing these precise character sequences." : {
 
     },
     "Hide posts with titles containing these whole words or phrases. Ignores case and punctuation (e.g., the keyword \"john\" will also filter \"John's\")." : {
@@ -4463,6 +4466,7 @@
       }
     },
     "Keyword Filters" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -3218,6 +3218,9 @@
         }
       }
     },
+    "Enable Literal Filters" : {
+
+    },
     "end.of.feed.icon.1" : {
       "comment" : "This is the key for an icon that appears next to the \"I think I've found the bottom!\" text. It is localized so that you can change the icon to fit better with your translation of the text.",
       "extractionState" : "extracted_with_value",
@@ -3943,7 +3946,11 @@
         }
       }
     },
+    "Hidden by filters" : {
+
+    },
     "Hidden by keyword filters" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -5289,6 +5296,9 @@
         }
       }
     },
+    "New Literal..." : {
+
+    },
     "New Password" : {
       "localizations" : {
         "fr" : {
@@ -6143,6 +6153,9 @@
           }
         }
       }
+    },
+    "Posts with these literal strings in their titles will be hidden. If you are a moderator or administrator of a matching post, it will appear in your feed but require you to tap to view its content." : {
+
     },
     "Pride" : {
       "localizations" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -1931,6 +1931,7 @@
       }
     },
     "Choose the default sort mode for posts and comments." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -1941,6 +1942,7 @@
       }
     },
     "Choose when Not Safe For Work content should be blurred." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -1961,6 +1963,7 @@
       }
     },
     "Choose whether to show a warning when opening a page that is likely to contain sensitive content." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -1992,6 +1995,7 @@
       }
     },
     "Choose which action to perform when you tap and hold the profile icon." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -2012,6 +2016,7 @@
       }
     },
     "Choose which languages appear in your feed. Posts and comments in other languages will be hidden." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -2646,6 +2651,7 @@
 
     },
     "Customize how content is displayed in your feed. Choose which types of content are blurred, and apply filters to hide posts from the feed altogether." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en-GB" : {
           "stringUnit" : {
@@ -2678,6 +2684,7 @@
       }
     },
     "Customize how often Mlem plays haptic feedback." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en-GB" : {
           "stringUnit" : {
@@ -2694,6 +2701,7 @@
       }
     },
     "Customize how your subscription list is sorted." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en-GB" : {
           "stringUnit" : {
@@ -2710,6 +2718,7 @@
       }
     },
     "Customize Mlem to work best for you. Some features are tied to system-wide accessibility settings." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en-GB" : {
           "stringUnit" : {
@@ -2726,6 +2735,7 @@
       }
     },
     "Customize the appearance of the tab bar." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en-GB" : {
           "stringUnit" : {
@@ -2742,6 +2752,7 @@
       }
     },
     "Customize the interaction bar for inbox items, and choose which types of notification are included in the tab bar badge." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en-GB" : {
           "stringUnit" : {
@@ -3026,6 +3037,7 @@
       }
     },
     "Display linked media from supported hosts in-app rather than as a link." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -4017,7 +4029,7 @@
         }
       }
     },
-    "Hide posts containing certain words, phrases, or character sequences from your feed.%@" : {
+    "Hide posts containing certain words, phrases, or character sequences from your feed." : {
 
     },
     "Hide posts with titles containing containing these precise character sequences." : {
@@ -4106,6 +4118,9 @@
           }
         }
       }
+    },
+    "If you are a moderator or administrator of a filtered post, it will appear in your feed but require you to tap to view its content." : {
+
     },
     "Image" : {
       "localizations" : {
@@ -4221,6 +4236,7 @@
       }
     },
     "In the Fediverse, many different links can point to the same piece of content. Choose which site to use when sharing content." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -4744,6 +4760,7 @@
       }
     },
     "Manage how Mlem handles links and control how images and videos are displayed." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -4754,6 +4771,7 @@
       }
     },
     "Manage how Mlem interacts with Lemmy instances and other websites." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -4764,6 +4782,7 @@
       }
     },
     "Manage settings related to content moderation." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -4774,6 +4793,7 @@
       }
     },
     "Manage your overall setup for Mlem." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -6395,6 +6415,7 @@
       }
     },
     "Read posts are shown with dimmed title text. If you like, you can choose an additional way of indicating read status." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -7875,6 +7896,7 @@
       }
     },
     "Some users set animated media as their avatar. Control whether these avatars should play their animations." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -8485,6 +8507,9 @@
         }
       }
     },
+    "These filters were saved by an older version of Mlem, and will not be compatible with future versions. To preserve compatibility, re-export your filters." : {
+
+    },
     "These options are stored locally in Mlem and not on your Lemmy account." : {
       "localizations" : {
         "fr" : {
@@ -8649,9 +8674,6 @@
           }
         }
       }
-    },
-    "This file was saved by an older version of Mlem, and will not be compatible with future versions. To preserve compatibility, re-export your filters." : {
-
     },
     "This instance is not part of the Fediseer Chain of Trust." : {
       "localizations" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -4014,7 +4014,7 @@
         }
       }
     },
-    "Hide posts containing certain words, phrases, or character sequences from your feed. If you are a moderator or administrator of a filtered post, it will appear in your feed but require you to tap to view its content." : {
+    "Hide posts containing certain words, phrases, or character sequences from your feed.%@" : {
 
     },
     "Hide posts with titles containing containing these precise character sequences." : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -3208,7 +3208,11 @@
         }
       }
     },
+    "Enable" : {
+
+    },
     "Enable Keyword Filters" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -3217,9 +3221,6 @@
           }
         }
       }
-    },
-    "Enable Literal Filters" : {
-
     },
     "end.of.feed.icon.1" : {
       "comment" : "This is the key for an icon that appears next to the \"I think I've found the bottom!\" text. It is localized so that you can change the icon to fit better with your translation of the text.",
@@ -4010,6 +4011,15 @@
         }
       }
     },
+    "Hide posts containing certain words, phrases, or character sequences from your feed. If you are a moderator or administrator of a filtered post, it will appear in your feed but require you to tap to view its content." : {
+
+    },
+    "Hide posts with titles containing containing these precise character sequences" : {
+
+    },
+    "Hide posts with titles containing these whole words or phrases. Ignores case and punctuation (e.g., the keyword \"john\" will also filter \"John's\")." : {
+
+    },
     "Hide Read" : {
       "localizations" : {
         "fr" : {
@@ -4462,6 +4472,9 @@
         }
       }
     },
+    "Keywords" : {
+
+    },
     "Large" : {
       "localizations" : {
         "fr" : {
@@ -4551,6 +4564,9 @@
           }
         }
       }
+    },
+    "Literals" : {
+
     },
     "Load directly from %@" : {
       "localizations" : {
@@ -6145,6 +6161,7 @@
       }
     },
     "Posts with these keywords in their titles will be hidden. If you are a moderator or administrator of a matching post, it will appear in your feed but require you to tap to view its content." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -6153,9 +6170,6 @@
           }
         }
       }
-    },
-    "Posts with these literal strings in their titles will be hidden. If you are a moderator or administrator of a matching post, it will appear in your feed but require you to tap to view its content." : {
-
     },
     "Pride" : {
       "localizations" : {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -2919,6 +2919,9 @@
         }
       }
     },
+    "Deprecated Format" : {
+
+    },
     "Description" : {
 
     },
@@ -6368,6 +6371,9 @@
         }
       }
     },
+    "Re-Export" : {
+
+    },
     "Read %lld posts" : {
       "localizations" : {
         "fr" : {
@@ -8643,6 +8649,9 @@
           }
         }
       }
+    },
+    "This file was saved by an older version of Mlem, and will not be compatible with future versions. To preserve compatibility, re-export your filters." : {
+
     },
     "This instance is not part of the Fediseer Chain of Trust." : {
       "localizations" : {

--- a/Mlem/Packages/ComponentViews/Sources/ComponentViews/View+VersionAwareDialog.swift
+++ b/Mlem/Packages/ComponentViews/Sources/ComponentViews/View+VersionAwareDialog.swift
@@ -15,7 +15,7 @@ public extension View {
         isPresented: Binding<Bool>,
         @ViewBuilder actions: @escaping () -> some View
     ) -> some View {
-        versionAwareDialog(String(localized: title), isPresented: isPresented, actions: actions)
+        versionAwareDialog(String(localized: title), isPresented: isPresented, actions: actions) {}
     }
     
     @_disfavoredOverload @ViewBuilder
@@ -30,6 +30,30 @@ public extension View {
             confirmationDialog(title, isPresented: isPresented, actions: actions) {
                 Text(title)
             }
+        }
+    }
+    
+    @ViewBuilder
+    func versionAwareDialog(
+        _ title: LocalizedStringResource,
+        isPresented: Binding<Bool>,
+        @ViewBuilder actions: @escaping () -> some View,
+        @ViewBuilder message: @escaping () -> some View
+    ) -> some View {
+        versionAwareDialog(String(localized: title), isPresented: isPresented, actions: actions, message: message)
+    }
+    
+    @_disfavoredOverload @ViewBuilder
+    func versionAwareDialog(
+        _ title: String,
+        isPresented: Binding<Bool>,
+        @ViewBuilder actions: @escaping () -> some View,
+        @ViewBuilder message: @escaping () -> some View
+    ) -> some View {
+        if #available(iOS 26, *) {
+            alert(title, isPresented: isPresented, actions: actions, message: message)
+        } else {
+            confirmationDialog(title, isPresented: isPresented, actions: actions, message: message)
         }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/String+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/String+Extensions.swift
@@ -58,6 +58,11 @@ public extension String {
         
         return false
     }
+    
+    // Returns true if this string contains any literals in  the given set
+    func failsLiteralFilter(literals: Set<String>) -> Bool {
+        return literals.contains(where: { self.contains($0) })
+    }
 }
 
 private enum MatchState {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterContext.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterContext.swift
@@ -19,16 +19,17 @@ public struct FilterContext {
         isAdmin: Bool,
         moderatedCommunityActorIds: Set<ActorIdentifier>,
         filteredKeywords: Set<String>,
-        filteredPhrases: Set<[String]>
+        filteredPhrases: Set<[String]>,
+        filteredLiterals: Set<String>
     ) {
         self.isAdmin = isAdmin
         self.moderatedCommunityActorIds = moderatedCommunityActorIds
         self.filteredKeywords = filteredKeywords
         self.filteredPhrases = filteredPhrases
-        self.filteredLiterals = ["% k"]
+        self.filteredLiterals = filteredLiterals
     }
     
     static func none() -> FilterContext {
-        .init(isAdmin: true, moderatedCommunityActorIds: [], filteredKeywords: [], filteredPhrases: [])
+        .init(isAdmin: true, moderatedCommunityActorIds: [], filteredKeywords: [], filteredPhrases: [], filteredLiterals: [])
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterContext.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterContext.swift
@@ -13,6 +13,7 @@ public struct FilterContext {
     public let moderatedCommunityActorIds: Set<ActorIdentifier>
     public let filteredKeywords: Set<String>
     public let filteredPhrases: Set<[String]>
+    public let filteredLiterals: Set<String>
     
     public init(
         isAdmin: Bool,
@@ -24,6 +25,7 @@ public struct FilterContext {
         self.moderatedCommunityActorIds = moderatedCommunityActorIds
         self.filteredKeywords = filteredKeywords
         self.filteredPhrases = filteredPhrases
+        self.filteredLiterals = ["% k"]
     }
     
     static func none() -> FilterContext {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/FilterProviding.swift
@@ -7,19 +7,40 @@
 
 import Foundation
 
-protocol FilterProviding<FilterTarget> {
-    associatedtype FilterTarget
+class FilterProviding<FilterTarget> {
+    var context: FilterContext
+    
+    /// How many items this filter has caught
+    var numFiltered: Int = 0
+    var active: Bool = true
+    
+    init(context: FilterContext) {
+        self.context = context
+    }
     
     /// Given a list of `FilterTarget`s, returns all members that pass the filter and tracks how many members do not
     /// - Parameter targets: list of `FilterTarget`s to filter
-    func filter(_ targets: [FilterTarget]) -> [FilterTarget]
+    func filter(_ targets: [FilterTarget]) -> [FilterTarget] {
+        let ret = targets.filter(shouldPassFilter)
+        numFiltered += targets.count - ret.count
+        return ret
+    }
     
     /// Clears the filter and processes all provided targets
     /// - Parameter targets: optional list of `FilterTarget`s; if present, these will be filtered and the results returned
-    func reset(with targets: [FilterTarget]?) -> [FilterTarget]
+    func reset(with targets: [FilterTarget]?) -> [FilterTarget] {
+        numFiltered = 0
+        if let targets { return filter(targets) }
+        return .init()
+    }
     
-    /// How many items this filter has caught
-    var numFiltered: Int { get }
+    /// Returns true if the given post should pass the filter, false otherwise
+    public func shouldPassFilter(_ item: FilterTarget) -> Bool {
+        preconditionFailure("This method must be implemented by the inheriting class")
+    }
     
-    var active: Bool { get set }
+    
+    func updateFilterContext(to context: FilterContext) {
+        self.context = context
+    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/DedupeFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/DedupeFilter.swift
@@ -8,21 +8,17 @@
 import Foundation
 
 /// Filter that dedupes ActorIdentifiable items by actorId
-class DedupeFilter<FilterTarget: ActorIdentifiable>: FilterProviding {
-    var numFiltered: Int = 0
+class DedupeFilter<FilterTarget: ActorIdentifiable>: FilterProviding<FilterTarget> {
     private var seen: Set<ActorIdentifier> = .init()
-    var active: Bool = true
     
-    func filter(_ targets: [FilterTarget]) -> [FilterTarget] {
-        let ret = targets.filter { seen.insert($0.actorId).inserted }
-        numFiltered += targets.count - ret.count
-        return ret
-    }
-    
-    func reset(with targets: [FilterTarget]?) -> [FilterTarget] {
+    override func reset(with targets: [FilterTarget]?) -> [FilterTarget] {
         numFiltered = 0
         seen = .init()
         if let targets { return filter(targets) }
         return .init()
+    }
+    
+    override public func shouldPassFilter(_ item: FilterTarget) -> Bool {
+        seen.insert(item.actorId).inserted
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/InboxDedupeFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/InboxDedupeFilter.swift
@@ -6,21 +6,17 @@
 //
 
 /// Filter that dedupes InboxIdentifiable items by inboxId
-class InboxDedupeFilter<FilterTarget: InboxIdentifiable>: FilterProviding {
-    var numFiltered: Int = 0
+class InboxDedupeFilter<FilterTarget: InboxIdentifiable>: FilterProviding<FilterTarget> {
     private var seen: Set<Int> = .init()
-    var active: Bool = true
     
-    func filter(_ targets: [FilterTarget]) -> [FilterTarget] {
-        let ret = targets.filter { seen.insert($0.inboxId).inserted }
-        numFiltered += targets.count - ret.count
-        return ret
-    }
-    
-    func reset(with targets: [FilterTarget]?) -> [FilterTarget] {
+    override func reset(with targets: [FilterTarget]?) -> [FilterTarget] {
         numFiltered = 0
         seen = .init()
         if let targets { return filter(targets) }
         return .init()
+    }
+    
+    override public func shouldPassFilter(_ item: FilterTarget) -> Bool {
+        seen.insert(item.inboxId).inserted
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostKeywordFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostKeywordFilter.swift
@@ -8,37 +8,10 @@
 import Foundation
 
 class PostKeywordFilter: FilterProviding<Post2> {
-//    typealias FilterTarget = Post2
-//    
-//    var numFiltered: Int = 0
-//    private var context: FilterContext
-//    var active: Bool = true
-//    
-//    init(context: FilterContext) {
-//        self.context = context
-//    }
-//    
-//    func filter(_ targets: [Post2]) -> [Post2] {
-//        let ret = targets.filter(shouldPassFilter)
-//        numFiltered += targets.count - ret.count
-//        return ret
-//    }
-//    
-//    func reset(with targets: [Post2]?) -> [Post2] {
-//        numFiltered = 0
-//        if let targets { return filter(targets) }
-//        return .init()
-//    }
-//    
-    /// Returns true if the given post should pass the filter, false otherwise
     override public func shouldPassFilter(_ post: Post2) -> Bool {
         // bypass filter for moderated/administrated posts
         if context.isAdmin || context.moderatedCommunityActorIds.contains(post.community.actorId) { return true }
         
         return !post.title.failsKeywordFilter(keywords: context.filteredKeywords, phrases: context.filteredPhrases)
     }
-//    
-//    func updateFilterContext(to context: FilterContext) {
-//        self.context = context
-//    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostKeywordFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostKeywordFilter.swift
@@ -7,38 +7,38 @@
 
 import Foundation
 
-class PostKeywordFilter: FilterProviding {
-    typealias FilterTarget = Post2
-    
-    var numFiltered: Int = 0
-    private var context: FilterContext
-    var active: Bool = true
-    
-    init(context: FilterContext) {
-        self.context = context
-    }
-    
-    func filter(_ targets: [Post2]) -> [Post2] {
-        let ret = targets.filter(shouldPassFilter)
-        numFiltered += targets.count - ret.count
-        return ret
-    }
-    
-    func reset(with targets: [Post2]?) -> [Post2] {
-        numFiltered = 0
-        if let targets { return filter(targets) }
-        return .init()
-    }
-    
+class PostKeywordFilter: FilterProviding<Post2> {
+//    typealias FilterTarget = Post2
+//    
+//    var numFiltered: Int = 0
+//    private var context: FilterContext
+//    var active: Bool = true
+//    
+//    init(context: FilterContext) {
+//        self.context = context
+//    }
+//    
+//    func filter(_ targets: [Post2]) -> [Post2] {
+//        let ret = targets.filter(shouldPassFilter)
+//        numFiltered += targets.count - ret.count
+//        return ret
+//    }
+//    
+//    func reset(with targets: [Post2]?) -> [Post2] {
+//        numFiltered = 0
+//        if let targets { return filter(targets) }
+//        return .init()
+//    }
+//    
     /// Returns true if the given post should pass the filter, false otherwise
-    public func shouldPassFilter(_ post: Post2) -> Bool {
+    override public func shouldPassFilter(_ post: Post2) -> Bool {
         // bypass filter for moderated/administrated posts
         if context.isAdmin || context.moderatedCommunityActorIds.contains(post.community.actorId) { return true }
         
         return !post.title.failsKeywordFilter(keywords: context.filteredKeywords, phrases: context.filteredPhrases)
     }
-    
-    func updateFilterContext(to context: FilterContext) {
-        self.context = context
-    }
+//    
+//    func updateFilterContext(to context: FilterContext) {
+//        self.context = context
+//    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostLiteralFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostLiteralFilter.swift
@@ -1,0 +1,44 @@
+//
+//  PostLiteralFilter.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2025-11-18.
+//
+
+import Foundation
+
+class PostLiteralFilter: FilterProviding {
+    typealias FilterTarget = Post2
+    
+    var numFiltered: Int = 0
+    private var context: FilterContext
+    var active: Bool = true
+    
+    init(context: FilterContext) {
+        self.context = context
+    }
+    
+    func filter(_ targets: [Post2]) -> [Post2] {
+        let ret = targets.filter(shouldPassFilter)
+        numFiltered += targets.count - ret.count
+        return ret
+    }
+    
+    func reset(with targets: [Post2]?) -> [Post2] {
+        numFiltered = 0
+        if let targets { return filter(targets) }
+        return .init()
+    }
+    
+    /// Returns true if the given post should pass the filter, false otherwise
+    public func shouldPassFilter(_ post: Post2) -> Bool {
+        // bypass filter for moderated/administrated posts
+        if context.isAdmin || context.moderatedCommunityActorIds.contains(post.community.actorId) { return true }
+        
+        return !post.title.failsLiteralFilter(literals: context.filteredLiterals)
+    }
+    
+    func updateFilterContext(to context: FilterContext) {
+        self.context = context
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostLiteralFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostLiteralFilter.swift
@@ -7,38 +7,11 @@
 
 import Foundation
 
-class PostLiteralFilter: FilterProviding {
-    typealias FilterTarget = Post2
-    
-    var numFiltered: Int = 0
-    private var context: FilterContext
-    var active: Bool = true
-    
-    init(context: FilterContext) {
-        self.context = context
-    }
-    
-    func filter(_ targets: [Post2]) -> [Post2] {
-        let ret = targets.filter(shouldPassFilter)
-        numFiltered += targets.count - ret.count
-        return ret
-    }
-    
-    func reset(with targets: [Post2]?) -> [Post2] {
-        numFiltered = 0
-        if let targets { return filter(targets) }
-        return .init()
-    }
-    
-    /// Returns true if the given post should pass the filter, false otherwise
-    public func shouldPassFilter(_ post: Post2) -> Bool {
+class PostLiteralFilter: FilterProviding<Post2> {
+    override public func shouldPassFilter(_ post: Post2) -> Bool {
         // bypass filter for moderated/administrated posts
         if context.isAdmin || context.moderatedCommunityActorIds.contains(post.community.actorId) { return true }
         
         return !post.title.failsLiteralFilter(literals: context.filteredLiterals)
-    }
-    
-    func updateFilterContext(to context: FilterContext) {
-        self.context = context
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/ReadFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/ReadFilter.swift
@@ -7,19 +7,8 @@
 
 import Foundation
 
-class ReadFilter<FilterTarget: ReadableProviding>: FilterProviding {
-    var numFiltered: Int = 0
-    var active: Bool = true
-    
-    func filter(_ targets: [FilterTarget]) -> [FilterTarget] {
-        let ret = targets.filter { !$0.read }
-        numFiltered += targets.count - ret.count
-        return ret
-    }
-    
-    func reset(with targets: [FilterTarget]?) -> [FilterTarget] {
-        numFiltered = 0
-        if let targets { return filter(targets) }
-        return .init()
+class ReadFilter<FilterTarget: ReadableProviding>: FilterProviding<FilterTarget> {
+    override public func shouldPassFilter(_ item: FilterTarget) -> Bool {
+        return !item.read
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/InboxItemFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/InboxItemFilter.swift
@@ -11,23 +11,23 @@ public enum InboxItemFilterType {
 
 class InboxItemFilter: MultiFilter<InboxItem> {
     private var readFilter: ReadFilter<InboxItem>
-    private var dedupeFilter: InboxDedupeFilter<InboxItem> = .init()
+    private var dedupeFilter: InboxDedupeFilter<InboxItem> = .init(context: .none())
     
     init(showRead: Bool) {
-        self.readFilter = .init()
+        self.readFilter = .init(context: .none())
         if showRead {
             readFilter.active = false
         }
     }
 
-    override func allFilters() -> [any FilterProviding<InboxItem>] {
+    override func allFilters() -> [FilterProviding<InboxItem>] {
         [
             readFilter,
             dedupeFilter
         ]
     }
     
-    override func getFilter(_ toGet: InboxItemFilterType) -> any FilterProviding<InboxItem> {
+    override func getFilter(_ toGet: InboxItemFilterType) -> FilterProviding<InboxItem> {
         switch toGet {
         case .read: readFilter
         case .dedupe: dedupeFilter

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/ModMailItemFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/ModMailItemFilter.swift
@@ -11,23 +11,23 @@ public enum ModMailItemFilterType {
 
 class ModMailItemFilter: MultiFilter<ModMailItem> {
     private var readFilter: ReadFilter<ModMailItem>
-    private var dedupeFilter: InboxDedupeFilter<ModMailItem> = .init()
+    private var dedupeFilter: InboxDedupeFilter<ModMailItem> = .init(context: .none())
     
     init(showRead: Bool) {
-        self.readFilter = .init()
+        self.readFilter = .init(context: .none())
         if showRead {
             readFilter.active = false
         }
     }
 
-    override func allFilters() -> [any FilterProviding<ModMailItem>] {
+    override func allFilters() -> [FilterProviding<ModMailItem>] {
         [
             readFilter,
             dedupeFilter
         ]
     }
     
-    override func getFilter(_ toGet: ModMailItemFilterType) -> any FilterProviding<ModMailItem> {
+    override func getFilter(_ toGet: ModMailItemFilterType) -> FilterProviding<ModMailItem> {
         switch toGet {
         case .read: readFilter
         case .dedupe: dedupeFilter

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/ModlogItemFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/ModlogItemFilter.swift
@@ -10,9 +10,9 @@ import Foundation
 public enum ModlogEntryFilterType {}
 
 class ModlogEntryFilter: MultiFilter<ModlogEntry> {
-    override func allFilters() -> [any FilterProviding<ModlogEntry>] {
+    override func allFilters() -> [FilterProviding<ModlogEntry>] {
         []
     }
     
-    override func getFilter(_ toGet: ModlogEntryFilterType) -> any FilterProviding<ModlogEntry> {}
+    override func getFilter(_ toGet: ModlogEntryFilterType) -> FilterProviding<ModlogEntry> {}
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/MultiFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/MultiFilter.swift
@@ -12,12 +12,12 @@ class MultiFilter<FilterTarget: Filterable> {
     
     /// Lists all filters in this MultiFilter. Used internally to iterate over filters and perform filtering logic. This function bridges the gap between the generic behavior, which wants a list of `[any FilterProviding<FilterTarget>]` to use in filtering, and the instantiating class, which is far more ergonomic if filters can be declared as simple member variables.
     /// - Returns: list of all filters in this MultiFilter
-    func allFilters() -> [any FilterProviding<FilterTarget>] { [] }
+    func allFilters() -> [FilterProviding<FilterTarget>] { [] }
     
     /// Gets a particular optional filter. Used internally to back the `activate`, `deactivate`, and `filteredCount` methods; as with `allFilters`, used to bridge generic and concrete behavior.
     /// - Parameter toGet: `OptionalFilters` describing the filter to get
     /// - Returns: filter corresponding to `toGet`
-    func getFilter(_ toGet: FilterTarget.FilterType) -> any FilterProviding<FilterTarget> {
+    func getFilter(_ toGet: FilterTarget.FilterType) -> FilterProviding<FilterTarget> {
         preconditionFailure("This method must be implemented by the instantiating class")
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/PostFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/PostFilter.swift
@@ -8,16 +8,18 @@
 import Foundation
 
 public enum PostFilterType {
-    case read, dedupe, keyword
+    case read, dedupe, keyword, literal
 }
 
 class PostFilter: MultiFilter<Post2> {
     private var readFilter: ReadFilter<Post2>
     private var dedupeFilter: DedupeFilter<Post2> = .init()
     private var keywordFilter: PostKeywordFilter
+    private var literalFilter: PostLiteralFilter
     
     init(showRead: Bool, context: FilterContext) {
         self.keywordFilter = .init(context: context)
+        self.literalFilter = .init(context: context)
         self.readFilter = .init()
         if showRead {
             readFilter.active = false
@@ -28,7 +30,8 @@ class PostFilter: MultiFilter<Post2> {
         [
             readFilter,
             dedupeFilter,
-            keywordFilter
+            keywordFilter,
+            literalFilter
         ]
     }
     
@@ -37,6 +40,7 @@ class PostFilter: MultiFilter<Post2> {
         case .read: readFilter
         case .dedupe: dedupeFilter
         case .keyword: keywordFilter
+        case .literal: literalFilter
         }
     }
     
@@ -44,5 +48,6 @@ class PostFilter: MultiFilter<Post2> {
     
     func updateContext(to context: FilterContext) {
         keywordFilter.updateFilterContext(to: context)
+        literalFilter.updateFilterContext(to: context)
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/PostFilter.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Filtering/PostFilter.swift
@@ -13,20 +13,20 @@ public enum PostFilterType {
 
 class PostFilter: MultiFilter<Post2> {
     private var readFilter: ReadFilter<Post2>
-    private var dedupeFilter: DedupeFilter<Post2> = .init()
+    private var dedupeFilter: DedupeFilter<Post2> = .init(context: .none())
     private var keywordFilter: PostKeywordFilter
     private var literalFilter: PostLiteralFilter
     
     init(showRead: Bool, context: FilterContext) {
         self.keywordFilter = .init(context: context)
         self.literalFilter = .init(context: context)
-        self.readFilter = .init()
+        self.readFilter = .init(context: .none())
         if showRead {
             readFilter.active = false
         }
     }
 
-    override func allFilters() -> [any FilterProviding<Post2>] {
+    override func allFilters() -> [FilterProviding<Post2>] {
         [
             readFilter,
             dedupeFilter,
@@ -35,7 +35,7 @@ class PostFilter: MultiFilter<Post2> {
         ]
     }
     
-    override func getFilter(_ toGet: PostFilterType) -> any FilterProviding<Post2> {
+    override func getFilter(_ toGet: PostFilterType) -> FilterProviding<Post2> {
         switch toGet {
         case .read: readFilter
         case .dedupe: dedupeFilter


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- progress towards #2361 

Adds a literal filter, which filters out posts if any filtered literal appears as an exact substring of the post's title.

Also refactors filters to inherit from a common `FilterProviding` class, eliminating a bunch of redundant code.