### PR TITLE
Fix newly-created comment not showing when post had zero comments

### DIFF
--- a/Mlem/App/Views/Shared/ExpandedPost/CommentPage.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/CommentPage.swift
@@ -46,7 +46,7 @@ struct CommentPage: View {
                 post: post,
                 contentLoaderError: proxy.error,
                 isLoading: proxy.isLoading,
-                tracker: $tracker,
+                tracker: tracker,
                 scrollTargetedComment: proxy.entity
             ) {
                 if let post, showViewPostButton || tracker?.nodes.first?.comment.depth != 0 {

--- a/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
@@ -154,6 +154,7 @@ class CommentTreeTracker: Hashable {
     
     func insertCreatedComment(_ comment: Comment2, parent: (any Comment1Providing)? = nil) {
         let wrapper = CommentTreeNode(comment)
+        nodesKeyedByActorId[comment.actorId] = wrapper
         if let parent {
             assert(!comment.parentCommentIds.isEmpty)
             nodesKeyedByActorId[parent.actorId]?.addChild(wrapper)

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Logic.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Logic.swift
@@ -55,6 +55,13 @@ extension ExpandedPostView {
         }
     }
     
+    var hasNoComments: Bool {
+        if tracker?.loadingState == .done {
+            return tracker?.nodesKeyedByActorId.count == 0
+        }
+        return (post?.commentCount_ ?? -1) == 0
+    }
+    
     var showLoadingSymbol: Bool {
         // Don't need to show ProgressView if there's nothing to scroll to
         if scrollTargetedComment == nil { return false }

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -120,7 +120,7 @@ struct ExpandedPostView<Content: View>: View {
                         } else if let contentLoaderError {
                             ErrorView(.init(error: contentLoaderError))
                                 .frame(maxWidth: .infinity)
-                        } else if (post.commentCount_ ?? -1) == 0 {
+                        } else if hasNoComments {
                             noCommentsView
                                 .padding(.top, Constants.main.doubleSpacing)
                         } else if let tracker {

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -36,7 +36,7 @@ struct ExpandedPostView<Content: View>: View {
     let highlightedComment: (any CommentStubProviding)?
     let content: Content
     
-    @Binding var tracker: CommentTreeTracker?
+    var tracker: CommentTreeTracker?
     @State var scrollTargetedComment: (any CommentStubProviding)?
 
     @State var scrolledToScrollTargetedComment: Bool = false
@@ -50,7 +50,7 @@ struct ExpandedPostView<Content: View>: View {
         post: (any PostStubProviding)?,
         contentLoaderError: Error?,
         isLoading: Bool,
-        tracker: Binding<CommentTreeTracker?>,
+        tracker: CommentTreeTracker?,
         highlightedComment: (any CommentStubProviding)? = nil,
         scrollTargetedComment: (any CommentStubProviding)? = nil,
         @ViewBuilder content: () -> Content = { EmptyView() }
@@ -60,7 +60,7 @@ struct ExpandedPostView<Content: View>: View {
         self.isLoading = isLoading
         self.highlightedComment = highlightedComment
         self.content = content()
-        self._tracker = tracker
+        self.tracker = tracker
         self._scrollTargetedComment = .init(wrappedValue: scrollTargetedComment)
     }
     

--- a/Mlem/App/Views/Shared/ExpandedPost/PostPage.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/PostPage.swift
@@ -32,7 +32,7 @@ struct PostPage: View {
                 post: proxy.entity,
                 contentLoaderError: proxy.error,
                 isLoading: proxy.isLoading,
-                tracker: $tracker,
+                tracker: tracker,
                 scrollTargetedComment: scrollTargetedComment
             ) {
                 if let post = post.wrappedValue as? any Post3Providing, !post.crossPosts.isEmpty {


### PR DESCRIPTION
If you replied to a post that has zero comments, it would not show the new comment. This has been fixed.

This may not completely fix the comments-not-showing up issue in the general case, I'm not sure.