### PR TITLE
Improve quick swipes/interactive navigation gesture conflict

### DIFF
--- a/Mlem/Packages/QuickSwipes/Sources/QuickSwipes/PanGesture.swift
+++ b/Mlem/Packages/QuickSwipes/Sources/QuickSwipes/PanGesture.swift
@@ -33,6 +33,9 @@ struct PanGesture: UIGestureRecognizerRepresentable {
         
         func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
             guard let panRecognizer = gestureRecognizer as? UIPanGestureRecognizer else { return false }
+            
+            // prevent swipe from interfering with interactive swipe back
+            guard panRecognizer.location(in: gestureRecognizer.view).x > 70 else { return false }
 
             let velocity = panRecognizer.velocity(in: gestureRecognizer.view)
             return abs(velocity.y) < abs(velocity.x)

--- a/Mlem/Packages/QuickSwipes/Sources/QuickSwipes/PanGesture.swift
+++ b/Mlem/Packages/QuickSwipes/Sources/QuickSwipes/PanGesture.swift
@@ -8,9 +8,11 @@
 import SwiftUI
 
 struct PanGesture: UIGestureRecognizerRepresentable {
+    /// If provided, the gesture will not register within `leadingBuffer` px of the leading edge
+    let leadingBuffer: CGFloat?
     var handle: (UIPanGestureRecognizer) -> Void
     
-    func makeCoordinator(converter: CoordinateSpaceConverter) -> Coordinator { .init() }
+    func makeCoordinator(converter: CoordinateSpaceConverter) -> Coordinator { .init(leadingBuffer: leadingBuffer) }
     
     func makeUIGestureRecognizer(context: Context) -> UIPanGestureRecognizer {
         let gesture = UIPanGestureRecognizer()
@@ -24,6 +26,12 @@ struct PanGesture: UIGestureRecognizerRepresentable {
     }
     
     class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        let leadingBuffer: CGFloat
+        
+        init(leadingBuffer: CGFloat?) {
+            self.leadingBuffer = leadingBuffer ?? 0
+        }
+        
         func gestureRecognizer(
             _ gestureRecognizer: UIGestureRecognizer,
             shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
@@ -35,7 +43,7 @@ struct PanGesture: UIGestureRecognizerRepresentable {
             guard let panRecognizer = gestureRecognizer as? UIPanGestureRecognizer else { return false }
             
             // prevent swipe from interfering with interactive swipe back
-            guard panRecognizer.location(in: gestureRecognizer.view).x > 70 else { return false }
+            guard panRecognizer.location(in: gestureRecognizer.view).x >= leadingBuffer else { return false }
 
             let velocity = panRecognizer.velocity(in: gestureRecognizer.view)
             return abs(velocity.y) < abs(velocity.x)

--- a/Mlem/Packages/QuickSwipes/Sources/QuickSwipes/QuickSwipesViewModifier.swift
+++ b/Mlem/Packages/QuickSwipes/Sources/QuickSwipes/QuickSwipesViewModifier.swift
@@ -78,7 +78,7 @@ struct QuickSwipeViewModifier: ViewModifier {
     func innerBody(content: Content) -> some View {
         content
             .gesture(
-                PanGesture { recognizer in
+                PanGesture(leadingBuffer: 70) { recognizer in
                     if [.ended, .cancelled].contains(recognizer.state) {
                         draggingUpdated(dragState: 0)
                     } else {


### PR DESCRIPTION
Addresses a longstanding complaint that the swipe gestures make interactively navigating back awkward. Quick swipe gestures now do not trigger on a small leading buffer zone, allowing the interactive dismissal gesture to be triggered more easily. Gestures on views that do not abut the edge (e.g., nested comments) should be unaffected.