### PR TITLE
Support granular Lemmy 1.0 instance-wide vote settings

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		03A6316D2D4E3D24009A47A6 /* ModeratorActionSeparationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A6316C2D4E3D24009A47A6 /* ModeratorActionSeparationSettingsView.swift */; };
 		03A631CC2D4FD18C009A47A6 /* Post+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A631CA2D4FCEF7009A47A6 /* Post+Mock.swift */; };
 		03A814292ED1BCA90023E9E8 /* ModlogView+Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A814282ED1BCA90023E9E8 /* ModlogView+Filters.swift */; };
+		03A818AD2EDCDBA20023E9E8 /* FederationMode+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A818AC2EDCDBA20023E9E8 /* FederationMode+Extensions.swift */; };
 		03A82FA12C0D1E8500D01A5C /* ApiClient+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A82FA02C0D1E8500D01A5C /* ApiClient+Extensions.swift */; };
 		03A82FA32C0D1F2400D01A5C /* View+ExternalApiWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A82FA22C0D1F2400D01A5C /* View+ExternalApiWarning.swift */; };
 		03A9FD162D7CEC09007A734D /* Theming in Frameworks */ = {isa = PBXBuildFile; productRef = 03A9FD152D7CEC09007A734D /* Theming */; };
@@ -840,6 +841,7 @@
 		03A6316C2D4E3D24009A47A6 /* ModeratorActionSeparationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeratorActionSeparationSettingsView.swift; sourceTree = "<group>"; };
 		03A631CA2D4FCEF7009A47A6 /* Post+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+Mock.swift"; sourceTree = "<group>"; };
 		03A814282ED1BCA90023E9E8 /* ModlogView+Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModlogView+Filters.swift"; sourceTree = "<group>"; };
+		03A818AC2EDCDBA20023E9E8 /* FederationMode+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FederationMode+Extensions.swift"; sourceTree = "<group>"; };
 		03A82FA02C0D1E8500D01A5C /* ApiClient+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApiClient+Extensions.swift"; sourceTree = "<group>"; };
 		03A82FA22C0D1F2400D01A5C /* View+ExternalApiWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ExternalApiWarning.swift"; sourceTree = "<group>"; };
 		03A9FD172D7CFC20007A734D /* Palette+Oled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Palette+Oled.swift"; sourceTree = "<group>"; };
@@ -2002,6 +2004,7 @@
 				0318BA9E2D72405F006CA71F /* PostSortType+Extensions.swift */,
 				038C86562D888EC100543F70 /* CommentSortType+Extensions.swift */,
 				0368F34E2D734066007DEB70 /* SearchSortType+Extensions.swift */,
+				03A818AC2EDCDBA20023E9E8 /* FederationMode+Extensions.swift */,
 				0368F34C2D733215007DEB70 /* SortTimeRange+Extensions.swift */,
 				CDCA44B32C176A4700C092B3 /* Array+Extensions.swift */,
 				0389DDC82C39658E0005B808 /* Binding+Extensions.swift */,
@@ -2754,6 +2757,7 @@
 				0397D4912C6CE871002C6CDC /* PostEditorView.swift in Sources */,
 				033171782CCE89E3002DA370 /* PurgableProviding+Extensions.swift in Sources */,
 				03D2A63B2C010B7500ED4FF2 /* GuestAccount.swift in Sources */,
+				03A818AD2EDCDBA20023E9E8 /* FederationMode+Extensions.swift in Sources */,
 				CDE1F1962C63DF89008AF042 /* PhoneConstants.swift in Sources */,
 				031EC5302E5F77D7003408B7 /* FeedContext.swift in Sources */,
 				0397D4862C6A24D2002C6CDC /* ReportableProviding+Extensions.swift in Sources */,

