### PR TITLE
Sort subscription list by instance secondarily

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SubscriptionList.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SubscriptionList.swift
@@ -174,6 +174,11 @@ public class SubscriptionList {
     }
 
     private func sortPredicate(_ first: Community2, _ second: Community2) -> Bool {
-        first.fullName.localizedCompare(second.fullName) == .orderedAscending
+        let result = first.name.localizedCompare(second.name)
+        return switch result {
+        case .orderedAscending: true
+        case .orderedDescending: false
+        case .orderedSame: first.host.localizedCompare(second.host) == .orderedAscending
+        }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SubscriptionList.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SubscriptionList.swift
@@ -174,6 +174,6 @@ public class SubscriptionList {
     }
 
     private func sortPredicate(_ first: Community2, _ second: Community2) -> Bool {
-        first.name.localizedCompare(second.name) == .orderedAscending
+        first.fullName.localizedCompare(second.fullName) == .orderedAscending
     }
 }


### PR DESCRIPTION
The subscription list is now sorted by name and then by instance if two communities have the same name.