### PR TITLE
Customisable community swipe actions

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -235,6 +235,7 @@
 		038C85D82D87696F00543F70 /* FeedToolbarOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038C85D72D87696F00543F70 /* FeedToolbarOptions.swift */; };
 		038C85E62D88337100543F70 /* CommentMockType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038C85E52D88337100543F70 /* CommentMockType.swift */; };
 		038C86572D888EC100543F70 /* CommentSortType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038C86562D888EC100543F70 /* CommentSortType+Extensions.swift */; };
+		038E1ABC2F58B9EF00D30F01 /* CommunityActionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038E1ABB2F58B9EF00D30F01 /* CommunityActionConfiguration.swift */; };
 		0391E0F92CFF17AE0040CCA8 /* ProfileSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0391E0F82CFF17AE0040CCA8 /* ProfileSettingsView.swift */; };
 		0391E0FB2D0066240040CCA8 /* ImageUploadMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0391E0FA2D0066240040CCA8 /* ImageUploadMenu.swift */; };
 		0391E0FE2D05B2DF0040CCA8 /* AdvancedSortView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0391E0FD2D05B2DF0040CCA8 /* AdvancedSortView.swift */; };
@@ -829,6 +830,7 @@
 		038C85D72D87696F00543F70 /* FeedToolbarOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedToolbarOptions.swift; sourceTree = "<group>"; };
 		038C85E52D88337100543F70 /* CommentMockType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentMockType.swift; sourceTree = "<group>"; };
 		038C86562D888EC100543F70 /* CommentSortType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentSortType+Extensions.swift"; sourceTree = "<group>"; };
+		038E1ABB2F58B9EF00D30F01 /* CommunityActionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityActionConfiguration.swift; sourceTree = "<group>"; };
 		0391E0F82CFF17AE0040CCA8 /* ProfileSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingsView.swift; sourceTree = "<group>"; };
 		0391E0FA2D0066240040CCA8 /* ImageUploadMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadMenu.swift; sourceTree = "<group>"; };
 		0391E0FD2D05B2DF0040CCA8 /* AdvancedSortView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSortView.swift; sourceTree = "<group>"; };
@@ -1666,6 +1668,7 @@
 		03AF91E62C1C65AE00E56644 /* Interaction */ = {
 			isa = PBXGroup;
 			children = (
+				038E1ABB2F58B9EF00D30F01 /* CommunityActionConfiguration.swift */,
 				0397D49B2C6EA73C002C6CDC /* InteractionBarConfiguration.swift */,
 				03AF91E42C1C61FA00E56644 /* PostBarConfiguration.swift */,
 				033F84BC2C2ACC5F002E3EDF /* CommentBarConfiguration.swift */,
@@ -3146,6 +3149,7 @@
 				03F6BD9A2D501041006A425E /* SeededRandomNumberGenerator.swift in Sources */,
 				036ED6792D0AF3740018E5EA /* PinnedSortTracker.swift in Sources */,
 				CDC44A362D1CBC280030F01C /* ReadPostIndicator.swift in Sources */,
+				038E1ABC2F58B9EF00D30F01 /* CommunityActionConfiguration.swift in Sources */,
 				0353948D2CA080EB00795AA5 /* FeedWelcomeView.swift in Sources */,
 				CD950E0F2F0ED6F7002A0595 /* FeedPostView.swift in Sources */,
 				0343C0482D3AD6DB001CF709 /* Set+Extensions.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		038C86572D888EC100543F70 /* CommentSortType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038C86562D888EC100543F70 /* CommentSortType+Extensions.swift */; };
 		038E1ABC2F58B9EF00D30F01 /* CommunityActionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038E1ABB2F58B9EF00D30F01 /* CommunityActionConfiguration.swift */; };
 		038E1AC02F58C76A00D30F01 /* NewSwipeActionEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038E1ABF2F58C76A00D30F01 /* NewSwipeActionEditorView.swift */; };
+		038E1ACA2F59C18100D30F01 /* CommunitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038E1AC92F59C18100D30F01 /* CommunitySettingsView.swift */; };
 		0391E0F92CFF17AE0040CCA8 /* ProfileSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0391E0F82CFF17AE0040CCA8 /* ProfileSettingsView.swift */; };
 		0391E0FB2D0066240040CCA8 /* ImageUploadMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0391E0FA2D0066240040CCA8 /* ImageUploadMenu.swift */; };
 		0391E0FE2D05B2DF0040CCA8 /* AdvancedSortView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0391E0FD2D05B2DF0040CCA8 /* AdvancedSortView.swift */; };
