### PR TITLE
Recognize .avif URLs as media instead of links

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
@@ -127,7 +127,7 @@ public extension URL {
     
     var isMedia: Bool {
         if scheme == "mlempreview" { return true }
-        return proxyAwarePathExtension?.isContainedIn(["jpg", "jpeg", "png", "webp", "gif", "mp4"]) ?? false
+        return proxyAwarePathExtension?.isContainedIn(["jpg", "jpeg", "png", "webp", "gif", "avif", "mp4"]) ?? false
     }
     
     var isYouTubeLink: Bool {


### PR DESCRIPTION
## Issues

- closes #2568

## Description

Recognizes `.avif` image URLs as media instead of displaying them as links.

## Implementation Notes

Added `"avif"` to the extension list in `URL.isMedia`.