### PR TITLE
Fix piefed.zip

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Instance2Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Instance2Snapshot+PieFed.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public extension Instance2Snapshot {
-    init(pieFed: PieFedSite, lemmy: PieFedLemmyCompatibleSiteView) throws(ApiClientError) {
+    init(pieFed: PieFedSite, lemmy: PieFedLemmyCompatibleSiteView?) throws(ApiClientError) {
         // I suspect these can only be `nil` when the `PieFedSite` is used in a request body
         
         guard let enableDownvotes = pieFed.enableDownvotes else {
@@ -23,13 +23,29 @@ public extension Instance2Snapshot {
             throw ApiClientError.responseMissingRequiredData("PieFedSite registrationMode")
         }
 
-        let counts = lemmy.counts
-        let activeUserCount: ActiveUserCount = .init(
-            sixMonths: counts.usersActiveHalfYear,
-            month: counts.usersActiveMonth,
-            week: counts.usersActiveWeek,
-            day: counts.usersActiveDay
-        )
+
+        let postCount: Int
+        let commentCount: Int
+        let communityCount: Int
+        let activeUserCount: ActiveUserCount
+
+        if let lemmy {
+            let counts = lemmy.counts
+            postCount = counts.posts
+            commentCount = counts.comments
+            communityCount = counts.communities
+            activeUserCount = .init(
+                sixMonths: counts.usersActiveHalfYear,
+                month: counts.usersActiveMonth,
+                week: counts.usersActiveWeek,
+                day: counts.usersActiveDay
+            )
+        } else {
+            postCount = 0
+            commentCount = 0
+            communityCount = 0
+            activeUserCount = .zero
+        }
 
         try self.init(
             instance: .init(from: pieFed),
@@ -56,9 +72,9 @@ public extension Instance2Snapshot {
             defaultPostListingMode: .list,
             defaultPostSortType: .hot,
             userCount: userCount,
-            postCount: counts.posts,
-            commentCount: counts.comments,
-            communityCount: counts.communities,
+            postCount: postCount,
+            commentCount: commentCount,
+            communityCount: communityCount,
             activeUserCount: activeUserCount
         )
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Instance3Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Instance3Snapshot+PieFed.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public extension Instance3Snapshot {
-    init(pieFed: PieFedGetSiteResponse, lemmy: PieFedLemmyCompatibleSiteResponse) throws(ApiClientError) {
+    init(pieFed: PieFedGetSiteResponse, lemmy: PieFedLemmyCompatibleSiteResponse?) throws(ApiClientError) {
         // In addition to having their own site request, PieFed also impersonates
         // Lemmy's site request at "api/v3/site". We also use that response here,
         // because the response contains some data that is missing from PieFed's
@@ -28,7 +28,7 @@ public extension Instance3Snapshot {
         }
 
         try self.init(
-            instance: .init(pieFed: pieFed.site, lemmy: lemmy.siteView),
+            instance: .init(pieFed: pieFed.site, lemmy: lemmy?.siteView),
             allLanguages: allLanguages.compactMap { .init($0) },
             software: .init(type: .pieFed, version: .init(pieFed.version)),
             allowedLanguageIds: .init(0 ... allLanguages.count - 1),

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
@@ -168,22 +168,27 @@ public extension PieFedConnection {
     }
     
     // Returns a raw API type. For use inside PieFedConnection only
-    internal func rawGetMyPerson() async throws -> (PieFedGetSiteResponse, PieFedLemmyCompatibleSiteResponse) {
+    internal func rawGetMyPerson() async throws -> (PieFedGetSiteResponse, PieFedLemmyCompatibleSiteResponse?) {
         async let pieFedResponse = await perform(PieFedGetSiteRequest())
         async let lemmyResponse = await perform(PieFedLemmyCompatibleGetSiteRequest())
-        return try await (pieFedResponse, lemmyResponse)
+        return (try await pieFedResponse, try? await lemmyResponse)
     }
     
     // Calls rawGetMyPerson, but if there's already a task running in the `contextDataManager` uses that instead.
-    internal func rawGetMyPersonWithContext() async throws -> (PieFedGetSiteResponse, PieFedLemmyCompatibleSiteResponse) {
-        if let ongoingTask = contextDataManager.ongoingTask {
-            return try await ongoingTask.result.get()
-        } else {
-            let task = Task { try await rawGetMyPerson() }
-            Task.detached {
-                _ = try await self.contextDataManager.getValue(task: task)
+    internal func rawGetMyPersonWithContext() async throws -> (PieFedGetSiteResponse, PieFedLemmyCompatibleSiteResponse?) {
+        do {
+            if let ongoingTask = contextDataManager.ongoingTask {
+                return try await ongoingTask.result.get()
+            } else {
+                let task = Task { try await rawGetMyPerson() }
+                Task.detached {
+                    _ = try await self.contextDataManager.getValue(task: task)
+                }
+                return try await task.result.get()
             }
-            return try await task.result.get()
+        } catch {
+            print("PERSON ERROR", error)
+            throw error
         }
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection.swift
@@ -25,7 +25,7 @@ public class PieFedConnection: InstanceConnection {
     public let baseUrl: URL
     public var token: String?
     
-    private(set) var contextDataManager: SharedTaskManager<Context, (PieFedGetSiteResponse, PieFedLemmyCompatibleSiteResponse)> = .init()
+    private(set) var contextDataManager: SharedTaskManager<Context, (PieFedGetSiteResponse, PieFedLemmyCompatibleSiteResponse?)> = .init()
 
     public var fetchedVersion: SiteVersion? {
         contextDataManager.fetchedValue?.siteVersion


### PR DESCRIPTION
Piefed.zip is running a new version of PieFed that breaks Mlem completely (and other clients, apparently). I expect that either they'll roll back to an earlier version or PieFed will fix the bug.

This fixes the issue on our side - if it's not fixed on their side by the time you see this, we could put out a TestFlight?