### PR TITLE
Customizable action sheet

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 		03D3A1EF2BB9CA1D009DE55E /* MenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D3A1EE2BB9CA1D009DE55E /* MenuButton.swift */; };
 		03D3A1F12BB9D48E009DE55E /* BasicAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D3A1F02BB9D48E009DE55E /* BasicAction.swift */; };
 		03D3A1F32BB9D49B009DE55E /* ActionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D3A1F22BB9D49B009DE55E /* ActionGroup.swift */; };
+		03D65D702F4B046F0041ADAF /* ContextMenuSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D65D6F2F4B046F0041ADAF /* ContextMenuSettingsView.swift */; };
 		03D8BF432DA55B6900506687 /* Icons in Frameworks */ = {isa = PBXBuildFile; productRef = 03D8BF422DA55B6900506687 /* Icons */; };
 		03DA4FB72CF115FB001C3C77 /* CommentEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B12C44409D001A1EB5 /* CommentEditorView.swift */; };
 		03DAEA772C64074E0064DE64 /* SubscriptionListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DAEA762C64074E0064DE64 /* SubscriptionListItemView.swift */; };
@@ -948,6 +949,7 @@
 		03D3A1EE2BB9CA1D009DE55E /* MenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuButton.swift; sourceTree = "<group>"; };
 		03D3A1F02BB9D48E009DE55E /* BasicAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicAction.swift; sourceTree = "<group>"; };
 		03D3A1F22BB9D49B009DE55E /* ActionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionGroup.swift; sourceTree = "<group>"; };
+		03D65D6F2F4B046F0041ADAF /* ContextMenuSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuSettingsView.swift; sourceTree = "<group>"; };
 		03DAEA762C64074E0064DE64 /* SubscriptionListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionListItemView.swift; sourceTree = "<group>"; };
 		03DD69412D4FDE8900F8950D /* Person+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Person+Mock.swift"; sourceTree = "<group>"; };
 		03DD69432D4FEA0000F8950D /* PreviewModifier+SampleEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreviewModifier+SampleEnvironment.swift"; sourceTree = "<group>"; };
@@ -1273,6 +1275,7 @@
 				03AB48542CBC0B8000567FF9 /* AccountAdvancedSettingsView.swift */,
 				03AB48582CBC14CE00567FF9 /* AccountEmailSettingsView.swift */,
 				03AB48512CBC042E00567FF9 /* AccountContentSettingsView.swift */,
+				03D65D6F2F4B046F0041ADAF /* ContextMenuSettingsView.swift */,
 				03134A572BEC1C46002662CC /* AccountListSettingsView.swift */,
 				03AD0A812CFDBFA0001EF9F7 /* AccountLocalSettingsView.swift */,
 				03AD0A832CFDC557001EF9F7 /* AccountNicknameFieldView.swift */,
@@ -3048,6 +3051,7 @@
 				CD10FA772C7A8622008985AD /* ImageSaver.swift in Sources */,
 				03267D822BED489C009D6268 /* AvatarBannerView.swift in Sources */,
 				031CA5752E5900C800CF0C0F /* SwipeConfiguration+Extensions.swift in Sources */,
+				03D65D702F4B046F0041ADAF /* ContextMenuSettingsView.swift in Sources */,
 				03500C2D2BF7FC2500CAA076 /* ToastView.swift in Sources */,
 				0311ADB92E4E0E0800EC3120 /* VisitAgainView.swift in Sources */,
 				CDB95FCD2EBD3230008669D9 /* SmallOverlayButtonLabel.swift in Sources */,

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -24,9 +24,15 @@ struct ActionSheet: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 0) {
                 content
                     .padding(16)
+                Button("Customize", icon: .general.edit) {
+                    navigation.replace(.contextMenuSettings)
+                }
+                .font(.footnote)
+                .padding(.horizontal, 32)
+                .padding(.top, -5)
             }
         }
         .presentationBackground(.themedGroupedBackground)

