### PR TITLE
Fix "block" being shown for blocked communities rather than "unblock"

### DIFF
--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -226,7 +226,7 @@ extension BlockAction {
                 callback: callback
             )
         }
-        environment.popupModel?.showPopup(message: "Community or User?", actions)
+        environment.popupModel?.showPopup(message: "Community or user?", actions)
     }
 
     @MainActor

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -215,13 +215,18 @@ extension BlockAction {
             let callback = {
                 submit(content: item, environment: environment)
             }
+            let label = Self.createLabel(
+                relationship: .indirect,
+                mode: item.blocked(environment: environment) ? .unblock : .block,
+                contentType: item.blockable is Person ? .personOnly: .communityOnly
+            )
             return .init(
-                title: item.blockable is Person ? "User" : "Community",
-                isDestructive: true,
+                title: label.title,
+                isDestructive: label.isDestructive,
                 callback: callback
             )
         }
-        environment.popupModel?.showPopup(message: "Block...", actions)
+        environment.popupModel?.showPopup(message: "Community or User?", actions)
     }
 
     @MainActor

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -212,9 +212,14 @@ extension BlockAction {
     @MainActor
     func executeMulti(environment: EnvironmentValues) {
         let actions: [PopupAnchorModel.Action] = content.map { item in
-            .init(title: item.blockable is Person ? "User" : "Community", isDestructive: true) {
+            let callback = {
                 submit(content: item, environment: environment)
             }
+            return .init(
+                title: item.blockable is Person ? "User" : "Community",
+                isDestructive: true,
+                callback: callback
+            )
         }
         environment.popupModel?.showPopup(message: "Block...", actions)
     }

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -226,7 +226,7 @@ extension BlockAction {
                 callback: callback
             )
         }
-        environment.popupModel?.showPopup(message: "Community or user?", actions)
+        environment.popupModel?.showPopup(message: "User or community?", actions)
     }
 
     @MainActor


### PR DESCRIPTION
Previously, the popup would show "block community" and "block user" even when one was already blocked. Now, it shows "unblock community" / "unblock user" instead:

<img width=30% alt="image" src="https://github.com/user-attachments/assets/4b64c05d-7788-462a-aba6-6f9c1163d839" />



Closes #2592