### PR TITLE
Bugfix scroll to top on tab reselect

### DIFF
--- a/Mlem/App/Globals/Definitions/TabReselectTracker.swift
+++ b/Mlem/App/Globals/Definitions/TabReselectTracker.swift
@@ -12,6 +12,7 @@ import SwiftUI
 class TabReselectTracker {
     var blockTabSwitch: Bool = false
     private(set) var flag: Bool = false
+    var consumers: Int = 0
 
     static var main: TabReselectTracker = .init()
 

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+TabReselectConsumer.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+TabReselectConsumer.swift
@@ -30,11 +30,13 @@ struct TabReselectionConsumer: ViewModifier {
             .onAppear {
                 if !displayed {
                     displayed = true
+                    tabReselectTracker.consumers += 1
                 }
             }
             .onDisappear {
                 if displayed {
                     displayed = false
+                    tabReselectTracker.consumers -= 1
                 }
             }
     }

--- a/Mlem/App/Views/Shared/CustomTabBarController.swift
+++ b/Mlem/App/Views/Shared/CustomTabBarController.swift
@@ -90,6 +90,7 @@ class CustomTabBarController: UITabBarController, UITabBarControllerDelegate {
            let item = viewController as? CustomTabViewHostingController {
             log.debug("\(item.item.title) tab re-selected")
             TabReselectTracker.main.signal()
+            return TabReselectTracker.main.consumers == 0
         }
         selectedIndexBinding = viewControllers?.firstIndex(of: viewController) ?? 0
         return true


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

iOS 26 implemented a default navigate back on tab reselect, which made reselect to scroll to top stop working. This adds a check to suppress that system behavior if there is a `.tabReselectConsumer` present.
