### PR TITLE
Notify user about hidden read posts on rapid feed refresh

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		6363D5C727EE196700E34822 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6363D5C627EE196700E34822 /* ContentView.swift */; };
 		6363D5C927EE196A00E34822 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6363D5C827EE196A00E34822 /* Assets.xcassets */; };
 		6DE1183C2A4A217400810C7E /* Profile View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE1183B2A4A217400810C7E /* Profile View.swift */; };
+		814CEF632F44577A0090F812 /* HiddenReadBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814CEF622F44577A0090F812 /* HiddenReadBannerView.swift */; };
 		81A179BC2DDE591700B17017 /* LongPressActionSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A179BB2DDE591700B17017 /* LongPressActionSettingsView.swift */; };
 		81A179BF2DDE5BF300B17017 /* TabBarLongPressAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A179BE2DDE5BF300B17017 /* TabBarLongPressAction.swift */; };
 		AD1B0D372A5F7A260006F554 /* Licenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1B0D362A5F7A260006F554 /* Licenses.swift */; };
@@ -964,6 +965,7 @@
 		6363D5D627EE196A00E34822 /* MlemTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MlemTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6363D5E027EE196A00E34822 /* MlemUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MlemUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6DE1183B2A4A217400810C7E /* Profile View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Profile View.swift"; sourceTree = "<group>"; };
+		814CEF622F44577A0090F812 /* HiddenReadBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenReadBannerView.swift; sourceTree = "<group>"; };
 		81A179BB2DDE591700B17017 /* LongPressActionSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongPressActionSettingsView.swift; sourceTree = "<group>"; };
 		81A179BE2DDE5BF300B17017 /* TabBarLongPressAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarLongPressAction.swift; sourceTree = "<group>"; };
 		AD1B0D362A5F7A260006F554 /* Licenses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Licenses.swift; sourceTree = "<group>"; };
@@ -2184,6 +2186,7 @@
 		CD7928212C73CB9B00FA712D /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				814CEF622F44577A0090F812 /* HiddenReadBannerView.swift */,
 				CD7928222C73CBA400FA712D /* TileScoreView.swift */,
 				0353948C2CA080EB00795AA5 /* FeedWelcomeView.swift */,
 				036A84542D98253400E95D50 /* UpdateBannerView.swift */,
@@ -2722,6 +2725,7 @@
 				039F588C2C7B574E00C61658 /* AdvancedSettingsView.swift in Sources */,
 				0320B6672C93504600D38548 /* SignUpView+Logic.swift in Sources */,
 				03E46ACD2D121C19002589DB /* HeadlinePostBodyView.swift in Sources */,
