### PR TITLE
Fix username shown twice for posts in mod mail

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/HeadlinePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/HeadlinePostView.swift
@@ -78,7 +78,7 @@ struct HeadlinePostView<EmbeddedContent: View>: View {
                 
                 HeadlinePostBodyView(post: post, requireConsistentHeight: requireConsistentHeight)
                 
-                if alwaysShowCreator, communityContext == nil {
+                if alwaysShowCreator, communityContext == nil, topNavigationLink != .creator {
                     personLink
                 }
                 

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/LargePostView.swift
@@ -86,7 +86,7 @@ struct LargePostView: View {
                 
                 LargePostBodyView(post: post, isPostPage: isPostPage, shouldBlur: shouldBlur)
                 
-                if (alwaysShowCreator && communityContext == nil) || isPostPage {
+                if (alwaysShowCreator && communityContext == nil && topNavigationLink != .creator) || isPostPage {
                     personLink
                 }
                 


### PR DESCRIPTION
## Issues

- closes #2507

## Description

Fixes the post creator name showing up twice on reported posts in mod mail.

## Implementation Notes

- In reports, `favoredLink: .creator` is passed, which already shows the creator at the top
- The `alwaysShowCreator` setting then shows it again below
- Added a check to skip the second one if the creator is already shown at the top
- Applied to both `HeadlinePostView` and `LargePostView`
- Normal feed views are not affected