### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci_build_26.yml
+++ b/.github/workflows/ci_build_26.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Build
       uses: "./.github/actions/ci_xcodebuild"
       with:
-        xcode_version: "26.0.1"
+        xcode_version: "26.4"
         xcodebuild_destination: "platform=iOS Simulator,name=iPhone 17,OS=26.4"
         xcodebuild_action: "build"

--- a/.github/workflows/ci_build_26.yml
+++ b/.github/workflows/ci_build_26.yml
@@ -25,5 +25,5 @@ jobs:
       uses: "./.github/actions/ci_xcodebuild"
       with:
         xcode_version: "26.0.1"
-        xcodebuild_destination: "platform=iOS Simulator,name=iPhone 17,OS=26.1"
+        xcodebuild_destination: "platform=iOS Simulator,name=iPhone 17,OS=26.4"
         xcodebuild_action: "build"

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -5,10 +5,22 @@ on:
     push:
         branches:
         - master
+        
+    pull_request
 
     # Run when we tweak Swift or supporting files
-    pull_request:
-        paths:
+#    pull_request:
+#        paths:
+#        - '.github/workflows/swiftlint.yml'
+#        - '.swiftlint.yml'
+#        - '**/*.swift'
+#        - 'Mlem.xcodeproj/project.pbxproj'
+
+- uses: dorny/paths-filter@v4
+  id: changes
+  with:
+    filters: |
+      src:
         - '.github/workflows/swiftlint.yml'
         - '.swiftlint.yml'
         - '**/*.swift'
@@ -16,6 +28,7 @@ on:
 
 jobs:
   SwiftLint:
+    if: steps.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -1,34 +1,32 @@
 name: CI - Lint
 
 on:
-    # Run in master as CI
-    push:
-        branches:
-        - master
-        
-    pull_request:
-        branches:
-        - master
-        - dev
+  # Run in master as CI
+  push:
+    branches:
+    - master
+      
+  pull_request:
+    branches:
+    - master
+    - dev
 
 jobs:
-    changes:
-        steps:
-            - uses: dorny/paths-filter@v4
-              id: changes
-              with:
-                filters: |
-                  src:
-                    - '.github/workflows/swiftlint.yml'
-                    - '.swiftlint.yml'
-                    - '**/*.swift'
-                    - 'Mlem.xcodeproj/project.pbxproj'
-    SwiftLint:
-        if: steps.changes.outputs.src == 'true'
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v1
-            - name: GitHub Action for SwiftLint
-            uses: norio-nomura/action-swiftlint@3.2.1
-            with:
-                args: --strict
+  SwiftLint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: dorny/paths-filter@v4
+      id: changes
+      with:
+        filters: |
+          src:
+            - '.github/workflows/swiftlint.yml'
+            - '.swiftlint.yml'
+            - '**/*.swift'
+            - 'Mlem.xcodeproj/project.pbxproj'
+    
+    - name: GitHub Action for SwiftLint
+      uses: norio-nomura/action-swiftlint@3.2.1
+      with:
+        args: --strict

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -6,7 +6,11 @@ on:
         branches:
         - master
         
-    pull_request
+    pull_request:
+        types:
+        - opened
+        - synchronized
+        - reopened
 
     # Run when we tweak Swift or supporting files
 #    pull_request:

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -7,10 +7,9 @@ on:
         - master
         
     pull_request:
-        types:
-        - opened
-        - synchronized
-        - reopened
+        branches:
+        - master
+        - dev
 
     # Run when we tweak Swift or supporting files
 #    pull_request:

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -11,23 +11,23 @@ on:
         - master
         - dev
 
-#- uses: dorny/paths-filter@v4
-#  id: changes
-#  with:
-#    filters: |
-#      src:
-#        - '.github/workflows/swiftlint.yml'
-#        - '.swiftlint.yml'
-#        - '**/*.swift'
-#        - 'Mlem.xcodeproj/project.pbxproj'
-
 jobs:
-  SwiftLint:
-    # if: steps.changes.outputs.src == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: GitHub Action for SwiftLint
-        uses: norio-nomura/action-swiftlint@3.2.1
-        with:
-            args: --strict
+    changes:
+        - uses: dorny/paths-filter@v4
+          id: changes
+          with:
+            filters: |
+              src:
+                - '.github/workflows/swiftlint.yml'
+                - '.swiftlint.yml'
+                - '**/*.swift'
+                - 'Mlem.xcodeproj/project.pbxproj'
+    SwiftLint:
+        if: steps.changes.outputs.src == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v1
+            - name: GitHub Action for SwiftLint
+            uses: norio-nomura/action-swiftlint@3.2.1
+            with:
+                args: --strict

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -11,27 +11,19 @@ on:
         - master
         - dev
 
-    # Run when we tweak Swift or supporting files
-#    pull_request:
-#        paths:
+#- uses: dorny/paths-filter@v4
+#  id: changes
+#  with:
+#    filters: |
+#      src:
 #        - '.github/workflows/swiftlint.yml'
 #        - '.swiftlint.yml'
 #        - '**/*.swift'
 #        - 'Mlem.xcodeproj/project.pbxproj'
 
-- uses: dorny/paths-filter@v4
-  id: changes
-  with:
-    filters: |
-      src:
-        - '.github/workflows/swiftlint.yml'
-        - '.swiftlint.yml'
-        - '**/*.swift'
-        - 'Mlem.xcodeproj/project.pbxproj'
-
 jobs:
   SwiftLint:
-    if: steps.changes.outputs.src == 'true'
+    # if: steps.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -13,15 +13,16 @@ on:
 
 jobs:
     changes:
-        - uses: dorny/paths-filter@v4
-          id: changes
-          with:
-            filters: |
-              src:
-                - '.github/workflows/swiftlint.yml'
-                - '.swiftlint.yml'
-                - '**/*.swift'
-                - 'Mlem.xcodeproj/project.pbxproj'
+        steps:
+            - uses: dorny/paths-filter@v4
+              id: changes
+              with:
+                filters: |
+                  src:
+                    - '.github/workflows/swiftlint.yml'
+                    - '.swiftlint.yml'
+                    - '**/*.swift'
+                    - 'Mlem.xcodeproj/project.pbxproj'
     SwiftLint:
         if: steps.changes.outputs.src == 'true'
         runs-on: ubuntu-latest


### PR DESCRIPTION
Makes some changes to improve CI behavior:
- Bumps versions in build to fix errors
- Lint now uses dorny/paths-filter to skip linting if source code unchanged; this allows the check to pass, rather than never running and getting stuck in the "expected" state.