### PR TITLE
New action system for posts

### DIFF
--- a/Mlem/App/Actions/BanAction.swift
+++ b/Mlem/App/Actions/BanAction.swift
@@ -72,6 +72,7 @@ extension ActionSeed {
     static let banCreator = ActionSeed("banCreator") { entity in
         switch entity {
         case let entity as any Comment2Providing: BanAction(entity: entity.creator)
+        case let entity as any Post2Providing: BanAction(entity: entity.creator)
         default: nil
         }
     }

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -10,7 +10,7 @@ import MlemMiddleware
 import SwiftUI
 
 struct BlockAction: Actions.Action {
-    enum Relationship { case identity, commentAuthor }
+    enum Relationship { case identity, author }
 
     let entity: any Person1Providing
     let relationship: Relationship
@@ -31,10 +31,11 @@ extension ActionSeed {
 
     static let blockCreator = ActionSeed(
         "blockCreator",
-        label: BlockAction.createLabel(relationship: .commentAuthor, mode: .block)
+        label: BlockAction.createLabel(relationship: .author, mode: .block)
     ) { entity in
         switch entity {
-        case let entity as any Comment2Providing: BlockAction(entity: entity.creator, relationship: .commentAuthor)
+        case let entity as any Comment2Providing: BlockAction(entity: entity.creator, relationship: .author)
+        case let entity as any Post2Providing: BlockAction(entity: entity.creator, relationship: .author)
         default: nil
         }
     }
@@ -49,8 +50,8 @@ extension BlockAction {
         let label: LocalizedStringResource = switch (relationship, mode) {
         case (.identity, .block): "Block"
         case (.identity, .unblock): "Unblock"
-        case (.commentAuthor, .block): "Block User"
-        case (.commentAuthor, .unblock): "Unblock User"
+        case (.author, .block): "Block User"
+        case (.author, .unblock): "Unblock User"
         }
 
         return switch mode {

--- a/Mlem/App/Actions/ContextMenu+Post.swift
+++ b/Mlem/App/Actions/ContextMenu+Post.swift
@@ -17,6 +17,7 @@ private let seeds: [ActionSeed] = [
     .reply,
     .selectText,
     .share,
+    .hide,
     .createImage,
     .report,
     .blockCreator,

--- a/Mlem/App/Actions/ContextMenu+Post.swift
+++ b/Mlem/App/Actions/ContextMenu+Post.swift
@@ -26,6 +26,7 @@ private let seeds: [ActionSeed] = [
 ]
 
 private let moderationSeeds: [ActionSeed] = [
+    .lock,
     .viewVotes,
     .remove,
     .banCreator,

--- a/Mlem/App/Actions/ContextMenu+Post.swift
+++ b/Mlem/App/Actions/ContextMenu+Post.swift
@@ -1,0 +1,84 @@
+//
+//  ContextMenu+Post.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-12-23.
+//
+
+import Actions
+import Icons
+import MlemMiddleware
+import SwiftUI
+
+private let seeds: [ActionSeed] = [
+    .upvote,
+    .downvote,
+    .save,
+    .reply,
+    .selectText,
+    .share,
+    .createImage,
+    .report,
+    .blockCreator,
+    .edit,
+    .delete
+]
+
+private let moderationSeeds: [ActionSeed] = [
+    .viewVotes,
+    .remove,
+    .banCreator,
+    .purge,
+    .purgeCreator
+]
+
+extension View {
+    func contextMenu(post: any Post1Providing) -> some View {
+        contextMenu {
+            ActionButtons { _ in
+                seeds.compactMap { $0.createAction(post) }
+            }
+        }
+    }
+}
+
+extension EllipsisMenu {
+    init(
+        icon: Icon = .general.menu,
+        size: CGFloat,
+        post: any Post1Providing,
+        type: Set<PostEllipsisMenuContent.ActionListType> = [.basic, .moderator]
+    ) where Content == PostEllipsisMenuContent {
+        self.icon = icon
+        self.size = size
+
+        self.content = PostEllipsisMenuContent(post: post, type: type)
+    }
+}
+
+struct PostEllipsisMenuContent: View {
+    enum ActionListType {
+        case basic, moderator
+    }
+
+    let post: any Post1Providing
+    let type: Set<ActionListType>
+
+    var body: some View {
+        if type.contains(.basic) {
+            ControlGroup {
+                ActionButtons { _ in
+                    seeds.compactMap { $0.createAction(post) }
+                }
+            }
+            .controlGroupStyle(.compactMenu)
+        }
+        if type.contains(.moderator) {
+            Section {
+                ActionButtons { _ in
+                    moderationSeeds.compactMap { $0.createAction(post) }
+                }
+            }
+        }
+    }
+}

--- a/Mlem/App/Actions/ContextMenu+Post.swift
+++ b/Mlem/App/Actions/ContextMenu+Post.swift
@@ -26,6 +26,7 @@ private let seeds: [ActionSeed] = [
 ]
 
 private let moderationSeeds: [ActionSeed] = [
+    .pin,
     .lock,
     .viewVotes,
     .remove,

--- a/Mlem/App/Actions/ContextMenu+Post.swift
+++ b/Mlem/App/Actions/ContextMenu+Post.swift
@@ -28,6 +28,7 @@ private let seeds: [ActionSeed] = [
 private let moderationSeeds: [ActionSeed] = [
     .pin,
     .lock,
+    .markNsfw,
     .viewVotes,
     .remove,
     .banCreator,

--- a/Mlem/App/Actions/CreateImageAction.swift
+++ b/Mlem/App/Actions/CreateImageAction.swift
@@ -40,12 +40,7 @@ extension CreateImageAction {
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
-        switch content {
-        case .post:
-            environment.feedContext == .post ? .enabled : .hidden
-        case .comment:
-            .enabled
-        }
+        environment.feedContext == .post ? .enabled : .hidden
     }
 }
 

--- a/Mlem/App/Actions/CreateImageAction.swift
+++ b/Mlem/App/Actions/CreateImageAction.swift
@@ -34,6 +34,19 @@ extension ActionSeed {
 
 extension CreateImageAction {
     static let label: ActionLabel = .init("Create Image", icon: .general.createImage)
+
+    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+        Self.label.withVisibility(visibility(environment))
+    }
+
+    private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
+        switch content {
+        case .post:
+            environment.feedContext == .post ? .enabled : .hidden
+        case .comment:
+            .enabled
+        }
+    }
 }
 
 // MARK: - Behavior

--- a/Mlem/App/Actions/HideAction.swift
+++ b/Mlem/App/Actions/HideAction.swift
@@ -1,0 +1,74 @@
+//
+//  HideAction.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-12-23.
+//
+
+import Actions
+import MlemMiddleware
+import SwiftUI
+
+struct HideAction: SimpleLabelAction {
+    let entity: any Post2Providing
+}
+
+// MARK: - Configurability
+
+extension ActionSeed {
+    static let hide = ActionSeed("hide") { entity in
+        switch entity {
+        case let entity as any Post2Providing: HideAction(entity: entity)
+        default: nil
+        }
+    }
+}
+
+// MARK: - Appearance
+
+extension HideAction {
+    static let hideLabel: ActionLabel = .init("Hide", icon: .general.hide)
+    static let showLabel: ActionLabel = .init("Show", icon: .general.show)
+    
+    static var label: ActionLabel { hideLabel }
+
+    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+        if entity.hidden {
+            Self.showLabel.withVisibility(visibility(environment))
+        } else {
+            Self.hideLabel.withVisibility(visibility(environment))
+        }
+    }
+
+    private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
+        if entity.api.canInteract(appState: environment.appState),
+            entity.api.supports(.hidePosts, defaultValue: false) {
+            .enabled
+        } else {
+            .hidden
+        }
+    }
+}
+
+// MARK: - Behavior
+
+extension HideAction {
+    @MainActor
+    func execute(environment: EnvironmentValues) {
+        entity.toggleHidden()
+        environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
+        if entity.hidden {
+            environment.toastModel?.add(
+                .undoable(
+                    "Hidden",
+                    icon: .general.hide,
+                    callback: {
+                        entity.updateHidden(false)
+                    }
+                )
+            )
+        } else {
+            environment.toastModel?.add(.success("Shown"))
+        }
+    }
+}

--- a/Mlem/App/Actions/LockAction.swift
+++ b/Mlem/App/Actions/LockAction.swift
@@ -41,10 +41,12 @@ extension LockAction {
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
-        if entity.api.canInteract(appState: environment.appState), entity.canModerate {
-            .enabled
+        if entity.api.canInteract(appState: environment.appState),
+           entity.canModerate,
+           Settings.get(\.menus_allModActions) || environment.feedContext == .post {
+            return .enabled
         } else {
-            .hidden
+            return .hidden
         }
     }
 }

--- a/Mlem/App/Actions/LockAction.swift
+++ b/Mlem/App/Actions/LockAction.swift
@@ -1,0 +1,66 @@
+//
+//  LockAction.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-12-23.
+//
+
+import Actions
+import MlemMiddleware
+import SwiftUI
+
+struct LockAction: SimpleLabelAction {
+    let entity: any Post2Providing
+}
+
+// MARK: - Configurability
+
+extension ActionSeed {
+    static let lock = ActionSeed("lock") { entity in
+        switch entity {
+        case let entity as any Post2Providing: LockAction(entity: entity)
+        default: nil
+        }
+    }
+}
+
+// MARK: - Appearance
+
+extension LockAction {
+    static let lockLabel: ActionLabel = .init("Lock", icon: .lemmy.addLock)
+    static let unlockLabel: ActionLabel = .init("Unlock", icon: .lemmy.removeLock)
+    
+    static var label: ActionLabel { lockLabel }
+
+    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+        if entity.locked {
+            Self.unlockLabel.withVisibility(visibility(environment))
+        } else {
+            Self.lockLabel.withVisibility(visibility(environment))
+        }
+    }
+
+    private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
+        if entity.api.canInteract(appState: environment.appState), entity.canModerate {
+            .enabled
+        } else {
+            .hidden
+        }
+    }
+}
+
+// MARK: - Behavior
+
+extension LockAction {
+    @MainActor
+    func execute(environment: EnvironmentValues) {
+        environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
+        environment.popupModel?.showPopup(
+            message: entity.locked ? "Really unlock this post?" : "Really lock this post?",
+            [
+            .init(title: "Yes", isDestructive: true) {
+                entity.toggleLocked()
+            }
+        ])
+    }
+}

--- a/Mlem/App/Actions/LockAction.swift
+++ b/Mlem/App/Actions/LockAction.swift
@@ -65,14 +65,35 @@ extension LockAction {
 extension LockAction {
     @MainActor
     func execute(environment: EnvironmentValues) {
-        environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
         environment.popupModel?.showPopup(
             message: entity.locked ? "Really unlock this post?" : "Really lock this post?",
             [
             .init(title: "Yes", isDestructive: true) {
-                environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
-                entity.toggleLocked()
+                let shouldLock = !entity.locked
+                entity.toggleLocked { status in
+                    self.handleResult(
+                        status: status,
+                        shouldLock: shouldLock,
+                        environment: environment
+                    )
+                }
             }
         ])
+    }
+
+    @MainActor
+    func handleResult(
+        status: UpdateStatus,
+        shouldLock: Bool,
+        environment: EnvironmentValues
+    ) {
+        switch status {
+        case .success:
+            environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
+        case .failure: 
+            environment.toastModel?.add(
+                .failure(shouldLock ? "Failed to lock post" : "Failed to unlock post")
+            )
+        }
     }
 }

--- a/Mlem/App/Actions/LockAction.swift
+++ b/Mlem/App/Actions/LockAction.swift
@@ -27,8 +27,17 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension LockAction {
-    static let lockLabel: ActionLabel = .init("Lock", icon: .lemmy.addLock)
-    static let unlockLabel: ActionLabel = .init("Unlock", icon: .lemmy.removeLock)
+    static let lockLabel: ActionLabel = .init(
+        "Lock",
+        icon: .lemmy.addLock,
+        color: .themedLockAccent
+    )
+
+    static let unlockLabel: ActionLabel = .init(
+        "Unlock",
+        icon: .lemmy.removeLock,
+        color: .themedLockAccent
+    )
     
     static var label: ActionLabel { lockLabel }
 

--- a/Mlem/App/Actions/LockAction.swift
+++ b/Mlem/App/Actions/LockAction.swift
@@ -59,6 +59,7 @@ extension LockAction {
             message: entity.locked ? "Really unlock this post?" : "Really lock this post?",
             [
             .init(title: "Yes", isDestructive: true) {
+                environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
                 entity.toggleLocked()
             }
         ])

--- a/Mlem/App/Actions/MarkNsfwAction.swift
+++ b/Mlem/App/Actions/MarkNsfwAction.swift
@@ -1,0 +1,84 @@
+//
+//  MarkNsfwAction.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-12-23.
+//
+
+import Actions
+import MlemMiddleware
+import SwiftUI
+
+struct MarkNsfwAction: SimpleLabelAction {
+    let entity: any Post2Providing
+}
+
+// MARK: - Configurability
+
+extension ActionSeed {
+    static let markNsfw = ActionSeed("markNsfw") { entity in
+        switch entity {
+        case let entity as any Post2Providing: MarkNsfwAction(entity: entity)
+        default: nil
+        }
+    }
+}
+
+// MARK: - Appearance
+
+extension MarkNsfwAction {
+    static let addLabel: ActionLabel = .init(
+        "Add NSFW Tag",
+        icon: .settings.blurNsfw,
+        color: .themedNegative
+    )
+
+    static let removeLabel: ActionLabel = .init(
+        "Remove Nsfw Tag",
+        icon: .settings.blurNsfw,
+        color: .themedNegative
+    )
+    
+    static var label: ActionLabel { addLabel }
+
+    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+        if entity.nsfw {
+            Self.removeLabel.withVisibility(visibility(environment))
+        } else {
+            Self.addLabel.withVisibility(visibility(environment))
+        }
+    }
+
+    private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
+        if entity.api.canInteract(appState: environment.appState),
+           entity.canModerate,
+           entity.community.apiIsLocal, // Setting NSFW doesn't work on non-local communities at the time of writing
+           entity.api.supports(.moderatorSetNsfw, defaultValue: false) {
+            return .enabled
+        } else {
+            return .hidden
+        }
+    }
+}
+
+// MARK: - Behavior
+
+extension MarkNsfwAction {
+    @MainActor
+    func execute(environment: EnvironmentValues) {
+        environment.popupModel?.showPopup(
+            message: entity.nsfw ? "Really remove NSFW tag?" : "Really add NSFW tag?",
+            [
+            .init(title: "Yes", isDestructive: true) {
+                entity.toggleNsfw { status in
+                    switch status {
+                    case .success:
+                        environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
+                    case .failure: 
+                        environment.toastModel?.add(.failure("Failed to set NSFW status"))
+                    }
+                }
+            }
+        ])
+    }
+}

--- a/Mlem/App/Actions/PinAction.swift
+++ b/Mlem/App/Actions/PinAction.swift
@@ -97,8 +97,7 @@ extension PinAction {
             message: entity.pinnedCommunity ? "Really unpin this post?" : "Really pin this post?",
             [
             .init(title: "Yes", isDestructive: false) {
-                environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
-                entity.togglePinnedCommunity()
+                togglePinnedCommunity(environment: environment)
             }
         ])
     }
@@ -109,14 +108,52 @@ extension PinAction {
             message: "Choose target...",
             [
                 .init(title: entity.pinnedCommunity ? "Unpin from community" : "Pin to community") {
-                    environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
-                    entity.togglePinnedCommunity()
+                    togglePinnedCommunity(environment: environment)
                 },
                 .init(title: entity.pinnedInstance ? "Unpin from instance" : "Pin to instance") {
-                    environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
-                    entity.togglePinnedInstance()
+                    togglePinnedInstance(environment: environment)
                 }
             ]
         )
+    }
+
+    @MainActor
+    func togglePinnedCommunity(environment: EnvironmentValues) {
+        let shouldPin = entity.pinnedCommunity
+        entity.togglePinnedCommunity { status in
+            handleResult(
+                status: status,
+                shouldPin: shouldPin,
+                environment: environment
+            )
+        }
+    }
+
+    @MainActor
+    func togglePinnedInstance(environment: EnvironmentValues) {
+        let shouldPin = entity.pinnedInstance
+        entity.togglePinnedInstance { status in
+            handleResult(
+                status: status,
+                shouldPin: shouldPin,
+                environment: environment
+            )
+        }
+    }
+
+    @MainActor
+    func handleResult(
+        status: UpdateStatus,
+        shouldPin: Bool,
+        environment: EnvironmentValues
+    ) {
+        switch status {
+        case .success:
+            environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
+        case .failure: 
+            environment.toastModel?.add(
+                .failure(shouldPin ? "Failed to pin post" : "Failed to unpin post")
+            )
+        }
     }
 }

--- a/Mlem/App/Actions/PinAction.swift
+++ b/Mlem/App/Actions/PinAction.swift
@@ -82,6 +82,7 @@ extension PinAction {
             message: entity.pinnedCommunity ? "Really unpin this post?" : "Really pin this post?",
             [
             .init(title: "Yes", isDestructive: false) {
+                environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
                 entity.togglePinnedCommunity()
             }
         ])
@@ -93,9 +94,11 @@ extension PinAction {
             message: "Choose target...",
             [
                 .init(title: entity.pinnedCommunity ? "Unpin from community" : "Pin to community") {
+                    environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
                     entity.togglePinnedCommunity()
                 },
                 .init(title: entity.pinnedInstance ? "Unpin from instance" : "Pin to instance") {
+                    environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
                     entity.togglePinnedInstance()
                 }
             ]

--- a/Mlem/App/Actions/PinAction.swift
+++ b/Mlem/App/Actions/PinAction.swift
@@ -1,0 +1,104 @@
+//
+//  PinAction.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2025-12-23.
+//
+
+import Actions
+import MlemMiddleware
+import SwiftUI
+
+struct PinAction: SimpleLabelAction {
+    let entity: any Post2Providing
+}
+
+// MARK: - Configurability
+
+extension ActionSeed {
+    static let pin = ActionSeed("pin") { entity in
+        switch entity {
+        case let entity as any Post2Providing: PinAction(entity: entity)
+        default: nil
+        }
+    }
+}
+
+// MARK: - Appearance
+
+extension PinAction {
+    static let pinLabel: ActionLabel = .init("Pin", icon: .lemmy.addPin)
+    static let unpinLabel: ActionLabel = .init("Unpin", icon: .lemmy.removePin)
+
+    static let pinDetailsLabel: ActionLabel = .init("Pin...", icon: .lemmy.addPin)
+    
+    static var label: ActionLabel { pinLabel }
+
+    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+        let label: ActionLabel = if entity.api.isAdmin {
+            switch (entity.pinnedInstance, entity.pinnedCommunity) {
+            case (true, true):
+                Self.unpinLabel
+            case (true, false), (false, true):
+                Self.pinDetailsLabel
+            case (false, false):
+                Self.pinLabel
+            }
+        } else {
+            if entity.pinnedCommunity {
+                Self.unpinLabel
+            } else {
+                Self.pinLabel
+            }
+        }
+
+        return label.withVisibility(visibility(environment))
+    }
+
+    private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
+        if entity.api.canInteract(appState: environment.appState), entity.canModerate {
+            .enabled
+        } else {
+            .hidden
+        }
+    }
+}
+
+// MARK: - Behavior
+
+extension PinAction {
+    @MainActor
+    func execute(environment: EnvironmentValues) {
+        if entity.api.isAdmin {
+            executeAsAdmin(environment: environment)
+        } else {
+            executeAsModerator(environment: environment)
+        }
+    }
+
+    @MainActor
+    func executeAsModerator(environment: EnvironmentValues) {
+        environment.popupModel?.showPopup(
+            message: entity.pinnedCommunity ? "Really unpin this post?" : "Really pin this post?",
+            [
+            .init(title: "Yes", isDestructive: false) {
+                entity.togglePinnedCommunity()
+            }
+        ])
+    }
+
+    @MainActor
+    func executeAsAdmin(environment: EnvironmentValues) {
+        environment.popupModel?.showPopup(
+            message: "Choose target...",
+            [
+                .init(title: entity.pinnedCommunity ? "Unpin from community" : "Pin to community") {
+                    entity.togglePinnedCommunity()
+                },
+                .init(title: entity.pinnedInstance ? "Unpin from instance" : "Pin to instance") {
+                    entity.togglePinnedInstance()
+                }
+            ]
+        )
+    }
+}

