### PR TITLE
Fix missing padding on interaction bar editor settings header

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Views.swift
@@ -241,6 +241,7 @@ extension InteractionBarEditorView {
             title: "Interaction Bar",
             description: "Tap and hold items to add, remove, or rearrange them."
         ) {}
+            .padding(Constants.main.standardSpacing)
             .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.largeItemCornerRadius))
     }
     

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mlem is a beautiful, intuitive, open source iOS client for [Lemmy](https://join-
 <a href="https://apps.apple.com/app/id6450543782"><img src="https://github.com/user-attachments/assets/a21869b5-521f-4e24-8c53-a35cd74dfb94" alt="Download on the App Store" width="175vw"></a>
 
 > [!NOTE]
-> Mlem requires iOS 17 or later.
+> Mlem requires iOS 18.0 or later.
 
 If you'd like to participate in the beta version of Mlem, you can [join our Testflight program](https://testflight.apple.com/join/W6ajfKQt).
 


### PR DESCRIPTION
## Issues

- closes #2512

## Description

Adds padding to the interaction bar editor settings header.

## Implementation Notes

The editor uses a `VStack` rather than a `Form`, so the header needs explicit padding. Uses `Constants.main.standardSpacing` for consistency.
