### PR TITLE
Fix resolve action only showing in ellipsis menu for posts, not context menu

### DIFF
--- a/Mlem/App/Actions/ContextMenu+Comment.swift
+++ b/Mlem/App/Actions/ContextMenu+Comment.swift
@@ -35,8 +35,13 @@ private let moderationSeeds: [ActionSeed] = [
 extension View {
     func contextMenu(comment: any Comment1Providing) -> some View {
         contextMenu {
-            ActionButtons { _ in
-                seeds.compactMap { $0.createAction(comment) }
+            ActionButtons { environment in
+                var ret = seeds.compactMap { $0.createAction(comment) }
+                if let reportContext = environment.reportContext,
+                    let resolveAction = ActionSeed.resolveReport.createAction(reportContext) {
+                    ret.append(resolveAction)
+                }
+                return ret
             }
         }
     }

--- a/Mlem/App/Actions/ContextMenu+Comment.swift
+++ b/Mlem/App/Actions/ContextMenu+Comment.swift
@@ -35,13 +35,8 @@ private let moderationSeeds: [ActionSeed] = [
 extension View {
     func contextMenu(comment: any Comment1Providing) -> some View {
         contextMenu {
-            ActionButtons { environment in
-                var ret = seeds.compactMap { $0.createAction(comment) }
-                if let reportContext = environment.reportContext,
-                    let resolveAction = ActionSeed.resolveReport.createAction(reportContext) {
-                    ret.append(resolveAction)
-                }
-                return ret
+            ActionButtons { _ in
+                seeds.compactMap { $0.createAction(comment) }
             }
         }
     }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
@@ -76,7 +76,8 @@ struct FeedPostView<EmbeddedContent: View>: View {
                         appState: appState,
                         showAllActions: false,
                         navigation: navigation,
-                        commentTreeTracker: commentTreeTracker
+                        commentTreeTracker: commentTreeTracker,
+                        report: reportContext
                     ) }
             }
         }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/FeedPostView.swift
@@ -76,8 +76,8 @@ struct FeedPostView<EmbeddedContent: View>: View {
                         appState: appState,
                         showAllActions: false,
                         navigation: navigation,
-                        commentTreeTracker: commentTreeTracker,
-                        report: reportContext
+                        report: reportContext,
+                        commentTreeTracker: commentTreeTracker
                     ) }
             }
         }


### PR DESCRIPTION
This was also an issue in 1.3 I think; unlike #2503 which fixed something we broke in TF