### PR TITLE
Preserve removed comment content from being overwritten (Modlog)

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment.swift
@@ -106,7 +106,9 @@ public class Comment:
     }
     
     public func update(with properties: CommentProperties) {
-        setIfChanged(\.content, properties.content)
+        if !properties.removed {
+            setIfChanged(\.content, properties.content)
+        }
         setIfChanged(\.updated, properties.updated)
         setIfChanged(\.distinguished, properties.distinguished)
         setIfChanged(\.languageId, properties.languageId)


### PR DESCRIPTION
## Issues

- closes #2548

## Description

Fixes removed comments showing up empty in the modlog. When navigating to a removed comment, the API returns empty content, which was overwriting the locally stored content.

## Implementation Notes

- Added a guard in `Comment.update(with:)` to skip updating `content` when the incoming data has `removed` set to `true`