### PR TITLE
New action system for communities

### DIFF
--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -85,8 +85,8 @@ extension ActionSeed {
         label: BlockAction.createLabel(relationship: .direct, mode: .block, contentType: .multi)
     ) { entity in
         switch entity {
-        case let entity as any Person1Providing: BlockAction(content: [.blockable(entity)], relationship: .direct)
         case let entity as any InstanceStubProviding: BlockAction(content: [.instance(entity)], relationship: .direct)
+        case let entity as any Blockable: BlockAction(content: [.blockable(entity)], relationship: .direct)
         default: nil
         }
     }

--- a/Mlem/App/Actions/ContextMenu+Community.swift
+++ b/Mlem/App/Actions/ContextMenu+Community.swift
@@ -10,6 +10,7 @@ import MlemMiddleware
 import SwiftUI
 
 private let seeds: [ActionSeed] = [
+    .newPost,
     .goToInstance,
     .copyName,
     .share,

--- a/Mlem/App/Actions/ContextMenu+Community.swift
+++ b/Mlem/App/Actions/ContextMenu+Community.swift
@@ -12,6 +12,7 @@ import SwiftUI
 private let seeds: [ActionSeed] = [
     .newPost,
     .subscribe,
+    .favorite,
     .goToInstance,
     .copyName,
     .share,

--- a/Mlem/App/Actions/ContextMenu+Community.swift
+++ b/Mlem/App/Actions/ContextMenu+Community.swift
@@ -1,0 +1,33 @@
+//
+//  ContextMenu+Community.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-02-08.
+//
+
+import Actions
+import MlemMiddleware
+import SwiftUI
+
+private let seeds: [ActionSeed] = [
+    .goToInstance,
+    .copyName,
+    .share,
+    .block
+]
+
+extension ActionButtons {
+    init(community: any Community1Providing) {
+        self.init { _ in
+            seeds.compactMap { $0.createAction(community) }
+        }
+    }
+}
+
+extension View {
+    func contextMenu(community: any Community1Providing) -> some View {
+        contextMenu {
+            ActionButtons(community: community)
+        }
+    }
+}

--- a/Mlem/App/Actions/ContextMenu+Community.swift
+++ b/Mlem/App/Actions/ContextMenu+Community.swift
@@ -16,7 +16,9 @@ private let seeds: [ActionSeed] = [
     .goToInstance,
     .copyName,
     .share,
-    .block
+    .block,
+    .remove,
+    .purge
 ]
 
 extension ActionButtons {

--- a/Mlem/App/Actions/ContextMenu+Community.swift
+++ b/Mlem/App/Actions/ContextMenu+Community.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 private let seeds: [ActionSeed] = [
     .newPost,
+    .subscribe,
     .goToInstance,
     .copyName,
     .share,

--- a/Mlem/App/Actions/CopyNameAction.swift
+++ b/Mlem/App/Actions/CopyNameAction.swift
@@ -25,6 +25,8 @@ extension ActionSeed {
         switch entity {
         case let entity as any Person1Providing:
             CopyNameAction(text: entity.fullNameWithPrefix, relationship: .identity)
+        case let entity as any Community1Providing:
+            CopyNameAction(text: entity.fullNameWithPrefix, relationship: .identity)
         default:
             nil
         }

--- a/Mlem/App/Actions/FavoriteAction.swift
+++ b/Mlem/App/Actions/FavoriteAction.swift
@@ -1,0 +1,85 @@
+//
+//  FavoriteAction.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-02-08.
+//
+
+import Actions
+import MlemMiddleware
+import SwiftUI
+
+struct FavoriteAction: SimpleLabelAction {
+    let entity: any Community1Providing
+}
+
+// MARK: - Configurability
+
+extension ActionSeed {
+    static let favorite = ActionSeed("favorite") { entity in
+        switch entity {
+        case let entity as any Community1Providing: FavoriteAction(entity: entity)
+        default: nil
+        }
+    }
+}
+
+// MARK: - Appearance
+
+extension FavoriteAction {
+    static let favoriteLabel: ActionLabel = .init(
+        "Favorite",
+        icon: .lemmy.favorite,
+        color: .themedFavorite
+    )
+    static let unfavoriteLabel: ActionLabel = .init(
+        "Unfavorite",
+        icon: .lemmy.unfavorite,
+        color: .themedFavorite
+    )
+    
+    static var label: ActionLabel { favoriteLabel }
+
+    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+        guard let subscribed = entity.favorited_  else {
+            return Self.favoriteLabel.withVisibility(.hidden)
+        }
+        if subscribed {
+            return Self.unfavoriteLabel.withVisibility(visibility(environment))
+        } else {
+            return Self.favoriteLabel.withVisibility(visibility(environment))
+        }
+    }
+
+    private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
+        guard entity.api.canInteract(appState: environment.appState) else { return .hidden }
+        return .enabled
+    }
+}
+
+// MARK: - Behavior
+
+extension FavoriteAction {
+    @MainActor
+    func execute(environment: EnvironmentValues) {
+        guard let entity = entity as? any Community2Providing else { return }
+        environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
+        if entity.favorited {
+            environment.toastModel?.add(
+                .undoable(
+                    "Unfavorited",
+                    icon: .lemmy.unfavorite,
+                    callback: {
+                        entity.updateFavorite(true)
+                    },
+                    color: .themedFavorite
+                )
+            )
+        } else {
+            environment.toastModel?.add(
+                .basic("Favorited", icon: .lemmy.favorite, color: .themedFavorite)
+            )
+        }
+        entity.toggleFavorite()
+    }
+}

--- a/Mlem/App/Actions/NewPostAction.swift
+++ b/Mlem/App/Actions/NewPostAction.swift
@@ -1,0 +1,48 @@
+//
+//  NewPostAction.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-02-08.
+//
+
+import Actions
+import MlemMiddleware
+import SwiftUI
+
+struct NewPostAction: SimpleLabelAction {
+    let entity: any Community1Providing
+}
+
+// MARK: - Configurability
+
+extension ActionSeed {
+    static let newPost = ActionSeed("newPost") { entity in
+        switch entity {
+        case let entity as any Community1Providing: NewPostAction(entity: entity)
+        default: nil
+        }
+    }
+}
+
+// MARK: - Appearance
+
+extension NewPostAction {
+    static let label: ActionLabel = .init("New Post", icon: .lemmy.send)
+
+    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+        if entity.api.canInteract(appState: environment.appState) {
+            Self.label.withVisibility(.enabled)
+        } else {
+            Self.label.withVisibility(.disabled)
+        }
+    }
+}
+
+// MARK: - Behavior
+
+extension NewPostAction {
+    @MainActor
+    func execute(environment: EnvironmentValues) {
+        environment.navigation?.openSheet(.createPost(community: self.entity, type: nil, feedLoader: environment.feedLoader)) 
+    }
+}

--- a/Mlem/App/Actions/SaveAction.swift
+++ b/Mlem/App/Actions/SaveAction.swift
@@ -10,7 +10,7 @@ import MlemMiddleware
 import SwiftUI
 
 struct SaveAction: SimpleLabelAction {
-    let entity: InteractableProviding
+    let entity: any InteractableProviding
 }
 
 // MARK: - Configurability

--- a/Mlem/App/Actions/SubscribeAction.swift
+++ b/Mlem/App/Actions/SubscribeAction.swift
@@ -1,0 +1,86 @@
+//
+//  SubscribeAction.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-02-08.
+//
+
+import Actions
+import MlemMiddleware
+import SwiftUI
+
+struct SubscribeAction: SimpleLabelAction {
+    let entity: any Community1Providing
+}
+
+// MARK: - Configurability
+
+extension ActionSeed {
+    static let subscribe = ActionSeed("subscribe") { entity in
+        switch entity {
+        case let entity as any Community1Providing: SubscribeAction(entity: entity)
+        default: nil
+        }
+    }
+}
+
+// MARK: - Appearance
+
+extension SubscribeAction {
+    static let subscribeLabel: ActionLabel = .init(
+        "Subscribe",
+        icon: .lemmy.subscribe,
+        color: .themedPositive
+    )
+    static let unsubscribeLabel: ActionLabel = .init(
+        "Unsubscribe",
+        icon: .lemmy.unsubscribe,
+        color: .themedNegative
+    )
+    
+    static var label: ActionLabel { subscribeLabel }
+
+    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+        guard let subscribed = entity.subscribed_  else {
+            return Self.subscribeLabel.withVisibility(.hidden)
+        }
+        if subscribed {
+            return Self.unsubscribeLabel.withVisibility(visibility(environment))
+        } else {
+            return Self.subscribeLabel.withVisibility(visibility(environment))
+        }
+    }
+
+    private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
+        guard entity.api.canInteract(appState: environment.appState) else { return .hidden }
+        return .enabled
+    }
+}
+
+// MARK: - Behavior
+
+extension SubscribeAction {
+    @MainActor
+    func execute(environment: EnvironmentValues) {
+        guard let entity = entity as? any Community2Providing else { return }
+        environment.hapticManager.play(haptic: .lightSuccess, tier: .low)
+        let wasFavorited = entity.favorited
+        if entity.subscribed {
+            environment.toastModel?.add(
+                .undoable(
+                    "Unsubscribed",
+                    icon: .lemmy.didUnsubscribe,
+                    callback: {
+                        if wasFavorited {
+                            entity.updateFavorite(true)
+                        } else {
+                            entity.updateSubscribe(true)
+                        }
+                    },
+                    color: .themedAccent
+                )
+            )
+        }
+        entity.toggleSubscribe()
+    }
+}

