### PR TITLE
Show community name in post navigation bar

### DIFF
--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -81,6 +81,7 @@ struct ExpandedPostView<Content: View>: View {
                 }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .conditionalNavigationTitle(post.community.value?.name ?? "")
         .overlay {
             VStack {
                 if showLoadingSymbol {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2582 

Note that longer community names get left-aligned; this is Apple system behavior. Keeping it like that seemed neater than truncating or trying to hack font size down.