### PR TITLE
Support PieFed in the test inbox

### DIFF
--- a/Mlem/App/Views/Shared/TestInboxView.swift
+++ b/Mlem/App/Views/Shared/TestInboxView.swift
@@ -86,11 +86,11 @@ private struct TestInboxSectionView: View {
         do {
             switch type {
             case .reply:
-                notifications = try await appState.firstApi.getReplyNotifications()
+                notifications = try await appState.firstApi.getReplyNotifications(page: 1, limit: 5, unreadOnly: false)
             case .mention:
-                notifications = try await appState.firstApi.getMentionNotifications()
+                notifications = try await appState.firstApi.getMentionNotifications(page: 1, limit: 5, unreadOnly: false)
             case .message:
-                notifications = try await appState.firstApi.getMessageNotifications()
+                notifications = try await appState.firstApi.getMessageNotifications(page: 1, limit: 5, unreadOnly: false)
             }
         } catch {
             handleError(error)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -58,21 +58,45 @@ public extension ApiClient {
         )
     }
 
-    func getReplyNotifications() async throws -> [InboxNotification] {
+    func getReplyNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotification] {
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
-        let snapshots = try await repository.getReplyNotifications()
+        let snapshots = try await repository.getReplyNotifications(
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
         return await caches.notification.getModels(api: self, from: snapshots, myPersonId: myPersonId)
     }
     
-    func getMentionNotifications() async throws -> [InboxNotification] {
+    func getMentionNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotification] {
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
-        let snapshots = try await repository.getMentionNotifications()
+        let snapshots = try await repository.getMentionNotifications(
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
         return await caches.notification.getModels(api: self, from: snapshots, myPersonId: myPersonId)
     }
 
-    func getMessageNotifications() async throws -> [InboxNotification] {
+    func getMessageNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotification] {
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
-        let snapshots = try await repository.getMessageNotifications()
+        let snapshots = try await repository.getMessageNotifications(
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
         return await caches.notification.getModels(api: self, from: snapshots, myPersonId: myPersonId)
     }
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
@@ -54,21 +54,45 @@ extension ApiRepository {
         }
     }
 
-    func getReplyNotifications() async throws -> [InboxNotificationSnapshot] {
+    func getReplyNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot] {
         try await performingForConnection { connection in
-            try await connection.getReplyNotifications()
+            try await connection.getReplyNotifications(
+                page: page,
+                limit: limit,
+                unreadOnly: unreadOnly
+            )
         }
     }
     
-    func getMentionNotifications() async throws -> [InboxNotificationSnapshot] {
+    func getMentionNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot] {
         try await performingForConnection { connection in
-            try await connection.getMentionNotifications()
+            try await connection.getMentionNotifications(
+                page: page,
+                limit: limit,
+                unreadOnly: unreadOnly
+            )
         }
     }
 
-    func getMessageNotifications() async throws -> [InboxNotificationSnapshot] {
+    func getMessageNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot] {
         try await performingForConnection { connection in
-            try await connection.getMessageNotifications()
+            try await connection.getMessageNotifications(
+                page: page,
+                limit: limit,
+                unreadOnly: unreadOnly
+            )
         }
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Comment2Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Comment2Snapshot+PieFed.swift
@@ -48,4 +48,24 @@ public extension Comment2Snapshot {
             saved: report.saved
         )
     }
+
+    init(from reply: PieFedCommentReplyView) throws(ApiClientError) {
+        let votes: VotesModel = .init(
+            from: reply.counts,
+            myVote: .guaranteedInit(from: reply.myVote)
+        )
+
+        try self.init(
+            comment: .init(from: reply.comment),
+            creator: .init(from: reply.creator),
+            post: .init(from: reply.post),
+            community: .init(from: reply.community),
+            commentCount: reply.counts.childCount,
+            creatorIsModerator: reply.creatorIsModerator,
+            creatorIsAdmin: reply.creatorIsAdmin,
+            creatorBannedFromCommunity: reply.creatorBannedFromCommunity,
+            votes: votes,
+            saved: reply.saved
+        )
+    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/InboxNotificationSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/InboxNotificationSnapshot+PieFed.swift
@@ -1,0 +1,25 @@
+//
+//  InboxNotificationSnapshot+PieFed.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-12-22.
+//
+
+import Foundation
+
+extension InboxNotificationSnapshot {
+    init(from replyView: PieFedCommentReplyView) throws(ApiClientError) {
+        try self.init(
+            id: LegacyNotificationIdWrapper(type: .reply, id: replyView.commentReply.id).hashValue,
+            contentId: replyView.commentReply.id,
+            read: replyView.commentReply.read,
+            content: .reply(.init(from: replyView))
+        )
+    }
+}
+
+// This can be removed once we drop support for < Lemmy 1.0
+private struct LegacyNotificationIdWrapper: Hashable {
+    let type: InboxNotificationContentType
+    let id: Int
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/InboxNotificationSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/InboxNotificationSnapshot+PieFed.swift
@@ -8,12 +8,21 @@
 import Foundation
 
 extension InboxNotificationSnapshot {
-    init(from replyView: PieFedCommentReplyView) throws(ApiClientError) {
+    init(from replyView: PieFedCommentReplyView, isMention: Bool) throws(ApiClientError) {
         try self.init(
-            id: LegacyNotificationIdWrapper(type: .reply, id: replyView.commentReply.id).hashValue,
+            id: LegacyNotificationIdWrapper(type: isMention ? .mention : .reply, id: replyView.commentReply.id).hashValue,
             contentId: replyView.commentReply.id,
             read: replyView.commentReply.read,
             content: .reply(.init(from: replyView))
+        )
+    }
+
+    init(from messageView: PieFedPrivateMessageView) throws(ApiClientError) {
+        try self.init(
+            id: LegacyNotificationIdWrapper(type: .message, id: messageView.privateMessage.id).hashValue,
+            contentId: messageView.privateMessage.id,
+            read: messageView.privateMessage.read,
+            content: .message(.init(from: messageView))
         )
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -438,9 +438,23 @@ public protocol InstanceConnection {
         unreadOnly: Bool
     ) async throws -> [Message2Snapshot]
     
-    func getReplyNotifications() async throws -> [InboxNotificationSnapshot]
-    func getMentionNotifications() async throws -> [InboxNotificationSnapshot]
-    func getMessageNotifications() async throws -> [InboxNotificationSnapshot]
+    func getReplyNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot]
+
+    func getMentionNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot]
+
+    func getMessageNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot]
 
     func markNotificationAsRead(
         type: InboxNotificationContentType,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -59,36 +59,48 @@ public extension LemmyConnection {
         return try response.privateMessages.map { try .init(from: $0) }
     }
     
-    func getReplyNotifications() async throws -> [InboxNotificationSnapshot] {
+    func getReplyNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot] {
         let response = try await performingForEndpoint { _ in
             LemmyListRepliesRequest(
                 sort: .new,
-                page: 1,
-                limit: 5,
-                unreadOnly: false
+                page: page,
+                limit: limit,
+                unreadOnly: unreadOnly
             )
         }
         return try response.replies.map { try .init(from: $0) }
     }
 
-    func getMentionNotifications() async throws -> [InboxNotificationSnapshot] {
+    func getMentionNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot] {
         let response = try await performingForEndpoint { _ in
             LemmyListMentionsRequest(
                 sort: .new,
-                page: 1,
-                limit: 5,
-                unreadOnly: false
+                page: page,
+                limit: limit,
+                unreadOnly: unreadOnly
             )
         }
         return try response.mentions.map { try .init(from: $0) }
     }
 
-    func getMessageNotifications() async throws -> [InboxNotificationSnapshot] {
+    func getMessageNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot] {
         let response = try await performingForEndpoint { _ in
             LemmyGetPrivateMessageRequest(
-                unreadOnly: false,
-                page: 1,
-                limit: 5,
+                unreadOnly: unreadOnly,
+                page: page,
+                limit: limit,
                 creatorId: nil
             )
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -127,7 +127,14 @@ public extension PieFedConnection {
         contentId: Int,
         read: Bool
     ) async throws {
-        throw ApiClientError.featureUnsupported
+        switch type {
+        case .reply:
+            try await self.markReplyAsRead(id: contentId, read: read)
+        case .mention:
+            try await self.markMentionAsRead(id: contentId, read: read)
+        case .message:
+            try await self.markMessageAsRead(id: contentId, read: read)
+        }
     }
 
     func markAllAsRead() async throws {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -96,7 +96,14 @@ public extension PieFedConnection {
         limit: Int,
         unreadOnly: Bool
     ) async throws -> [InboxNotificationSnapshot] {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedGetMentionsRequest(
+            sort: .new,
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
+        let response = try await perform(request)
+        return try response.replies.map { try .init(from: $0) }
     }
 
     func getMessageNotifications(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -81,7 +81,14 @@ public extension PieFedConnection {
         limit: Int,
         unreadOnly: Bool
     ) async throws -> [InboxNotificationSnapshot] {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedGetRepliesRequest(
+            sort: .new,
+            page: page,
+            limit: limit,
+            unreadOnly: unreadOnly
+        )
+        let response = try await perform(request)
+        return try response.replies.map { try .init(from: $0) }
     }
 
     func getMentionNotifications(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -76,15 +76,27 @@ public extension PieFedConnection {
         }
     }
     
-    func getReplyNotifications() async throws -> [InboxNotificationSnapshot] {
+    func getReplyNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot] {
         throw ApiClientError.featureUnsupported
     }
 
-    func getMentionNotifications() async throws -> [InboxNotificationSnapshot] {
+    func getMentionNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot] {
         throw ApiClientError.featureUnsupported
     }
 
-    func getMessageNotifications() async throws -> [InboxNotificationSnapshot] {
+    func getMessageNotifications(
+        page: Int,
+        limit: Int,
+        unreadOnly: Bool
+    ) async throws -> [InboxNotificationSnapshot] {
         throw ApiClientError.featureUnsupported
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -88,7 +88,7 @@ public extension PieFedConnection {
             unreadOnly: unreadOnly
         )
         let response = try await perform(request)
-        return try response.replies.map { try .init(from: $0) }
+        return try response.replies.map { try .init(from: $0, isMention: false) }
     }
 
     func getMentionNotifications(
@@ -103,7 +103,7 @@ public extension PieFedConnection {
             unreadOnly: unreadOnly
         )
         let response = try await perform(request)
-        return try response.replies.map { try .init(from: $0) }
+        return try response.replies.map { try .init(from: $0, isMention: true) }
     }
 
     func getMessageNotifications(
@@ -111,7 +111,14 @@ public extension PieFedConnection {
         limit: Int,
         unreadOnly: Bool
     ) async throws -> [InboxNotificationSnapshot] {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedListPrivateMessagesRequest(
+            unreadOnly: unreadOnly,
+            page: page,
+            limit: limit,
+            creatorId: nil
+        )
+        let response = try await perform(request)
+        return try response.privateMessages.map { try .init(from: $0) }
     }
     
     func markNotificationAsRead(


### PR DESCRIPTION
Closes #2339

I'm considering rewriting the current inbox feed loader to use `InboxNotification` soon-ish. It looks relatively easy to do. It may need rewriting again to support the Lemmy 1.0 code, but we've got too many things in a half-finished state and I'd like to get this new system into production.