@@ -833,6 +834,7 @@
 		038C86562D888EC100543F70 /* CommentSortType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentSortType+Extensions.swift"; sourceTree = "<group>"; };
 		038E1ABB2F58B9EF00D30F01 /* CommunityActionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityActionConfiguration.swift; sourceTree = "<group>"; };
 		038E1ABF2F58C76A00D30F01 /* NewSwipeActionEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSwipeActionEditorView.swift; sourceTree = "<group>"; };
+		038E1AC92F59C18100D30F01 /* CommunitySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunitySettingsView.swift; sourceTree = "<group>"; };
 		0391E0F82CFF17AE0040CCA8 /* ProfileSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingsView.swift; sourceTree = "<group>"; };
 		0391E0FA2D0066240040CCA8 /* ImageUploadMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadMenu.swift; sourceTree = "<group>"; };
 		0391E0FD2D05B2DF0040CCA8 /* AdvancedSortView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSortView.swift; sourceTree = "<group>"; };
@@ -1317,6 +1319,7 @@
 				03A6316C2D4E3D24009A47A6 /* ModeratorActionSeparationSettingsView.swift */,
 				03BF11C42D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift */,
 				CDBFCB692C04EFFE008CD468 /* PostSettingsView.swift */,
+				038E1AC92F59C18100D30F01 /* CommunitySettingsView.swift */,
 				037F783E2D3BD05500D4E180 /* PostSettingsView+PostSizePicker.swift */,
 				037F78442D3C25AB00D4E180 /* PostSubscriptionIndicatorSettingsView.swift */,
 				037F78422D3C129B00D4E180 /* PostThumbnailSettingsView.swift */,
@@ -2812,6 +2815,7 @@
 				03BF11CA2D4027E900CC1F66 /* DevicePickerItem.swift in Sources */,
 				037029A12D6B9A3900B749DF /* View+TabBarPreview.swift in Sources */,
 				033F84C12C2AD072002E3EDF /* CommentTreeNode.swift in Sources */,
+				038E1ACA2F59C18100D30F01 /* CommunitySettingsView.swift in Sources */,
 				034B94832C09340A00039AF4 /* MarkdownConfiguration+Extensions.swift in Sources */,
 				034CC0302D22C5BE00C557D3 /* WarningOverlayView.swift in Sources */,
 				CDB3DDFD2DA485D200F407AB /* SettingsValues.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		038C85E62D88337100543F70 /* CommentMockType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038C85E52D88337100543F70 /* CommentMockType.swift */; };
 		038C86572D888EC100543F70 /* CommentSortType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038C86562D888EC100543F70 /* CommentSortType+Extensions.swift */; };
 		038E1ABC2F58B9EF00D30F01 /* CommunityActionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038E1ABB2F58B9EF00D30F01 /* CommunityActionConfiguration.swift */; };
+		038E1AC02F58C76A00D30F01 /* NewSwipeActionEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038E1ABF2F58C76A00D30F01 /* NewSwipeActionEditorView.swift */; };
 		0391E0F92CFF17AE0040CCA8 /* ProfileSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0391E0F82CFF17AE0040CCA8 /* ProfileSettingsView.swift */; };
 		0391E0FB2D0066240040CCA8 /* ImageUploadMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0391E0FA2D0066240040CCA8 /* ImageUploadMenu.swift */; };
 		0391E0FE2D05B2DF0040CCA8 /* AdvancedSortView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0391E0FD2D05B2DF0040CCA8 /* AdvancedSortView.swift */; };
@@ -831,6 +832,7 @@
 		038C85E52D88337100543F70 /* CommentMockType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentMockType.swift; sourceTree = "<group>"; };
 		038C86562D888EC100543F70 /* CommentSortType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentSortType+Extensions.swift"; sourceTree = "<group>"; };
 		038E1ABB2F58B9EF00D30F01 /* CommunityActionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityActionConfiguration.swift; sourceTree = "<group>"; };
+		038E1ABF2F58C76A00D30F01 /* NewSwipeActionEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSwipeActionEditorView.swift; sourceTree = "<group>"; };
 		0391E0F82CFF17AE0040CCA8 /* ProfileSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingsView.swift; sourceTree = "<group>"; };
 		0391E0FA2D0066240040CCA8 /* ImageUploadMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadMenu.swift; sourceTree = "<group>"; };
 		0391E0FD2D05B2DF0040CCA8 /* AdvancedSortView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSortView.swift; sourceTree = "<group>"; };
@@ -1326,6 +1328,7 @@
 				03D284052D2AEE3A00A6659B /* TabBarSettingsView.swift */,
 				031E2D5A2BEFC9460003BC45 /* ThemeSettingsView.swift */,
 				03414FDD2D9411EA005503AF /* SwipeActionEditorView.swift */,
+				038E1ABF2F58C76A00D30F01 /* NewSwipeActionEditorView.swift */,
 				039F588D2C7B598000C61658 /* Components */,
 				033FCB262C5E3933007B7CD1 /* Icon */,
 				0397D4982C6EA68A002C6CDC /* InteractionBarEditor */,
@@ -3151,6 +3154,7 @@
 				CDC44A362D1CBC280030F01C /* ReadPostIndicator.swift in Sources */,
 				038E1ABC2F58B9EF00D30F01 /* CommunityActionConfiguration.swift in Sources */,
 				0353948D2CA080EB00795AA5 /* FeedWelcomeView.swift in Sources */,
+				038E1AC02F58C76A00D30F01 /* NewSwipeActionEditorView.swift in Sources */,
 				CD950E0F2F0ED6F7002A0595 /* FeedPostView.swift in Sources */,
 				0343C0482D3AD6DB001CF709 /* Set+Extensions.swift in Sources */,
 				034A85712EC0A1FA00E5F904 /* InstanceCommunityListView.swift in Sources */,

