### PR TITLE
Don't play haptics when tapping ended poll, show toast instead

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/PostPollView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/PostPollView.swift
@@ -129,6 +129,10 @@ struct PostPollView: View {
         .padding(.vertical, 8)
         .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: 16))
         .onTapGesture {
+            if poll.hasEnded {
+                toastModel?.add(.basic("Poll has ended", subtitle: "This poll is no longer accepting votes.", duration: 3))
+                return
+            }
             if poll.hasVoted {
                 toastModel?.add(.basic("Already voted", subtitle: "You cannot change your vote.", duration: 3))
                 return

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -6167,6 +6167,16 @@
         }
       }
     },
+    "Poll has ended" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le sondage est terminé"
+          }
+        }
+      }
+    },
     "Popular" : {
       "localizations" : {
         "fr" : {
@@ -8963,6 +8973,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cette page ne peut pas être affichée car Cloudflare a bloqué la requête."
+          }
+        }
+      }
+    },
+    "This poll is no longer accepting votes." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce sondage n'accepte plus de votes."
           }
         }
       }


### PR DESCRIPTION
## Issues

- closes #2589

## Description

Prevents haptic feedback when tapping a poll answer after the poll has ended, and shows an informative toast instead.

## Implementation Notes

- Added `poll.hasEnded` guard at the top of the tap gesture handler in `PostPollView.choiceView`, before the haptic and selection logic
- Shows a toast ("Poll has ended") matching the existing `hasVoted` pattern for consistency