### PR TITLE
Show toast when hide read is toggled

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
@@ -141,7 +141,7 @@ extension InboxView {
         Button {
             showRead.toggle()
             let message: LocalizedStringResource = showRead ? "Showing Read" : "Hiding Read"
-            ToastModel.main.add(.success(message))
+            toastModel.add(.success(message))
         } label: {
             Label("Hide Read", icon: .general.filterMenu)
                 .symbolVariant(showRead ? .none : .fill)

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView+Views.swift
@@ -140,6 +140,8 @@ extension InboxView {
     var hideReadButton: some View {
         Button {
             showRead.toggle()
+            let message: LocalizedStringResource = showRead ? "Showing Read" : "Hiding Read"
+            ToastModel.main.add(.success(message))
         } label: {
             Label("Hide Read", icon: .general.filterMenu)
                 .symbolVariant(showRead ? .none : .fill)

--- a/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
+++ b/Mlem/App/Views/Root/Tabs/Inbox/InboxView.swift
@@ -16,6 +16,7 @@ struct InboxView: View {
     @Environment(HapticManager.self) var hapticManager
     @Environment(NavigationLayer.self) var navigation
     @Environment(FiltersTracker.self) var filtersTracker
+    @Environment(ToastModel.self) var toastModel
     
     @Setting(\.inbox_showRead) var showRead
     

--- a/Mlem/App/Views/Shared/FeedToolbarOptions.swift
+++ b/Mlem/App/Views/Shared/FeedToolbarOptions.swift
@@ -19,6 +19,8 @@ struct FeedToolbarOptions: ToolbarContent {
             SwiftUI.Section {
                 Button(showRead ? "Hide Read" : "Show Read", icon: .settings.hideRead) {
                     showRead.toggle()
+                    let message: LocalizedStringResource = showRead ? "Showing Read" : "Hiding Read"
+                    ToastModel.main.add(.success(message))
                 }
                 
                 Menu {

--- a/Mlem/App/Views/Shared/FeedToolbarOptions.swift
+++ b/Mlem/App/Views/Shared/FeedToolbarOptions.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct FeedToolbarOptions: ToolbarContent {
     @Environment(AppState.self) var appState
+    @Environment(ToastModel.self) var toastModel
     
     @Setting(\.post_size) var postSize
     @Setting(\.feed_showRead) var showRead
@@ -20,7 +21,7 @@ struct FeedToolbarOptions: ToolbarContent {
                 Button(showRead ? "Hide Read" : "Show Read", icon: .settings.hideRead) {
                     showRead.toggle()
                     let message: LocalizedStringResource = showRead ? "Showing Read" : "Hiding Read"
-                    ToastModel.main.add(.success(message))
+                    toastModel.add(.success(message))
                 }
                 
                 Menu {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -4204,7 +4204,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Masquer la lecture"
+            "value" : "Masquer les lus"
           }
         }
       }
@@ -4225,6 +4225,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Masquer les icônes du site web"
+          }
+        }
+      }
+    },
+    "Hiding Read" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lus masqués"
           }
         }
       }
@@ -7938,7 +7948,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afficher lu"
+            "value" : "Afficher les lus"
           }
         }
       }
@@ -7979,6 +7989,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afficher les avertissements lors de l'ouverture..."
+          }
+        }
+      }
+    },
+    "Showing Read" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lus affichés"
           }
         }
       }


### PR DESCRIPTION
## Issues

- closes #2308

## Description

Shows a toast when the user taps "Hide Read" or "Show Read" in the feed or inbox.

## Implementation Notes

- Added toast in `FeedToolbarOptions` and `InboxView+Views`
- Uses `.success()` toast to match existing patterns
- Uses explicit `LocalizedStringResource` type so Xcode picks up the strings for localization