--- a/Mlem/App/Actions/ActionSeedSwipeConfiguration.swift
+++ b/Mlem/App/Actions/ActionSeedSwipeConfiguration.swift
@@ -1,0 +1,27 @@
+//
+//  ActionSeedSwipeConfiguration.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-03-04.
+//
+
+import Actions
+import Foundation
+
+struct ActionSeedSwipeConfiguration: Encodable {
+    var leading: [ActionSeed]   
+    var trailing: [ActionSeed]
+
+    enum CodingKeys: CodingKey {
+        case leading, trailing
+    }
+}
+
+extension ActionSeedSwipeConfiguration {
+    init(from container: KeyedDecodingContainer<CodingKeys>, availableActions: [ActionSeed]) throws {
+        let leading = try container.decode([String].self, forKey: .leading) 
+        self.leading = leading.compactMap { key in availableActions.first(where: {$0.key == key}) }
+        let trailing = try container.decode([String].self, forKey: .trailing) 
+        self.trailing = trailing.compactMap { key in availableActions.first(where: {$0.key == key}) }
+    }
+}

--- a/Mlem/App/Actions/ContextMenu+Community.swift
+++ b/Mlem/App/Actions/ContextMenu+Community.swift
@@ -9,22 +9,10 @@ import Actions
 import MlemMiddleware
 import SwiftUI
 
-private let seeds: [ActionSeed] = [
-    .newPost,
-    .subscribe,
-    .favorite,
-    .goToInstance,
-    .copyName,
-    .share,
-    .block,
-    .remove,
-    .purge
-]
-
 extension ActionButtons {
     init(community: any Community1Providing) {
         self.init { _ in
-            seeds.compactMap { $0.createAction(community) }
+            CommunityActionConfiguration.availableActions.all.compactMap { $0.createAction(community) }
         }
     }
 }

--- a/Mlem/App/Actions/ContextMenu+Community.swift
+++ b/Mlem/App/Actions/ContextMenu+Community.swift
@@ -23,4 +23,12 @@ extension View {
             ActionButtons(community: community)
         }
     }
+
+    @ViewBuilder
+    func quickSwipes(community: any Community1Providing, configuration: CommunityActionConfiguration) -> some View {
+        quickSwipes(
+            leading: configuration.swipes.leading.compactMap { $0.createAction(community) },
+            trailing: configuration.swipes.trailing.compactMap { $0.createAction(community) }
+        )
+    }
 }

--- a/Mlem/App/Actions/CopyNameAction.swift
+++ b/Mlem/App/Actions/CopyNameAction.swift
@@ -55,7 +55,8 @@ extension CopyNameAction {
     static func createLabel(relationship: Relationship) -> ActionLabel {
         .init(
             relationship == .identity ? "Copy Name" : "Copy Username",
-            icon: .general.copy
+            icon: .general.copy,
+            color: .themedColorfulAccent(4)
         )
     }
 

--- a/Mlem/App/Actions/GoToInstanceAction.swift
+++ b/Mlem/App/Actions/GoToInstanceAction.swift
@@ -27,10 +27,18 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension GoToInstanceAction {
-    static let label: ActionLabel = .init("Go to Instance", icon: .lemmy.instance)
+    static let label: ActionLabel = .init(
+        "Go to Instance",
+        icon: .lemmy.instance,
+        color: .themedColorfulAccent(1)
+    )
 
     func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        .init(entity.host, icon: .lemmy.instance)
+        .init(
+            entity.host,
+            icon: .lemmy.instance,
+            color: .themedColorfulAccent(1)
+        )
     }
 }
 

--- a/Mlem/App/Actions/GoToInstanceAction.swift
+++ b/Mlem/App/Actions/GoToInstanceAction.swift
@@ -34,11 +34,7 @@ extension GoToInstanceAction {
     )
 
     func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        .init(
-            entity.host,
-            icon: .lemmy.instance,
-            color: .themedColorfulAccent(1)
-        )
+        Self.label.withTitle(entity.host)
     }
 }
 

--- a/Mlem/App/Actions/ShareAction.swift
+++ b/Mlem/App/Actions/ShareAction.swift
@@ -33,7 +33,11 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension ShareAction {
-    static let label: ActionLabel = .init("Share...", icon: .general.share)
+    static let label: ActionLabel = .init(
+        "Share...",
+        icon: .general.share,
+        color: .themedColorfulAccent(3)
+    )
 }
 
 // MARK: - Behavior

--- a/Mlem/App/Configuration/User Settings/SettingsValues.swift
+++ b/Mlem/App/Configuration/User Settings/SettingsValues.swift
@@ -115,6 +115,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
     var interactionBar_post: PostBarConfiguration
     var interactionBar_comment: CommentBarConfiguration
     var interactionBar_reply: ReplyBarConfiguration
+    var interactionBar_community: CommunityActionConfiguration
     var interactionBar_postReport: PostBarConfiguration
     var interactionBar_commentReport: CommentBarConfiguration
     var interactionBar_alternateReportLayout: Bool
