### PR TITLE
Fix only top-level comments showing on Lemmy 1.0

### DIFF
--- a/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
@@ -174,8 +174,10 @@ class CommentTreeTracker: Hashable {
         var output: [CommentTreeNode] = clear ? [] : nodes
         var commentsKeyedById: [Int: CommentTreeNode] = [:]
         var commentsKeyedByActorId: [ActorIdentifier: CommentTreeNode] = clear ? [:] : nodesKeyedByActorId
+
+        var sortedComments = newComments.sorted { $0.depth < $1.depth }
         
-        for comment in await self.sortComments(newComments) {
+        for comment in sortedComments {
             if commentsKeyedByActorId.keys.contains(comment.actorId) {
                 commentsKeyedById[comment.id] = commentsKeyedByActorId[comment.actorId]
                 continue
@@ -195,14 +197,6 @@ class CommentTreeTracker: Hashable {
         nodesKeyedByActorId = commentsKeyedByActorId
     }
 
-    private func sortComments(_ comments: [Comment2]) async -> any Sequence<Comment2> {
-        guard let first = comments.first else { return [] }
-        if (try? await first.api.supports(.commentTreeSortedByDepthAscending)) ?? false {
-            return comments
-        }
-        return comments.sorted { $0.depth < $1.depth }
-    }
-    
     private func resolveCommentTree(comments newComments: [Comment2]) {
         var commentsKeyedById: [Int: CommentTreeNode] = [:]
         

--- a/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
@@ -175,14 +175,7 @@ class CommentTreeTracker: Hashable {
         var commentsKeyedById: [Int: CommentTreeNode] = [:]
         var commentsKeyedByActorId: [ActorIdentifier: CommentTreeNode] = clear ? [:] : nodesKeyedByActorId
         
-        let sortedComments: [Comment2]
-        if await (try? newComments.first?.api.supports(.commentTreeSortedByDepth)) ?? false {
-            sortedComments = newComments
-        } else {
-            sortedComments = newComments.sorted { $0.depth < $1.depth }
-        }
-        
-        for comment in sortedComments {
+        for comment in await self.sortComments(newComments) {
             if commentsKeyedByActorId.keys.contains(comment.actorId) {
                 commentsKeyedById[comment.id] = commentsKeyedByActorId[comment.actorId]
                 continue
@@ -200,6 +193,14 @@ class CommentTreeTracker: Hashable {
         }
         nodes = output
         nodesKeyedByActorId = commentsKeyedByActorId
+    }
+
+    private func sortComments(_ comments: [Comment2]) async -> any Sequence<Comment2> {
+        guard let first = comments.first else { return [] }
+        if (try? await first.api.supports(.commentTreeSortedByDepthAscending)) ?? false {
+            return comments
+        }
+        return comments.sorted { $0.depth < $1.depth }
     }
     
     private func resolveCommentTree(comments newComments: [Comment2]) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -47,7 +47,6 @@ public enum Feature: Hashable {
     case editModeratorList
     case editCommunityDescription
     
-    case commentTreeSortedByDepthAscending
     case uploadImages
     case commentSearch
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -47,7 +47,7 @@ public enum Feature: Hashable {
     case editModeratorList
     case editCommunityDescription
     
-    case commentTreeSortedByDepth
+    case commentTreeSortedByDepthAscending
     case uploadImages
     case commentSearch
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -43,8 +43,6 @@ public extension LemmyConnection {
              .hidePosts, .editDisplayName, .editProfile, .autoMarkPostReadOnInteract, .blockInstances,
              .fetchLinkMetadata, .unbanWithReason, .customPostThumbnail, .banFromNonLocalCommunity, .editCommunityDescription:
             true
-        case .commentTreeSortedByDepthAscending:
-            version < .v1_0_0
         case .moderatorSetNsfw:
             false
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -36,13 +36,15 @@ public extension LemmyConnection {
         case let .listingType(listingType):
             version >= listingType.minimumVersion
         case .searchLocalCommunities, .viewInstanceSettings, .viewInstanceCreationDate, .modlog,
-             .logIn, .signUp, .viewCommunityActiveUsers, .commentTreeSortedByDepth, .uploadImages,
+             .logIn, .signUp, .viewCommunityActiveUsers, .uploadImages,
              .editAccountSettings, .viewMentionsAndPrivateMessages, .viewReports, .editAndDeletePrivateMessages,
              .reportPrivateMessages, .viewVotes, .purgeContent, .removeCommunity, .banFromInstance,
              .banFromCommunity, .editModeratorList, .commentSearch, .undeletePrivateMessages, .searchLocalPeople,
              .hidePosts, .editDisplayName, .editProfile, .autoMarkPostReadOnInteract, .blockInstances,
              .fetchLinkMetadata, .unbanWithReason, .customPostThumbnail, .banFromNonLocalCommunity, .editCommunityDescription:
             true
+        case .commentTreeSortedByDepthAscending:
+            version < .v1_0_0
         case .moderatorSetNsfw:
             false
         }


### PR DESCRIPTION
On Lemmy 0.19, comments were sorted by depth ascending, which our logic relied upon. In Lemmy 1.0, they are sorted by depth descending.