### PR TITLE
Fix missing "edit" and "block community" actions for posts

### DIFF
--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -10,10 +10,54 @@ import MlemMiddleware
 import SwiftUI
 
 struct BlockAction: Actions.Action {
-    enum Relationship { case identity, author }
+    enum Content: Hashable {
+        case person(any Person1Providing)
+        case community(any Community1Providing)
 
-    let entity: any Person1Providing
+        var entity: any Blockable {
+            switch self {
+            case let .person(person): person
+            case let .community(community): community
+            }
+        }
+
+        var blocked: Bool {
+            switch self {
+            case let .person(person): person.blocked
+            case let .community(community): community.blocked
+            }
+        }
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.entity.actorId == rhs.entity.actorId
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(entity.actorId)
+        }
+    }
+
+    enum Relationship { case direct, indirect }
+
+    enum ContentType { case personOnly, communityOnly, multi }
+
+    let content: Set<Content>
     let relationship: Relationship
+
+    var contentType: ContentType {
+        if content.count > 1 {
+            return .multi
+        }
+        guard let first = content.first else {
+            assertionFailure()
+            return .multi
+        } 
+
+        return switch first {
+        case .person: .personOnly
+        case .community: .communityOnly
+        }
+    }
 }
 
 // MARK: - Configurability