--- a/Mlem/App/Actions/PinAction.swift
+++ b/Mlem/App/Actions/PinAction.swift
@@ -56,7 +56,9 @@ extension PinAction {
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
-        if entity.api.canInteract(appState: environment.appState), entity.canModerate {
+        if entity.api.canInteract(appState: environment.appState),
+            entity.canModerate,
+            Settings.get(\.menus_allModActions) || environment.feedContext == .post {
             .enabled
         } else {
             .hidden

--- a/Mlem/App/Actions/PinAction.swift
+++ b/Mlem/App/Actions/PinAction.swift
@@ -27,10 +27,23 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension PinAction {
-    static let pinLabel: ActionLabel = .init("Pin", icon: .lemmy.addPin)
-    static let unpinLabel: ActionLabel = .init("Unpin", icon: .lemmy.removePin)
+    static let pinLabel: ActionLabel = .init(
+        "Pin",
+        icon: .lemmy.addPin,
+        color: .themedModeration
+    )
 
-    static let pinDetailsLabel: ActionLabel = .init("Pin...", icon: .lemmy.addPin)
+    static let unpinLabel: ActionLabel = .init(
+        "Unpin",
+        icon: .lemmy.removePin,
+        color: .themedModeration
+    )
+
+    static let pinDetailsLabel: ActionLabel = .init(
+        "Pin...",
+        icon: .lemmy.addPin,
+        color: .themedModeration
+    )
     
     static var label: ActionLabel { pinLabel }
 

--- a/Mlem/App/Actions/SelectTextAction.swift
+++ b/Mlem/App/Actions/SelectTextAction.swift
@@ -26,6 +26,8 @@ extension ActionSeed {
             SelectTextAction(text: entity.content)
         case let entity as any Comment1Providing:
             SelectTextAction(text: entity.content)
+        case let entity as any Post1Providing:
+            SelectTextAction(text: entity.selectableContent ?? "")
         default:
             nil
         }

--- a/Mlem/App/Actions/ViewVotesAction.swift
+++ b/Mlem/App/Actions/ViewVotesAction.swift
@@ -47,6 +47,8 @@ extension ViewVotesAction {
         guard let community = entity.community_ else { return .hidden }
         let canModerate = myPerson.moderates(communityId: community.id)
         guard canModerate else { return .hidden }
+
+        guard Settings.get(\.menus_allModActions) || environment.feedContext == .post else { return .hidden }
         guard entity.api.supports(.viewVotes, defaultValue: true) else { return .hidden }
 
         return .enabled

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -203,14 +203,7 @@ struct ExpandedPostView<Content: View>: View {
             ProgressView()
         } else {
             ToolbarEllipsisMenu {
-                MenuButtons {
-                    post.allMenuActions(
-                        appState: appState,
-                        expanded: true,
-                        navigation: navigation,
-                        commentTreeTracker: tracker
-                    )
-                }
+                PostEllipsisMenuContent(post: post, type: [.basic, .moderator])
                 if !tapPostsToCollapse {
                     Section {
                         Button(

--- a/Mlem/App/Views/Shared/PostEllipsisMenus.swift
+++ b/Mlem/App/Views/Shared/PostEllipsisMenus.swift
@@ -31,28 +31,16 @@ struct PostEllipsisMenus: View {
             }
             if moderatorActionGrouping == .separateMenu {
                 if post.canModerate {
-                    EllipsisMenu(icon: .lemmy.moderation, size: size) {
-                        post.moderatorMenuActions(appState: appState, showAllActions: false, navigation: navigation, report: reportContext)
-                    }
-                }
-                EllipsisMenu(size: size) {
-                    post.basicMenuActions(
-                        appState: appState,
-                        expanded: false,
-                        navigation: navigation,
-                        commentTreeTracker: commentTreeTracker
+                    EllipsisMenu(
+                        icon: .lemmy.moderation,
+                        size: size,
+                        post: post,
+                        type: [.moderator]
                     )
                 }
+                EllipsisMenu(size: size, post: post, type: [.basic])
             } else {
-                EllipsisMenu(size: size) {
-                    post.allMenuActions(
-                        appState: appState,
-                        showAllActions: false,
-                        navigation: navigation,
-                        report: reportContext,
-                        commentTreeTracker: commentTreeTracker
-                    )
-                }
+                EllipsisMenu(size: size, post: post, type: [.basic, .moderator])
             }
         }
     }


### PR DESCRIPTION
The new action system is now used in post ellipsis menus and in the `ExpandedPostView` toolbar. It is not yet used in post context menus.

Functional changes:
- Admins previously had separate "pin instance" and "pin community" buttons. These have now been merged into one, in the same way that we did for the "ban" action.
- The "create image" action is no longer shown for comments when they appear outside of `ExpandedPostView`