### PR TITLE
Fix blocking community on Lemmy (and update types)

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/PersonalUnreadCountSnapshot+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/PersonalUnreadCountSnapshot+Lemmy.swift
@@ -9,11 +9,8 @@ import Foundation
 
 extension PersonalUnreadCountSnapshot {
     init(from response: LemmyGetUnreadCountResponse) throws(ApiClientError) {
-        guard let replies = response.replies, let mentions = response.mentions, let messages = response.privateMessages else {
-            throw ApiClientError.featureUnsupported
-        }
-        self.replies = replies
-        self.mentions = mentions
-        self.messages = messages
+        self.replies = response.replies
+        self.mentions = response.mentions
+        self.messages = response.privateMessages
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ReportUnreadCountSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ReportUnreadCountSnapshot.swift
@@ -13,9 +13,6 @@ public struct ReportUnreadCountSnapshot {
     let messages: Int
     
     init(from response: LemmyGetReportCountResponse) throws(ApiClientError) {
-        guard response.count == nil else {
-            throw ApiClientError.featureUnsupported
-        }
         self.comments = response.commentReports ?? 0
         self.posts = response.postReports ?? 0
         self.messages = response.privateMessageReports ?? 0

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Community.swift
@@ -116,7 +116,12 @@ public extension LemmyConnection {
         let response = try await performingForEndpoint { endpoint in
             LemmyUserBlockCommunityRequest(endpoint: endpoint, communityId: id, block: block)
         }
-        return try .init(from: response.communityView)
+        switch response {
+        case let .lemmyBlockCommunityResponse(response):
+            return try .init(from: response.communityView)
+        case let .lemmyCommunityResponse(response):
+            return try .init(from: response.communityView)
+        }
     }
     
     @discardableResult

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Context.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Context.swift
@@ -18,7 +18,7 @@ extension LemmyConnection {
             switch endpoint {
             case .v3:
                 async let site = await self.perform(LemmyGetSiteRequest(endpoint: .v3), endpoint: .v3)
-                async let other = await self.perform(LemmyUnreadCountRequest(endpoint: .v3), endpoint: .v3)
+                async let other = await self.perform(LemmyUnreadCountRequest(), endpoint: .v3)
                 do {
                     _ = try await other
                 } catch ApiClientError.notLoggedIn {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -167,7 +167,7 @@ public extension LemmyConnection {
     
     func getPersonalUnreadCount() async throws -> PersonalUnreadCountSnapshot {
         let response = try await performingForEndpoint { endpoint in
-            LemmyUnreadCountRequest(endpoint: endpoint)
+            LemmyUnreadCountRequest()
         }
         return try .init(from: response)
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
@@ -101,7 +101,12 @@ public extension LemmyConnection {
         let response = try await performingForEndpoint { endpoint in
             LemmyUserBlockPersonRequest(endpoint: endpoint, personId: id, block: block)
         }
-        return try .init(from: response.personView)
+        switch response {
+        case let .lemmyBlockPersonResponse(response):
+            return try .init(from: response.personView)
+        case let .lemmyPersonResponse(response):
+            return try .init(from: response.personView)
+        }
     }
     
     @discardableResult

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+RegistrationApplication.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+RegistrationApplication.swift
@@ -10,7 +10,12 @@ import Foundation
 public extension LemmyConnection {
     func getRegistrationApplicationCount() async throws -> Int {
         let response = try await performingForEndpoint { endpoint in
-            LemmyGetUnreadRegistrationApplicationCountRequest(endpoint: endpoint)
+            switch endpoint {
+            case .v3:
+            LemmyGetUnreadRegistrationApplicationCountRequest()
+            case .v4:
+                throw ApiClientError.featureUnsupported
+            }
         }
         return response.registrationApplications
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Report.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Report.swift
@@ -10,7 +10,12 @@ import Foundation
 public extension LemmyConnection {
     func getReportCount(communityId: Int? = nil) async throws -> ReportUnreadCountSnapshot {
         let response = try await performingForEndpoint { endpoint in
-            LemmyReportCountRequest(endpoint: endpoint, communityId: communityId)
+            switch endpoint {
+            case .v3:
+                LemmyReportCountRequest(communityId: communityId)
+            case .v4:
+                throw ApiClientError.featureUnsupported
+            }
         }
         return try .init(from: response)
     }


### PR DESCRIPTION
> [!note]
> See also [the MlemApiTypes PR](https://github.com/mlemgroup/MlemApiTypes/pull/45)

Closes #2513

There was a decoding error due to our schema not matching what was returned on Lemmy pre-1.0. The block would still take effect on the server, but the posts wouldn't disappear from the feed. We should put this in a patch release at some point.