@@ -21,21 +65,27 @@ struct BlockAction: Actions.Action {
 extension ActionSeed {
     static let block = ActionSeed(
         "block",
-        label: BlockAction.createLabel(relationship: .identity, mode: .block)
+        label: BlockAction.createLabel(relationship: .direct, mode: .block, contentType: .multi)
     ) { entity in
         switch entity {
-        case let entity as any Person1Providing: BlockAction(entity: entity, relationship: .identity)
+        case let entity as any Person1Providing: BlockAction(content: [.person(entity)], relationship: .direct)
         default: nil
         }
     }
 
     static let blockCreator = ActionSeed(
         "blockCreator",
-        label: BlockAction.createLabel(relationship: .author, mode: .block)
+        label: BlockAction.createLabel(relationship: .indirect, mode: .block, contentType: .personOnly)
     ) { entity in
         switch entity {
-        case let entity as any Comment2Providing: BlockAction(entity: entity.creator, relationship: .author)
-        case let entity as any Post2Providing: BlockAction(entity: entity.creator, relationship: .author)
+        case let entity as any Comment2Providing: BlockAction(
+            content: [.person(entity.creator)],
+            relationship: .indirect
+        )
+        case let entity as any Post2Providing: BlockAction(
+            content: [.person(entity.creator), .community(entity.community)],
+            relationship: .indirect
+        )
         default: nil
         }
     }
@@ -46,12 +96,16 @@ extension ActionSeed {
 extension BlockAction {
     enum Mode { case block, unblock }
 
-    static func createLabel(relationship: Relationship, mode: Mode) -> ActionLabel {
-        let label: LocalizedStringResource = switch (relationship, mode) {
-        case (.identity, .block): "Block"
-        case (.identity, .unblock): "Unblock"
-        case (.author, .block): "Block User"
-        case (.author, .unblock): "Unblock User"
+    static func createLabel(relationship: Relationship, mode: Mode, contentType: ContentType) -> ActionLabel {
+        let label: LocalizedStringResource = switch (relationship, mode, contentType) {
+        case (.direct, .block, _): "Block"
+        case (.direct, .unblock, _): "Unblock"
+        case (.indirect, .block, .personOnly): "Block User"
+        case (.indirect, .unblock, .personOnly): "Unblock User"
+        case (.indirect, .block, .communityOnly): "Block Community"
+        case (.indirect, .unblock, .communityOnly): "Unblock Community"
+        case (.indirect, .block, .multi): "Block..."
+        case (.indirect, .unblock, .multi): "Unblock..."
         }
 
         return switch mode {
@@ -72,15 +126,26 @@ extension BlockAction {
     func createLabel(environment: EnvironmentValues) -> ActionLabel {
         Self.createLabel(
             relationship: self.relationship,
-            mode: entity.blocked ? .unblock : .block
+            mode: content.first!.entity.blocked ? .unblock : .block,
+            contentType: contentType
         ).withVisibility(visibility(environment))
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
-        guard entity.api.canInteract(appState: environment.appState) else { return .hidden }
+        let canInteract = content.allSatisfy { $0.entity.api.canInteract(appState: environment.appState) }
+        guard canInteract else { return .hidden }
+
+        guard let first = content.first else {
+            assertionFailure()
+            return .hidden
+        }
         
-        guard let myPersonId = entity.api.myPerson?.id else { return .hidden }
-        return entity.id == myPersonId ? .hidden : .enabled
+        if let person = content.compactMap({ $0.entity as? any Person }).first {
+            guard let myPersonId = first.entity.api.myPerson?.id else { return .hidden }
+            guard person.id != myPersonId else { return .hidden }
+        }
+
+        return .enabled
     }
 }
 
@@ -89,23 +154,60 @@ extension BlockAction {
 extension BlockAction {
     @MainActor
     func execute(environment: EnvironmentValues) {
+        if content.count > 1 {
+            executeMulti(environment: environment)
+            return
+        }
+
+        guard let first = content.first else {
+            assertionFailure()
+            return
+        }
+
+        execute(entity: first.entity, environment: environment)
+    }
+
+    @MainActor
+    func executeMulti(environment: EnvironmentValues) {
+        var actions: [PopupAnchorModel.Action] = content.map(\.entity).map { entity in
+            .init(title: entity is any Person ? "User" : "Community", isDestructive: true) {
+                Task {
+                    let response = await entity.toggleBlocked().value
+                    let toast = createToast(didBlock: entity.blocked, requestStatus: response) {
+                        entity.updateBlocked(false)
+                    }
+                    environment.toastModel?.add(toast)
+                }
+            }
+        }
+        environment.popupModel?.showPopup(message: "Block...", actions)
+    }
+
+    @MainActor
+    func execute(entity: any Blockable, environment: EnvironmentValues) {
         environment.popupModel?.showPopup(message: "Really block this user?", [
             .init(title: "Yes", isDestructive: true) {
                 Task {
                     let response = await entity.toggleBlocked().value
-                    let toast = createToast(didBlock: entity.blocked, requestStatus: response)
+                    let toast = createToast(didBlock: entity.blocked, requestStatus: response) {
+                        entity.updateBlocked(false)
+                    }
                     environment.toastModel?.add(toast)
                 }
             }
         ])
     }
 
-    private func createToast(didBlock: Bool, requestStatus: StateUpdateResult) -> ToastType {
+    private func createToast(
+        didBlock: Bool,
+        requestStatus: StateUpdateResult,
+        undo: @escaping () -> Void
+    ) -> ToastType {
         switch (didBlock, requestStatus) {
         case (true, .succeeded): .undoable(
                 "Blocked",
                 icon: .lemmy.block,
-                callback: { entity.updateBlocked(false) },
+                callback: undo,
                 color: .themedNegative
             )
         case (true, _): .failure("Failed to block!")

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -10,42 +10,15 @@ import MlemMiddleware
 import SwiftUI
 
 struct BlockAction: Actions.Action {
-    enum Content: Hashable {
-        case person(any Person1Providing)
-        case community(any Community1Providing)
-
-        var entity: any Blockable {
-            switch self {
-            case let .person(person): person
-            case let .community(community): community
-            }
-        }
-
-        var blocked: Bool {
-            switch self {
-            case let .person(person): person.blocked
-            case let .community(community): community.blocked
-            }
-        }
-
-        static func == (lhs: Self, rhs: Self) -> Bool {
-            lhs.entity.actorId == rhs.entity.actorId
-        }
-
-        func hash(into hasher: inout Hasher) {
-            hasher.combine(entity.actorId)
-        }
-    }
-
     enum Relationship { case direct, indirect }
 
     enum ContentType { case personOnly, communityOnly, multi }
 
-    let content: Set<Content>
+    let content: [any Blockable]
     let relationship: Relationship
 }
 
-extension Set<BlockAction.Content> {
+private extension [any Blockable] {
     var contentType: BlockAction.ContentType {
         if self.count > 1 {
             return .multi
@@ -56,8 +29,9 @@ extension Set<BlockAction.Content> {
         } 
 
         return switch first {
-        case .person: .personOnly
-        case .community: .communityOnly
+        case is any Person: .personOnly
+        case is any Community: .communityOnly
+        default: .multi
         }
     }
 }
@@ -70,7 +44,7 @@ extension ActionSeed {
         label: BlockAction.createLabel(relationship: .direct, mode: .block, contentType: .multi)
     ) { entity in
         switch entity {
-        case let entity as any Person1Providing: BlockAction(content: [.person(entity)], relationship: .direct)
+        case let entity as any Person1Providing: BlockAction(content: [entity], relationship: .direct)
         default: nil
         }
     }
@@ -81,11 +55,11 @@ extension ActionSeed {
     ) { entity in
         switch entity {
         case let entity as any Comment2Providing: BlockAction(
-            content: [.person(entity.creator)],
+            content: [entity.creator],
             relationship: .indirect
         )
         case let entity as any Post2Providing: BlockAction(
-            content: [.person(entity.creator), .community(entity.community)],
+            content: [entity.creator, entity.community],
             relationship: .indirect
         )
         default: nil
@@ -128,13 +102,13 @@ extension BlockAction {
     func createLabel(environment: EnvironmentValues) -> ActionLabel {
         Self.createLabel(
             relationship: self.relationship,
-            mode: content.first!.entity.blocked ? .unblock : .block,
+            mode: content.first!.blocked ? .unblock : .block,
             contentType: content.contentType
         ).withVisibility(visibility(environment))
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
-        let canInteract = content.allSatisfy { $0.entity.api.canInteract(appState: environment.appState) }
+        let canInteract = content.allSatisfy { $0.api.canInteract(appState: environment.appState) }
         guard canInteract else { return .hidden }
 
         guard let first = content.first else {
@@ -142,8 +116,8 @@ extension BlockAction {
             return .hidden
         }
         
-        if let person = content.compactMap({ $0.entity as? any Person }).first {
-            guard let myPersonId = first.entity.api.myPerson?.id else { return .hidden }
+        if let person = content.compactMap({ $0 as? any Person }).first {
+            guard let myPersonId = first.api.myPerson?.id else { return .hidden }
             guard person.id != myPersonId else { return .hidden }
         }
 
@@ -166,12 +140,12 @@ extension BlockAction {
             return
         }
 
-        execute(entity: first.entity, environment: environment)
+        execute(entity: first, environment: environment)
     }
 
     @MainActor
     func executeMulti(environment: EnvironmentValues) {
-        var actions: [PopupAnchorModel.Action] = content.map(\.entity).map { entity in
+        let actions: [PopupAnchorModel.Action] = content.map { entity in
             .init(title: entity is any Person ? "User" : "Community", isDestructive: true) {
                 Task {
                     let response = await entity.toggleBlocked().value

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -12,10 +12,23 @@ import SwiftUI
 struct BlockAction: Actions.Action {
     enum Relationship { case direct, indirect }
 
-    enum ContentType { case personOnly, communityOnly, multi }
+    enum ContentType {
+        case personOnly, communityOnly, multi, other
+    }
 
     let content: [any Blockable]
     let relationship: Relationship
+
+    var availableContent: [any Blockable] {
+        content.filter { entity in
+            if let entity = entity as? any Person {
+                guard let myPersonId = entity.api.myPerson?.id else { return true }
+                return entity.id != myPersonId 
+            } else {
+                return true
+            }
+        }
+    }
 }
 
 private extension [any Blockable] {
@@ -24,14 +37,13 @@ private extension [any Blockable] {
             return .multi
         }
         guard let first = self.first else {
-            assertionFailure()
-            return .multi
+            return .other
         } 
 
         return switch first {
         case is any Person: .personOnly
         case is any Community: .communityOnly
-        default: .multi
+        default: .other
         }
     }
 }
@@ -72,6 +84,7 @@ extension ActionSeed {
 extension BlockAction {
     enum Mode { case block, unblock }
 
+    // swiftlint:disable:next cyclomatic_complexity
     static func createLabel(relationship: Relationship, mode: Mode, contentType: ContentType) -> ActionLabel {
         let label: LocalizedStringResource = switch (relationship, mode, contentType) {
         case (.direct, .block, _): "Block"
@@ -82,6 +95,7 @@ extension BlockAction {
         case (.indirect, .unblock, .communityOnly): "Unblock Community"
         case (.indirect, .block, .multi): "Block..."
         case (.indirect, .unblock, .multi): "Unblock..."
+        case (_, _, .other): "Block..."
         }
 
         return switch mode {
@@ -103,7 +117,7 @@ extension BlockAction {
         Self.createLabel(
             relationship: self.relationship,
             mode: content.first!.blocked ? .unblock : .block,
-            contentType: content.contentType
+            contentType: availableContent.contentType
         ).withVisibility(visibility(environment))
     }
 
@@ -130,12 +144,12 @@ extension BlockAction {
 extension BlockAction {
     @MainActor
     func execute(environment: EnvironmentValues) {
-        if content.count > 1 {
+        if availableContent.count > 1 {
             executeMulti(environment: environment)
             return
         }
 
-        guard let first = content.first else {
+        guard let first = availableContent.first else {
             assertionFailure()
             return
         }

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -43,12 +43,14 @@ struct BlockAction: Actions.Action {
 
     let content: Set<Content>
     let relationship: Relationship
+}
 
-    var contentType: ContentType {
-        if content.count > 1 {
+extension Set<BlockAction.Content> {
+    var contentType: BlockAction.ContentType {
+        if self.count > 1 {
             return .multi
         }
-        guard let first = content.first else {
+        guard let first = self.first else {
             assertionFailure()
             return .multi
         } 
@@ -127,7 +129,7 @@ extension BlockAction {
         Self.createLabel(
             relationship: self.relationship,
             mode: content.first!.entity.blocked ? .unblock : .block,
-            contentType: contentType
+            contentType: content.contentType
         ).withVisibility(visibility(environment))
     }
 

--- a/Mlem/App/Actions/EditAction.swift
+++ b/Mlem/App/Actions/EditAction.swift
@@ -11,11 +11,13 @@ import SwiftUI
 
 struct EditAction: SimpleLabelAction {
     enum Content {
+        case post(any Post1Providing)
         case comment(any Comment1Providing)
         case message(any Message1Providing)
         
         var value: any OwnershipProviding {
             switch self {
+            case let .post(post): post
             case let .comment(comment): comment
             case let .message(message): message
             }
@@ -32,6 +34,7 @@ extension ActionSeed {
         switch entity {
         case let entity as any Message1Providing: EditAction(content: .message(entity))
         case let entity as any Comment1Providing: EditAction(content: .comment(entity))
+        case let entity as any Post1Providing: EditAction(content: .post(entity))
         default: nil
         }
     }
@@ -63,6 +66,12 @@ extension EditAction {
         case let .comment(comment):
             if let comment = comment as? any Comment2Providing {
                 environment.navigation?.openSheet(.editComment(comment.comment2, context: nil))
+            } else {
+                assertionFailure()
+            }
+        case let .post(post):
+            if let post = post as? any Post2Providing {
+                environment.navigation?.openSheet(.editPost(post.post2))
             } else {
                 assertionFailure()
             }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/Community1Providing.swift
@@ -11,6 +11,7 @@ public protocol Community1Providing:
     CommunityStubProviding,
     Profile2Providing,
     CommunityOrPerson,
+    Blockable,
     ContentIdentifiable,
     RemovableProviding,
     PurgableProviding,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityOrPersonStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityOrPersonStub.swift
@@ -19,3 +19,14 @@ public extension CommunityOrPerson {
     
     var fullNameWithPrefix: String { "\(Self.identifierPrefix)\(name)@\(host)" }
 }
+
+
+public protocol Blockable: ContentModel, ActorIdentifiable {
+    var blocked: Bool { get }
+
+    @discardableResult
+    func updateBlocked(_ newValue: Bool) -> Task<StateUpdateResult, Never> 
+
+    @discardableResult
+    func toggleBlocked() -> Task<StateUpdateResult, Never> 
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/Person1Providing.swift
@@ -11,6 +11,7 @@ public protocol Person1Providing:
     PersonStubProviding,
     Profile2Providing,
     CommunityOrPerson,
+    Blockable,
     ContentIdentifiable,
     SelectableContentProviding,
     PurgableProviding,


### PR DESCRIPTION
Currently, blocking a community will result in a "failed to block" message. This is because an error occurs in the `ApiClient`. It was also broken before this PR, but there was no error message. I will fix it in a separate PR