--- a/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
@@ -17,36 +17,6 @@ extension Community1Providing {
     
     // MARK: Operations
     
-    func toggleSubscribe(feedback: Set<FeedbackType>) {
-        if let self2 {
-            if feedback.contains(.haptic) {
-                HapticManager.main.play(haptic: .lightSuccess, tier: .low)
-            }
-            if feedback.contains(.toast) {
-                let wasFavorited = self2.favorited
-                if self2.subscribed {
-                    ToastModel.main.add(
-                        .undoable(
-                            "Unsubscribed",
-                            icon: .lemmy.didUnsubscribe,
-                            callback: {
-                                if wasFavorited {
-                                    self2.updateFavorite(true)
-                                } else {
-                                    self2.updateSubscribe(true)
-                                }
-                            },
-                            color: .themedAccent
-                        )
-                    )
-                }
-            }
-            self2.toggleSubscribe()
-        } else {
-            handleError(MlemError.modelError("No self2 found"), silent: true)
-        }
-    }
-    
     func toggleBlocked(feedback: Set<FeedbackType>) {
         if feedback.contains(.toast) {
             if !blocked {

--- a/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Community1Providing+Extensions.swift
@@ -17,11 +17,6 @@ extension Community1Providing {
     
     // MARK: Operations
     
-    @MainActor
-    func showNewPostSheet(feedLoader: CommunityPostFeedLoader? = nil) {
-        NavigationModel.main.openSheet(.createPost(community: self, type: nil, feedLoader: feedLoader))
-    }
-    
     func toggleSubscribe(feedback: Set<FeedbackType>) {
         if let self2 {
             if feedback.contains(.haptic) {
@@ -47,35 +42,6 @@ extension Community1Providing {
                 }
             }
             self2.toggleSubscribe()
-        } else {
-            handleError(MlemError.modelError("No self2 found"), silent: true)
-        }
-    }
-    
-    func toggleFavorite(feedback: Set<FeedbackType>) {
-        if let self2 {
-            if feedback.contains(.haptic) {
-                HapticManager.main.play(haptic: .lightSuccess, tier: .low)
-            }
-            if feedback.contains(.toast) {
-                if self2.favorited {
-                    ToastModel.main.add(
-                        .undoable(
-                            "Unfavorited",
-                            icon: .lemmy.unfavorite,
-                            callback: {
-                                self2.updateFavorite(true)
-                            },
-                            color: .themedFavorite
-                        )
-                    )
-                } else {
-                    ToastModel.main.add(
-                        .basic("Favorited", icon: .lemmy.favorite, color: .themedFavorite)
-                    )
-                }
-            }
-            self2.toggleFavorite()
         } else {
             handleError(MlemError.modelError("No self2 found"), silent: true)
         }
@@ -108,112 +74,5 @@ extension Community1Providing {
             }
         }
         toggleBlocked()
-    }
-    
-    // MARK: Action Collections
-    
-    @ActionBuilder
-    func menuActions(
-        appState: AppState,
-        feedback: Set<FeedbackType> = [.haptic, .toast],
-        navigation: NavigationLayer?,
-        feedLoader: CommunityPostFeedLoader?
-    ) -> [any Action] {
-        newPostAction(appState: appState, feedLoader: feedLoader)
-        subscribeAction(appState: appState, feedback: feedback)
-        favoriteAction(appState: appState, feedback: feedback)
-        openInstanceAction(navigation: navigation)
-        copyNameAction()
-        shareAction(navigation: navigation)
-        blockAction(appState: appState, feedback: feedback)
-        if api.isAdmin {
-            ActionGroup {
-                if api.supports(.removeCommunity, defaultValue: false) {
-                    removeAction(appState: appState)
-                }
-                if api.supports(.purgeContent, defaultValue: false) {
-                    purgeAction(appState: appState)
-                }
-            }
-        }
-    }
-    
-    func swipeActions(appState: AppState) -> SwipeConfiguration {
-        .init(
-            leadingActions: {},
-            trailingActions: {
-                if api.canInteract(appState: appState) {
-                    subscribeAction(appState: appState, feedback: [.haptic])
-                    favoriteAction(appState: appState, feedback: [.haptic])
-                }
-            }
-        )
-    }
-    
-    // MARK: Actions
-    
-    func newPostAction(appState: AppState, feedLoader: CommunityPostFeedLoader?) -> BasicAction {
-        let callback: (@MainActor () -> Void)?
-        if api.canInteract(appState: appState) {
-            callback = {
-                self.showNewPostSheet(feedLoader: feedLoader)
-            }
-        } else {
-            callback = nil
-        }
-        
-        return .init(
-            id: "newPost\(uid)",
-            appearance: .init(
-                label: "New Post",
-                color: .themedAccent,
-                icon: Icons.send,
-                swipeIcon2: Icons.sendFill
-            ),
-            callback: callback
-        )
-    }
-    
-    func subscribeAction(appState: AppState, feedback: Set<FeedbackType> = []) -> BasicAction {
-        let isOn: Bool = self2?.subscribed ?? false
-        return .init(
-            id: "subscribe\(actorId.description)",
-            appearance: .init(
-                label: isOn ? "Unsubscribe" : "Subscribe",
-                isOn: isOn,
-                isDestructive: isOn,
-                color: isOn ? .themedNegative : .themedPositive,
-                icon: isOn ? Icons.unsubscribe : Icons.subscribe,
-                swipeIcon1: isOn ? Icons.unsubscribePerson : Icons.subscribePerson,
-                swipeIcon2: isOn ? Icons.unsubscribePersonFill : Icons.subscribePersonFill
-            ),
-            callback: api.canInteract(appState: appState) ? { @MainActor in self.self2?.toggleSubscribe(feedback: feedback) } : nil
-        )
-    }
-    
-    func favoriteAction(appState: AppState, feedback: Set<FeedbackType> = []) -> BasicAction {
-        let isOn: Bool = self2?.favorited ?? false
-        return .init(
-            id: "favorite\(actorId.description)",
-            appearance: .init(
-                label: isOn ? "Unfavorite" : "Favorite",
-                isOn: isOn,
-                color: .themedFavorite,
-                icon: isOn ? Icons.unfavorite : Icons.favorite,
-                menuIcon: isOn ? Icons.favoriteFill : Icons.favorite,
-                swipeIcon1: isOn ? Icons.unfavorite : Icons.favorite,
-                swipeIcon2: isOn ? Icons.unfavoriteFill : Icons.favoriteFill
-            ),
-            callback: api.canInteract(appState: appState) ? { @MainActor in self.self2?.toggleFavorite(feedback: feedback) } : nil
-        )
-    }
-    
-    func blockAction(appState: AppState, feedback: Set<FeedbackType> = [], showConfirmation: Bool = true) -> BasicAction {
-        .init(
-            id: "block\(uid)",
-            appearance: .block(isOn: blocked),
-            confirmationPrompt: (!blocked && showConfirmation) ? "Really block this community?" : nil,
-            callback: api.canInteract(appState: appState) ? { @MainActor in self.toggleBlocked(feedback: feedback) } : nil
-        )
     }
 }

--- a/Mlem/App/Utility/Extensions/EnvironmentValues+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/EnvironmentValues+Extensions.swift
@@ -15,6 +15,7 @@ extension EnvironmentValues {
     @Entry var communityContext: (any Community1Providing)?
     @Entry var reportContext: Report?
     @Entry var feedContext: FeedContext?
+    @Entry var feedLoader: (any FeedLoading)?
     
     @Entry var parentFrameWidth: CGFloat = .zero
     @Entry var isRootView: Bool = false

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 30/07/2024.
 //
 
+import Actions
 import Dependencies
 import LemmyMarkdownUI
 import MlemMiddleware
@@ -142,7 +143,8 @@ struct CommunityView: View {
         .conditionalNavigationTitle(community.name)
         .toolbar {
             ToolbarItemGroup(placement: .secondaryAction) {
-                MenuButtons { community.menuActions(appState: appState, navigation: navigation, feedLoader: postFeedLoader) }
+                ActionButtons(community: community)
+                    .environment(postFeedLoader)
             }
         }
         // don't show the refresh popup if community api isn't the active api, since that indicates an unresolvable community

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -7,6 +7,7 @@
 
 import Actions
 import Dependencies
+import Haptics
 import LemmyMarkdownUI
 import MlemMiddleware
 import SwiftUI
@@ -31,6 +32,7 @@ struct CommunityView: View {
     @Environment(AppState.self) var appState
     @Environment(NavigationLayer.self) var navigation
     @Environment(FiltersTracker.self) var filtersTracker
+    @Environment(HapticManager.self) var hapticManager
     @Environment(\.palette) var palette
     @Environment(\.dismiss) var dismiss
     
@@ -214,8 +216,9 @@ struct CommunityView: View {
     func subscribeButton(community: any Community) -> some View {
         let subscribed = community.subscribed_ ?? false
         Button {
-            if community.api.willSendToken {
-                community.toggleSubscribe(feedback: [.haptic])
+            if let community = community as? any Community2Providing, community.api.willSendToken {
+                hapticManager.play(haptic: .gentleInfo, tier: .low)
+                community.toggleSubscribe()
             }
         } label: {
             HStack {

--- a/Mlem/App/Views/Root/Login/SignUpView+Views.swift
+++ b/Mlem/App/Views/Root/Login/SignUpView+Views.swift
@@ -215,7 +215,7 @@ extension SignUpView {
             }
             .foregroundStyle(.themedCaution)
             .listRowBackground(
-                RoundedRectangle(cornerRadius: UIDevice.isIos26 ? 25 : 10)
+                RoundedRectangle(cornerRadius: UIDevice.isIos26 ? 26 : 10)
                     .stroke(.themedCaution, lineWidth: 3)
                     .background(.themedCaution.opacity(0.1))
                     .clipShape(RoundedRectangle(cornerRadius: 10))

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListItemView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListItemView.swift
@@ -9,6 +9,7 @@ import MlemMiddleware
 import SwiftUI
 
 struct SubscriptionListItemView: View {
+    @Environment(\.self) var environment
     @Environment(AppState.self) private var appState
     @Environment(NavigationLayer.self) private var navigation
 
@@ -24,7 +25,7 @@ struct SubscriptionListItemView: View {
             .contextMenu(community: community)
             .swipeActions(edge: .trailing) {
                 Button("Unsubscribe", icon: .lemmy.unsubscribe) {
-                    community.toggleSubscribe(feedback: [.toast])
+                    SubscribeAction(entity: community).execute(environment: environment)
                 }
                 .buttonStyle(.automatic)
                 .labelStyle(.iconOnly)

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListItemView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListItemView.swift
@@ -21,9 +21,9 @@ struct SubscriptionListItemView: View {
     
     var body: some View {
         SubscriptionListNavigationButton(.community(community), label: label)
-            .contextMenu { community.menuActions(appState: appState, feedback: [.toast], navigation: navigation, feedLoader: nil) }
+            .contextMenu(community: community)
             .swipeActions(edge: .trailing) {
-                Button("Unsubscribe", icon: .general.failure) {
+                Button("Unsubscribe", icon: .lemmy.unsubscribe) {
                     community.toggleSubscribe(feedback: [.toast])
                 }
                 .buttonStyle(.automatic)

--- a/Mlem/App/Views/Shared/Search/Results/CommunityListRow.swift
+++ b/Mlem/App/Views/Shared/Search/Results/CommunityListRow.swift
@@ -55,7 +55,7 @@ struct CommunityListRow<Content2: View>: View {
         .background(.themedSecondaryGroupedBackground)
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu(community: community)
-        .quickSwipes(community.swipeActions(appState: appState))
+        .quickSwipes(leading: [], trailing: [SubscribeAction(entity: community), FavoriteAction(entity: community)])
         .popupAnchor()
         .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }

--- a/Mlem/App/Views/Shared/Search/Results/CommunityListRow.swift
+++ b/Mlem/App/Views/Shared/Search/Results/CommunityListRow.swift
@@ -56,6 +56,7 @@ struct CommunityListRow<Content2: View>: View {
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu(community: community)
         .quickSwipes(community.swipeActions(appState: appState))
+        .popupAnchor()
         .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
 }

--- a/Mlem/App/Views/Shared/Search/Results/CommunityListRow.swift
+++ b/Mlem/App/Views/Shared/Search/Results/CommunityListRow.swift
@@ -54,7 +54,7 @@ struct CommunityListRow<Content2: View>: View {
         .padding(.vertical, 6)
         .background(.themedSecondaryGroupedBackground)
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
-        .contextMenu { community.menuActions(appState: appState, navigation: navigation, feedLoader: nil) }
+        .contextMenu(community: community)
         .quickSwipes(community.swipeActions(appState: appState))
         .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }

--- a/Mlem/App/Views/Shared/WarningView.swift
+++ b/Mlem/App/Views/Shared/WarningView.swift
@@ -64,9 +64,9 @@ struct WarningView: View {
     }
     
     var backgroundRect: some View {
-        RoundedRectangle(cornerRadius: Constants.main.standardSpacing)
+        RoundedRectangle(cornerRadius: 26)
             .stroke(color, lineWidth: 3)
             .background(color.opacity(0.1))
-            .clipShape(RoundedRectangle(cornerRadius: Constants.main.standardSpacing))
+            .clipShape(RoundedRectangle(cornerRadius: 26))
     }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtonWithVisibilityControl.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtonWithVisibilityControl.swift
@@ -23,6 +23,11 @@ public struct ActionButtonWithVisibilityControl: View {
                 action.execute(environment: environment)
             }
             .disabled(label.visibility == .disabled)
+
+            // Without this, destructive items appear black in the
+            // subscription list due to a shim we've got in there #2374.
+            // Intentionally unthemed.
+            .tint(label.isDestructive ? .red : .primary)
         }
     }
 }


### PR DESCRIPTION
Functional changes:

The "Unsubscribe" action is no longer red. I think this is slightly better; it's not really _that_ destructive. If you disagree, I don't mind keeping it red.

The "subscribe" swipe action now uses the `plus.circle` symbol rather than `person.crop.circle.badge.plus`. This is a technical limitation with the new action system. I may fix this in future, but for now I think this icon is fine.

Increased the border radius of `WarningView` to match the increased border radius on iOS 26. This fixes a rendering bug in the "purge" sheet.