+				814CEF632F44577A0090F812 /* HiddenReadBannerView.swift in Sources */,
 				039F58882C7B531800C61658 /* SquircleLabelStyle.swift in Sources */,
 				035EDEF22C2DE94B00F51144 /* _assignIfNotEqual.swift in Sources */,
 				035EDEF32C2DE94B00F51144 /* SearchBar.swift in Sources */,

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+OutdatedFeedPopup.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+OutdatedFeedPopup.swift
@@ -29,8 +29,8 @@ private struct OutdatedFeedPopupModifier: ViewModifier {
         content
             .refreshable(isEnabled: feedLoader != nil) {
                 if let feedLoader {
-                    onManualRefresh?()
                     await refresh(feedLoader, clearBeforeRefresh: false)
+                    onManualRefresh?()
                 }
             }
             .onChange(of: apiChangeHash) {

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+OutdatedFeedPopup.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+OutdatedFeedPopup.swift
@@ -15,10 +15,12 @@ private struct OutdatedFeedPopupModifier: ViewModifier {
     let feedLoader: (any FeedLoading)?
     
     let canShowPopup: Bool
-    
-    init(feedLoader: (any FeedLoading)?, showPopup canShowPopup: Bool) {
+    let onManualRefresh: (() -> Void)?
+
+    init(feedLoader: (any FeedLoading)?, showPopup canShowPopup: Bool, onManualRefresh: (() -> Void)? = nil) {
         self.feedLoader = feedLoader
         self.canShowPopup = canShowPopup
+        self.onManualRefresh = onManualRefresh
     }
     
     @State var showRefreshPopup: Bool = false
@@ -27,6 +29,7 @@ private struct OutdatedFeedPopupModifier: ViewModifier {
         content
             .refreshable(isEnabled: feedLoader != nil) {
                 if let feedLoader {
+                    onManualRefresh?()
                     await refresh(feedLoader, clearBeforeRefresh: false)
                 }
             }
@@ -95,7 +98,7 @@ private struct OutdatedFeedPopupModifier: ViewModifier {
 }
 
 extension View {
-    func outdatedFeedPopup(feedLoader: (any FeedLoading)?, showPopup: Bool = true) -> some View {
-        modifier(OutdatedFeedPopupModifier(feedLoader: feedLoader, showPopup: showPopup))
+    func outdatedFeedPopup(feedLoader: (any FeedLoading)?, showPopup: Bool = true, onManualRefresh: (() -> Void)? = nil) -> some View {
+        modifier(OutdatedFeedPopupModifier(feedLoader: feedLoader, showPopup: showPopup, onManualRefresh: onManualRefresh))
     }
 }

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -37,6 +37,7 @@ struct CommunityView: View {
     @Environment(\.dismiss) var dismiss
     
     @Setting(\.post_size) var postSize
+    @Setting(\.feed_showRead) var showRead
     @Setting(\.safety_enableNsfwCommunityWarning) var showNsfwCommunityWarning
     @Setting(\.safety_blurNsfw) var blurNsfw
     
@@ -51,6 +52,8 @@ struct CommunityView: View {
     
     @State var showingConfirmation: Bool = false
     @State var newMod: Person?
+    @State var showHiddenReadBanner: Bool = false
+    @State var lastRefreshDate: Date?
     
     init(
         community: AnyCommunity,
@@ -142,6 +145,7 @@ struct CommunityView: View {
             }
             .environment(\.communityContext, community)
         }
+        .animation(.snappy, value: showHiddenReadBanner && !showRead)
         .conditionalNavigationTitle(community.name)
         .toolbar {
             ToolbarItemGroup(placement: .secondaryAction) {
@@ -153,8 +157,23 @@ struct CommunityView: View {
         .popupAnchor()
         .outdatedFeedPopup(
             feedLoader: postFeedLoader,
-            showPopup: selectedTab == .posts && community.api === appState.firstApi
+            showPopup: selectedTab == .posts && community.api === appState.firstApi,
+            onManualRefresh: {
+                guard !showRead else { return }
+                let now = Date()
+                if let lastRefresh = lastRefreshDate,
+                   now.timeIntervalSince(lastRefresh) < 5 {
+                    showHiddenReadBanner = true
+                }
+                lastRefreshDate = now
+            }
         )
+        .onChange(of: showRead) {
+            if showRead {
+                showHiddenReadBanner = false
+            }
+            lastRefreshDate = nil
+        }
         .fullScreenCover(isPresented: $warningPresented) {
             WarningOverlayView(
                 text: "This community likely contains graphic or explicit content.",
@@ -177,6 +196,12 @@ struct CommunityView: View {
             .foregroundStyle(.themedWarning)
             .padding(.top, Constants.main.doubleSpacing)
         } else {
+            if showHiddenReadBanner, !showRead {
+                HiddenReadBannerView {
+                    showHiddenReadBanner = false
+                }
+                .padding([.horizontal, .bottom], Constants.main.standardSpacing)
+            }
             PostGridView(postFeedLoader: postFeedLoader)
         }
     }

--- a/Mlem/App/Views/Root/Tabs/Feeds/Components/HiddenReadBannerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Components/HiddenReadBannerView.swift
@@ -2,7 +2,7 @@
 //  HiddenReadBannerView.swift
 //  Mlem
 //
-//  Created on 2026-02-17.
+//  Created by Bedir Ekim on 2026-02-17.
 //
 
 import SwiftUI

--- a/Mlem/App/Views/Root/Tabs/Feeds/Components/HiddenReadBannerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Components/HiddenReadBannerView.swift
@@ -1,0 +1,43 @@
+//
+//  HiddenReadBannerView.swift
+//  Mlem
+//
+//  Created on 2026-02-17.
+//
+
+import SwiftUI
+
+struct HiddenReadBannerView: View {
+    @Setting(\.feed_showRead) var showRead
+
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: Constants.main.standardSpacing) {
+            Text("Looking for something? Read posts are hidden.")
+                .font(.subheadline)
+                .foregroundStyle(.themedAccent)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(spacing: Constants.main.standardSpacing) {
+                Button {
+                    showRead = true
+                } label: {
+                    Text("Show Read")
+                        .frame(maxWidth: 400)
+                        .padding(.vertical, 4)
+                }
+                .buttonStyle(.borderedProminent)
+                Button {
+                    onDismiss()
+                } label: {
+                    Text("Dismiss")
+                        .frame(maxWidth: 400)
+                        .padding(.vertical, 4)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(Constants.main.standardSpacing)
+        .background(.themedAccent.opacity(0.2), in: .rect(cornerRadius: Constants.main.standardSpacing))
+    }
+}

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -29,6 +29,8 @@ struct FeedsView: View {
     @State var postFeedLoader: AggregatePostFeedLoader?
     @State var scrollToTopTrigger: Bool = false
     @State var initialListingType: ListingType?
+    @State var showHiddenReadBanner: Bool = false
+    @State var lastRefreshDate: Date?
     
     var feedOptions: [ListingType] {
         ListingType.cases(for: appState.firstAccount.accountType, api: appState.firstApi)
@@ -61,6 +63,10 @@ struct FeedsView: View {
             .navigationBarTitleDisplayMode(.inline)
             .onChange(of: showRead) {
                 scrollToTopTrigger.toggle()
+                if showRead {
+                    showHiddenReadBanner = false
+                }
+                lastRefreshDate = nil
             }
             .onChange(of: appState.firstApi, initial: false) {
                 // ensure we always are showing an appropriate feed
@@ -82,7 +88,15 @@ struct FeedsView: View {
                 }
             }
             .task { await setupFeedLoader() }
-            .outdatedFeedPopup(feedLoader: postFeedLoader)
+            .outdatedFeedPopup(feedLoader: postFeedLoader, onManualRefresh: {
+                guard !showRead else { return }
+                let now = Date()
+                if let lastRefresh = lastRefreshDate,
+                   now.timeIntervalSince(lastRefresh) < 5 {
+                    showHiddenReadBanner = true
+                }
+                lastRefreshDate = now
+            })
             .environment(\.feedContext, postFeedLoader?.feedType.feedContext)
     }
     
@@ -101,6 +115,12 @@ struct FeedsView: View {
                            lastTestFlightUpdate != testflightUrl {
                             UpdateBannerView(url: testflightUrl)
                                 .padding([.horizontal, .bottom], Constants.main.standardSpacing)
+                        }
+                        if showHiddenReadBanner, !showRead {
+                            HiddenReadBannerView {
+                                showHiddenReadBanner = false
+                            }
+                            .padding([.horizontal, .bottom], Constants.main.standardSpacing)
                         }
                         PostGridView(postFeedLoader: postFeedLoader)
                     } header: {

--- a/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/FeedsView.swift
@@ -139,6 +139,7 @@ struct FeedsView: View {
                     }
                 }
                 .animation(.snappy, value: backendClient.testflightUpdate != lastTestFlightUpdate)
+                .animation(.snappy, value: showHiddenReadBanner && !showRead)
             } else {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -4921,6 +4921,16 @@
         }
       }
     },
+    "Looking for something? Read posts are hidden." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous cherchez quelque chose ? Les publications lues sont masquées."
+          }
+        }
+      }
+    },
     "Low" : {
       "localizations" : {
         "fr" : {


### PR DESCRIPTION
## Issues

- closes #2309

## Description

Adds a banner when the user pulls to refresh twice in quick succession with "Hide Read" enabled, explaining that read posts are hidden and offering a "Show Read" button.

## Implementation Notes

- `HiddenReadBannerView`: New banner view matching existing banner styling (FeedWelcomeView/UpdateBannerView)
- `FeedsView`: Tracks last manual refresh timestamp, shows banner if two refreshes occur within 5 seconds while `feed_showRead` is false
- `View+OutdatedFeedPopup`: Added `onManualRefresh` callback to detect pull-to-refresh specifically (not initial loads or infinite scroll)
- Banner dismisses via "Show Read" (toggles setting) or "Dismiss" (hides banner only)
- Updated French localization for this banner's message