@@ -260,6 +261,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.interactionBar_post = try container.decodeIfPresent(PostBarConfiguration.self, forKey: ._interactionBar_post) ?? .default
         self.interactionBar_comment = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: ._interactionBar_comment) ?? .default
         self.interactionBar_reply = try container.decodeIfPresent(ReplyBarConfiguration.self, forKey: ._interactionBar_reply) ?? .default
+        self.interactionBar_community = try container.decodeIfPresent(CommunityActionConfiguration.self, forKey: ._interactionBar_community) ?? .init()
         self.interactionBar_postReport = try container.decodeIfPresent(PostBarConfiguration.self, forKey: ._interactionBar_postReport) ?? .reportDefault_
         self.interactionBar_commentReport = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: ._interactionBar_commentReport) ?? .reportDefault_
         self.interactionBar_alternateReportLayout = try container.decodeIfPresent(Bool.self, forKey: ._interactionBar_alternateReportLayout) ?? false
@@ -361,6 +363,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         interactionBar_post = otherValues.interactionBar_post
         interactionBar_comment = otherValues.interactionBar_comment
         interactionBar_reply = otherValues.interactionBar_reply
+        interactionBar_community = otherValues.interactionBar_community
         interactionBar_postReport = otherValues.interactionBar_postReport
         interactionBar_commentReport = otherValues.interactionBar_commentReport
         interactionBar_alternateReportLayout = otherValues.interactionBar_alternateReportLayout
@@ -469,6 +472,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         case _interactionBar_post = "interactionBar_post"
         case _interactionBar_comment = "interactionBar_comment"
         case _interactionBar_reply = "interactionBar_reply"
+        case _interactionBar_community = "interactionBar_community"
         case _interactionBar_postReport = "interactionBar_postReport"
         case _interactionBar_commentReport = "interactionBar_commentReport"
         case _interactionBar_alternateReportLayout = "interactionBar_alternateReportLayout"
@@ -582,6 +586,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.interactionBar_post = interactionBarConfigurations.post
         self.interactionBar_comment = interactionBarConfigurations.comment
         self.interactionBar_reply = interactionBarConfigurations.reply
+        self.interactionBar_community = .init() // Added in 2.5
         self.interactionBar_postReport = interactionBarConfigurations.postReport
         self.interactionBar_commentReport = interactionBarConfigurations.commentReport
     }

--- a/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
@@ -1,0 +1,28 @@
+//
+//  CommunityActionConfiguration.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-03-04.
+//
+
+import Actions
+import Foundation
+
+struct CommunityActionConfiguration: Codable {
+    static var availableActions: ActionSeedSections { .init(sections: [
+            [
+                .newPost,
+                .subscribe,
+                .favorite,
+                .goToInstance,
+                .copyName,
+                .share
+            ],
+            [
+                .block,
+                .remove,
+                .purge
+            ]
+        ])
+    }
+}

--- a/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
@@ -67,21 +67,3 @@ struct CommunityActionConfiguration: Codable {
         try container.encode(self.swipes_, forKey: .swipes)
     }
 }
-
-struct ActionSeedSwipeConfiguration: Encodable {
-    var leading: [ActionSeed]   
-    var trailing: [ActionSeed]
-
-    enum CodingKeys: CodingKey {
-        case leading, trailing
-    }
-}
-
-extension ActionSeedSwipeConfiguration {
-    init(from container: KeyedDecodingContainer<CodingKeys>, availableActions: [ActionSeed]) throws {
-        let leading = try container.decode([String].self, forKey: .leading) 
-        self.leading = leading.compactMap { key in availableActions.first(where: {$0.key == key}) }
-        let trailing = try container.decode([String].self, forKey: .trailing) 
-        self.trailing = trailing.compactMap { key in availableActions.first(where: {$0.key == key}) }
-    }
-}

