### PR TITLE
Auto-dismiss TestFlight banner when navigating to update post from feed

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Feeds/Components/UpdateBannerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Components/UpdateBannerView.swift
@@ -60,6 +60,12 @@ struct UpdateBannerView: View {
                 }
             }
         }
+        .onChange(of: navigation.path) {
+            if case .post(let post, _, _, _) = navigation.path.last,
+               post.allResolvableUrls.contains(url) {
+                dismiss()
+            }
+        }
     }
     
     func dismiss() {


### PR DESCRIPTION
## Issues

- closes #2365

## Description

Hides the TestFlight update banner when the user opens the update post from their feed.

## Implementation Notes

- Added `.onChange(of: navigation.path)` to `UpdateBannerView`
- Checks if the user navigated to a post matching the banner URL
- Uses `allResolvableUrls` to match the URL regardless of which instance the user is on
- Calls the existing `dismiss()` function