### PR TITLE
Add swipe action colors to new action system

### DIFF
--- a/Mlem/App/Actions/BanAction.swift
+++ b/Mlem/App/Actions/BanAction.swift
@@ -73,7 +73,12 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension BanAction {
-    static let label: ActionLabel = .init("Ban", icon: .lemmy.banFromCommunity, isDestructive: true)
+    static let label: ActionLabel = .init(
+        "Ban",
+        icon: .lemmy.banFromCommunity,
+        color: .themedNegative,
+        isDestructive: true
+    )
 
     func createLabel(environment: EnvironmentValues) -> ActionLabel {
         let label: ActionLabel
@@ -84,18 +89,36 @@ extension BanAction {
         switch (bannedFrom: appliedBanScopes, canBanFrom: actionableBanScopes) {
         case (bannedFrom: .none, canBanFrom: .both),
              (bannedFrom: .anyNotContaining(.instance), canBanFrom: .instanceOnly):
-            label = .init("Ban", icon: .lemmy.banFromInstance, isDestructive: true)
+            label = .init(
+                "Ban",
+                icon: .lemmy.banFromInstance,
+                color: .themedNegative,
+                isDestructive: true
+            )
 
         case (bannedFrom: .anyContaining(.instance), canBanFrom: .instanceOnly),
              (bannedFrom: .both, canBanFrom: .both):
-            label = .init("Unban", icon: .lemmy.unbanFromInstance)
+            label = .init(
+                "Unban",
+                icon: .lemmy.unbanFromInstance,
+                color: .themedPositive
+            )
 
         case (bannedFrom: .instanceOnly, canBanFrom: .both),
              (bannedFrom: .communityOnly, canBanFrom: .both):
-            label = .init("Ban...", icon: .lemmy.banFromInstance, isDestructive: true)
+            label = .init(
+                "Ban...",
+                icon: .lemmy.banFromInstance,
+                color: .themedNegative,
+                isDestructive: true
+            )
 
         case (bannedFrom: .anyContaining(.community), canBanFrom: .communityOnly):
-            label = .init("Unban", icon: .lemmy.unbanFromCommunity)
+            label = .init(
+                "Unban",
+                icon: .lemmy.unbanFromCommunity,
+                color: .themedPositive
+            )
 
         case (bannedFrom: .anyNotContaining(.community), canBanFrom: .communityOnly):
             label = Self.label

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -27,8 +27,17 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension BlockAction {
-    static let blockLabel: ActionLabel = .init("Block User", icon: .lemmy.block, isDestructive: true)
-    static let unblockLabel: ActionLabel = .init("Unblock User", icon: .lemmy.unblock)
+    static let blockLabel: ActionLabel = .init(
+        "Block User",
+        icon: .lemmy.block,
+        color: .themedNegative,
+        isDestructive: true
+    )
+    static let unblockLabel: ActionLabel = .init(
+        "Unblock User",
+        icon: .lemmy.unblock,
+        color: .themedPositive
+    )
     
     static var label: ActionLabel { blockLabel }
 

--- a/Mlem/App/Actions/DeleteAction.swift
+++ b/Mlem/App/Actions/DeleteAction.swift
@@ -27,8 +27,17 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension DeleteAction {
-    static let deleteLabel: ActionLabel = .init("Delete", icon: .general.delete, isDestructive: true)
-    static let restoreLabel: ActionLabel = .init("Restore", icon: .lemmy.restore)
+    static let deleteLabel: ActionLabel = .init(
+        "Delete",
+        icon: .general.delete,
+        color: .themedNegative,
+        isDestructive: true
+    )
+    static let restoreLabel: ActionLabel = .init(
+        "Restore",
+        icon: .lemmy.restore,
+        color: .themedPositive
+    )
     
     static var label: ActionLabel { deleteLabel }
 

--- a/Mlem/App/Actions/MarkReadAction.swift
+++ b/Mlem/App/Actions/MarkReadAction.swift
@@ -27,8 +27,16 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension MarkReadAction {
-    static let markReadLabel: ActionLabel = .init("Mark Read", icon: .lemmy.markRead)
-    static let markUnreadLabel: ActionLabel = .init("Mark Unread", icon: .lemmy.markUnread)
+    static let markReadLabel: ActionLabel = .init(
+        "Mark Read",
+        icon: .lemmy.markRead,
+        color: .themedRead
+    )
+    static let markUnreadLabel: ActionLabel = .init(
+        "Mark Unread",
+        icon: .lemmy.markUnread,
+        color: .themedRead
+    )
     
     static var label: ActionLabel { markReadLabel }
 

--- a/Mlem/App/Actions/PurgeAction.swift
+++ b/Mlem/App/Actions/PurgeAction.swift
@@ -35,8 +35,18 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension PurgeAction {
-    static let label: ActionLabel = .init("Purge", icon: .lemmy.purge, isDestructive: true)
-    static let verboseLabel: ActionLabel = .init("Purge User", icon: .lemmy.purge, isDestructive: true)
+    static let label: ActionLabel = .init(
+        "Purge",
+        icon: .lemmy.purge,
+        color: .themedNegative,
+        isDestructive: true
+    )
+    static let verboseLabel: ActionLabel = .init(
+        "Purge User",
+        icon: .lemmy.purge,
+        color: .themedNegative,
+        isDestructive: true
+    )
     
     func createLabel(environment: EnvironmentValues) -> ActionLabel {
         if useVerboseLabel {

--- a/Mlem/App/Actions/RemoveAction.swift
+++ b/Mlem/App/Actions/RemoveAction.swift
@@ -27,10 +27,26 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension RemoveAction {
-    static let label: ActionLabel = .init("Remove", icon: .lemmy.remove, isDestructive: true)
+    static let removeLabel: ActionLabel = .init(
+        "Remove",
+        icon: .lemmy.remove,
+        color: .themedNegative,
+        isDestructive: true
+    )
+    static let restoreLabel: ActionLabel = .init(
+        "Restore",
+        icon: .lemmy.restore,
+        color: .themedPositive
+    )
+    
+    static var label: ActionLabel { removeLabel }
     
     func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.label.withVisibility(visibility(environment))
+        if entity.removed {
+            Self.restoreLabel.withVisibility(visibility(environment))
+        } else {
+            Self.removeLabel.withVisibility(visibility(environment))
+        }
     }
     
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/ReportAction.swift
+++ b/Mlem/App/Actions/ReportAction.swift
@@ -30,6 +30,7 @@ extension ReportAction {
     static let label: ActionLabel = .init(
         "Report",
         icon: .lemmy.report,
+        color: .themedNegative,
         isDestructive: true
     )
     

--- a/Mlem/App/Actions/SaveAction.swift
+++ b/Mlem/App/Actions/SaveAction.swift
@@ -27,8 +27,16 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension SaveAction {
-    static let saveLabel: ActionLabel = .init("Save", icon: .lemmy.saved.representingState(active: false))
-    static let unsaveLabel: ActionLabel = .init("Saved", icon: .lemmy.saved.representingState(active: true))
+    static let saveLabel: ActionLabel = .init(
+        "Save",
+        icon: .lemmy.saved.representingState(active: false),
+        color: .themedSave
+    )
+    static let unsaveLabel: ActionLabel = .init(
+        "Saved",
+        icon: .lemmy.saved.representingState(active: true),
+        color: .themedSave
+    )
     
     static var label: ActionLabel { saveLabel }
 

--- a/Mlem/App/Actions/ViewVotesAction.swift
+++ b/Mlem/App/Actions/ViewVotesAction.swift
@@ -28,7 +28,11 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension ViewVotesAction {
-    static let label: ActionLabel = .init("View Votes", icon: .lemmy.votes)
+    static let label: ActionLabel = .init(
+        "View Votes",
+        icon: .lemmy.votes,
+        color: .themedColorfulAccent(4)
+    )
     
     func createLabel(environment: EnvironmentValues) -> ActionLabel {
         Self.label.withVisibility(visibility(environment))

--- a/Mlem/App/Actions/VoteAction.swift
+++ b/Mlem/App/Actions/VoteAction.swift
@@ -31,10 +31,26 @@ private func createVoteAction(_ entity: Any, type: ScoringOperation) -> VoteActi
 // MARK: - Appearance
 
 extension VoteAction {
-    static let upvoteLabel: ActionLabel = .init("Upvote", icon: .lemmy.upvoted.representingState(active: false))
-    static let downvoteLabel: ActionLabel = .init("Downvote", icon: .lemmy.downvoted.representingState(active: false))
-    static let removeUpvoteLabel: ActionLabel = .init("Upvoted", icon: .lemmy.upvoted.representingState(active: true))
-    static let removeDownvoteLabel: ActionLabel = .init("Downvoted", icon: .lemmy.downvoted.representingState(active: true))
+    static let upvoteLabel: ActionLabel = .init(
+        "Upvote",
+        icon: .lemmy.upvoted.representingState(active: false),
+        color: .themedUpvote
+    )
+    static let downvoteLabel: ActionLabel = .init(
+        "Downvote",
+        icon: .lemmy.downvoted.representingState(active: false),
+        color: .themedDownvote
+    )
+    static let removeUpvoteLabel: ActionLabel = .init(
+        "Upvoted",
+        icon: .lemmy.upvoted.representingState(active: true),
+        color: .themedUpvote
+    )
+    static let removeDownvoteLabel: ActionLabel = .init(
+        "Downvoted",
+        icon: .lemmy.downvoted.representingState(active: true),
+        color: .themedDownvote
+    )
     
     static var label: ActionLabel { upvoteLabel }
 

--- a/Mlem/App/Utility/Extensions/QuickSwipeAction+Actions.swift
+++ b/Mlem/App/Utility/Extensions/QuickSwipeAction+Actions.swift
@@ -15,7 +15,7 @@ private extension QuickSwipeAction {
         if label.visibility == .hidden { return nil }
         self.init(
             icon: label.icon,
-            color: .themedAccent,
+            color: label.color,
             enabled: label.visibility == .enabled,
             confirmationPrompt: nil,
             callback: callback

--- a/Mlem/Packages/Actions/Package.swift
+++ b/Mlem/Packages/Actions/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
 
     ],
     dependencies: [
-        .package(path: "../Icons")
+        .package(path: "../Icons"),
+        .package(path: "../Theming")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -23,7 +24,8 @@ let package = Package(
         .target(
             name: "Actions",
             dependencies: [
-                .byName(name: "Icons")
+                .byName(name: "Icons"),
+                .byName(name: "Theming")
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5),

--- a/Mlem/Packages/Actions/Sources/Actions/ActionLabel.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionLabel.swift
@@ -7,21 +7,25 @@
 
 import Foundation
 import Icons
+import Theming
 
 public struct ActionLabel {
     public let title: String
     public var icon: Icon
+    public var color: ThemedColor
     public var isDestructive: Bool
     public var visibility: ActionVisiblity
     
     public init(
         _ title: LocalizedStringResource,
         icon: Icon,
+        color: ThemedColor = .themedAccent,
         isDestructive: Bool = false,
         visibility: ActionVisiblity = .enabled
     ) {
         self.title = .init(localized: title)
         self.icon = icon
+        self.color = color
         self.isDestructive = isDestructive
         self.visibility = visibility
     }
@@ -30,11 +34,13 @@ public struct ActionLabel {
     public init(
         _ title: String,
         icon: Icon,
+        color: ThemedColor = .themedAccent,
         isDestructive: Bool = false,
         visibility: ActionVisiblity = .enabled
     ) {
         self.title = title
         self.icon = icon
+        self.color = color
         self.isDestructive = isDestructive
         self.visibility = visibility
     }


### PR DESCRIPTION
Closes #2459. The "mark read" swipe action in the test inbox is now purple.

Also fixed a bug where `RemoveAction` would still be labelled "remove" when a comment is already removed, rather than "restore". This affected the ellipsis menu in comments, which uses the new action system.