--- a/Mlem/App/Actions/VoteAction.swift
+++ b/Mlem/App/Actions/VoteAction.swift
@@ -58,11 +58,21 @@ extension VoteAction {
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
         guard entity.api.canInteract(appState: environment.appState) else { return .hidden }
 
-        if type == .downvote {
-            guard entity.api.downvotesEnabled else { return .hidden }
-        }
+        let voteFederationMode = entity.api.voteFederationMode
 
-        return .enabled
+        switch (self.type, entity is any Post1Providing) {
+        case (.upvote, true):
+            return voteFederationMode.postUpvote == .all ? .enabled : .hidden
+        case (.downvote, true):
+            return voteFederationMode.postDownvote == .all ? .enabled : .hidden
+        case (.upvote, false):
+            return voteFederationMode.commentUpvote == .all ? .enabled : .hidden
+        case (.downvote, false):
+            return voteFederationMode.commentDownvote == .all ? .enabled : .hidden
+        default:
+            assertionFailure()
+            return .hidden
+        }
     }
 }
 

--- a/Mlem/App/Utility/Extensions/ApiClient+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/ApiClient+Extensions.swift
@@ -18,8 +18,8 @@ extension ApiClient {
     
     func canInteract(appState: AppState) -> Bool { isActive(appState: appState) && token != nil }
     
-    var downvotesEnabled: Bool {
-        myInstance?.downvotesEnabled ?? true
+    var voteFederationMode: VoteFederationMode {
+        myInstance?.voteFederationMode ?? .all
     }
     
     func getPostLinkOrUseOpenGraph(url: URL) async throws -> PostLink {

--- a/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment1Providing+Extensions.swift
@@ -30,6 +30,10 @@ extension Comment1Providing {
         return api.myPerson?.moderates(communityId: id) ?? false || api.isAdmin
     }
 
+    var downvotesEnabled: Bool {
+        api.voteFederationMode.commentDownvote != .disable
+    }
+
     @ActionBuilder
     func allMenuActions(
         appState: AppState,
@@ -65,7 +69,7 @@ extension Comment1Providing {
     ) -> [any Action] {
         ActionGroup(displayMode: .compactSection) {
             upvoteAction(appState: appState, feedback: feedback)
-            downvoteAction(appState: appState, feedback: feedback)
+            downvoteAction(appState: appState, feedback: feedback, downvotesEnabled: downvotesEnabled)
             saveAction(appState: appState, feedback: feedback)
             replyAction(appState: appState, commentTreeTracker: commentTreeTracker)
             if !deleted {
@@ -129,7 +133,7 @@ extension Comment1Providing {
     ) -> (any Action)? {
         switch type {
         case .upvote: upvoteAction(appState: appState, feedback: [.haptic])
-        case .downvote: api.downvotesEnabled ? downvoteAction(appState: appState, feedback: [.haptic]) : nil
+        case .downvote: downvotesEnabled ? downvoteAction(appState: appState, feedback: [.haptic], downvotesEnabled: downvotesEnabled) : nil
         case .save: saveAction(appState: appState, feedback: [.haptic])
         case .reply: replyAction(appState: appState, commentTreeTracker: commentTreeTracker)
         case .share: shareAction(navigation: navigation)
@@ -150,9 +154,9 @@ extension Comment1Providing {
         commentTreeTracker: CommentTreeTracker? = nil
     ) -> Counter? {
         switch type {
-        case .score: scoreCounter(appState: appState)
+        case .score: scoreCounter(appState: appState, downvotesEnabled: downvotesEnabled)
         case .upvote: upvoteCounter(appState: appState)
-        case .downvote: api.downvotesEnabled ? downvoteCounter(appState: appState) : nil
+        case .downvote: downvotesEnabled ? downvoteCounter(appState: appState, downvotesEnabled: downvotesEnabled) : nil
         case .reply: replyCounter(appState: appState, commentTreeTracker: commentTreeTracker)
         }
     }
@@ -161,9 +165,9 @@ extension Comment1Providing {
         switch type {
         case .created: createdReadout
         // swiftlint:disable:next void_function_in_ternary
-        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout(showColor: showColor)
+        case .score: downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout(showColor: showColor)
         case .upvote: upvoteReadout(showColor: showColor)
-        case .downvote: api.downvotesEnabled ? downvoteReadout(showColor: showColor) : nil
+        case .downvote: downvotesEnabled ? downvoteReadout(showColor: showColor) : nil
         case .comment: commentReadout
         case .saved: savedReadout(showColor: showColor)
         }

--- a/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Interactable1Providing+Extensions.swift
@@ -99,19 +99,26 @@ extension Interactable1Providing {
         )
     }
     
-    func downvoteCounter(appState: AppState) -> Counter {
+    func downvoteCounter(appState: AppState, downvotesEnabled: Bool) -> Counter {
         .init(
             value: self2?.votes.downvotes,
-            leadingAction: downvoteAction(appState: appState, feedback: [.haptic]),
+            leadingAction: downvoteAction(appState: appState, feedback: [.haptic], downvotesEnabled: downvotesEnabled),
             trailingAction: nil
         )
     }
     
-    func scoreCounter(appState: AppState) -> Counter {
+    func scoreCounter(
+        appState: AppState,
+        downvotesEnabled: Bool
+    ) -> Counter {
         .init(
             value: self2?.votes.total,
             leadingAction: upvoteAction(appState: appState, feedback: [.haptic]),
-            trailingAction: api.downvotesEnabled ? downvoteAction(appState: appState, feedback: [.haptic]) : nil
+            trailingAction: downvotesEnabled ? downvoteAction(
+                appState: appState,
+                feedback: [.haptic],
+                downvotesEnabled: downvotesEnabled
+            ) : nil
         )
     }
     
@@ -133,8 +140,12 @@ extension Interactable1Providing {
         )
     }
     
-    func downvoteAction(appState: AppState, feedback: Set<FeedbackType> = []) -> BasicAction {
-        let enabled = api.canInteract(appState: appState) && api.downvotesEnabled
+    func downvoteAction(
+        appState: AppState,
+        feedback: Set<FeedbackType> = [],
+        downvotesEnabled: Bool
+    ) -> BasicAction {
+        let enabled = api.canInteract(appState: appState) && downvotesEnabled
         return .init(
             id: "downvote\(uid)",
             appearance: .downvote(isOn: self2?.votes.myVote ?? .none == .downvote),

--- a/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post1Providing+Extensions.swift
@@ -22,6 +22,10 @@ extension Post1Providing {
     var canModerate: Bool {
         api.myPerson?.moderates(communityId: communityId) ?? false || api.isAdmin
     }
+
+    var downvotesEnabled: Bool {
+        api.voteFederationMode.postDownvote != .disable
+    }
     
     @MainActor
     func showEditSheet() {
@@ -179,7 +183,7 @@ extension Post1Providing {
     ) -> [any Action] {
         ActionGroup(displayMode: .compactSection) {
             upvoteAction(appState: appState, feedback: feedback)
-            downvoteAction(appState: appState, feedback: feedback)
+            downvoteAction(appState: appState, feedback: feedback, downvotesEnabled: downvotesEnabled)
             saveAction(appState: appState, feedback: feedback)
             replyAction(appState: appState, commentTreeTracker: commentTreeTracker)
             if !deleted {
@@ -260,7 +264,7 @@ extension Post1Providing {
     ) -> (any Action)? {
         switch type {
         case .upvote: upvoteAction(appState: appState, feedback: feedback)
-        case .downvote: api.downvotesEnabled ? downvoteAction(appState: appState, feedback: feedback) : nil
+        case .downvote: downvotesEnabled ? downvoteAction(appState: appState, feedback: feedback, downvotesEnabled: downvotesEnabled) : nil
         case .save: saveAction(appState: appState, feedback: feedback)
         case .reply: replyAction(appState: appState, commentTreeTracker: commentTreeTracker)
         case .share: shareAction(navigation: navigation)
@@ -292,9 +296,9 @@ extension Post1Providing {
         commentTreeTracker: CommentTreeTracker? = nil
     ) -> Counter? {
         switch type {
-        case .score: scoreCounter(appState: appState)
+        case .score: scoreCounter(appState: appState, downvotesEnabled: downvotesEnabled)
         case .upvote: upvoteCounter(appState: appState)
-        case .downvote: api.downvotesEnabled ? downvoteCounter(appState: appState) : nil
+        case .downvote: downvotesEnabled ? downvoteCounter(appState: appState, downvotesEnabled: downvotesEnabled) : nil
         case .reply: replyCounter(appState: appState, commentTreeTracker: commentTreeTracker)
         }
     }
@@ -303,9 +307,9 @@ extension Post1Providing {
         switch type {
         case .created: createdReadout
         // swiftlint:disable:next void_function_in_ternary
-        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout(showColor: showColor)
+        case .score: downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout(showColor: showColor)
         case .upvote: upvoteReadout(showColor: showColor)
-        case .downvote: api.downvotesEnabled ? downvoteReadout(showColor: showColor) : nil
+        case .downvote: downvotesEnabled ? downvoteReadout(showColor: showColor) : nil
         case .comment: commentReadout
         case .saved: savedReadout(showColor: showColor)
         }

--- a/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Reply1Providing+Extensions.swift
@@ -9,6 +9,10 @@ import MlemMiddleware
 
 extension Reply1Providing {
     private var self2: (any Reply2Providing)? { self as? any Reply2Providing }
+
+    var downvotesEnabled: Bool {
+        api.voteFederationMode.commentDownvote != .disable
+    }
     
     @ActionBuilder
     func menuActions(
@@ -18,7 +22,7 @@ extension Reply1Providing {
     ) -> [any Action] {
         ActionGroup(displayMode: .compactSection) {
             upvoteAction(appState: appState, feedback: feedback)
-            downvoteAction(appState: appState, feedback: feedback)
+            downvoteAction(appState: appState, feedback: feedback, downvotesEnabled: downvotesEnabled)
             saveAction(appState: appState, feedback: feedback)
             replyAction(appState: appState)
             markReadAction(appState: appState, feedback: feedback)
@@ -38,7 +42,7 @@ extension Reply1Providing {
     func action(appState: AppState, type: ReplyBarConfiguration.ActionType) -> (any Action)? {
         switch type {
         case .upvote: upvoteAction(appState: appState, feedback: [.haptic])
-        case .downvote: api.downvotesEnabled ? downvoteAction(appState: appState, feedback: [.haptic]) : nil
+        case .downvote: downvotesEnabled ? downvoteAction(appState: appState, feedback: [.haptic], downvotesEnabled: downvotesEnabled) : nil
         case .save: saveAction(appState: appState, feedback: [.haptic])
         case .reply: replyAction(appState: appState)
         case .markRead: markReadAction(appState: appState, feedback: [.haptic])
@@ -49,9 +53,9 @@ extension Reply1Providing {
     
     func counter(appState: AppState, type: ReplyBarConfiguration.CounterType) -> Counter? {
         switch type {
-        case .score: scoreCounter(appState: appState)
+        case .score: scoreCounter(appState: appState, downvotesEnabled: downvotesEnabled)
         case .upvote: upvoteCounter(appState: appState)
-        case .downvote: api.downvotesEnabled ? downvoteCounter(appState: appState) : nil
+        case .downvote: downvotesEnabled ? downvoteCounter(appState: appState, downvotesEnabled: downvotesEnabled) : nil
         case .reply: replyCounter(appState: appState)
         }
     }
@@ -60,9 +64,9 @@ extension Reply1Providing {
         switch type {
         case .created: createdReadout
         // swiftlint:disable:next void_function_in_ternary
-        case .score: api.downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout(showColor: showColor)
+        case .score: downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout(showColor: showColor)
         case .upvote: upvoteReadout(showColor: showColor)
-        case .downvote: api.downvotesEnabled ? downvoteReadout(showColor: showColor) : nil
+        case .downvote: downvotesEnabled ? downvoteReadout(showColor: showColor) : nil
         case .comment: commentReadout
         case .saved: savedReadout(showColor: showColor)
         }

--- a/Mlem/App/Utility/Extensions/Content Models/ScoringOperation+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/ScoringOperation+Extensions.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 2024-12-18.
 //
 
+import Icons
 import MlemMiddleware
 import SwiftUI
 import Theming
@@ -15,6 +16,14 @@ extension ScoringOperation {
         case .none: Icons.resetVoteSquare
         case .upvote: Icons.upvoteSquare
         case .downvote: Icons.downvoteSquare
+        }
+    }
+
+    var icon: Icon {
+        switch self {
+        case .none: .lemmy.removeUpvote
+        case .upvote: .lemmy.addUpvote
+        case .downvote: .lemmy.addDownvote
         }
     }
     

--- a/Mlem/App/Utility/Extensions/FederationMode+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/FederationMode+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  FederationMode+Extensions.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-11-30.
+//  
+
+import Foundation
+import Theming
+import MlemMiddleware
+
+extension FederationMode {
+    var label: LocalizedStringResource {
+        switch self {
+        case .all: "Enabled"
+        case .local: "Local Only"
+        case .disable: "Disabled"
+        }
+    }
+    
+    var color: ThemedColor {
+        switch self {
+        case .all: .themedPositive
+        case .local: .themedWarning
+        case .disable: .themedNegative
+        }
+    }
+}

--- a/Mlem/App/Views/Pages/Instance/InstanceDetailsView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceDetailsView.swift
@@ -10,6 +10,7 @@ import MlemMiddleware
 import SwiftUI
 import Theming
 
+// swiftlint:disable:next type_body_length
 struct InstanceDetailsView: View {
     @State private var showingSlurRegex: Bool = false
     @State var uptimeData: UptimeDataStatus?
@@ -121,6 +122,34 @@ struct InstanceDetailsView: View {
                 }
             }
         }
+
+        FormSection {
+            VStack(alignment: .leading, spacing: 0) {
+                voteFederationRow(
+                    "Post Upvotes",
+                    type: .upvote,
+                    value: instance.voteFederationMode_?.postUpvote ?? .all
+                )
+                Divider()
+                voteFederationRow(
+                    "Post Downvotes",
+                    type: .downvote,
+                    value: instance.voteFederationMode_?.commentDownvote ?? .all
+                )
+                Divider()
+                voteFederationRow(
+                    "Comment Upvotes",
+                    type: .upvote,
+                    value: instance.voteFederationMode_?.commentUpvote ?? .all
+                )
+                Divider()
+                voteFederationRow(
+                    "Comment Downvotes",
+                    type: .downvote,
+                    value: instance.voteFederationMode_?.commentDownvote ?? .all
+                )
+            }
+        }
         
         FormSection {
             VStack(alignment: .leading, spacing: 0) {
@@ -128,12 +157,6 @@ struct InstanceDetailsView: View {
                     "NSFW Content",
                     icon: .settings.blurNsfw,
                     value: instance.nsfwContentEnabled_ ?? false
-                )
-                Divider()
-                settingRow(
-                    "Downvotes",
-                    icon: .lemmy.downvoted,
-                    value: instance.downvotesEnabled_ ?? false
                 )
                 Divider()
                 settingRow(
@@ -246,6 +269,20 @@ struct InstanceDetailsView: View {
             color: value ? .themedPositive : .themedNegative
         )
     }
+
+    @ViewBuilder
+    func voteFederationRow(
+        _ label: LocalizedStringResource,
+        type: ScoringOperation,
+        value: FederationMode
+    ) -> some View {
+        settingRow(
+            label,
+            icon: type.icon,
+            value: value.label,
+            color: value.color
+        )
+    }
     
     @ViewBuilder
     var uptimeSummary: some View {
@@ -256,11 +293,9 @@ struct InstanceDetailsView: View {
                 Spacer()
                 
                 if case .success = uptimeData {
-                    // NavigationLink(.instanceUptime(instance: instance, uptimeData: uptimeData)) {
                     (Text("Details") + Text(verbatim: " ") + Text(Image(icon: .general.forward)))
                         .font(.footnote)
                         .foregroundStyle(.themedAccent)
-                    // }
                 }
             }
             

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/InstanceCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/InstanceCaches.swift
@@ -74,7 +74,7 @@ class Instance2Cache: ApiTypeBackedCache<Instance2, Instance2Snapshot> {
             api: api,
             instance1: api.caches.instance1.getModel(api: api, from: snapshot.instance),
             setup: snapshot.setup,
-            downvotesEnabled: snapshot.downvotesEnabled,
+            voteFederationMode: snapshot.voteFederationMode,
             nsfwContentEnabled: snapshot.nsfwContentEnabled,
             communityCreationRestrictedToAdmins: snapshot.communityCreationRestrictedToAdmins,
             emailVerificationRequired: snapshot.emailVerificationRequired,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Instance+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Instance+CacheExtensions.swift
@@ -32,7 +32,7 @@ extension Instance2: CacheIdentifiable {
         instance1.update(with: snapshot.instance)
         
         setIfChanged(\.setup, snapshot.setup)
-        setIfChanged(\.downvotesEnabled, snapshot.downvotesEnabled)
+        setIfChanged(\.voteFederationMode, snapshot.voteFederationMode)
         setIfChanged(\.nsfwContentEnabled, snapshot.nsfwContentEnabled)
         setIfChanged(\.communityCreationRestrictedToAdmins, snapshot.communityCreationRestrictedToAdmins)
         setIfChanged(\.emailVerificationRequired, snapshot.emailVerificationRequired)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/FederationPolicy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/FederationPolicy.swift
@@ -31,3 +31,28 @@ public struct FederationPolicy {
         self.blocked = blocked
     }
 }
+
+public enum FederationMode: Hashable {
+    case all, local, disable
+}
+
+public struct VoteFederationMode: Hashable {
+    public let postUpvote: FederationMode
+    public let postDownvote: FederationMode
+    public let commentUpvote: FederationMode
+    public let commentDownvote: FederationMode
+
+    public static let all: Self = .init(
+        postUpvote: .all,
+        postDownvote: .all,
+        commentUpvote: .all,
+        commentDownvote: .all
+    )
+
+    public static let downvotesDisabled: Self = .init(
+        postUpvote: .all,
+        postDownvote: .disable,
+        commentUpvote: .all,
+        commentDownvote: .disable
+    )
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance2.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance2.swift
@@ -17,7 +17,8 @@ public final class Instance2: Instance2Providing {
     public let instance1: Instance1
     
     public var setup: Bool
-    public var downvotesEnabled: Bool
+
+    public var voteFederationMode: VoteFederationMode
     public var nsfwContentEnabled: Bool
     public var communityCreationRestrictedToAdmins: Bool
     public var emailVerificationRequired: Bool
@@ -49,7 +50,7 @@ public final class Instance2: Instance2Providing {
         api: ApiClient,
         instance1: Instance1,
         setup: Bool,
-        downvotesEnabled: Bool,
+        voteFederationMode: VoteFederationMode,
         nsfwContentEnabled: Bool,
         communityCreationRestrictedToAdmins: Bool,
         emailVerificationRequired: Bool,
@@ -79,7 +80,7 @@ public final class Instance2: Instance2Providing {
         self.api = api
         self.instance1 = instance1
         self.setup = setup
-        self.downvotesEnabled = downvotesEnabled
+        self.voteFederationMode = voteFederationMode
         self.nsfwContentEnabled = nsfwContentEnabled
         self.communityCreationRestrictedToAdmins = communityCreationRestrictedToAdmins
         self.emailVerificationRequired = emailVerificationRequired

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance2Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/Instance2Providing.swift
@@ -11,7 +11,7 @@ public protocol Instance2Providing: Instance1Providing {
     var instance2: Instance2 { get }
     
     var setup: Bool { get }
-    var downvotesEnabled: Bool { get }
+    var voteFederationMode: VoteFederationMode { get }
     var nsfwContentEnabled: Bool { get }
     var communityCreationRestrictedToAdmins: Bool { get }
     var emailVerificationRequired: Bool { get }
@@ -44,7 +44,7 @@ public extension Instance2Providing {
     var instance1: Instance1 { instance2.instance1 }
     
     var setup: Bool { instance2.setup }
-    var downvotesEnabled: Bool { instance2.downvotesEnabled }
+    var voteFederationMode: VoteFederationMode { instance2.voteFederationMode }
     var nsfwContentEnabled: Bool { instance2.nsfwContentEnabled }
     var communityCreationRestrictedToAdmins: Bool { instance2.communityCreationRestrictedToAdmins }
     var emailVerificationRequired: Bool { instance2.emailVerificationRequired }
@@ -72,7 +72,7 @@ public extension Instance2Providing {
     var activeUserCount: ActiveUserCount { instance2.activeUserCount }
 
     var setup_: Bool? { instance2.setup }
-    var downvotesEnabled_: Bool? { instance2.downvotesEnabled }
+    var voteFederationMode_: VoteFederationMode? { instance2.voteFederationMode }
     var nsfwContentEnabled_: Bool? { instance2.nsfwContentEnabled }
     var communityCreationRestrictedToAdmins_: Bool? { instance2.communityCreationRestrictedToAdmins }
     var emailVerificationRequired_: Bool? { instance2.emailVerificationRequired }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/InstanceStubProviding.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/InstanceStubProviding.swift
@@ -27,7 +27,7 @@ public protocol InstanceStubProviding: ActorIdentifiable, ContentModel {
     
     // From Instance2Providing. These are defined as nil in the extension below
     var setup_: Bool? { get }
-    var downvotesEnabled_: Bool? { get }
+    var voteFederationMode_: VoteFederationMode? { get }
     var nsfwContentEnabled_: Bool? { get }
     var communityCreationRestrictedToAdmins_: Bool? { get }
     var emailVerificationRequired_: Bool? { get }
@@ -77,7 +77,7 @@ public extension InstanceStubProviding {
     var contentWarning_: String? { nil }
     
     var setup_: Bool? { nil }
-    var downvotesEnabled_: Bool? { nil }
+    var voteFederationMode_: VoteFederationMode? { nil }
     var nsfwContentEnabled_: Bool? { nil }
     var communityCreationRestrictedToAdmins_: Bool? { nil }
     var emailVerificationRequired_: Bool? { nil }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/FederationMode+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/FederationMode+Lemmy.swift
@@ -1,0 +1,18 @@
+//
+//  FederationMode+Lemmy.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-11-30.
+//
+
+import Foundation
+
+extension FederationMode {
+    init(from federationMode: LemmyFederationMode) {
+        self = switch federationMode {
+        case .all: .all
+        case .local: .local
+        case .disable: .disable
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/Instance2Snapshot+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/Instance2Snapshot+Lemmy.swift
@@ -64,10 +64,28 @@ extension Instance2Snapshot {
             )
         }
 
+        let voteFederationMode: VoteFederationMode
+        if let commentDownvotes = site.localSite.commentDownvotes,
+            let commentUpvotes = site.localSite.commentUpvotes,
+            let postDownvotes = site.localSite.postDownvotes,
+            let postUpvotes = site.localSite.postUpvotes
+        {
+            voteFederationMode = .init(
+                postUpvote: .init(from: postUpvotes),
+                postDownvote: .init(from: postDownvotes),
+                commentUpvote: .init(from: commentUpvotes),
+                commentDownvote: .init(from: commentDownvotes)
+            )
+        } else if let enableDownvotes = site.localSite.enableDownvotes {
+            voteFederationMode = enableDownvotes ? .all : .downvotesDisabled
+        } else {
+            throw .responseMissingRequiredData("LemmySiteView downvoteFederationMode")
+        }
+
         try self.init(
             instance: .init(from: site.site),
             setup: site.localSite.siteSetup,
-            downvotesEnabled: site.localSite.enableDownvotes ?? false, // TODO: 1.0 support
+            voteFederationMode: voteFederationMode,
             nsfwContentEnabled: nsfwContentEnabled,
             communityCreationRestrictedToAdmins: site.localSite.communityCreationAdminOnly,
             emailVerificationRequired: site.localSite.requireEmailVerification,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Instance2Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Instance2Snapshot+PieFed.swift
@@ -20,7 +20,7 @@ public extension Instance2Snapshot {
         }
         
         guard let registrationMode = pieFed.registrationMode else {
-            throw ApiClientError.responseMissingRequiredData("PieFedSite downvotesEnabled")
+            throw ApiClientError.responseMissingRequiredData("PieFedSite registrationMode")
         }
 
         let counts = lemmy.counts
@@ -34,7 +34,7 @@ public extension Instance2Snapshot {
         try self.init(
             instance: .init(from: pieFed),
             setup: true,
-            downvotesEnabled: enableDownvotes,
+            voteFederationMode: enableDownvotes ? .all : .downvotesDisabled,
             nsfwContentEnabled: false,
             communityCreationRestrictedToAdmins: false,
             emailVerificationRequired: true,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Instance/Instance2Snapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/Instance/Instance2Snapshot.swift
@@ -15,7 +15,7 @@ public struct Instance2Snapshot: CacheIdentifiable {
     // May change. If you add/remove items from this list,
     // remember to also amend the `update` method of Post2!
     public var setup: Bool
-    public var downvotesEnabled: Bool
+    public var voteFederationMode: VoteFederationMode
     public var nsfwContentEnabled: Bool
     public var communityCreationRestrictedToAdmins: Bool
     public var emailVerificationRequired: Bool
@@ -47,7 +47,7 @@ public struct Instance2Snapshot: CacheIdentifiable {
     public init(
         instance: Instance1Snapshot,
         setup: Bool,
-        downvotesEnabled: Bool,
+        voteFederationMode: VoteFederationMode,
         nsfwContentEnabled: Bool,
         communityCreationRestrictedToAdmins: Bool,
         emailVerificationRequired: Bool,
@@ -76,7 +76,7 @@ public struct Instance2Snapshot: CacheIdentifiable {
     ) {
         self.instance = instance
         self.setup = setup
-        self.downvotesEnabled = downvotesEnabled
+        self.voteFederationMode = voteFederationMode
         self.nsfwContentEnabled = nsfwContentEnabled
         self.communityCreationRestrictedToAdmins = communityCreationRestrictedToAdmins
         self.emailVerificationRequired = emailVerificationRequired


### PR DESCRIPTION
In Lemmy 0.19, there was a `downvotesEnabled` instance setting. In Lemmy 1.0, this has been replaced with four new settings:
- Post upvotes
- Post downvotes
- Comment upvotes
- Comment downvotes

Each setting is a three-case enum:
- On
- Off
- Local only

This PR adds support for those settings.

I have _not_ added support for hiding the upvote button when "post upvotes" or "comment upvotes" is disabled. This is because the action system will be replaced soon anyways. I have added support for this to the new action system.

Closes #2450