### PR TITLE
Implement inbox on Lemmy 1.0

### DIFF
--- a/Mlem/App/Views/Shared/TestInboxView.swift
+++ b/Mlem/App/Views/Shared/TestInboxView.swift
@@ -86,11 +86,26 @@ private struct TestInboxSectionView: View {
         do {
             switch type {
             case .reply:
-                notifications = try await appState.firstApi.getReplyNotifications(page: 1, limit: 5, unreadOnly: false)
+                notifications = try await appState.firstApi.getReplyNotifications(
+                    page: 1,
+                    cursor: nil,
+                    limit: 5,
+                    unreadOnly: false
+                ).notifications
             case .mention:
-                notifications = try await appState.firstApi.getMentionNotifications(page: 1, limit: 5, unreadOnly: false)
+                notifications = try await appState.firstApi.getMentionNotifications(
+                    page: 1,
+                    cursor: nil,
+                    limit: 5,
+                    unreadOnly: false
+                ).notifications
             case .message:
-                notifications = try await appState.firstApi.getMessageNotifications(page: 1, limit: 5, unreadOnly: false)
+                notifications = try await appState.firstApi.getMessageNotifications(
+                    page: 1,
+                    cursor: nil,
+                    limit: 5,
+                    unreadOnly: false
+                ).notifications
             }
         } catch {
             handleError(error)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -29,45 +29,60 @@ public extension ApiClient {
     }
 
     func getReplyNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotification] {
+    ) async throws -> (notifications: [InboxNotification], cursor: String?) {
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
-        let snapshots = try await repository.getReplyNotifications(
+        let response = try await repository.getReplyNotifications(
             page: page,
+            cursor: cursor,
             limit: limit,
             unreadOnly: unreadOnly
         )
-        return await caches.notification.getModels(api: self, from: snapshots, myPersonId: myPersonId)
+        return await (
+            notifications: caches.notification.getModels(api: self, from: response.notifications, myPersonId: myPersonId),
+            cursor: response.cursor
+        )
     }
     
     func getMentionNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotification] {
+    ) async throws -> (notifications: [InboxNotification], cursor: String?) {
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
-        let snapshots = try await repository.getMentionNotifications(
+        let response = try await repository.getMentionNotifications(
             page: page,
+            cursor: cursor,
             limit: limit,
             unreadOnly: unreadOnly
         )
-        return await caches.notification.getModels(api: self, from: snapshots, myPersonId: myPersonId)
+        return await (
+            notifications: caches.notification.getModels(api: self, from: response.notifications, myPersonId: myPersonId),
+            cursor: response.cursor
+        )
     }
 
     func getMessageNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotification] {
+    ) async throws -> (notifications: [InboxNotification], cursor: String?) {
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
-        let snapshots = try await repository.getMessageNotifications(
+        let response = try await repository.getMessageNotifications(
             page: page,
+            cursor: cursor,
             limit: limit,
             unreadOnly: unreadOnly
         )
-        return await caches.notification.getModels(api: self, from: snapshots, myPersonId: myPersonId)
+        return await (
+            notifications: caches.notification.getModels(api: self, from: response.notifications, myPersonId: myPersonId),
+            cursor: response.cursor
+        )
     }
 
     func markAllAsRead() async throws {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
@@ -23,13 +23,15 @@ extension ApiRepository {
     }
 
     func getReplyNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot] {
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
         try await performingForConnection { connection in
             try await connection.getReplyNotifications(
                 page: page,
+                cursor: cursor,
                 limit: limit,
                 unreadOnly: unreadOnly
             )
@@ -37,13 +39,15 @@ extension ApiRepository {
     }
     
     func getMentionNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot] {
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
         try await performingForConnection { connection in
             try await connection.getMentionNotifications(
                 page: page,
+                cursor: cursor,
                 limit: limit,
                 unreadOnly: unreadOnly
             )
@@ -51,13 +55,15 @@ extension ApiRepository {
     }
 
     func getMessageNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot] {
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
         try await performingForConnection { connection in
             try await connection.getMessageNotifications(
                 page: page,
+                cursor: cursor,
                 limit: limit,
                 unreadOnly: unreadOnly
             )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Inbox.swift
@@ -92,24 +92,6 @@ extension ApiRepository {
         }
     }
     
-    func markReplyAsRead(id: Int, read: Bool = true, semaphore: UInt? = nil) async throws {
-        try await performingForConnection { connection in
-            try await connection.markReplyAsRead(id: id, read: read)
-        }
-    }
-    
-    func markMentionAsRead(id: Int, read: Bool = true, semaphore: UInt? = nil) async throws {
-        try await performingForConnection { connection in
-            try await connection.markMentionAsRead(id: id, read: read)
-        }
-    }
-    
-    func markMessageAsRead(id: Int, read: Bool = true, semaphore: UInt? = nil) async throws {
-        try await performingForConnection { connection in
-            try await connection.markMessageAsRead(id: id, read: read)
-        }
-    }
-    
     func getPersonalUnreadCount() async throws -> PersonalUnreadCountSnapshot {
         try await performingForConnection { connection in
             try await connection.getPersonalUnreadCount()

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/InboxNotificationSnapshot+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/InboxNotificationSnapshot+Lemmy.swift
@@ -38,6 +38,32 @@ extension InboxNotificationSnapshot {
             content: .message(.init(from: messageView))
         )
     }
+
+    init(from notification: LemmyNotificationView) throws(ApiClientError) {
+        let contentId: Int
+        let content: InboxNotificationContentSnapshot
+
+        switch notification.data {
+        case let .privateMessage(message):
+            contentId = message.privateMessage.id
+            content = try .message(.init(from: message))
+        case let .comment(comment) where notification.notification.kind == .mention:
+            contentId = comment.comment.id
+            content = try .mention(.init(from: comment))
+        case let .comment(comment) where  notification.notification.kind == .reply:
+            contentId = comment.comment.id
+            content = try .reply(.init(from: comment))
+        default:
+            throw ApiClientError.featureUnsupported
+        }
+
+        self.init(
+            id: notification.notification.id,
+            contentId: contentId,
+            read: notification.notification.read,
+            content: content
+        )
+    }
 }
 
 // This can be removed once we drop support for < Lemmy 1.0

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/InboxNotification+Snapshots.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Notification/InboxNotification+Snapshots.swift
@@ -10,7 +10,12 @@ import Foundation
 extension InboxNotification {
     @MainActor
     func snapshotUpdate(with snapshot: InboxNotificationSnapshot, isResultOfTask: Bool) {
-        setIfChanged(\.read, snapshot.read)
+        switch self.content {
+        case let .message(message) where message.isOwnMessage:
+            break
+        default:
+            setIfChanged(\.read, snapshot.read)
+        }
     }
     
     func takeSnapshot() -> InboxNotificationSnapshot? {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MentionChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MentionChildFeedLoader.swift
@@ -20,6 +20,20 @@ public class MentionChildFeedLoader: InboxChildFeedLoader {
                 nextCursor: response.cursor
             )
         }
+
+        override func fetchCursor(_ cursor: String) async throws -> FetchResponse {
+            let response = try await api.getMentionNotifications(
+                page: nil,
+                cursor: cursor,
+                limit: pageSize,
+                unreadOnly: unreadOnly
+            )
+            return .init(
+                items: response.notifications,
+                prevCursor: nil,
+                nextCursor: response.cursor
+            )
+        }
     }
     
     public init(api: ApiClient, pageSize: Int, sortType: FeedLoaderSort.SortType, showRead: Bool) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MentionChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MentionChildFeedLoader.swift
@@ -10,13 +10,14 @@ public class MentionChildFeedLoader: InboxChildFeedLoader {
         override func fetchPage(_ page: Int) async throws -> FetchResponse {
             let response = try await api.getMentionNotifications(
                 page: page,
+                cursor: nil,
                 limit: pageSize,
                 unreadOnly: unreadOnly
             )
             return .init(
-                items: response,
+                items: response.notifications,
                 prevCursor: nil,
-                nextCursor: nil
+                nextCursor: response.cursor
             )
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MessageChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MessageChildFeedLoader.swift
@@ -10,13 +10,14 @@ public class MessageChildFeedLoader: InboxChildFeedLoader {
         override func fetchPage(_ page: Int) async throws -> FetchResponse {
             let response = try await api.getMessageNotifications(
                 page: page,
+                cursor: nil,
                 limit: pageSize,
                 unreadOnly: unreadOnly
             )
             return .init(
-                items: response,
+                items: response.notifications,
                 prevCursor: nil,
-                nextCursor: nil
+                nextCursor: response.cursor
             )
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MessageChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/MessageChildFeedLoader.swift
@@ -20,6 +20,20 @@ public class MessageChildFeedLoader: InboxChildFeedLoader {
                 nextCursor: response.cursor
             )
         }
+
+        override func fetchCursor(_ cursor: String) async throws -> FetchResponse {
+            let response = try await api.getMessageNotifications(
+                page: nil,
+                cursor: cursor,
+                limit: pageSize,
+                unreadOnly: unreadOnly
+            )
+            return .init(
+                items: response.notifications,
+                prevCursor: nil,
+                nextCursor: response.cursor
+            )
+        }
     }
 
     public init(api: ApiClient, pageSize: Int, sortType: FeedLoaderSort.SortType, showRead: Bool) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/ReplyChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/ReplyChildFeedLoader.swift
@@ -10,13 +10,14 @@ public class ReplyChildFeedLoader: InboxChildFeedLoader {
         override func fetchPage(_ page: Int) async throws -> FetchResponse {
             let response = try await api.getReplyNotifications(
                 page: page,
+                cursor: nil,
                 limit: pageSize,
                 unreadOnly: unreadOnly
             )
             return .init(
-                items: response,
+                items: response.notifications,
                 prevCursor: nil,
-                nextCursor: nil
+                nextCursor: response.cursor
             )
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/ReplyChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/InboxFeedLoader/ReplyChildFeedLoader.swift
@@ -20,6 +20,20 @@ public class ReplyChildFeedLoader: InboxChildFeedLoader {
                 nextCursor: response.cursor
             )
         }
+
+        override func fetchCursor(_ cursor: String) async throws -> FetchResponse {
+            let response = try await api.getReplyNotifications(
+                page: nil,
+                cursor: cursor,
+                limit: pageSize,
+                unreadOnly: unreadOnly
+            )
+            return .init(
+                items: response.notifications,
+                prevCursor: nil,
+                nextCursor: response.cursor
+            )
+        }
     }
 
     public init(api: ApiClient, pageSize: Int, sortType: FeedLoaderSort.SortType, showRead: Bool) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -453,9 +453,6 @@ public protocol InstanceConnection {
     ) async throws
         
     func markAllAsRead() async throws
-    func markReplyAsRead(id: Int, read: Bool) async throws
-    func markMentionAsRead(id: Int, read: Bool) async throws
-    func markMessageAsRead(id: Int, read: Bool) async throws
     func getPersonalUnreadCount() async throws -> PersonalUnreadCountSnapshot
     func createMessage(personId: Int, content: String) async throws -> Message2Snapshot
     @discardableResult

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -425,22 +425,25 @@ public protocol InstanceConnection {
     ) async throws -> [Message2Snapshot]
     
     func getReplyNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot]
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?)
 
     func getMentionNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot]
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?)
 
     func getMessageNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot]
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?)
 
     func markNotificationAsRead(
         type: InboxNotificationContentType,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -67,16 +67,32 @@ public extension LemmyConnection {
         limit: Int,
         unreadOnly: Bool
     ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
-        let response = try await performingForEndpoint { endpoint in
-            guard let page else { throw ApiClientError.featureUnsupported }
-            return LemmyGetPrivateMessageRequest(
-                unreadOnly: unreadOnly,
-                page: page,
-                limit: limit,
-                creatorId: nil
-            )
+        try await processingForEndpoint { endpoint in
+            switch endpoint {
+            case .v3:
+                guard let page else { throw ApiClientError.featureUnsupported }
+                let request = LemmyGetPrivateMessageRequest(
+                    unreadOnly: unreadOnly,
+                    page: page,
+                    limit: limit,
+                    creatorId: nil
+                )
+                let response = try await self.perform(request, endpoint: .v3)
+                return try (notifications: response.privateMessages.map { try .init(from: $0) }, cursor: nil)
+            case .v4:
+                let request = LemmyListNotificationsRequest(
+                    type_: .privateMessage,
+                    unreadOnly: unreadOnly,
+                    pageCursor: cursor,
+                    limit: limit
+                )
+                let response = try await self.perform(request, endpoint: .v4)
+                return try (
+                    notifications: response.items.map { try .init(from: $0) },
+                    cursor: response.nextPage
+                )
+            }
         }
-        return try (notifications: response.privateMessages.map { try .init(from: $0) }, cursor: nil)
     }
     
     func markNotificationAsRead(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -26,51 +26,57 @@ public extension LemmyConnection {
     }
     
     func getReplyNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot] {
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
         let response = try await performingForEndpoint { _ in
-            LemmyListRepliesRequest(
+            guard let page else { throw ApiClientError.featureUnsupported }
+            return LemmyListRepliesRequest(
                 sort: .new,
                 page: page,
                 limit: limit,
                 unreadOnly: unreadOnly
             )
         }
-        return try response.replies.map { try .init(from: $0) }
+        return try (notifications: response.replies.map { try .init(from: $0) }, cursor: nil)
     }
 
     func getMentionNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot] {
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
         let response = try await performingForEndpoint { _ in
-            LemmyListMentionsRequest(
+            guard let page else { throw ApiClientError.featureUnsupported }
+            return LemmyListMentionsRequest(
                 sort: .new,
                 page: page,
                 limit: limit,
                 unreadOnly: unreadOnly
             )
         }
-        return try response.mentions.map { try .init(from: $0) }
+        return try (notifications: response.mentions.map { try .init(from: $0) }, cursor: nil)
     }
 
     func getMessageNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot] {
-        let response = try await performingForEndpoint { _ in
-            LemmyGetPrivateMessageRequest(
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
+        let response = try await performingForEndpoint { endpoint in
+            guard let page else { throw ApiClientError.featureUnsupported }
+            return LemmyGetPrivateMessageRequest(
                 unreadOnly: unreadOnly,
                 page: page,
                 limit: limit,
                 creatorId: nil
             )
         }
-        return try response.privateMessages.map { try .init(from: $0) }
+        return try (notifications: response.privateMessages.map { try .init(from: $0) }, cursor: nil)
     }
     
     func markNotificationAsRead(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -134,8 +134,13 @@ public extension LemmyConnection {
         read: Bool = true
     ) async throws {
         try await processingForEndpoint { endpoint in
-            guard endpoint == .v3 else { throw ApiClientError.featureUnsupported }
-            try await self.markNotificationAsReadV3(type: type, contentId: contentId, read: read)
+            switch endpoint {
+            case .v3:
+                try await self.markNotificationAsReadV3(type: type, contentId: contentId, read: read)
+            case .v4:
+                let request = LemmyMarkNotificationAsReadRequest(notificationId: id, read: read)
+                try await self.perform(request, endpoint: .v4)
+            }
         }
     }
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -135,14 +135,22 @@ public extension LemmyConnection {
     ) async throws {
         try await processingForEndpoint { endpoint in
             guard endpoint == .v3 else { throw ApiClientError.featureUnsupported }
-            switch type {
-            case .reply:
-                try await self.markReplyAsRead(id: contentId, read: read)
-            case .mention:
-                try await self.markMentionAsRead(id: contentId, read: read)
-            case .message:
-                try await self.markMessageAsRead(id: contentId, read: read)
-            }
+            try await self.markNotificationAsReadV3(type: type, contentId: contentId, read: read)
+        }
+    }
+
+    private func markNotificationAsReadV3(
+        type: InboxNotificationContentType,
+        contentId: Int,
+        read: Bool
+    ) async throws {
+        switch type {
+        case .reply:
+            try await self.markReplyAsRead(id: contentId, read: read)
+        case .mention:
+            try await self.markMentionAsRead(id: contentId, read: read)
+        case .message:
+            try await self.markMessageAsRead(id: contentId, read: read)
         }
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -151,50 +151,17 @@ public extension LemmyConnection {
     ) async throws {
         switch type {
         case .reply:
-            try await self.markReplyAsRead(id: contentId, read: read)
+            try await self.perform(LemmyMarkReplyAsReadRequest(commentReplyId: contentId, read: read), endpoint: .v3)
         case .mention:
-            try await self.markMentionAsRead(id: contentId, read: read)
+            try await self.perform(LemmyMarkPersonMentionAsReadRequest(personMentionId: contentId, read: read), endpoint: .v3)
         case .message:
-            try await self.markMessageAsRead(id: contentId, read: read)
+            try await self.perform(LemmyMarkPmAsReadRequest(privateMessageId: contentId, read: read), endpoint: .v3)
         }
     }
     
     func markAllAsRead() async throws {
         _ = try await performingForEndpoint { endpoint in
             LemmyMarkAllNotificationsReadRequest(endpoint: endpoint)
-        }
-    }
-    
-    func markReplyAsRead(id: Int, read: Bool = true) async throws {
-        try await processingForEndpoint { endpoint in
-            switch endpoint {
-            case .v3:
-                try await self.perform(LemmyMarkReplyAsReadRequest(commentReplyId: id, read: read), endpoint: .v3)
-            case .v4:
-                try await self.perform(LemmyMarkNotificationAsReadRequest(notificationId: id, read: read), endpoint: .v4)
-            }
-        }
-    }
-    
-    func markMentionAsRead(id: Int, read: Bool = true) async throws {
-        try await processingForEndpoint { endpoint in
-            switch endpoint {
-            case .v3:
-                try await self.perform(LemmyMarkPersonMentionAsReadRequest(personMentionId: id, read: read), endpoint: .v3)
-            case .v4:
-                try await self.perform(LemmyMarkNotificationAsReadRequest(notificationId: id, read: read), endpoint: .v4)
-            }
-        }
-    }
-    
-    func markMessageAsRead(id: Int, read: Bool = true) async throws {
-        try await processingForEndpoint { endpoint in
-            switch endpoint {
-            case .v3:
-                try await self.perform(LemmyMarkPmAsReadRequest(privateMessageId: id, read: read), endpoint: .v3)
-            case .v4:
-                try await self.perform(LemmyMarkNotificationAsReadRequest(notificationId: id, read: read), endpoint: .v4)
-            }
         }
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Inbox.swift
@@ -31,16 +31,32 @@ public extension LemmyConnection {
         limit: Int,
         unreadOnly: Bool
     ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
-        let response = try await performingForEndpoint { _ in
-            guard let page else { throw ApiClientError.featureUnsupported }
-            return LemmyListRepliesRequest(
-                sort: .new,
-                page: page,
-                limit: limit,
-                unreadOnly: unreadOnly
-            )
+        try await processingForEndpoint { endpoint in
+            switch endpoint {
+            case .v3:
+                guard let page else { throw ApiClientError.featureUnsupported }
+                let request = LemmyListRepliesRequest(
+                    sort: .new,
+                    page: page,
+                    limit: limit,
+                    unreadOnly: unreadOnly
+                )
+                let response = try await self.perform(request, endpoint: .v3)
+                return try (notifications: response.replies.map { try .init(from: $0) }, cursor: nil)
+            case .v4:
+                let request = LemmyListNotificationsRequest(
+                    type_: .reply,
+                    unreadOnly: unreadOnly,
+                    pageCursor: cursor,
+                    limit: limit
+                )
+                let response = try await self.perform(request, endpoint: .v4)
+                return try (
+                    notifications: response.items.map { try .init(from: $0) },
+                    cursor: response.nextPage
+                )
+            }
         }
-        return try (notifications: response.replies.map { try .init(from: $0) }, cursor: nil)
     }
 
     func getMentionNotifications(
@@ -49,16 +65,32 @@ public extension LemmyConnection {
         limit: Int,
         unreadOnly: Bool
     ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
-        let response = try await performingForEndpoint { _ in
-            guard let page else { throw ApiClientError.featureUnsupported }
-            return LemmyListMentionsRequest(
-                sort: .new,
-                page: page,
-                limit: limit,
-                unreadOnly: unreadOnly
-            )
+        try await processingForEndpoint { endpoint in
+            switch endpoint {
+            case .v3:
+                guard let page else { throw ApiClientError.featureUnsupported }
+                let request = LemmyListMentionsRequest(
+                    sort: .new,
+                    page: page,
+                    limit: limit,
+                    unreadOnly: unreadOnly
+                )
+                let response = try await self.perform(request, endpoint: .v3)
+                return try (notifications: response.mentions.map { try .init(from: $0) }, cursor: nil)
+            case .v4:
+                let request = LemmyListNotificationsRequest(
+                    type_: .mention,
+                    unreadOnly: unreadOnly,
+                    pageCursor: cursor,
+                    limit: limit
+                )
+                let response = try await self.perform(request, endpoint: .v4)
+                return try (
+                    notifications: response.items.map { try .init(from: $0) },
+                    cursor: response.nextPage
+                )
+            }
         }
-        return try (notifications: response.mentions.map { try .init(from: $0) }, cursor: nil)
     }
 
     func getMessageNotifications(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -102,23 +102,23 @@ public extension PieFedConnection {
         }
     }
 
+    private func markReplyAsRead(id: Int, read: Bool = true) async throws {
+        let request = PieFedMarkReplyAsReadRequest(commentReplyId: id, read: read)
+        try await perform(request)
+    }
+    
+    private func markMentionAsRead(id: Int, read: Bool = true) async throws {
+        let request = PieFedMarkReplyAsReadRequest(commentReplyId: id, read: read)
+        try await perform(request)
+    }
+    
+    private func markMessageAsRead(id: Int, read: Bool = true) async throws {
+        let request = PieFedMarkPrivateMessageAsReadRequest(privateMessageId: id, read: read)
+        try await perform(request)
+    }
+    
     func markAllAsRead() async throws {
         let request = PieFedMarkAllRepliesReadRequest()
-        try await perform(request)
-    }
-    
-    func markReplyAsRead(id: Int, read: Bool = true) async throws {
-        let request = PieFedMarkReplyAsReadRequest(commentReplyId: id, read: read)
-        try await perform(request)
-    }
-    
-    func markMentionAsRead(id: Int, read: Bool = true) async throws {
-        let request = PieFedMarkReplyAsReadRequest(commentReplyId: id, read: read)
-        try await perform(request)
-    }
-    
-    func markMessageAsRead(id: Int, read: Bool = true) async throws {
-        let request = PieFedMarkPrivateMessageAsReadRequest(privateMessageId: id, read: read)
         try await perform(request)
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Inbox.swift
@@ -39,10 +39,11 @@ public extension PieFedConnection {
     }
     
     func getReplyNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot] {
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
         let request = PieFedGetRepliesRequest(
             sort: .new,
             page: page,
@@ -50,14 +51,15 @@ public extension PieFedConnection {
             unreadOnly: unreadOnly
         )
         let response = try await perform(request)
-        return try response.replies.map { try .init(from: $0, isMention: false) }
+        return try (notifications: response.replies.map { try .init(from: $0, isMention: false) }, cursor: nil)
     }
 
     func getMentionNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot] {
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
         let request = PieFedGetMentionsRequest(
             sort: .new,
             page: page,
@@ -65,14 +67,15 @@ public extension PieFedConnection {
             unreadOnly: unreadOnly
         )
         let response = try await perform(request)
-        return try response.replies.map { try .init(from: $0, isMention: true) }
+        return try (notifications: response.replies.map { try .init(from: $0, isMention: true) }, cursor: nil)
     }
 
     func getMessageNotifications(
-        page: Int,
+        page: Int?,
+        cursor: String?,
         limit: Int,
         unreadOnly: Bool
-    ) async throws -> [InboxNotificationSnapshot] {
+    ) async throws -> (notifications: [InboxNotificationSnapshot], cursor: String?) {
         let request = PieFedListPrivateMessagesRequest(
             unreadOnly: unreadOnly,
             page: page,
@@ -80,7 +83,7 @@ public extension PieFedConnection {
             creatorId: nil
         )
         let response = try await perform(request)
-        return try response.privateMessages.map { try .init(from: $0) }
+        return try (notifications: response.privateMessages.map { try .init(from: $0) }, cursor: nil)
     }
     
     func markNotificationAsRead(


### PR DESCRIPTION
On Lemmy 1.0, you can now load the inbox and mark items as read.

Closes #2340, closes #2157

Known issues:
- When you open the inbox, you get a 404 error. This is caused by fetching the mod mail, which we haven't implemented yet.
- The inbox tab count may not stay in sync. This is a separate issue (#1787)