### PR TITLE
Remove `Message1.read` property

### DIFF
--- a/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Message1Providing+Extensions.swift
@@ -5,17 +5,18 @@
 //  Created by Sjmarf on 05/07/2024.
 //
 
+import Haptics
 import MlemMiddleware
 import QuickSwipes
 
 extension Message1Providing {
     var self2: (any Message2Providing)? { self as? any Message2Providing }
         
-    func swipeActions(appState: AppState) -> SwipeConfiguration {
+    func swipeActions(notification: InboxNotification?, appState: AppState) -> SwipeConfiguration {
         .init(
             trailingActions: {
-                if api.canInteract(appState: appState), !isOwnMessage {
-                    markReadAction(appState: appState, feedback: [.haptic])
+                if api.canInteract(appState: appState), !isOwnMessage, let notification {
+                    markReadAction(appState: appState, notification: notification, feedback: [.haptic])
                 }
             }
         )
@@ -28,6 +29,7 @@ extension Message1Providing {
         isInMessageFeed: Bool = false,
         editCallback: (@MainActor () -> Void)?,
         navigation: NavigationLayer? = nil,
+        notification: InboxNotification? = nil,
         report: Report? = nil
     ) -> [any Action] {
         basicMenuActions(
@@ -35,7 +37,8 @@ extension Message1Providing {
             feedback: feedback,
             isInMessageFeed: isInMessageFeed,
             editCallback: editCallback,
-            navigation: navigation
+            navigation: navigation,
+            notification: notification
         )
         if api.isAdmin {
             ActionGroup(
@@ -47,20 +50,23 @@ extension Message1Providing {
         }
     }
         
-    @ActionBuilder
-    func basicMenuActions(
+    // swiftlint:disable:next cyclomatic_complexity
+    @ActionBuilder func basicMenuActions(
         appState: AppState,
         feedback: Set<FeedbackType> = [.haptic, .toast],
         isInMessageFeed: Bool = false,
         editCallback: (@MainActor () -> Void)?,
         navigation: NavigationLayer? = nil,
+        notification: InboxNotification? = nil,
         report: Report? = nil
     ) -> [any Action] {
         if !isOwnMessage {
             if let navigation, !isInMessageFeed {
                 replyAction(appState: appState, navigation: navigation)
             }
-            markReadAction(appState: appState, feedback: feedback)
+            if let notification {
+                markReadAction(appState: appState, notification: notification, feedback: feedback)
+            }
         }
         if !deleted {
             selectTextAction()
@@ -126,6 +132,18 @@ extension Message1Providing {
             id: "blockCreator\(uid)",
             appearance: .blockCreator(),
             callback: api.canInteract(appState: appState) ? { @MainActor in self.self2?.creator.toggleBlocked(feedback: feedback) } : nil
+        )
+    }
+
+    func markReadAction(appState: AppState, notification: InboxNotification, feedback: Set<FeedbackType> = []) -> BasicAction {
+        .init(
+            id: "markRead\(uid)",
+            appearance: .markRead(isOn: notification.read),
+            callback: api.canInteract(appState: appState) ? {
+                @MainActor in
+                notification.toggleRead()
+                HapticManager.main.play(haptic: .lightSuccess, tier: .low)
+            } : nil
         )
     }
 }

--- a/Mlem/App/Views/Pages/MessageFeedView/MessageFeedView.swift
+++ b/Mlem/App/Views/Pages/MessageFeedView/MessageFeedView.swift
@@ -94,11 +94,6 @@ struct MessageFeedView: View {
                     }
                     .scrollTargetLayout()
                     .padding(.top, 50)
-                    .onChange(of: feedLoader.items.isEmpty) {
-                        for message in feedLoader.items {
-                            message.updateRead(true)
-                        }
-                    }
                     .onReceive(timer) { _ in
                         Task { @MainActor in
                             do {

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
@@ -17,7 +17,7 @@ extension InboxView {
                     Group {
                         switch notification.content {
                         case let .message(message):
-                            MessageView(message: message, isInInbox: true)
+                            MessageView(message: message, notification: notification)
                         case let .reply(comment), let .mention(comment):
                             ReplyView(notification: notification, comment: comment)
                         }

--- a/Mlem/App/Views/Shared/MessageView.swift
+++ b/Mlem/App/Views/Shared/MessageView.swift
@@ -17,16 +17,16 @@ struct MessageView<EmbeddedContent: View>: View {
     @Setting(\.menus_modActionGrouping) var moderatorActionGrouping
     
     let message: any Message
-    let isInInbox: Bool
+    let notification: InboxNotification?
     let embeddedContent: EmbeddedContent
     
     init(
         message: any Message,
-        isInInbox: Bool = false,
+        notification: InboxNotification?,
         @ViewBuilder embeddedContent: () -> EmbeddedContent = { EmptyView() }
     ) {
         self.message = message
-        self.isInInbox = isInInbox
+        self.notification = notification
         self.embeddedContent = embeddedContent()
     }
     
@@ -35,9 +35,9 @@ struct MessageView<EmbeddedContent: View>: View {
             HStack {
                 FullyQualifiedLinkView(message.creator_, labelStyle: .small)
                 Spacer()
-                if isInInbox {
+                if let notification {
                     Image(icon: message.isOwnMessage ? .lemmy.send : .lemmy.message)
-                        .symbolVariant(message.read ? .none : .fill)
+                        .symbolVariant(notification.read ? .none : .fill)
                         .foregroundStyle(.themedAccent)
                 }
                 ellipsisMenus
@@ -66,11 +66,17 @@ struct MessageView<EmbeddedContent: View>: View {
         .clipped()
         .background(.themedSecondaryGroupedBackground)
         .contentShape(.rect)
-        .quickSwipes(message.swipeActions(appState: appState))
+        .quickSwipes(message.swipeActions(notification: notification, appState: appState))
         .clipShape(.rect(cornerRadius: Constants.main.standardSpacing))
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu {
-            message.allMenuActions(appState: appState, editCallback: editMessage, navigation: navigation, report: reportContext)
+            message.allMenuActions(
+                appState: appState,
+                editCallback: editMessage,
+                navigation: navigation,
+                notification: notification,
+                report: reportContext
+            )
         }
         .paletteBorder(cornerRadius: Constants.main.standardSpacing)
         .onTapGesture {
@@ -89,11 +95,22 @@ struct MessageView<EmbeddedContent: View>: View {
                     }
                 }
                 EllipsisMenu(size: 24) {
-                    message.basicMenuActions(appState: appState, editCallback: editMessage, navigation: navigation)
+                    message.basicMenuActions(
+                        appState: appState,
+                        editCallback: editMessage,
+                        navigation: navigation,
+                        notification: notification
+                    )
                 }
             } else {
                 EllipsisMenu(size: 24) {
-                    message.allMenuActions(appState: appState, editCallback: editMessage, navigation: navigation, report: reportContext)
+                    message.allMenuActions(
+                        appState: appState,
+                        editCallback: editMessage,
+                        navigation: navigation,
+                        notification: notification,
+                        report: reportContext
+                    )
                 }
             }
         }

--- a/Mlem/App/Views/Shared/ReportView.swift
+++ b/Mlem/App/Views/Shared/ReportView.swift
@@ -38,7 +38,7 @@ struct ReportView: View {
                 }
             }
         case let .message(message):
-            MessageView(message: message) {
+            MessageView(message: message, notification: nil) {
                 reportDetailsView
                 resolveButton
             }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -73,21 +73,11 @@ public extension ApiClient {
     func markAllAsRead() async throws {
         try await repository.markAllAsRead()
         _ = await Task { @MainActor in
-            for message in caches.message1.itemCache.value.values {
-                message.content?.readManager.updateWithReceivedValue(true, semaphore: nil)
-            }
             for notification in caches.notification.itemCache.value.values {
                 notification.content?.read = true
             }
         }.result
         unreadCount?.clear(.personal)
-    }
-    
-    func markMessageAsRead(id: Int, read: Bool = true, semaphore: UInt? = nil) async throws {
-        try await repository.markMessageAsRead(id: id, read: read)
-        if let message = caches.message1.retrieveModel(cacheId: id) {
-            message.readManager.updateWithReceivedValue(read, semaphore: semaphore)
-        }
     }
     
     /// Get an ``UnreadCount`` object that continues to be updated by the ``ApiClient`` whenever an inbox item is marked read/unread.

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/MessageCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/MessageCaches.swift
@@ -30,8 +30,7 @@ class Message1Cache: CoreCache<Message1> {
             content: snapshot.content,
             deleted: snapshot.deleted,
             created: snapshot.created,
-            updated: snapshot.updated,
-            read: snapshot.read
+            updated: snapshot.updated
         )
         itemCache.put(newItem)
         return newItem

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/NotificationCaches.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Caches/NotificationCaches.swift
@@ -31,11 +31,18 @@ class NotificationCache: CoreCache<InboxNotification> {
             .message(api.caches.message2.getModel(api: api, from: messageSnapshot, myPersonId: myPersonId))
         }
 
+        let read: Bool = switch snapshot.content {
+        case let .message(messageSnapshot):
+            messageSnapshot.creator.id == myPersonId ? true : snapshot.read
+        default:
+            snapshot.read
+        }
+
         let newItem: InboxNotification = .init(
             api: api,
             id: snapshot.id,
             contentId: snapshot.contentId,
-            read: snapshot.read,
+            read: read,
             content: content
         )
         itemCache.put(newItem)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Message+CacheExtensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Caching/Conformance/Message+CacheExtensions.swift
@@ -16,9 +16,6 @@ extension Message1: CacheIdentifiable {
         setIfChanged(\.updated, snapshot.updated)
         
         deletedManager.updateWithReceivedValue(snapshot.deleted, semaphore: semaphore)
-        if !isOwnMessage {
-            readManager.updateWithReceivedValue(snapshot.read, semaphore: semaphore)
-        }
     }
 }
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1.swift
@@ -23,9 +23,6 @@ public final class Message1: Message1Providing {
     public var updated: Date?
     public let isOwnMessage: Bool
     
-    let readManager: StateManager<Bool>
-    public var read: Bool { readManager.displayedValue }
-    
     var deletedManager: StateManager<Bool>
     public var deleted: Bool { deletedManager.displayedValue }
     
@@ -40,7 +37,6 @@ public final class Message1: Message1Providing {
         deleted: Bool,
         created: Date,
         updated: Date?,
-        read: Bool
     ) {
         self.api = api
         self.actorId = actorId
@@ -52,14 +48,5 @@ public final class Message1: Message1Providing {
         self.deletedManager = .init(wrappedValue: deleted)
         self.created = created
         self.updated = updated
-        self.readManager = .init(wrappedValue: isOwnMessage ? true : read)
-        readManager.onSet = { newValue, type, _ in
-            if type == .begin || type == .rollback {
-                api.unreadCount?.updateUnverifiedItem(itemType: .message, isRead: newValue)
-            }
-        }
-        readManager.onVerify = { newValue, _ in
-            api.unreadCount?.verifyItem(itemType: .message, isRead: newValue)
-        }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1Providing+Snapshots.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1Providing+Snapshots.swift
@@ -17,7 +17,7 @@ extension Message1Providing {
             created: created,
             content: content,
             updated: updated,
-            read: read,
+            read: false,
             deleted: deleted
         )
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1Providing.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Message/Message1Providing.swift
@@ -11,7 +11,6 @@ public protocol Message1Providing:
     ContentModel,
     ActorIdentifiable,
     ContentIdentifiable,
-    InboxItemProviding,
     DeletableProviding,
     ReportableProviding,
     SelectableContentProviding {
@@ -24,7 +23,6 @@ public protocol Message1Providing:
     var deleted: Bool { get }
     var created: Date { get }
     var updated: Date? { get }
-    var read: Bool { get }
     
     var id_: Int? { get }
     var creatorId_: Int? { get }
@@ -33,7 +31,6 @@ public protocol Message1Providing:
     var deleted_: Bool? { get }
     var created_: Date? { get }
     var updated_: Date? { get }
-    var read_: Bool? { get }
     
     // From Message2Providing
     var creator_: Person1? { get }
@@ -58,7 +55,6 @@ public extension Message1Providing {
     var deleted: Bool { message1.deleted }
     var created: Date { message1.created }
     var updated: Date? { message1.updated }
-    var read: Bool { message1.read }
     var isOwnMessage: Bool { message1.isOwnMessage }
     
     var id_: Int? { message1.id }
@@ -68,7 +64,6 @@ public extension Message1Providing {
     var deleted_: Bool? { message1.deleted }
     var created_: Date? { message1.created }
     var updated_: Date? { message1.updated }
-    var read_: Bool? { message1.read }
     var isOwnMessage_: Bool? { message1.isOwnMessage }
     
     var creator_: Person1? { nil }
@@ -81,16 +76,7 @@ public extension Message1Providing {
 }
 
 public extension Message1Providing {
-    private var readManager: StateManager<Bool> { message1.readManager }
     private var deletedManager: StateManager<Bool> { message1.deletedManager }
-    
-    // `toggleRead` is defined in `InboxItemProviding`
-    @discardableResult
-    func updateRead(_ newValue: Bool) -> Task<StateUpdateResult, Never> {
-        readManager.performRequest(expectedResult: newValue) { semaphore in
-            try await self.api.markMessageAsRead(id: self.id, read: newValue, semaphore: semaphore)
-        }
-    }
     
     func reply(content: String) async throws -> Message2 {
         try await api.createMessage(personId: recipientId, content: content)


### PR DESCRIPTION
`read` is also stored on `InboxNotification`, so this property was redundant.

Closes #2338