--- a/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
@@ -9,6 +9,12 @@ import Actions
 import Foundation
 
 struct CommunityActionConfiguration: Codable {
+    private let swipes_: ActionSeedSwipeConfiguration?
+
+    var swipes: ActionSeedSwipeConfiguration {
+        swipes_ ?? Self.defaultSwipes
+    }
+
     static var availableActions: ActionSeedSections { .init(sections: [
             [
                 .newPost,
@@ -24,5 +30,49 @@ struct CommunityActionConfiguration: Codable {
                 .purge
             ]
         ])
+    }
+
+    static var defaultSwipes: ActionSeedSwipeConfiguration {
+        .init(leading: [], trailing: [.subscribe, .favorite])
+    }
+
+    enum CodingKeys: CodingKey {
+        case swipes
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let swipeConfigurationContainer = try? container.nestedContainer(
+            keyedBy: ActionSeedSwipeConfiguration.CodingKeys.self,
+            forKey: .swipes
+        )
+        if let swipeConfigurationContainer {
+            self.swipes_ = try .init(from: swipeConfigurationContainer, availableActions: Self.availableActions.all)
+        } else {
+            self.swipes_ = nil
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.swipes_, forKey: .swipes)
+    }
+}
+
+struct ActionSeedSwipeConfiguration: Encodable {
+    let leading: [ActionSeed]   
+    let trailing: [ActionSeed]
+
+    enum CodingKeys: CodingKey {
+        case leading, trailing
+    }
+}
+
+extension ActionSeedSwipeConfiguration {
+    init(from container: KeyedDecodingContainer<CodingKeys>, availableActions: [ActionSeed]) throws {
+        let leading = try container.decode([String].self, forKey: .leading) 
+        self.leading = leading.compactMap { key in availableActions.first(where: {$0.key == key}) }
+        let trailing = try container.decode([String].self, forKey: .trailing) 
+        self.trailing = trailing.compactMap { key in availableActions.first(where: {$0.key == key}) }
     }
 }

--- a/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
@@ -40,6 +40,10 @@ struct CommunityActionConfiguration: Codable {
         case swipes
     }
 
+    init() {
+        self.swipes_ = nil
+    }
+
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let swipeConfigurationContainer = try? container.nestedContainer(

--- a/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
@@ -9,10 +9,15 @@ import Actions
 import Foundation
 
 struct CommunityActionConfiguration: Codable {
-    private let swipes_: ActionSeedSwipeConfiguration?
+    private var swipes_: ActionSeedSwipeConfiguration?
 
     var swipes: ActionSeedSwipeConfiguration {
-        swipes_ ?? Self.defaultSwipes
+        get {
+            swipes_ ?? Self.defaultSwipes
+        }
+        set {
+            swipes_ = newValue
+        }
     }
 
     static var availableActions: ActionSeedSections { .init(sections: [
@@ -64,8 +69,8 @@ struct CommunityActionConfiguration: Codable {
 }
 
 struct ActionSeedSwipeConfiguration: Encodable {
-    let leading: [ActionSeed]   
-    let trailing: [ActionSeed]
+    var leading: [ActionSeed]   
+    var trailing: [ActionSeed]
 
     enum CodingKeys: CodingKey {
         case leading, trailing

--- a/Mlem/App/Views/Root/Tabs/Settings/CommunitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/CommunitySettingsView.swift
@@ -1,0 +1,36 @@
+//
+//  CommunitySettingsView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-03-05.
+//
+
+import SwiftUI
+
+struct CommunitySettingsView: View {
+    @Setting(\.community_showAvatar) var showCommunityAvatar
+
+    var body: some View {
+        Form {
+            SettingsHeaderView(
+                title: "Communities",
+                description: "Customize the appearance of communities.",
+                icon: .lemmy.community
+            )
+            .gradientTint(.themedCommunityAccent)
+            Section {
+                NavigationLink("Subscription List", destination: .settings(.subscriptionList))
+                NavigationLink("Swipe Actions", destination: .settings(.swipeActions(.community)))
+            }
+            Section {
+                Toggle("Community Avatar", icon: .lemmy.community, isOn: $showCommunityAvatar)
+                    .symbolVariant(.circle)
+            } footer: {
+                Text("Choose whether to show community avatars on posts.")
+            }
+        }
+        .withConditionalLabelStyle()
+        .contentMargins(.top, 16)
+        .hiddenNavigationTitle("Communities")
+    }
+}

--- a/Mlem/App/Views/Root/Tabs/Settings/Components/SettingsHeaderView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/Components/SettingsHeaderView.swift
@@ -73,13 +73,14 @@ extension SettingsHeaderView {
         }
     }
     
+    @_disfavoredOverload
     init(
         title: LocalizedStringResource,
-        description: String,
+        description: some StringProtocol,
         icon: Icon
     ) where IconView == SettingsHeaderIconView {
         self.title = .init(localized: title)
-        self.description = description
+        self.description = String(description)
         self.icon = SettingsHeaderIconView(icon: icon)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/NewSwipeActionEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/NewSwipeActionEditorView.swift
@@ -1,0 +1,74 @@
+//
+//  NewSwipeActionEditorView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-03-04.
+//
+
+import Actions
+import SwiftUI
+
+struct NewSwipeActionEditorView: View {
+    @Setting(\.interactionBar_community) var configuration
+    
+    var body: some View {
+        Form {
+            ActionListView(
+                title: "Left",
+                actions: Binding(get: { configuration.swipes.leading }, set: { configuration.swipes.leading = $0 }),
+                allActions: CommunityActionConfiguration.availableActions.all
+            )
+            ActionListView(
+                title: "Right",
+                actions: Binding(get: { configuration.swipes.trailing }, set: { configuration.swipes.trailing = $0 }),
+                allActions: CommunityActionConfiguration.availableActions.all
+            )
+            Button("Reset") {
+                configuration = .init()
+            }
+        }
+        .environment(\.editMode, .constant(.active))
+        .navigationTitle("Swipe Actions")
+    }
+}
+
+private struct ActionListView: View {
+    let title: LocalizedStringResource
+    @Binding var actions: [ActionSeed]
+    var allActions: [ActionSeed]
+    
+    var body: some View {
+        Section(title) {
+            ForEach(actions, id: \.hashValue) { action in
+                HStack {
+                    Label(action.label.title, icon: action.label.icon)
+                        .symbolVariant(.fill)
+                        .gradientTint(action.label.color)
+                    Spacer()
+                }
+                .tag(action)
+            }
+            .onMove { old, new in
+                actions.move(fromOffsets: old, toOffset: new)
+            }
+            .onDelete { offsets in
+                actions.remove(atOffsets: offsets)
+            }
+            .labelStyle(.squircle)
+            addButtonView
+                .disabled(actions.count >= 3)
+        }
+    }
+    
+    @ViewBuilder
+    var addButtonView: some View {
+        Menu("Add", icon: .general.add) {
+            ForEach(allActions, id: \.self) { action in
+                Button(action.label.title, icon: action.label.icon) {
+                    actions.append(action)
+                }
+                .disabled(actions.contains(action))
+            }
+        }
+    }
+}

--- a/Mlem/App/Views/Root/Tabs/Settings/NewSwipeActionEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/NewSwipeActionEditorView.swift
@@ -9,23 +9,22 @@ import Actions
 import SwiftUI
 
 struct NewSwipeActionEditorView: View {
-    @Setting(\.interactionBar_community) var configuration
-    
+    @Binding var configuration: ActionSeedSwipeConfiguration
+    let onReset: () -> Void
+
     var body: some View {
         Form {
             ActionListView(
                 title: "Left",
-                actions: Binding(get: { configuration.swipes.leading }, set: { configuration.swipes.leading = $0 }),
+                actions: Binding(get: { configuration.leading }, set: { configuration.leading = $0 }),
                 allActions: CommunityActionConfiguration.availableActions.all
             )
             ActionListView(
                 title: "Right",
-                actions: Binding(get: { configuration.swipes.trailing }, set: { configuration.swipes.trailing = $0 }),
+                actions: Binding(get: { configuration.trailing }, set: { configuration.trailing = $0 }),
                 allActions: CommunityActionConfiguration.availableActions.all
             )
-            Button("Reset") {
-                configuration = .init()
-            }
+            Button("Reset", action: onReset)
         }
         .environment(\.editMode, .constant(.active))
         .navigationTitle("Swipe Actions")

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -88,10 +88,8 @@ struct SettingsView: View {
                     .gradientTint(.themedCommentAccent)
                 NavigationLink("Inbox", icon: .lemmy.inbox, destination: .settings(.inbox))
                     .gradientTint(.themedInbox)
-                NavigationLink("Community", icon: .lemmy.community, destination: .settings(.swipeActions(.community)))
+                NavigationLink("Communities", icon: .lemmy.community, destination: .settings(.community))
                     .gradientTint(.themedCommunityAccent)
-                NavigationLink("Subscription List", icon: .lemmy.subscriptionList, destination: .settings(.subscriptionList))
-                    .gradientTint(.themedColorfulAccent(4))
                 NavigationLink("Tab Bar", icon: .settings.tabBar, destination: .settings(.tabBar))
                     .gradientTint(.themedColorfulAccent(5))
             }

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -88,7 +88,7 @@ struct SettingsView: View {
                     .gradientTint(.themedCommentAccent)
                 NavigationLink("Inbox", icon: .lemmy.inbox, destination: .settings(.inbox))
                     .gradientTint(.themedInbox)
-                NavigationLink("Community", icon: .lemmy.community, destination: .settings(.newSwipeActions))
+                NavigationLink("Community", icon: .lemmy.community, destination: .settings(.swipeActions(.community)))
                     .gradientTint(.themedCommunityAccent)
                 NavigationLink("Subscription List", icon: .lemmy.subscriptionList, destination: .settings(.subscriptionList))
                     .gradientTint(.themedColorfulAccent(4))

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -88,8 +88,10 @@ struct SettingsView: View {
                     .gradientTint(.themedCommentAccent)
                 NavigationLink("Inbox", icon: .lemmy.inbox, destination: .settings(.inbox))
                     .gradientTint(.themedInbox)
-                NavigationLink("Subscription List", icon: .lemmy.subscriptionList, destination: .settings(.subscriptionList))
+                NavigationLink("Community", icon: .lemmy.community, destination: .settings(.newSwipeActions))
                     .gradientTint(.themedCommunityAccent)
+                NavigationLink("Subscription List", icon: .lemmy.subscriptionList, destination: .settings(.subscriptionList))
+                    .gradientTint(.themedColorfulAccent(4))
                 NavigationLink("Tab Bar", icon: .settings.tabBar, destination: .settings(.tabBar))
                     .gradientTint(.themedColorfulAccent(5))
             }

--- a/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SubscriptionListSettingsView.swift
@@ -20,7 +20,7 @@ struct SubscriptionListSettingsView: View {
                 description: "Customize how your subscription list is sorted.",
                 icon: .lemmy.subscriptionList
             )
-            .gradientTint(.themedCommunityAccent)
+            .gradientTint(.themedColorfulAccent(4))
             Section("Sort by...") {
                 Picker("Sort by...", selection: $sort) {
                     ForEach(SubscriptionListSort.allCases, id: \.self) { item in

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -30,7 +30,7 @@ enum SettingsPage: Hashable {
     case externalLinks, sharingLinks, tappableLinks
     case importExportSettings
     case theme, icon
-    case post, comment, inbox, subscriptionList
+    case post, comment, inbox, community, subscriptionList
     case tabBar, longPressAction
     case postThumbnail, postSubscriptionIndicator, postReadIndicator
     case commentMaximumDepth, commentJumpButton
@@ -116,6 +116,8 @@ enum SettingsPage: Hashable {
             IconSettingsView()
         case .post:
             PostSettingsView()
+        case .community:
+            CommunitySettingsView()
         case .postThumbnail:
             PostThumbnailSettingsView()
         case .postSubscriptionIndicator:

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -34,6 +34,7 @@ enum SettingsPage: Hashable {
     case about, advanced, developer, errorLog
     case interactionBar(ContentActionType)
     case swipeActions(ContentActionType)
+    case newSwipeActions
     case postBarWidgetPicker(HashWrapper<Binding<PostBarConfiguration>>)
     case commentBarWidgetPicker(HashWrapper<Binding<CommentBarConfiguration>>)
     case replyBarWidgetPicker(HashWrapper<Binding<ReplyBarConfiguration>>)
@@ -156,6 +157,8 @@ enum SettingsPage: Hashable {
             LongPressActionSettingsView()
         case .inboxBadge:
             InboxBadgeSettingsView()
+        case .newSwipeActions:
+            NewSwipeActionEditorView()
         case let .swipeActions(type):
             switch type {
             case .post:

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -12,6 +12,10 @@ enum SettingsPage: Hashable {
     enum ContentActionType: Hashable {
         case post, comment, reply, postReport, commentReport
     }
+
+    enum SwipeActionSettingType: Hashable {
+        case post, comment, reply, postReport, commentReport, community
+    }
     
     case root
     case accounts, account
@@ -33,8 +37,7 @@ enum SettingsPage: Hashable {
     case inboxBadge
     case about, advanced, developer, errorLog
     case interactionBar(ContentActionType)
-    case swipeActions(ContentActionType)
-    case newSwipeActions
+    case swipeActions(SwipeActionSettingType)
     case postBarWidgetPicker(HashWrapper<Binding<PostBarConfiguration>>)
     case commentBarWidgetPicker(HashWrapper<Binding<CommentBarConfiguration>>)
     case replyBarWidgetPicker(HashWrapper<Binding<ReplyBarConfiguration>>)
@@ -157,20 +160,6 @@ enum SettingsPage: Hashable {
             LongPressActionSettingsView()
         case .inboxBadge:
             InboxBadgeSettingsView()
-        case .newSwipeActions:
-            NewSwipeActionEditorView(
-                configuration: .init(
-                    get: {
-                        Settings.get(\.interactionBar_community).swipes
-                    }, set: {
-                        var configuration = Settings.get(\.interactionBar_community)
-                        configuration.swipes = $0
-                        Settings.set(\.interactionBar_community, to: configuration)
-                    }
-                ),
-                onReset: {
-                        Settings.set(\.interactionBar_community, to: .init())
-                })
         case let .swipeActions(type):
             switch type {
             case .post:
@@ -183,6 +172,20 @@ enum SettingsPage: Hashable {
                 SwipeActionEditorView(setting: \.interactionBar_postReport, isReport: true)
             case .commentReport:
                 SwipeActionEditorView(setting: \.interactionBar_commentReport, isReport: true)
+            case .community:
+                NewSwipeActionEditorView(
+                    configuration: .init(
+                        get: {
+                            Settings.get(\.interactionBar_community).swipes
+                        }, set: {
+                            var configuration = Settings.get(\.interactionBar_community)
+                            configuration.swipes = $0
+                            Settings.set(\.interactionBar_community, to: configuration)
+                        }
+                    ),
+                    onReset: {
+                            Settings.set(\.interactionBar_community, to: .init())
+                    })
             }
         case let .interactionBar(type):
             switch type {

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -158,7 +158,19 @@ enum SettingsPage: Hashable {
         case .inboxBadge:
             InboxBadgeSettingsView()
         case .newSwipeActions:
-            NewSwipeActionEditorView()
+            NewSwipeActionEditorView(
+                configuration: .init(
+                    get: {
+                        Settings.get(\.interactionBar_community).swipes
+                    }, set: {
+                        var configuration = Settings.get(\.interactionBar_community)
+                        configuration.swipes = $0
+                        Settings.set(\.interactionBar_community, to: configuration)
+                    }
+                ),
+                onReset: {
+                        Settings.set(\.interactionBar_community, to: .init())
+                })
         case let .swipeActions(type):
             switch type {
             case .post:

--- a/Mlem/App/Views/Shared/Search/Results/CommunityListRow.swift
+++ b/Mlem/App/Views/Shared/Search/Results/CommunityListRow.swift
@@ -14,6 +14,7 @@ struct CommunityListRow<Content2: View>: View {
     
     @Environment(AppState.self) var appState
     @Environment(NavigationLayer.self) var navigation
+    @Setting(\.interactionBar_community) var communityActionConfiguration
     
     let community: any Community
     let content: Content
@@ -55,7 +56,7 @@ struct CommunityListRow<Content2: View>: View {
         .background(.themedSecondaryGroupedBackground)
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu(community: community)
-        .quickSwipes(leading: [], trailing: [SubscribeAction(entity: community), FavoriteAction(entity: community)])
+        .quickSwipes(community: community, configuration: communityActionConfiguration)
         .popupAnchor()
         .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -2075,6 +2075,12 @@
         }
       }
     },
+    "Choose the default sort mode for posts and comments." : {
+
+    },
+    "Choose when Not Safe For Work content should be blurred." : {
+
+    },
     "Choose whether to show a user's account age next to their username." : {
       "localizations" : {
         "fr" : {
@@ -2084,6 +2090,12 @@
           }
         }
       }
+    },
+    "Choose whether to show a warning when opening a page that is likely to contain sensitive content." : {
+
+    },
+    "Choose whether to show community avatars on posts." : {
+
     },
     "Choose whether to use alternate interaction bar and swipe action layouts for post and comment reports in Mod Mail." : {
       "localizations" : {
@@ -2095,6 +2107,9 @@
         }
       }
     },
+    "Choose which action to perform when you tap and hold the profile icon." : {
+
+    },
     "Choose which feed is shown when the app opens." : {
       "localizations" : {
         "fr" : {
@@ -2104,6 +2119,9 @@
           }
         }
       }
+    },
+    "Choose which languages appear in your feed. Posts and comments in other languages will be hidden." : {
+
     },
     "Choose which widgets to display in your palette." : {
       "localizations" : {
@@ -2821,6 +2839,9 @@
         }
       }
     },
+    "Customize how content is displayed in your feed. Choose which types of content are blurred, and apply filters to hide posts from the feed altogether." : {
+
+    },
     "Customize how moderator actions are separated from regular actions in context menus." : {
       "localizations" : {
         "en-GB" : {
@@ -2836,6 +2857,31 @@
           }
         }
       }
+    },
+    "Customize how often Mlem plays haptic feedback." : {
+
+    },
+    "Customize how your subscription list is sorted." : {
+
+    },
+    "Customize Mlem to work best for you. Some features are tied to system-wide accessibility settings." : {
+
+    },
+    "Customize the appearance of communities." : {
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Customise the appearance of communities."
+          }
+        }
+      }
+    },
+    "Customize the appearance of the tab bar." : {
+
+    },
+    "Customize the interaction bar for inbox items, and choose which types of notification are included in the tab bar badge." : {
+
     },
     "Data not available" : {
       "localizations" : {
@@ -3118,6 +3164,9 @@
           }
         }
       }
+    },
+    "Display linked media from supported hosts in-app rather than as a link." : {
+
     },
     "Display Name" : {
       "localizations" : {
@@ -4439,6 +4488,9 @@
         }
       }
     },
+    "In the Fediverse, many different links can point to the same piece of content. Choose which site to use when sharing content." : {
+
+    },
     "Inbox" : {
       "localizations" : {
         "fr" : {
@@ -4970,6 +5022,18 @@
           }
         }
       }
+    },
+    "Manage how Mlem handles links and control how images and videos are displayed." : {
+
+    },
+    "Manage how Mlem interacts with Lemmy instances and other websites." : {
+
+    },
+    "Manage settings related to content moderation." : {
+
+    },
+    "Manage your overall setup for Mlem." : {
+
     },
     "Mark Read" : {
       "localizations" : {
@@ -6650,6 +6714,9 @@
         }
       }
     },
+    "Read posts are shown with dimmed title text. If you like, you can choose an additional way of indicating read status." : {
+
+    },
     "Really add NSFW tag?" : {
       "localizations" : {
         "fr" : {
@@ -8202,6 +8269,9 @@
           }
         }
       }
+    },
+    "Some users set animated media as their avatar. Control whether these avatars should play their animations." : {
+
     },
     "Sort" : {
       "localizations" : {

--- a/Mlem/Packages/Actions/Sources/Actions/ActionLabel.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionLabel.swift
@@ -10,7 +10,7 @@ import Icons
 import Theming
 
 public struct ActionLabel {
-    public let title: String
+    public var title: String
     public var icon: Icon
     public var color: ThemedColor
     public var isDestructive: Bool
@@ -48,6 +48,19 @@ public struct ActionLabel {
     public func withVisibility(_ visibility: ActionVisiblity) -> ActionLabel {
         var new = self
         new.visibility = visibility
+        return new
+    }
+
+    public func withTitle(_ title: LocalizedStringResource) -> ActionLabel {
+        var new = self
+        new.title = .init(localized: title)
+        return new
+    }
+
+    @_disfavoredOverload
+    public func withTitle(_ title: some StringProtocol) -> ActionLabel {
+        var new = self
+        new.title = String(title)
         return new
     }
 }


### PR DESCRIPTION
Added a setting for customising community swipe actions. There's a new section called "communities" at the top level of settings that opens the editor directly. Not sure if this is the best place to put the setting?

Partially completes #2617