### PR TITLE
Compact comment readout improvements

### DIFF
--- a/Mlem/App/Configuration/User Settings/SettingsValues.swift
+++ b/Mlem/App/Configuration/User Settings/SettingsValues.swift
@@ -50,6 +50,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
     var comment_createImage_showCreator: Bool
     var comment_createImage_showStats: Bool
     var comment_createImage_colorScheme: UIUserInterfaceStyle
+    var comment_showDownvotesCompact: Bool
     var community_showAvatar: Bool
     var community_showBanner: Bool
     var community_showInstance: Bool
@@ -172,6 +173,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.comment_gestures_tapToCollapse = try container.decodeIfPresent(Bool.self, forKey: ._comment_gestures_tapToCollapse) ?? true
         self.comment_jumpButton = try container.decodeIfPresent(CommentJumpButtonLocation.self, forKey: ._comment_jumpButton) ?? .bottomTrailing
         self.comment_showCreatorInstance = try container.decodeIfPresent(Bool.self, forKey: ._comment_showCreatorInstance) ?? true
+        self.comment_showDownvotesCompact = try container.decodeIfPresent(Bool.self, forKey: ._comment_showDownvotesCompact) ?? false
         
         if let value = try container.decodeIfPresent(Int.self, forKey: ._comment_maxDepth) {
             self.comment_maxDepth = value
@@ -322,6 +324,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         comment_createImage_showCreator = otherValues.comment_createImage_showCreator
         comment_createImage_showStats = otherValues.comment_createImage_showStats
         comment_createImage_colorScheme = otherValues.comment_createImage_colorScheme
+        comment_showDownvotesCompact = otherValues.comment_showDownvotesCompact
         community_showAvatar = otherValues.community_showAvatar
         community_showBanner = otherValues.community_showBanner
         community_showInstance = otherValues.community_showInstance
@@ -433,6 +436,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         case _comment_createImage_showCreator = "comment_createImage_showCreator"
         case _comment_createImage_showStats = "comment_createImage_showStats"
         case _comment_createImage_colorScheme = "comment_createImage_colorScheme"
+        case _comment_showDownvotesCompact = "comment_showDownvotesCompact"
         case _community_showAvatar = "community_showAvatar"
         case _community_showBanner = "community_showBanner"
         case _community_showInstance = "community_showInstance"
@@ -554,6 +558,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.comment_createImage_showCreator = true // Added in 2.4
         self.comment_createImage_showStats = true // Added in 2.4
         self.comment_createImage_colorScheme = .unspecified // Added in 2.4
+        self.comment_showDownvotesCompact = false // Added in 2.5
         self.community_showAvatar = settings.showCommunityAvatar
         self.community_showBanner = true // Removed in 2.0
         self.community_showInstance = true // Removed in 2.0

--- a/Mlem/App/Utility/Extensions/Array+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Array+Extensions.swift
@@ -15,6 +15,12 @@ extension Array {
         
         return self[index]
     }
+    
+    mutating func appendIfPresent(_ newElement: Element?) {
+        if let newElement {
+            self.append(newElement)
+        }
+    }
 }
 
 extension Sequence where Element: Hashable {

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
@@ -23,13 +23,11 @@ struct CompactPostView: View {
     let post: Post
     var requireConsistentHeight: Bool = false
     
-    var readouts: [PostBarConfiguration.ReadoutType?] {
-        let saved: PostBarConfiguration.ReadoutType? = post.saved.value ?? false ? .saved : nil
-        if showDownvotesCompact {
-            return [.created, .upvote, .downvote, .comment, saved]
-        } else {
-            return [.created, .score, .comment, saved]
-        }
+    var readouts: [PostBarConfiguration.ReadoutType] {
+        var readouts: [PostBarConfiguration.ReadoutType] = [.created]
+        readouts.append(contentsOf: showDownvotesCompact ? [.upvote, .downvote, .comment] : [.score, .comment])
+        readouts.appendIfPresent(post.saved.value ?? false ? .saved : nil)
+        return readouts
     }
     
     var blurred: Bool {

--- a/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
@@ -12,6 +12,7 @@ struct CommentSettingsView: View {
     @Setting(\.comment_gestures_tapToCollapse) var tapCommentsToCollapse
     @Setting(\.comment_maxDepth) var maxCommentDepth
     @Setting(\.comment_jumpButton) var jumpButton
+    @Setting(\.comment_showDownvotesCompact) var showDownvotesCompact
     @Setting(\.interactionBar_comment) var commentInteractionBar
 
     var body: some View {
@@ -43,6 +44,8 @@ struct CommentSettingsView: View {
                     icon: .settings.commentDepth,
                     destination: .settings(.commentMaximumDepth)
                 )
+                
+                Toggle("Show Downvotes Separately", icon: .lemmy.votes, isOn: $showDownvotesCompact)
             }
             Section {
                 Toggle("Tap to Collapse", icon: .general.collapse, isOn: $tapCommentsToCollapse)

--- a/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
@@ -45,7 +45,9 @@ struct CommentSettingsView: View {
                     destination: .settings(.commentMaximumDepth)
                 )
                 
+        if compactComments {
                 Toggle("Show Downvotes Separately", icon: .lemmy.votes, isOn: $showDownvotesCompact)
+        }
             }
             Section {
                 Toggle("Tap to Collapse", icon: .general.collapse, isOn: $tapCommentsToCollapse)

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -18,6 +18,7 @@ struct CommentView<EmbeddedContent: View>: View {
     @Environment(\.palette) private var palette
     
     @Setting(\.comment_compact) var compactComments
+    @Setting(\.comment_showDownvotesCompact) var showDownvotesCompact
     @Setting(\.menus_modActionGrouping) var moderatorActionGrouping
     @Setting(\.interactionBar_comment) var commentInteractionBar
     @Setting(\.interactionBar_commentReport) var commentReportInteractionBar
@@ -34,6 +35,15 @@ struct CommentView<EmbeddedContent: View>: View {
     let inFeed: Bool
     let highlight: Bool
     let depthOffset: Int
+    
+    var compactReadouts: [CommentBarConfiguration.ReadoutType?] {
+        let saved: CommentBarConfiguration.ReadoutType? = comment.saved.value ?? false ? .saved : nil
+        if showDownvotesCompact {
+            return [.created, .upvote, .downvote, .comment, saved]
+        } else {
+            return [.created, .score, .comment, saved]
+        }
+    }
     
     init(
         comment: Comment,
@@ -85,7 +95,7 @@ struct CommentView<EmbeddedContent: View>: View {
                         if compact, !collapsed {
                             InfoStackView(
                                 comment: comment,
-                                readouts: commentInteractionBar.readouts,
+                                readouts: compactReadouts,
                                 coloredReadouts: .init(CommentBarConfiguration.ReadoutType.allCases)
                             )
                             .layoutPriority(1)
@@ -141,6 +151,16 @@ struct CommentView<EmbeddedContent: View>: View {
             Spacer()
             Group {
                 if collapsed {
+                    if let saved = comment.saved.value, let votes = comment.votes.value {
+                        Group {
+                            postTag(active: saved, icon: .lemmy.saved.representingState(active: true), color: .themedSave) +
+                            Text(verbatim: " ") +
+                            postTag(active: votes.myVote != .none, icon: .init(votes.iconName), color: votes.iconColor)
+                        }
+                        .lineLimit(1)
+                        .font(.caption)
+                    }
+                    
                     Image(icon: .general.expand)
                         .frame(height: 10)
                         .imageScale(.small)

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -36,13 +36,11 @@ struct CommentView<EmbeddedContent: View>: View {
     let highlight: Bool
     let depthOffset: Int
     
-    var compactReadouts: [CommentBarConfiguration.ReadoutType?] {
-        let saved: CommentBarConfiguration.ReadoutType? = comment.saved.value ?? false ? .saved : nil
-        if showDownvotesCompact {
-            return [.created, .upvote, .downvote, .comment, saved]
-        } else {
-            return [.created, .score, .comment, saved]
-        }
+    var compactReadouts: [CommentBarConfiguration.ReadoutType] {
+        var readouts: [CommentBarConfiguration.ReadoutType] = [.created]
+        readouts.append(contentsOf: showDownvotesCompact ? [.upvote, .downvote, .comment] : [.score, .comment])
+        readouts.appendIfPresent(comment.saved.value ?? false ? .saved : nil)
+        return readouts
     }
     
     init(

--- a/Mlem/App/Views/Shared/InfoStackView.swift
+++ b/Mlem/App/Views/Shared/InfoStackView.swift
@@ -61,10 +61,13 @@ extension InfoStackView {
     
     init(
         comment: Comment,
-        readouts: [CommentBarConfiguration.ReadoutType],
+        readouts: [CommentBarConfiguration.ReadoutType?],
         coloredReadouts: Set<CommentBarConfiguration.ReadoutType>
     ) {
-        self.readouts = readouts.compactMap { comment.readout(type: $0, showColor: coloredReadouts.contains($0)) }
+        self.readouts = readouts.compactMap {
+            if let readoutType = $0 { return comment.readout(type: readoutType, showColor: coloredReadouts.contains(readoutType)) }
+            return nil
+        }
     }
 }
 

--- a/Mlem/App/Views/Shared/InfoStackView.swift
+++ b/Mlem/App/Views/Shared/InfoStackView.swift
@@ -61,13 +61,10 @@ extension InfoStackView {
     
     init(
         comment: Comment,
-        readouts: [CommentBarConfiguration.ReadoutType?],
+        readouts: [CommentBarConfiguration.ReadoutType],
         coloredReadouts: Set<CommentBarConfiguration.ReadoutType>
     ) {
-        self.readouts = readouts.compactMap {
-            if let readoutType = $0 { return comment.readout(type: readoutType, showColor: coloredReadouts.contains(readoutType)) }
-            return nil
-        }
+        self.readouts = readouts.compactMap { comment.readout(type: $0, showColor: coloredReadouts.contains($0)) }
     }
 }
 

--- a/Mlem/App/Views/Shared/InfoStackView.swift
+++ b/Mlem/App/Views/Shared/InfoStackView.swift
@@ -52,11 +52,8 @@ struct ReadoutView: View {
 }
 
 extension InfoStackView {
-    init(post: Post, readouts: [PostBarConfiguration.ReadoutType?], coloredReadouts: Set<PostBarConfiguration.ReadoutType>) {
-        self.readouts = readouts.compactMap {
-            if let readoutType = $0 { return post.readout(type: readoutType, showColor: coloredReadouts.contains(readoutType)) }
-            return nil
-        }
+    init(post: Post, readouts: [PostBarConfiguration.ReadoutType], coloredReadouts: Set<PostBarConfiguration.ReadoutType>) {
+        self.readouts = readouts.compactMap { post.readout(type: $0, showColor: coloredReadouts.contains($0)) }
     }
     
     init(


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2683 

## Description

- Compact comments now use a static set of readouts rather than the configured interaction bar readouts
- Added a toggle to show comment downvotes separately (same behavior as posts)
- Collapsed comments now indicate upvote, downvote, and saved status. This follows the same behavior as the compact/tiled saved indicator, where a readout is only shown if the user has voted/saved.