--- a/Mlem/App/Actions/ContextMenu+InboxNotification.swift
+++ b/Mlem/App/Actions/ContextMenu+InboxNotification.swift
@@ -9,15 +9,9 @@ import Actions
 import MlemMiddleware
 import SwiftUI
 
-private let topLevelSeeds: [ActionSeed] = [
-    .markRead,
-    .share,
-    .blockCreator,
-    .report
-]
-
 private struct InboxNotificationContextMenuViewModifier: ViewModifier {
     @Environment(NavigationLayer.self) var navigation
+    @Setting(\.interactionBar_reply) var replyBarConfiguration
 
     let notification: InboxNotification
 
@@ -25,7 +19,7 @@ private struct InboxNotificationContextMenuViewModifier: ViewModifier {
         content
             .contextMenu {
                 ActionButtons { _ in
-                    topLevelSeeds.compactMap {
+                    replyBarConfiguration.contextMenu.compactMap {
                         $0.createAction(notification) ?? $0.createAction(notification.content.wrappedValue)
                     }
                 }

--- a/Mlem/App/Actions/ContextMenu+InboxNotification.swift
+++ b/Mlem/App/Actions/ContextMenu+InboxNotification.swift
@@ -39,30 +39,9 @@ private struct InboxNotificationContextMenuViewModifier: ViewModifier {
     }
 
     var sheetSections: [ActionSheetSection] {
-        [
-            .init(actions: createActions(seeds: [
-                .upvote,
-                .downvote,
-                .save,
-                .reply,
-                .markRead,
-                .selectText,
-                .share,
-                .report,
-                .edit,
-                .delete
-            ])),
-            .init(actions: createActions(seeds: [
-                .blockCreator,
-                .copyAuthorName,
-                .openCreatorModlog,
-                .sendCreatorMessage
-            ])),
-            .init(actions: createActions(seeds: [
-                .banCreator,
-                .purgeCreator
-            ]))
-        ]
+        ReplyBarConfiguration.availableActions.map { seeds in
+            .init(actions: self.createActions(seeds: seeds))
+        }
     }
 
     func createActions(seeds: [ActionSeed]) -> [any Actions.Action] {

--- a/Mlem/App/Actions/VoteAction.swift
+++ b/Mlem/App/Actions/VoteAction.swift
@@ -9,7 +9,7 @@ import Actions
 import MlemMiddleware
 import SwiftUI
 
-struct VoteAction: SimpleLabelAction {
+struct VoteAction: Actions.Action {
     let entity: any InteractableProviding
     let type: ScoringOperation
 }
@@ -17,8 +17,12 @@ struct VoteAction: SimpleLabelAction {
 // MARK: - Configurability
 
 extension ActionSeed {
-    static let upvote = ActionSeed("upvote") { createVoteAction($0, type: .upvote) }
-    static let downvote = ActionSeed("downvote") { createVoteAction($0, type: .downvote) }
+    static let upvote = ActionSeed("upvote", label: VoteAction.upvoteLabel) {
+        createVoteAction($0, type: .upvote)
+    }
+    static let downvote = ActionSeed("downvote", label: VoteAction.downvoteLabel) {
+        createVoteAction($0, type: .downvote)
+    }
 }
 
 private func createVoteAction(_ entity: Any, type: ScoringOperation) -> VoteAction? {
@@ -51,8 +55,6 @@ extension VoteAction {
         icon: .lemmy.downvoted.representingState(active: true),
         color: .themedDownvote
     )
-    
-    static var label: ActionLabel { upvoteLabel }
 
     func createLabel(environment: EnvironmentValues) -> ActionLabel {
         guard let votes = entity.votes.value else { return Self.upvoteLabel.withVisibility(.hidden) }

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -114,6 +114,7 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
     var readouts: [ReadoutType]
     var leadingSwipes: [ActionType]
     var trailingSwipes: [ActionType]
+    var contextMenu: [ActionSeed]
 
     var availableWidgets: Set<Item>
     func widgetPickerPage(_ configuration: Binding<Self>) -> SettingsPage { .replyBarWidgetPicker(configuration) }
@@ -131,9 +132,10 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
         self.leadingSwipes = leadingSwipes
         self.trailingSwipes = trailingSwipes
         self.readouts = readouts
+        self.contextMenu = Self.defaultContextMenu
         self.availableWidgets = availableWidgets
     }
-    
+
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.leading = try container.decodeIfPresent([Item].self, forKey: .leading) ?? [.counter(.score)]
@@ -143,6 +145,13 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
         self.readouts = try container.decodeIfPresent([ReadoutType].self, forKey: .readouts) ?? [.created, .comment]
         self.availableWidgets = try container.decodeIfPresent(Set<Item>.self, forKey: .availableWidgets) ??
             .init(CounterType.defaultWidgets.map { .counter($0) } + ActionType.defaultWidgets.map { .action($0) })
+
+        if let contextMenuKeys = try container.decodeIfPresent([String].self, forKey: .contextMenu) {
+            let allActions = Self.availableActions.reduce([], +) 
+            self.contextMenu = contextMenuKeys.compactMap { key in allActions.first(where: {$0.key == key}) }
+        } else {
+            self.contextMenu = Self.defaultContextMenu
+        }
     }
     
     static var `default`: Self {
@@ -181,6 +190,10 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
                 .purgeCreator
             ]
         ]
+    }
+
+    static var defaultContextMenu: [ActionSeed] {
+        [.markRead, .share, .blockCreator, .report]
     }
     
     static var reportDefault: Self? { nil }

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 14/06/2024.
 //
 
+import Actions
 import Foundation
 import MlemMiddleware
 import SwiftUI
@@ -153,6 +154,33 @@ struct ReplyBarConfiguration: InteractionBarConfiguration {
             readouts: [.created, .comment],
             availableWidgets: .init(CounterType.defaultWidgets.map { .counter($0) } + ActionType.defaultWidgets.map { .action($0) })
         )
+    }
+
+    static var availableActions: [[ActionSeed]] {
+        [
+            [
+                .upvote,
+                .downvote,
+                .save,
+                .reply,
+                .markRead,
+                .selectText,
+                .share,
+                .report,
+                .edit,
+                .delete
+            ],
+            [
+                .blockCreator,
+                .copyAuthorName,
+                .openCreatorModlog,
+                .sendCreatorMessage
+            ],
+            [
+                .banCreator,
+                .purgeCreator
+            ]
+        ]
     }
     
     static var reportDefault: Self? { nil }

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -1,0 +1,16 @@
+//
+//  ContextMenuSettingsView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-02-22.
+//
+
+import SwiftUI
+
+struct ContextMenuSettingsView: View {
+    var body: some View {
+        Form {
+            Text("Hello world")
+        }
+    }
+}

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 2026-02-22.
 //
 
+import ComponentViews
 import Actions
 import SwiftUI
 
@@ -54,6 +55,11 @@ struct ContextMenuSettingsView: View {
                 drawerActionSectionView(seeds)
             }
         }
+        .toolbar {
+            CloseButtonToolbarItem(ios18Label: .xmark)
+        }
+        .navigationTitle("Customize Context Menu")
+        .navigationBarTitleDisplayMode(.inline)
         .environment(\.editMode, .constant(.active))
     }
 

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -5,12 +5,68 @@
 //  Created by Sjmarf on 2026-02-22.
 //
 
+import Actions
 import SwiftUI
+
+private var sheetSections: [[ActionSeed]] {
+    [
+        [
+            .upvote,
+            .downvote,
+            .save,
+            .reply,
+            .markRead,
+            .selectText,
+            .share,
+            .report,
+            .edit,
+            .delete
+        ],
+        [
+            .blockCreator,
+            .copyAuthorName,
+            .openCreatorModlog,
+            .sendCreatorMessage
+        ],
+        [
+            .banCreator,
+            .purgeCreator
+        ]
+    ]
+}
 
 struct ContextMenuSettingsView: View {
     var body: some View {
         Form {
-            Text("Hello world")
+            ForEach(Array(sheetSections.enumerated()), id: \.offset) { _, seeds in
+                drawerActionSectionView(seeds)
+            }
         }
+    }
+
+    @ViewBuilder
+    func drawerActionSectionView(_ seeds: [ActionSeed]) -> some View {
+        Section {
+            ForEach(seeds, id: \.key, content: drawerActionRowView)
+        }
+    }
+
+    @ViewBuilder
+    func drawerActionRowView(_ seed: ActionSeed) -> some View {
+        Button {
+            
+        } label: {
+            HStack {
+                Label(seed.label)
+                    .imageScale(.small)
+                    .foregroundStyle(seed.label.isDestructive ? .themedWarning : .themedPrimary)
+                Spacer()
+                Image(icon: .general.add)
+                    .symbolVariant(.circle.fill)
+                    .foregroundStyle(.themedAccent)
+                    .imageScale(.large)
+            }
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -47,6 +47,9 @@ struct ContextMenuSettingsView: View {
             .onMove { fromOffsets, toOffset in
                 selected.move(fromOffsets: fromOffsets, toOffset: toOffset)
             }
+            .onDelete { offsets in
+                selected.remove(atOffsets: offsets)
+            }
             ForEach(Array(sheetSections.enumerated()), id: \.offset) { _, seeds in
                 drawerActionSectionView(seeds)
             }

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -44,10 +44,14 @@ struct ContextMenuSettingsView: View {
                 Label(seed.label)
                     .foregroundStyle(seed.label.isDestructive ? .themedWarning : .themedPrimary)
             }
+            .onMove { fromOffsets, toOffset in
+                selected.move(fromOffsets: fromOffsets, toOffset: toOffset)
+            }
             ForEach(Array(sheetSections.enumerated()), id: \.offset) { _, seeds in
                 drawerActionSectionView(seeds)
             }
         }
+        .environment(\.editMode, .constant(.active))
     }
 
     @ViewBuilder

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -10,19 +10,19 @@ import Actions
 import SwiftUI
 
 struct ContextMenuSettingsView: View {
-    @State var selected: [ActionSeed] = []
+    @Setting(\.interactionBar_reply) var replyBarConfiguration
 
     var body: some View {
         Form {
-            ForEach(selected, id: \.key) { seed in
+            ForEach(replyBarConfiguration.contextMenu, id: \.key) { seed in
                 Label(seed.label)
                     .foregroundStyle(seed.label.isDestructive ? .themedWarning : .themedPrimary)
             }
             .onMove { fromOffsets, toOffset in
-                selected.move(fromOffsets: fromOffsets, toOffset: toOffset)
+                replyBarConfiguration.contextMenu.move(fromOffsets: fromOffsets, toOffset: toOffset)
             }
             .onDelete { offsets in
-                selected.remove(atOffsets: offsets)
+                replyBarConfiguration.contextMenu.remove(atOffsets: offsets)
             }
             ForEach(Array(ReplyBarConfiguration.availableActions.enumerated()), id: \.offset) { _, seeds in
                 drawerActionSectionView(seeds)
@@ -47,14 +47,14 @@ struct ContextMenuSettingsView: View {
     func drawerActionRowView(_ seed: ActionSeed) -> some View {
         Button {
             withAnimation {
-                selected.append(seed)
+                replyBarConfiguration.contextMenu.append(seed)
             }
         } label: {
             HStack {
                 Label(seed.label)
                     .foregroundStyle(seed.label.isDestructive ? .themedWarning : .themedPrimary)
                 Spacer()
-                if !selected.contains(seed) {
+                if !replyBarConfiguration.contextMenu.contains(seed) {
                     Image(icon: .general.add)
                         .symbolVariant(.circle.fill)
                         .foregroundStyle(.themedAccent)
@@ -63,6 +63,6 @@ struct ContextMenuSettingsView: View {
             }
         }
         .buttonStyle(.plain)
-        .disabled(selected.contains(seed))
+        .disabled(replyBarConfiguration.contextMenu.contains(seed))
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -68,12 +68,15 @@ struct ContextMenuSettingsView: View {
                 Label(seed.label)
                     .foregroundStyle(seed.label.isDestructive ? .themedWarning : .themedPrimary)
                 Spacer()
-                Image(icon: .general.add)
-                    .symbolVariant(.circle.fill)
-                    .foregroundStyle(.themedAccent)
-                    .imageScale(.large)
+                if !selected.contains(seed) {
+                    Image(icon: .general.add)
+                        .symbolVariant(.circle.fill)
+                        .foregroundStyle(.themedAccent)
+                        .imageScale(.large)
+                }
             }
         }
         .buttonStyle(.plain)
+        .disabled(selected.contains(seed))
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -36,8 +36,14 @@ private var sheetSections: [[ActionSeed]] {
 }
 
 struct ContextMenuSettingsView: View {
+    @State var selected: [ActionSeed] = []
+
     var body: some View {
         Form {
+            ForEach(selected, id: \.key) { seed in
+                Label(seed.label)
+                    .foregroundStyle(seed.label.isDestructive ? .themedWarning : .themedPrimary)
+            }
             ForEach(Array(sheetSections.enumerated()), id: \.offset) { _, seeds in
                 drawerActionSectionView(seeds)
             }
@@ -54,11 +60,12 @@ struct ContextMenuSettingsView: View {
     @ViewBuilder
     func drawerActionRowView(_ seed: ActionSeed) -> some View {
         Button {
-            
+            withAnimation {
+                selected.append(seed)
+            }
         } label: {
             HStack {
                 Label(seed.label)
-                    .imageScale(.small)
                     .foregroundStyle(seed.label.isDestructive ? .themedWarning : .themedPrimary)
                 Spacer()
                 Image(icon: .general.add)

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -9,33 +9,6 @@ import ComponentViews
 import Actions
 import SwiftUI
 
-private var sheetSections: [[ActionSeed]] {
-    [
-        [
-            .upvote,
-            .downvote,
-            .save,
-            .reply,
-            .markRead,
-            .selectText,
-            .share,
-            .report,
-            .edit,
-            .delete
-        ],
-        [
-            .blockCreator,
-            .copyAuthorName,
-            .openCreatorModlog,
-            .sendCreatorMessage
-        ],
-        [
-            .banCreator,
-            .purgeCreator
-        ]
-    ]
-}
-
 struct ContextMenuSettingsView: View {
     @State var selected: [ActionSeed] = []
 
@@ -51,7 +24,7 @@ struct ContextMenuSettingsView: View {
             .onDelete { offsets in
                 selected.remove(atOffsets: offsets)
             }
-            ForEach(Array(sheetSections.enumerated()), id: \.offset) { _, seeds in
+            ForEach(Array(ReplyBarConfiguration.availableActions.enumerated()), id: \.offset) { _, seeds in
                 drawerActionSectionView(seeds)
             }
         }

--- a/Mlem/App/Views/Shared/Accounts/AccountListView.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView.swift
@@ -43,8 +43,8 @@ struct AccountListView: View {
         }
         
         @_disfavoredOverload
-        init(header: String, accounts: [any Account]) {
-            self.header = header
+        init(header: some StringProtocol, accounts: [any Account]) {
+            self.header = String(header)
             self.accounts = accounts
         }
     }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -237,6 +237,8 @@ extension NavigationPage {
             ExportableCommentEditorView(comment: comment, commentTreeTracker: tracker)
         case let .actionSheet(sections):
             ActionSheet(sections: sections.wrappedValue)
+        case .contextMenuSettings:
+            ContextMenuSettingsView()
         }
     }
 }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -88,6 +88,7 @@ enum NavigationPage: Hashable {
     case exportPostImage(_ post: Post)
     case exportCommentImage(_ comment: Comment, tracker: CommentTreeTracker?)
     case actionSheet(_ actions: HashWrapper<[ActionSheetSection]>)
+    case contextMenuSettings
     
     static func post(
         _ post: Post,

--- a/Mlem/App/Views/Shared/Toast/ToastType.swift
+++ b/Mlem/App/Views/Shared/Toast/ToastType.swift
@@ -44,14 +44,14 @@ enum ToastType: Hashable {
     
     @_disfavoredOverload
     static func basic(
-        _ title: String,
+        _ title: some StringProtocol,
         subtitle: String? = nil,
         icon: Icon? = nil,
         color: ThemedColor? = nil,
         duration: Double = 1.5
     ) -> ToastType {
         .basic(
-            title: title,
+            title: String(title),
             subtitle: subtitle,
             icon: icon,
             color: color ?? .themedAccent,

--- a/Mlem/App/Views/Shared/WarningView.swift
+++ b/Mlem/App/Views/Shared/WarningView.swift
@@ -24,9 +24,9 @@ struct WarningView: View {
     }
     
     @_disfavoredOverload
-    init(icon: Icon, text: String, inList: Bool, overrideColor: ThemedColor? = nil) {
+    init(icon: Icon, text: some StringProtocol, inList: Bool, overrideColor: ThemedColor? = nil) {
         self.icon = icon
-        self.text = text
+        self.text = String(text)
         self.inList = inList
         self.overrideColor = overrideColor
     }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -2801,6 +2801,26 @@
         }
       }
     },
+    "Customize" : {
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Customise"
+          }
+        }
+      }
+    },
+    "Customize Context Menu" : {
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Customise Context Menu"
+          }
+        }
+      }
+    },
     "Customize how moderator actions are separated from regular actions in context menus." : {
       "localizations" : {
         "en-GB" : {

--- a/Mlem/Packages/Actions/Sources/Actions/ActionLabel.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionLabel.swift
@@ -32,13 +32,13 @@ public struct ActionLabel {
     
     @_disfavoredOverload
     public init(
-        _ title: String,
+        _ title: some StringProtocol,
         icon: Icon,
         color: ThemedColor = .themedAccent,
         isDestructive: Bool = false,
         visibility: ActionVisiblity = .enabled
     ) {
-        self.title = title
+        self.title = String(title)
         self.icon = icon
         self.color = color
         self.isDestructive = isDestructive

--- a/Mlem/Packages/Actions/Sources/Actions/ActionSeed.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionSeed.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public final class ActionSeed: Hashable {
+public final class ActionSeed: Hashable, Encodable {
     public let key: String
     private let actionType: any Action.Type
     
@@ -38,5 +38,9 @@ public final class ActionSeed: Hashable {
     
     public func hash(into hasher: inout Hasher) {
         hasher.combine(key)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        try self.key.encode(to: encoder)
     }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/ActionSeed.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionSeed.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ActionSeed: Hashable {
+public final class ActionSeed: Hashable {
     public let key: String
     private let actionType: any Action.Type
     
@@ -25,14 +25,14 @@ public struct ActionSeed: Hashable {
         self.actionType = T.self
     }
 
-    public init<T: SimpleLabelAction>(
+    public convenience init<T: SimpleLabelAction>(
         _ key: String,
         createAction: @escaping (Any) -> T?
     ) {
         self.init(key, label: T.label, createAction: createAction)
     }
     
-    public static func == (lhs: Self, rhs: Self) -> Bool {
+    public static func == (lhs: ActionSeed, rhs: ActionSeed) -> Bool {
         lhs.key == rhs.key
     }
     


### PR DESCRIPTION
Added customizability to the action sheet used in the test inbox. At the bottom of the action sheet, there's a "customize" button that opens an editor. Changes are persisted to the disk.