### PR TITLE
PieFed modlog

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		033171782CCE89E3002DA370 /* PurgableProviding+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033171772CCE89E3002DA370 /* PurgableProviding+Extensions.swift */; };
 		0335AE112D8991330094FFD9 /* View+HiddenNavigationTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0335AE102D8991330094FFD9 /* View+HiddenNavigationTitle.swift */; };
 		033819282D4424D9000AFC55 /* SafetyWarningsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033819272D4424D9000AFC55 /* SafetyWarningsSettingsView.swift */; };
+		03396A642FAF6ECF0000E27A /* UnavailableContentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03396A632FAF6ECF0000E27A /* UnavailableContentInfoView.swift */; };
 		033EF4102CB9AEF7004D8A3F /* ExpandedPostView+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033EF40F2CB9AEF7004D8A3F /* ExpandedPostView+Views.swift */; };
 		033F84492D18D1F400D87A9E /* MessageFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F84482D18D1F400D87A9E /* MessageFeedView.swift */; };
 		033F844D2D18D90900D87A9E /* MessageBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F844C2D18D90900D87A9E /* MessageBubbleView.swift */; };
@@ -703,6 +704,7 @@
 		033171772CCE89E3002DA370 /* PurgableProviding+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PurgableProviding+Extensions.swift"; sourceTree = "<group>"; };
 		0335AE102D8991330094FFD9 /* View+HiddenNavigationTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+HiddenNavigationTitle.swift"; sourceTree = "<group>"; };
 		033819272D4424D9000AFC55 /* SafetyWarningsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyWarningsSettingsView.swift; sourceTree = "<group>"; };
+		03396A632FAF6ECF0000E27A /* UnavailableContentInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnavailableContentInfoView.swift; sourceTree = "<group>"; };
 		033EF40F2CB9AEF7004D8A3F /* ExpandedPostView+Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExpandedPostView+Views.swift"; sourceTree = "<group>"; };
 		033F84482D18D1F400D87A9E /* MessageFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageFeedView.swift; sourceTree = "<group>"; };
 		033F844C2D18D90900D87A9E /* MessageBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubbleView.swift; sourceTree = "<group>"; };
@@ -1417,6 +1419,7 @@
 		033F84722D1C784600D87A9E /* Modlog */ = {
 			isa = PBXGroup;
 			children = (
+				03396A632FAF6ECF0000E27A /* UnavailableContentInfoView.swift */,
 				033F84702D1C784600D87A9E /* ModlogEntryView.swift */,
 				033F84712D1C784600D87A9E /* ModlogView.swift */,
 				03A814282ED1BCA90023E9E8 /* ModlogView+Filters.swift */,
@@ -2919,6 +2922,7 @@
 				033819282D4424D9000AFC55 /* SafetyWarningsSettingsView.swift in Sources */,
 				030EE3042D651A4100D58C2C /* View+Refreshable.swift in Sources */,
 				03ECD7212C8654BA00D48BF6 /* PostEditorView+Toolbar.swift in Sources */,
+				03396A642FAF6ECF0000E27A /* UnavailableContentInfoView.swift in Sources */,
 				CD3485BD2D501573006748B8 /* ZoomSliderSettingsView.swift in Sources */,
 				033EF4102CB9AEF7004D8A3F /* ExpandedPostView+Views.swift in Sources */,
 				CDF60A012E998BB5005FA3F1 /* Data+Extensions.swift in Sources */,

--- a/Mlem/App/Utility/Extensions/Content Models/ModlogEntryContent+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/ModlogEntryContent+Extensions.swift
@@ -64,7 +64,7 @@ extension ModlogEntryContent {
     }
     
     // swiftlint:disable:next cyclomatic_complexity function_body_length
-    func label(userText: Text?) -> LocalizedStringKey {
+    func label(userText: Text?, api: ApiClient) -> LocalizedStringKey {
         switch self {
         case let .removePost(_, _, removed, _):
             if let userText {
@@ -91,7 +91,7 @@ extension ModlogEntryContent {
                 locked ? "Post was locked" : "Post was unlocked"
             }
         case let .pinPost(_, community, pinned, type):
-            pinLabel(userText: userText, community: community, pinned: pinned, type: type)
+            pinLabel(userText: userText, type: .init(community: community, api: api, type: type), pinned: pinned)
         case .purgePost:
             if let userText {
                 "\(userText) purged a post"
@@ -150,16 +150,48 @@ extension ModlogEntryContent {
     }
 }
 
+private enum PinLabelType {
+    case community(Community?)
+    case instance(ApiClient)
+
+    init(community: Community?, api: ApiClient, type: PostFeatureType) {
+        switch type {
+        case .community:
+            self = .community(community)
+        case .instance:
+            self = .instance(api)
+        }
+    }
+
+    var label: String? {
+        switch self {
+        case let .community(community): community?.fullName
+        case let .instance(api): api.host
+        }
+    }
+}
+
 private func pinLabel(
     userText: Text?,
-    community: Community,
+    type: PinLabelType,
     pinned: Bool,
-    type: PostFeatureType
 ) -> LocalizedStringKey {
-    let target: String = (type == .community ? community.fullName : community.api.host)
-    if let userText {
-        return pinned ? "\(userText) pinned a post to \(target)" : "\(userText) unpinned a post from \(target)"
-    } else {
-        return pinned ? "Post was pinned to \(target)" : "Post was unpinned from \(target)"
+    switch (userText, type.label, pinned) {
+    case let (.some(userText), .some(target), true):
+        "\(userText) pinned a post to \(target)" 
+    case let (.some(userText), .some(target), false):
+        "\(userText) unpinned a post from \(target)" 
+    case let (.some(userText), nil, true):
+        "\(userText) pinned a post to a community" 
+    case let (.some(userText), nil, false):
+        "\(userText) unpinned a post from a community" 
+    case let (nil, .some(target), true):
+        "Post was pinned to \(target)" 
+    case let (nil, .some(target), false):
+        "Post was unpinned from \(target)" 
+    case (nil, nil, true):
+        "Post was pinned to a community"
+    case (nil, nil, false):
+        "Post was unpinned from a community"
     }
 }

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -8,6 +8,7 @@
 import MlemMiddleware
 import SwiftUI
 
+// swiftlint:disable:next type_body_length
 struct ModlogEntryView: View {
     @Environment(\.palette) var palette
     
@@ -70,7 +71,12 @@ struct ModlogEntryView: View {
         switch entry.type {
         case let .removePost(post, community: community, removed: _, reason: reason):
             reasonView(reason)
-            postLink(post: post, community: community)
+            if let post {
+                postLink(post: post, community: community)
+            } else {
+                unavailableView()
+                communityLink(community: community)
+            }
         case let .lockPost(post, community: community, locked: _):
             postLink(post: post, community: community)
         case let .pinPost(post, community: community, pinned: _, type: _):
@@ -237,6 +243,44 @@ struct ModlogEntryView: View {
         NavigationLink(.comment(comment, exposeRemovedContent: true)) {
             VStack {
                 Text(comment.content)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(5)
+            }
+            .foregroundStyle(.themedSecondary)
+            .padding(Constants.main.standardSpacing)
+            .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+            .paletteBorder(cornerRadius: Constants.main.standardSpacing)
+        }
+        .id("\(id)_modlog_footer")
+    }
+
+    @ViewBuilder
+    func unavailableView() -> some View {
+            HStack {
+                Text("Post unavailable")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.subheadline)
+                    .italic()
+                Spacer()
+                Button("More info", icon: .settings.ask) {
+                    
+                }
+                .labelStyle(.iconOnly)
+            }
+            .foregroundStyle(.themedSecondary)
+            .padding(Constants.main.standardSpacing)
+            .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+            .paletteBorder(cornerRadius: Constants.main.standardSpacing)
+    }
+
+    @ViewBuilder
+    func communityLink(community: Community) -> some View {
+        NavigationLink(.community(community, visitContext: .other)) {
+            VStack {
+                Text(community.fullNameWithPrefix)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .font(.subheadline)
                     .fontWeight(.semibold)

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -79,9 +79,9 @@ struct ModlogEntryView: View {
             postLink(post: post, community: community)
         case let .purgePost(reason: reason):
             reasonView(reason)
-        case let .removeComment(comment, creator: _, post: _, community: _, removed: _, reason: reason):
+        case let .removeComment(comment, creator: _, post: _, community: community, removed: _, reason: reason):
             reasonView(reason)
-            commentLink(comment: comment)
+            commentLink(comment: comment, community: community)
         case let .purgeComment(reason: reason):
             reasonView(reason)
         case let .removeCommunity(community, removed: _, reason: reason):
@@ -240,22 +240,27 @@ struct ModlogEntryView: View {
     }
     
     @ViewBuilder
-    func commentLink(comment: Comment) -> some View {
-        NavigationLink(.comment(comment, exposeRemovedContent: true)) {
-            VStack {
-                Text(comment.content)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                    .multilineTextAlignment(.leading)
-                    .lineLimit(5)
+    func commentLink(comment: Comment?, community: Community) -> some View {
+        if let comment {
+            NavigationLink(.comment(comment, exposeRemovedContent: true)) {
+                VStack {
+                    Text(comment.content)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(5)
+                }
+                .foregroundStyle(.themedSecondary)
+                .padding(Constants.main.standardSpacing)
+                .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+                .paletteBorder(cornerRadius: Constants.main.standardSpacing)
             }
-            .foregroundStyle(.themedSecondary)
-            .padding(Constants.main.standardSpacing)
-            .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
-            .paletteBorder(cornerRadius: Constants.main.standardSpacing)
+            .id("\(id)_modlog_footer")
+        } else {
+            unavailableView()
+            communityLink(community: community)
         }
-        .id("\(id)_modlog_footer")
     }
 
     @ViewBuilder

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 // swiftlint:disable:next type_body_length
 struct ModlogEntryView: View {
     @Environment(\.palette) var palette
+    @Environment(\.navigation) var navigation
     
     let entry: ModlogEntry
     var targetCommunity: Community?
@@ -266,7 +267,7 @@ struct ModlogEntryView: View {
                     .italic()
                 Spacer()
                 Button("More info", icon: .settings.ask) {
-                    
+                    navigation?.openSheet(.unavailableContentInfo)
                 }
                 .labelStyle(.iconOnly)
             }

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -240,7 +240,7 @@ struct ModlogEntryView: View {
     }
     
     @ViewBuilder
-    func commentLink(comment: Comment?, community: Community) -> some View {
+    func commentLink(comment: Comment?, community: Community?) -> some View {
         if let comment {
             NavigationLink(.comment(comment, exposeRemovedContent: true)) {
                 VStack {
@@ -259,7 +259,9 @@ struct ModlogEntryView: View {
             .id("\(id)_modlog_footer")
         } else {
             unavailableView()
-            communityLink(community: community)
+            if let community {
+                communityLink(community: community)
+            }
         }
     }
 

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -101,7 +101,11 @@ struct ModlogEntryView: View {
         case let .updatePersonModeratorStatus(person: person, community: community, appointed: appointed):
             updatePersonModeratorStatusView(person: person, community: community, appointed: appointed)
         case let .updatePersonAdminStatus(person: person, appointed: appointed):
-            updatePersonModeratorStatusView(person: person, community: nil, appointed: appointed)
+            if let person {
+                updatePersonModeratorStatusView(person: person, community: nil, appointed: appointed)
+            } else {
+                unavailableView()
+            }
         case let .banPersonFromCommunity(person: person, community: community, banned: banned, reason: reason, expires: expires):
             reasonView(reason)
             banPersonView(person: person, community: community, banned: banned, expires: expires)
@@ -232,47 +236,52 @@ struct ModlogEntryView: View {
     
     @ViewBuilder
     func postLink(post: Post?, community: Community) -> some View {
-        if let post {
-            NavigationLink(.post(post)) {
-                FooterLinkView(title: post.title, subtitle: community.fullNameWithPrefix)
+        Group {
+            if let post {
+                NavigationLink(.post(post)) {
+                    FooterLinkView(title: post.title, subtitle: community.fullNameWithPrefix)
+                }
+            } else {
+                unavailableView()
+                communityLink(community: community)
             }
-            .id("\(id)_modlog_footer")
-        } else {
-            unavailableView()
-            communityLink(community: community)
         }
+        .id("\(id)_modlog_footer")
     }
     
     @ViewBuilder
     func commentLink(comment: Comment?, community: Community?) -> some View {
-        if let comment {
-            NavigationLink(.comment(comment, exposeRemovedContent: true)) {
-                VStack {
-                    Text(comment.content)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .multilineTextAlignment(.leading)
-                        .lineLimit(5)
+        Group {
+            if let comment {
+                NavigationLink(.comment(comment, exposeRemovedContent: true)) {
+                    VStack {
+                        Text(comment.content)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .multilineTextAlignment(.leading)
+                            .lineLimit(5)
+                    }
+                    .foregroundStyle(.themedSecondary)
+                    .padding(Constants.main.standardSpacing)
+                    .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+                    .paletteBorder(cornerRadius: Constants.main.standardSpacing)
                 }
-                .foregroundStyle(.themedSecondary)
-                .padding(Constants.main.standardSpacing)
-                .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
-                .paletteBorder(cornerRadius: Constants.main.standardSpacing)
-            }
-            .id("\(id)_modlog_footer")
-        } else {
-            unavailableView()
-            if let community {
-                communityLink(community: community)
+            } else {
+                unavailableView()
+                if let community {
+                    communityLink(community: community)
+
+                }
             }
         }
+        .id("\(id)_modlog_footer")
     }
 
     @ViewBuilder
     func unavailableView() -> some View {
             HStack {
-                Text("Post unavailable")
+                Text("Content unavailable")
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .font(.subheadline)
                     .italic()

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -14,6 +14,7 @@ struct ModlogEntryView: View {
     @Environment(\.navigation) var navigation
     
     let entry: ModlogEntry
+    let api: ApiClient
     var targetCommunity: Community?
     @State private var id = UUID()
     
@@ -62,9 +63,9 @@ struct ModlogEntryView: View {
                 font: .footnote,
                 palette: palette
             )
-            return entry.type.label(userText: userText)
+            return entry.type.label(userText: userText, api: api)
         }
-        return entry.type.label(userText: nil)
+        return entry.type.label(userText: nil, api: api)
     }
     
     @ViewBuilder
@@ -235,15 +236,17 @@ struct ModlogEntryView: View {
     }
     
     @ViewBuilder
-    func postLink(post: Post?, community: Community) -> some View {
+    func postLink(post: Post?, community: Community?) -> some View {
         Group {
-            if let post {
+            if let post, let community {
                 NavigationLink(.post(post)) {
                     FooterLinkView(title: post.title, subtitle: community.fullNameWithPrefix)
                 }
             } else {
                 unavailableView("Post unavailable")
-                communityLink(community: community)
+                if let community {
+                    communityLink(community: community)
+                }
             }
         }
         .id("\(id)_modlog_footer")

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -89,7 +89,7 @@ struct ModlogEntryView: View {
             if let community {
                 FullyQualifiedLinkView(community, labelStyle: .medium)
             } else {
-                unavailableView()
+                unavailableView("Community unavailable")
             }
         case let .purgeCommunity(reason: reason):
             reasonView(reason)
@@ -104,7 +104,7 @@ struct ModlogEntryView: View {
             if let person {
                 updatePersonModeratorStatusView(person: person, community: nil, appointed: appointed)
             } else {
-                unavailableView()
+                unavailableView("User unavailable")
             }
         case let .banPersonFromCommunity(person: person, community: community, banned: banned, reason: reason, expires: expires):
             reasonView(reason)
@@ -242,7 +242,7 @@ struct ModlogEntryView: View {
                     FooterLinkView(title: post.title, subtitle: community.fullNameWithPrefix)
                 }
             } else {
-                unavailableView()
+                unavailableView("Post unavailable")
                 communityLink(community: community)
             }
         }
@@ -268,7 +268,7 @@ struct ModlogEntryView: View {
                     .paletteBorder(cornerRadius: Constants.main.standardSpacing)
                 }
             } else {
-                unavailableView()
+                unavailableView("Comment unavailable")
                 if let community {
                     communityLink(community: community)
 
@@ -279,9 +279,9 @@ struct ModlogEntryView: View {
     }
 
     @ViewBuilder
-    func unavailableView() -> some View {
+    func unavailableView(_ label: LocalizedStringKey) -> some View {
             HStack {
-                Text("Content unavailable")
+                Text(label)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .font(.subheadline)
                     .italic()

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -119,109 +119,128 @@ struct ModlogEntryView: View {
     }
     
     @ViewBuilder
-    func banPersonView(person: Person, community: Community?, banned: Bool, expires: Date?) -> some View {
-        VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
-            let userText = person.nameTextView(
-                showFlairs: true,
-                showInstance: true,
-                communityContext: targetCommunity ?? community,
-                font: .subheadline,
-                palette: palette
-            )
-            let targetText: Text
-            if let community {
-                targetText = community.nameTextView(
+    func banPersonView(person: Person?, community: Community?, banned: Bool, expires: Date?) -> some View {
+        if let person {
+            VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
+                let userText = person.nameTextView(
                     showFlairs: true,
                     showInstance: true,
+                    communityContext: targetCommunity ?? community,
                     font: .subheadline,
                     palette: palette
                 )
-            } else {
-                targetText = Text("Instance")
+                let targetText: Text
+                if let community {
+                    targetText = community.nameTextView(
+                        showFlairs: true,
+                        showInstance: true,
+                        font: .subheadline,
+                        palette: palette
+                    )
+                } else {
+                    targetText = Text("Instance")
+                }
+                if banned {
+                    let expiresText = expires?.formatted(date: .abbreviated, time: .omitted) ?? "Never"
+                    return Text("Banned: \(userText)\nFrom: \(targetText)\nExpires: \(expiresText)")
+                } else {
+                    return Text("Unbanned: \(userText)\nFrom: \(targetText)")
+                }
             }
-            if banned {
-                let expiresText = expires?.formatted(date: .abbreviated, time: .omitted) ?? "Never"
-                return Text("Banned: \(userText)\nFrom: \(targetText)\nExpires: \(expiresText)")
-            } else {
-                return Text("Unbanned: \(userText)\nFrom: \(targetText)")
+            .imageScale(.small)
+            .symbolVariant(.fill)
+            .foregroundStyle(.themedSecondary)
+            .font(.subheadline)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Constants.main.standardSpacing)
+            .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+            .paletteBorder(cornerRadius: Constants.main.standardSpacing)
+        } else {
+            unavailableView("User unavailable")
+            if let community {
+                communityLink(community: community)
             }
         }
-        .imageScale(.small)
-        .symbolVariant(.fill)
-        .foregroundStyle(.themedSecondary)
-        .font(.subheadline)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(Constants.main.standardSpacing)
-        .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
-        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
     
     @ViewBuilder
     func transferCommunityView(
-        person: Person,
+        person: Person?,
         community: Community
     ) -> some View {
-        VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
-            let userText = person.nameTextView(
-                showFlairs: true,
-                showInstance: true,
-                communityContext: targetCommunity ?? community,
-                font: .subheadline,
-                palette: palette
-            )
-            let communityText = community.nameTextView(
-                showFlairs: true,
-                showInstance: true,
-                font: .subheadline,
-                palette: palette
-            )
-            Text("Community: \(communityText)\nNew Owner: \(userText)")
-                .imageScale(.small)
-        }
-        .foregroundStyle(.themedSecondary)
-        .font(.subheadline)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(Constants.main.standardSpacing)
-        .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
-        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
-    }
-    
-    @ViewBuilder
-    func updatePersonModeratorStatusView(
-        person: Person,
-        community: Community?,
-        appointed: Bool
-    ) -> some View {
-        VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
-            let userText = person.nameTextView(
-                showFlairs: true,
-                showInstance: true,
-                communityContext: targetCommunity ?? community,
-                font: .subheadline,
-                palette: palette
-            )
-            if let community {
+        if let person {
+            VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
+                let userText = person.nameTextView(
+                    showFlairs: true,
+                    showInstance: true,
+                    communityContext: targetCommunity ?? community,
+                    font: .subheadline,
+                    palette: palette
+                )
                 let communityText = community.nameTextView(
                     showFlairs: true,
                     showInstance: true,
                     font: .subheadline,
                     palette: palette
                 )
-                Text(
-                    appointed ? "Appointed: \(userText)\nTo: \(communityText)" : "Removed: \(userText)\nFrom: \(communityText)"
+                Text("Community: \(communityText)\nNew Owner: \(userText)")
+                    .imageScale(.small)
+            }
+            .foregroundStyle(.themedSecondary)
+            .font(.subheadline)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Constants.main.standardSpacing)
+            .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+            .paletteBorder(cornerRadius: Constants.main.standardSpacing)
+        } else {
+            unavailableView("User unavailable")
+            communityLink(community: community)
+        }
+    }
+    
+    @ViewBuilder
+    func updatePersonModeratorStatusView(
+        person: Person?,
+        community: Community?,
+        appointed: Bool
+    ) -> some View {
+        if let person {
+            VStack(alignment: .leading, spacing: Constants.main.standardSpacing) {
+                let userText = person.nameTextView(
+                    showFlairs: true,
+                    showInstance: true,
+                    communityContext: targetCommunity ?? community,
+                    font: .subheadline,
+                    palette: palette
                 )
-            } else {
-                Text(appointed ? "Appointed: \(userText)" : "Removed: \(userText)")
+                if let community {
+                    let communityText = community.nameTextView(
+                        showFlairs: true,
+                        showInstance: true,
+                        font: .subheadline,
+                        palette: palette
+                    )
+                    Text(
+                        appointed ? "Appointed: \(userText)\nTo: \(communityText)" : "Removed: \(userText)\nFrom: \(communityText)"
+                    )
+                } else {
+                    Text(appointed ? "Appointed: \(userText)" : "Removed: \(userText)")
+                }
+            }
+            .foregroundStyle(.themedSecondary)
+            .imageScale(.small)
+            .symbolVariant(.fill)
+            .font(.subheadline)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Constants.main.standardSpacing)
+            .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+            .paletteBorder(cornerRadius: Constants.main.standardSpacing)
+        } else {
+            unavailableView("User unavailable")
+            if let community {
+                communityLink(community: community)
             }
         }
-        .foregroundStyle(.themedSecondary)
-        .imageScale(.small)
-        .symbolVariant(.fill)
-        .font(.subheadline)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(Constants.main.standardSpacing)
-        .background(.themedTertiaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
-        .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -72,12 +72,7 @@ struct ModlogEntryView: View {
         switch entry.type {
         case let .removePost(post, community: community, removed: _, reason: reason):
             reasonView(reason)
-            if let post {
-                postLink(post: post, community: community)
-            } else {
-                unavailableView()
-                communityLink(community: community)
-            }
+            postLink(post: post, community: community)
         case let .lockPost(post, community: community, locked: _):
             postLink(post: post, community: community)
         case let .pinPost(post, community: community, pinned: _, type: _):
@@ -232,11 +227,16 @@ struct ModlogEntryView: View {
     }
     
     @ViewBuilder
-    func postLink(post: Post, community: Community) -> some View {
-        NavigationLink(.post(post)) {
-            FooterLinkView(title: post.title, subtitle: community.fullNameWithPrefix)
+    func postLink(post: Post?, community: Community) -> some View {
+        if let post {
+            NavigationLink(.post(post)) {
+                FooterLinkView(title: post.title, subtitle: community.fullNameWithPrefix)
+            }
+            .id("\(id)_modlog_footer")
+        } else {
+            unavailableView()
+            communityLink(community: community)
         }
-        .id("\(id)_modlog_footer")
     }
     
     @ViewBuilder

--- a/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogEntryView.swift
@@ -86,7 +86,11 @@ struct ModlogEntryView: View {
             reasonView(reason)
         case let .removeCommunity(community, removed: _, reason: reason):
             reasonView(reason)
-            FullyQualifiedLinkView(community, labelStyle: .medium)
+            if let community {
+                FullyQualifiedLinkView(community, labelStyle: .medium)
+            } else {
+                unavailableView()
+            }
         case let .purgeCommunity(reason: reason):
             reasonView(reason)
         case let .hideCommunity(community, hidden: _, reason: reason):

--- a/Mlem/App/Views/Pages/Modlog/ModlogView.swift
+++ b/Mlem/App/Views/Pages/Modlog/ModlogView.swift
@@ -135,7 +135,7 @@ struct ModlogView: View {
     
     @ViewBuilder
     func entryView(_ entry: ModlogEntry) -> some View {
-        ModlogEntryView(entry: entry, targetCommunity: communityFilter?.communityValue)
+        ModlogEntryView(entry: entry, api: api, targetCommunity: communityFilter?.communityValue)
             .onAppear {
                 do {
                     try activeFeedLoader.loadIfThreshold(entry)

--- a/Mlem/App/Views/Pages/Modlog/UnavailableContentInfoView.swift
+++ b/Mlem/App/Views/Pages/Modlog/UnavailableContentInfoView.swift
@@ -12,7 +12,7 @@ struct UnavailableContentInfoView: View {
     var body: some View {
         FancyScrollView {
             // swiftlint:disable:next line_length
-            Text("This content is no longer available.\n\nIt may have been removed automatically. PieFed purges posts 7 days after they are removed or deleted.\n\nOr, it may have been purged by an administrator.")
+            Text("This content is no longer available.\n\nIt may have been removed automatically. PieFed purges content 7 days after it is removed.\n\nOr, it may have been purged by an administrator.")
                 .padding(.horizontal, 20)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/Mlem/App/Views/Pages/Modlog/UnavailableContentInfoView.swift
+++ b/Mlem/App/Views/Pages/Modlog/UnavailableContentInfoView.swift
@@ -1,0 +1,24 @@
+//
+//  UnavailableContentInfoView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-05-09.
+//
+
+import ComponentViews
+import SwiftUI
+
+struct UnavailableContentInfoView: View {
+    var body: some View {
+        FancyScrollView {
+            // swiftlint:disable:next line_length
+            Text("This content is no longer available.\n\nIt may have been removed automatically. PieFed purges posts 7 days after they are removed or deleted.\n\nOr, it may have been purged by an administrator.")
+                .padding(.horizontal, 20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .toolbar {
+            CloseButtonToolbarItem()
+        }
+        .presentationBackgroundInteraction(.enabled)
+    }
+}

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+PresentationDetents.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+PresentationDetents.swift
@@ -13,7 +13,7 @@ extension NavigationPage {
     // that it being handled by the navigation system. 
     var presentationDetentConfiguration: NavigationDetentConfiguration? {
         switch self {
-        case .selectText: .only(.medium)
+        case .selectText, .unavailableContentInfo: .only(.medium)
         case .actionSheet: .init([.medium, .large], default: .medium)
         case .externalApiInfo: .only(.medium)
         case .rulesList: .init([.medium, .large], default: .medium)

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -244,6 +244,8 @@ extension NavigationPage {
                 environment: environment.wrappedValue,
                 configuration: configuration
             )
+        case .unavailableContentInfo:
+            UnavailableContentInfoView()
         }
     }
 }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -91,6 +91,7 @@ enum NavigationPage: Hashable {
     case denyApplication(RegistrationApplication)
     case exportPostImage(_ post: Post)
     case exportCommentImage(_ comment: Comment, tracker: CommentTreeTracker?)
+    case unavailableContentInfo
 
     // If `configuration` is specified, show a "customise" button in the sheet for editing that configuration.
     // Otherwise, no "customise" button is shown.

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/ModlogEntryType+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/ModlogEntryType+Lemmy.swift
@@ -1,0 +1,30 @@
+//
+//  ModlogEntryType+Lemmy.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-03-12.
+//
+
+import Foundation
+
+extension ModlogEntryType {
+    var lemmyApiType: LemmyModlogKind {
+        switch self {
+        case .removePost: .modRemovePost
+        case .lockPost: .modLockPost
+        case .pinPost: .modFeaturePost
+        case .purgePost: .adminPurgePost
+        case .removeComment: .modRemoveComment
+        case .purgeComment: .adminPurgeComment
+        case .removeCommunity: .modRemoveCommunity
+        case .purgeCommunity: .adminPurgeCommunity
+        case .hideCommunity: .modHideCommunity
+        case .transferCommunityOwnership: .modTransferCommunity
+        case .updatePersonModeratorStatus: .modAddCommunity
+        case .updatePersonAdminStatus: .modAdd
+        case .banPersonFromCommunity: .modBanFromCommunity
+        case .banPersonFromInstance: .modBan
+        case .purgePerson: .adminPurgePerson
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
@@ -28,7 +28,7 @@ public enum ModlogEntryContent: Equatable {
     case purgePost(reason: String?)
     
     case removeComment(
-        _ comment: Comment,
+        _ comment: Comment?,
         creator: Person,
         post: Post,
         community: Community,
@@ -140,7 +140,7 @@ public enum ModlogEntryContent: Equatable {
             self = .purgePost(reason: reason)
         case let .removeComment(comment, creator, post, community, removed, reason):
             self = .removeComment(
-                api.caches.comment.getModel(api: api, from: .comment1(comment)),
+                api.caches.comment.getOptionalModel(api: api, from: comment.map { .comment1($0) }),
                 creator: api.caches.person.getModel(api: api, from: .person1(creator)),
                 post: api.caches.post.getModel(api: api, from: .post1(post)),
                 community: api.caches.community.getModel(api: api, from: .community1(community)),

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public enum ModlogEntryContent: Equatable {
     case removePost(
-        _ post: Post,
+        _ post: Post?,
         community: Community,
         removed: Bool,
         reason: String?
@@ -118,7 +118,7 @@ public enum ModlogEntryContent: Equatable {
         switch snapshot {
         case let .removePost(post, community, removed, reason):
             self = .removePost(
-                api.caches.post.getModel(api: api, from: .post1(post)),
+                api.caches.post.getOptionalModel(api: api, from: post.map { .post1($0) }),
                 community: api.caches.community.getModel(api: api, from: .community1(community)),
                 removed: removed,
                 reason: reason

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
@@ -15,12 +15,12 @@ public enum ModlogEntryContent: Equatable {
         reason: String?
     )
     case lockPost(
-        _ post: Post,
+        _ post: Post?,
         community: Community,
         locked: Bool
     )
     case pinPost(
-        _ post: Post,
+        _ post: Post?,
         community: Community,
         pinned: Bool,
         type: PostFeatureType
@@ -125,13 +125,13 @@ public enum ModlogEntryContent: Equatable {
             )
         case let .lockPost(post, community, locked):
             self = .lockPost(
-                api.caches.post.getModel(api: api, from: .post1(post)),
+                api.caches.post.getOptionalModel(api: api, from: post.map { .post1($0) }),
                 community: api.caches.community.getModel(api: api, from: .community1(community)),
                 locked: locked
             )
         case let .pinPost(post, community, pinned, type):
             self = .pinPost(
-                api.caches.post.getModel(api: api, from: .post1(post)),
+                api.caches.post.getOptionalModel(api: api, from: post.map { .post1($0) }),
                 community: api.caches.community.getModel(api: api, from: .community1(community)),
                 pinned: pinned,
                 type: type

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
@@ -38,7 +38,7 @@ public enum ModlogEntryContent: Equatable {
     case purgeComment(reason: String?)
     
     case removeCommunity(
-        _ community: Community,
+        _ community: Community?,
         removed: Bool,
         reason: String?
     )
@@ -151,7 +151,7 @@ public enum ModlogEntryContent: Equatable {
             self = .purgeComment(reason: reason)
         case let .removeCommunity(community, removed, reason):
             self = .removeCommunity(
-                api.caches.community.getModel(api: api, from: .community1(community)),
+                api.caches.community.getOptionalModel(api: api, from: community.map { .community1($0) }),
                 removed: removed,
                 reason: reason
             )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
@@ -50,12 +50,12 @@ public enum ModlogEntryContent: Equatable {
         reason: String?
     )
     case transferCommunityOwnership(
-        person: Person,
+        person: Person?,
         community: Community
     )
     
     case updatePersonModeratorStatus(
-        person: Person,
+        person: Person?,
         community: Community?,
         appointed: Bool
     )
@@ -64,14 +64,14 @@ public enum ModlogEntryContent: Equatable {
         appointed: Bool
     )
     case banPersonFromCommunity(
-        person: Person,
+        person: Person?,
         community: Community?,
         banned: Bool,
         reason: String?,
         expires: Date?
     )
     case banPersonFromInstance(
-        person: Person,
+        person: Person?,
         banned: Bool,
         reason: String?,
         expires: Date?
@@ -165,12 +165,12 @@ public enum ModlogEntryContent: Equatable {
             )
         case let .transferCommunityOwnership(person, community):
             self = .transferCommunityOwnership(
-                person: api.caches.person.getModel(api: api, from: .person1(person)),
+                person: api.caches.person.getOptionalModel(api: api, from: person.map { .person1($0) }),
                 community: api.caches.community.getModel(api: api, from: .community1(community)),
             )
         case let .updatePersonModeratorStatus(person, community, appointed):
             self = .updatePersonModeratorStatus(
-                person: api.caches.person.getModel(api: api, from: .person1(person)),
+                person: api.caches.person.getOptionalModel(api: api, from: person.map { .person1($0) }),
                 community: api.caches.community.getOptionalModel(api: api, from: community.map { .community1($0) }),
                 appointed: appointed
             )
@@ -181,7 +181,7 @@ public enum ModlogEntryContent: Equatable {
             )
         case let .banPersonFromCommunity(person, community, banned, reason, expires):
             self = .banPersonFromCommunity(
-                person: api.caches.person.getModel(api: api, from: .person1(person)),
+                person: api.caches.person.getOptionalModel(api: api, from: person.map { .person1($0) }),
                 community: api.caches.community.getOptionalModel(api: api, from: community.map { .community1($0) }),
                 banned: banned,
                 reason: reason,
@@ -189,7 +189,7 @@ public enum ModlogEntryContent: Equatable {
             )
         case let .banPersonFromInstance(person, banned, reason, expires):
             self = .banPersonFromInstance(
-                person: api.caches.person.getModel(api: api, from: .person1(person)),
+                person: api.caches.person.getOptionalModel(api: api, from: person.map { .person1($0) }),
                 banned: banned,
                 reason: reason,
                 expires: expires

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
@@ -29,9 +29,9 @@ public enum ModlogEntryContent: Equatable {
     
     case removeComment(
         _ comment: Comment?,
-        creator: Person,
-        post: Post,
-        community: Community,
+        creator: Person?,
+        post: Post?,
+        community: Community?,
         removed: Bool,
         reason: String?
     )
@@ -141,9 +141,9 @@ public enum ModlogEntryContent: Equatable {
         case let .removeComment(comment, creator, post, community, removed, reason):
             self = .removeComment(
                 api.caches.comment.getOptionalModel(api: api, from: comment.map { .comment1($0) }),
-                creator: api.caches.person.getModel(api: api, from: .person1(creator)),
-                post: api.caches.post.getModel(api: api, from: .post1(post)),
-                community: api.caches.community.getModel(api: api, from: .community1(community)),
+                creator: api.caches.person.getOptionalModel(api: api, from: creator.map { .person1($0) }),
+                post: api.caches.post.getOptionalModel(api: api, from: post.map { .post1($0) }),
+                community: api.caches.community.getOptionalModel(api: api, from: community.map { .community1($0) }),
                 removed: removed,
                 reason: reason
             )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
@@ -60,7 +60,7 @@ public enum ModlogEntryContent: Equatable {
         appointed: Bool
     )
     case updatePersonAdminStatus(
-        person: Person,
+        person: Person?,
         appointed: Bool
     )
     case banPersonFromCommunity(
@@ -176,7 +176,7 @@ public enum ModlogEntryContent: Equatable {
             )
         case let .updatePersonAdminStatus(person, appointed):
             self = .updatePersonAdminStatus(
-                person: api.caches.person.getModel(api: api, from: .person1(person)),
+                person: api.caches.person.getOptionalModel(api: api, from: person.map { .person1($0) }),
                 appointed: appointed
             )
         case let .banPersonFromCommunity(person, community, banned, reason, expires):

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Modlog/ModlogEntryContent.swift
@@ -10,18 +10,18 @@ import Foundation
 public enum ModlogEntryContent: Equatable {
     case removePost(
         _ post: Post?,
-        community: Community,
+        community: Community?,
         removed: Bool,
         reason: String?
     )
     case lockPost(
         _ post: Post?,
-        community: Community,
+        community: Community?,
         locked: Bool
     )
     case pinPost(
         _ post: Post?,
-        community: Community,
+        community: Community?,
         pinned: Bool,
         type: PostFeatureType
     )
@@ -45,7 +45,7 @@ public enum ModlogEntryContent: Equatable {
     case purgeCommunity(reason: String?)
     
     case hideCommunity(
-        _ community: Community,
+        _ community: Community?,
         hidden: Bool,
         reason: String?
     )
@@ -56,7 +56,7 @@ public enum ModlogEntryContent: Equatable {
     
     case updatePersonModeratorStatus(
         person: Person,
-        community: Community,
+        community: Community?,
         appointed: Bool
     )
     case updatePersonAdminStatus(
@@ -65,7 +65,7 @@ public enum ModlogEntryContent: Equatable {
     )
     case banPersonFromCommunity(
         person: Person,
-        community: Community,
+        community: Community?,
         banned: Bool,
         reason: String?,
         expires: Date?
@@ -119,20 +119,20 @@ public enum ModlogEntryContent: Equatable {
         case let .removePost(post, community, removed, reason):
             self = .removePost(
                 api.caches.post.getOptionalModel(api: api, from: post.map { .post1($0) }),
-                community: api.caches.community.getModel(api: api, from: .community1(community)),
+                community: api.caches.community.getOptionalModel(api: api, from: community.map { .community1($0) }),
                 removed: removed,
                 reason: reason
             )
         case let .lockPost(post, community, locked):
             self = .lockPost(
                 api.caches.post.getOptionalModel(api: api, from: post.map { .post1($0) }),
-                community: api.caches.community.getModel(api: api, from: .community1(community)),
+                community: api.caches.community.getOptionalModel(api: api, from: community.map { .community1($0) }),
                 locked: locked
             )
         case let .pinPost(post, community, pinned, type):
             self = .pinPost(
                 api.caches.post.getOptionalModel(api: api, from: post.map { .post1($0) }),
-                community: api.caches.community.getModel(api: api, from: .community1(community)),
+                community: api.caches.community.getOptionalModel(api: api, from: community.map { .community1($0) }),
                 pinned: pinned,
                 type: type
             )
@@ -159,19 +159,19 @@ public enum ModlogEntryContent: Equatable {
             self = .purgeCommunity(reason: reason)
         case let .hideCommunity(community, hidden, reason):
             self = .hideCommunity(
-                api.caches.community.getModel(api: api, from: .community1(community)),
+                api.caches.community.getOptionalModel(api: api, from: community.map { .community1($0) }),
                 hidden: hidden,
                 reason: reason
             )
         case let .transferCommunityOwnership(person, community):
             self = .transferCommunityOwnership(
                 person: api.caches.person.getModel(api: api, from: .person1(person)),
-                community: api.caches.community.getModel(api: api, from: .community1(community))
+                community: api.caches.community.getModel(api: api, from: .community1(community)),
             )
         case let .updatePersonModeratorStatus(person, community, appointed):
             self = .updatePersonModeratorStatus(
                 person: api.caches.person.getModel(api: api, from: .person1(person)),
-                community: api.caches.community.getModel(api: api, from: .community1(community)),
+                community: api.caches.community.getOptionalModel(api: api, from: community.map { .community1($0) }),
                 appointed: appointed
             )
         case let .updatePersonAdminStatus(person, appointed):
@@ -182,7 +182,7 @@ public enum ModlogEntryContent: Equatable {
         case let .banPersonFromCommunity(person, community, banned, reason, expires):
             self = .banPersonFromCommunity(
                 person: api.caches.person.getModel(api: api, from: .person1(person)),
-                community: api.caches.community.getModel(api: api, from: .community1(community)),
+                community: api.caches.community.getOptionalModel(api: api, from: community.map { .community1($0) }),
                 banned: banned,
                 reason: reason,
                 expires: expires

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ModlogEntryType.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/ModlogEntryType.swift
@@ -57,24 +57,4 @@ public enum ModlogEntryType: CaseIterable {
             return nil
         }
     }
-    
-    var apiType: LemmyModlogKind {
-        switch self {
-        case .removePost: .modRemovePost
-        case .lockPost: .modLockPost
-        case .pinPost: .modFeaturePost
-        case .purgePost: .adminPurgePost
-        case .removeComment: .modRemoveComment
-        case .purgeComment: .adminPurgeComment
-        case .removeCommunity: .modRemoveCommunity
-        case .purgeCommunity: .adminPurgeCommunity
-        case .hideCommunity: .modHideCommunity
-        case .transferCommunityOwnership: .modTransferCommunity
-        case .updatePersonModeratorStatus: .modAddCommunity
-        case .updatePersonAdminStatus: .modAdd
-        case .banPersonFromCommunity: .modBanFromCommunity
-        case .banPersonFromInstance: .modBan
-        case .purgePerson: .adminPurgePerson
-        }
-    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
@@ -1,0 +1,174 @@
+//
+//  ModlogEntryContentSnapshot+PieFed.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-03-12.
+//
+
+import Foundation
+
+extension ModlogEntryContentSnapshot {
+    init(from view: PieFedModRemovePostView) throws(ApiClientError) {
+        guard let post = view.post else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModRemovePostView post")
+        }
+        guard let community = view.community else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModRemovePostView community")
+        }
+        self = try .removePost(
+            .init(from: post),
+            community: .init(from: community),
+            removed: view.modRemovePost.removed,
+            reason: view.modRemovePost.reason
+        )
+    }
+    
+    init(from view: PieFedModLockPostView) throws(ApiClientError) {
+        guard let post = view.post else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModLockPostView post")
+        }
+        guard let community = view.community else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModLockPostView community")
+        }
+        self = try .lockPost(
+            .init(from: post),
+            community: .init(from: community),
+            locked: view.modLockPost.locked
+        )
+    }
+    
+    init(from view: PieFedModFeaturePostView) throws(ApiClientError) {
+        guard let post = view.post else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModFeaturePostView post")
+        }
+        guard let community = view.community else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModFeaturePostView community")
+        }
+        self = try .pinPost(
+            .init(from: post),
+            community: .init(from: community),
+            pinned: view.modFeaturePost.featured,
+            type: view.modFeaturePost.isFeaturedCommunity ? .community : .instance
+        )
+    }
+    
+    init(from view: PieFedAdminPurgePostView) throws(ApiClientError) {
+        self = .purgePost(reason: view.adminPurgePost.reason)
+    }
+    
+    init(from view: PieFedModRemoveCommentView) throws(ApiClientError) {
+        guard let comment = view.comment else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommentView comment")
+        }
+        guard let commenter = view.commenter else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommentView commenter")
+        }
+        guard let post = view.post else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommentView post")
+        }
+        guard let community = view.community else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommentView community")
+        }
+        self = try .removeComment(
+            .init(from: comment),
+            creator: .init(from: commenter),
+            post: .init(from: post),
+            community: .init(from: community),
+            removed: view.modRemoveComment.removed,
+            reason: view.modRemoveComment.reason
+        )
+    }
+    
+    init(from view: PieFedAdminPurgeCommentView) throws(ApiClientError) {
+        self = .purgeComment(reason: view.adminPurgeComment.reason)
+    }
+    
+    init(from view: PieFedModRemoveCommunityView) throws(ApiClientError) {
+        guard let community = view.community else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommunityView community")
+        }
+        self = try .removeCommunity(
+            .init(from: community),
+            removed: view.modRemoveCommunity.removed,
+            reason: view.modRemoveCommunity.reason
+        )
+    }
+    
+    init(from view: PieFedAdminPurgeCommunityView) throws(ApiClientError) {
+        self = .purgeCommunity(reason: view.adminPurgeCommunity.reason)
+    }
+    
+    init(from view: PieFedModHideCommunityView) throws(ApiClientError) {
+        self = try .hideCommunity(
+            .init(from: view.community),
+            hidden: view.modHideCommunity.hidden,
+            reason: view.modHideCommunity.reason
+        )
+    }
+    
+    init(from view: PieFedModTransferCommunityView) throws(ApiClientError) {
+        guard let moddedPerson = view.moddedPerson else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModTransferCommunityView bassedPerson")
+        }
+        self = try .transferCommunityOwnership(
+            person: .init(from: moddedPerson),
+            community: .init(from: view.community)
+        )
+    }
+    
+    init(from view: PieFedModAddCommunityView) throws(ApiClientError) {
+        guard let moddedPerson = view.moddedPerson else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModAddCommunityView bassedPerson")
+        }
+        guard let community = view.community else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModAddCommunityView community")
+        }
+        self = try .updatePersonModeratorStatus(
+            person: .init(from: moddedPerson),
+            community: .init(from: community),
+            appointed: !view.modAddCommunity.removed
+        )
+    }
+    
+    init(from view: PieFedModAddView) throws(ApiClientError) {
+        guard let moddedPerson = view.moddedPerson else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModAddView moddedPerson")
+        }
+        self = try .updatePersonAdminStatus(
+            person: .init(from: moddedPerson),
+            appointed: !view.modAdd.removed
+        )
+    }
+    
+    init(from view: PieFedModBanFromCommunityView) throws(ApiClientError) {
+        guard let bannedPerson = view.bannedPerson else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModBanFromCommunityView bannedPerson")
+        }
+        guard let community = view.community else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModBanFromCommunityView community")
+        }
+        self = try .banPersonFromCommunity(
+            person: .init(from: bannedPerson),
+            community: .init(from: community),
+            banned: view.modBanFromCommunity.banned,
+            reason: view.modBanFromCommunity.reason,
+            expires: view.modBanFromCommunity.expires
+        )
+    }
+    
+    init(from view: PieFedModBanView) throws(ApiClientError) {
+        guard let bannedPerson = view.bannedPerson else {
+            throw ApiClientError.responseMissingRequiredData("PieFedModBanView bannedPerson")
+        }
+        self = try .banPersonFromInstance(
+            person: .init(from: bannedPerson),
+            banned: view.modBan.banned,
+            reason: view.modBan.reason,
+            expires: view.modBan.expires
+        )
+    }
+    
+    init(from view: PieFedAdminPurgePersonView) throws(ApiClientError) {
+        self = .purgePerson(reason: view.adminPurgePerson.reason)
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
@@ -21,28 +21,22 @@ extension ModlogEntryContentSnapshot {
     }
     
     init(from view: PieFedModLockPostView) throws(ApiClientError) {
-        guard let post = view.post else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModLockPostView post")
-        }
         guard let community = view.community else {
             throw ApiClientError.responseMissingRequiredData("PieFedModLockPostView community")
         }
         self = try .lockPost(
-            .init(from: post),
+            view.post.map(Post1Snapshot.init),
             community: .init(from: community),
             locked: view.modLockPost.locked
         )
     }
     
     init(from view: PieFedModFeaturePostView) throws(ApiClientError) {
-        guard let post = view.post else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModFeaturePostView post")
-        }
         guard let community = view.community else {
             throw ApiClientError.responseMissingRequiredData("PieFedModFeaturePostView community")
         }
         self = try .pinPost(
-            .init(from: post),
+            view.post.map(Post1Snapshot.init),
             community: .init(from: community),
             pinned: view.modFeaturePost.featured,
             type: view.modFeaturePost.isFeaturedCommunity ? .community : .instance

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
@@ -48,9 +48,6 @@ extension ModlogEntryContentSnapshot {
     }
     
     init(from view: PieFedModRemoveCommentView) throws(ApiClientError) {
-        guard let comment = view.comment else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommentView comment")
-        }
         guard let commenter = view.commenter else {
             throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommentView commenter")
         }
@@ -61,7 +58,7 @@ extension ModlogEntryContentSnapshot {
             throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommentView community")
         }
         self = try .removeComment(
-            .init(from: comment),
+            view.comment.map(Comment1Snapshot.init),
             creator: .init(from: commenter),
             post: .init(from: post),
             community: .init(from: community),

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
@@ -113,11 +113,10 @@ extension ModlogEntryContentSnapshot {
     }
     
     init(from view: PieFedModAddView) throws(ApiClientError) {
-        guard let moddedPerson = view.moddedPerson else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModAddView moddedPerson")
-        }
         self = try .updatePersonAdminStatus(
-            person: .init(from: moddedPerson),
+            person: view.moddedPerson.map { person throws(ApiClientError) in
+                try .init(from: person)
+            },
             appointed: !view.modAdd.removed
         )
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
@@ -67,11 +67,10 @@ extension ModlogEntryContentSnapshot {
     }
     
     init(from view: PieFedModRemoveCommunityView) throws(ApiClientError) {
-        guard let community = view.community else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommunityView community")
-        }
         self = try .removeCommunity(
-            .init(from: community),
+            view.community.map { community throws(ApiClientError) in
+                try .init(from: community)
+            },
             removed: view.modRemoveCommunity.removed,
             reason: view.modRemoveCommunity.reason
         )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
@@ -86,21 +86,19 @@ extension ModlogEntryContentSnapshot {
     }
     
     init(from view: PieFedModTransferCommunityView) throws(ApiClientError) {
-        guard let moddedPerson = view.moddedPerson else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModTransferCommunityView bassedPerson")
-        }
         self = try .transferCommunityOwnership(
-            person: .init(from: moddedPerson),
+            person: view.moddedPerson.map { person throws(ApiClientError) in
+                try .init(from: person)
+            },
             community: .init(from: view.community)
         )
     }
     
     init(from view: PieFedModAddCommunityView) throws(ApiClientError) {
-        guard let moddedPerson = view.moddedPerson else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModAddCommunityView bassedPerson")
-        }
         self = try .updatePersonModeratorStatus(
-            person: .init(from: moddedPerson),
+            person: view.moddedPerson.map { person throws(ApiClientError) in
+                try .init(from: person)
+            },
             community: view.community.map { community throws(ApiClientError) in
                 try .init(from: community)
             },
@@ -118,11 +116,10 @@ extension ModlogEntryContentSnapshot {
     }
     
     init(from view: PieFedModBanFromCommunityView) throws(ApiClientError) {
-        guard let bannedPerson = view.bannedPerson else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModBanFromCommunityView bannedPerson")
-        }
         self = try .banPersonFromCommunity(
-            person: .init(from: bannedPerson),
+            person: view.bannedPerson.map { person throws(ApiClientError) in
+                try .init(from: person)
+            },
             community: view.community.map { community throws(ApiClientError) in
                 try .init(from: community)
             },
@@ -133,11 +130,10 @@ extension ModlogEntryContentSnapshot {
     }
     
     init(from view: PieFedModBanView) throws(ApiClientError) {
-        guard let bannedPerson = view.bannedPerson else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModBanView bannedPerson")
-        }
         self = try .banPersonFromInstance(
-            person: .init(from: bannedPerson),
+            person: view.bannedPerson.map { person throws(ApiClientError) in
+                try .init(from: person)
+            },
             banned: view.modBan.banned,
             reason: view.modBan.reason,
             expires: view.modBan.expires

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
@@ -9,35 +9,32 @@ import Foundation
 
 extension ModlogEntryContentSnapshot {
     init(from view: PieFedModRemovePostView) throws(ApiClientError) {
-        guard let community = view.community else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModRemovePostView community")
-        }
         self = try .removePost(
             view.post.map(Post1Snapshot.init),
-            community: .init(from: community),
+            community: view.community.map { community throws(ApiClientError) in
+                try .init(from: community)
+            },
             removed: view.modRemovePost.removed,
             reason: view.modRemovePost.reason
         )
     }
     
     init(from view: PieFedModLockPostView) throws(ApiClientError) {
-        guard let community = view.community else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModLockPostView community")
-        }
         self = try .lockPost(
             view.post.map(Post1Snapshot.init),
-            community: .init(from: community),
+            community: view.community.map { community throws(ApiClientError) in
+                try .init(from: community)
+            },
             locked: view.modLockPost.locked
         )
     }
     
     init(from view: PieFedModFeaturePostView) throws(ApiClientError) {
-        guard let community = view.community else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModFeaturePostView community")
-        }
         self = try .pinPost(
             view.post.map(Post1Snapshot.init),
-            community: .init(from: community),
+            community: view.community.map { community throws(ApiClientError) in
+                try .init(from: community)
+            },
             pinned: view.modFeaturePost.featured,
             type: view.modFeaturePost.isFeaturedCommunity ? .community : .instance
         )
@@ -102,12 +99,11 @@ extension ModlogEntryContentSnapshot {
         guard let moddedPerson = view.moddedPerson else {
             throw ApiClientError.responseMissingRequiredData("PieFedModAddCommunityView bassedPerson")
         }
-        guard let community = view.community else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModAddCommunityView community")
-        }
         self = try .updatePersonModeratorStatus(
             person: .init(from: moddedPerson),
-            community: .init(from: community),
+            community: view.community.map { community throws(ApiClientError) in
+                try .init(from: community)
+            },
             appointed: !view.modAddCommunity.removed
         )
     }
@@ -125,12 +121,11 @@ extension ModlogEntryContentSnapshot {
         guard let bannedPerson = view.bannedPerson else {
             throw ApiClientError.responseMissingRequiredData("PieFedModBanFromCommunityView bannedPerson")
         }
-        guard let community = view.community else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModBanFromCommunityView community")
-        }
         self = try .banPersonFromCommunity(
             person: .init(from: bannedPerson),
-            community: .init(from: community),
+            community: view.community.map { community throws(ApiClientError) in
+                try .init(from: community)
+            },
             banned: view.modBanFromCommunity.banned,
             reason: view.modBanFromCommunity.reason,
             expires: view.modBanFromCommunity.expires

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
@@ -9,14 +9,11 @@ import Foundation
 
 extension ModlogEntryContentSnapshot {
     init(from view: PieFedModRemovePostView) throws(ApiClientError) {
-        guard let post = view.post else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModRemovePostView post")
-        }
         guard let community = view.community else {
             throw ApiClientError.responseMissingRequiredData("PieFedModRemovePostView community")
         }
         self = try .removePost(
-            .init(from: post),
+            view.post.map(Post1Snapshot.init),
             community: .init(from: community),
             removed: view.modRemovePost.removed,
             reason: view.modRemovePost.reason

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryContentSnapshot+PieFed.swift
@@ -48,20 +48,15 @@ extension ModlogEntryContentSnapshot {
     }
     
     init(from view: PieFedModRemoveCommentView) throws(ApiClientError) {
-        guard let commenter = view.commenter else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommentView commenter")
-        }
-        guard let post = view.post else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommentView post")
-        }
-        guard let community = view.community else {
-            throw ApiClientError.responseMissingRequiredData("PieFedModRemoveCommentView community")
-        }
         self = try .removeComment(
             view.comment.map(Comment1Snapshot.init),
-            creator: .init(from: commenter),
-            post: .init(from: post),
-            community: .init(from: community),
+            creator: view.commenter.map { person throws(ApiClientError) in
+                try .init(from: person)
+            },
+            post: view.post.map(Post1Snapshot.init),
+            community: view.community.map { community throws(ApiClientError) in
+                try .init(from: community)
+            },
             removed: view.modRemoveComment.removed,
             reason: view.modRemoveComment.reason
         )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntrySnapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntrySnapshot+PieFed.swift
@@ -1,0 +1,224 @@
+//
+//  ModlogEntrySnapshot+PieFed.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-03-12.
+//
+
+import Foundation
+
+extension ModlogEntrySnapshot {
+    init(from view: PieFedModRemovePostView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.moderator {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.modRemovePost.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedModLockPostView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.moderator {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.modLockPost.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedModFeaturePostView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.moderator {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.modFeaturePost.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedAdminPurgePostView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.admin {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.adminPurgePost.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedModRemoveCommentView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.moderator {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.modRemoveComment.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedAdminPurgeCommentView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.admin {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.adminPurgeComment.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedModRemoveCommunityView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.moderator {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.modRemoveCommunity.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedAdminPurgeCommunityView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.admin {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.adminPurgeCommunity.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedModHideCommunityView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.admin {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.modHideCommunity.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedModTransferCommunityView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.moderator {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.modTransferCommunity.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedModAddCommunityView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.moderator {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+        try self.init(
+            created: view.modAddCommunity.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedModAddView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.moderator {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+
+        try self.init(
+            created: view.modAdd.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedModBanFromCommunityView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.moderator {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+
+        try self.init(
+            created: view.modBanFromCommunity.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedModBanView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.moderator {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+
+        try self.init(
+            created: view.modBan.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+    
+    init(from view: PieFedAdminPurgePersonView) throws(ApiClientError) {
+        let moderator: Person1Snapshot?
+        if let value = view.admin {
+            moderator = try Person1Snapshot(from: value, allPropertiesPresent: true)
+        } else {
+            moderator = nil
+        }
+
+        try self.init(
+            created: view.adminPurgePerson.when_,
+            moderator: moderator,
+            type: .init(from: view)
+        )
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryType+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ModlogEntryType+PieFed.swift
@@ -1,0 +1,30 @@
+//
+//  ModlogEntryType+PieFed.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-03-12.
+//
+
+import Foundation
+
+extension ModlogEntryType {
+    var piefedApiType: PieFedModlogActionType {
+        switch self {
+        case .removePost: .modRemovePost
+        case .lockPost: .modLockPost
+        case .pinPost: .modFeaturePost
+        case .purgePost: .adminPurgePost
+        case .removeComment: .modRemoveComment
+        case .purgeComment: .adminPurgeComment
+        case .removeCommunity: .modRemoveCommunity
+        case .purgeCommunity: .adminPurgeCommunity
+        case .hideCommunity: .modHideCommunity
+        case .transferCommunityOwnership: .modTransferCommunity
+        case .updatePersonModeratorStatus: .modAddCommunity
+        case .updatePersonAdminStatus: .modAdd
+        case .banPersonFromCommunity: .modBanFromCommunity
+        case .banPersonFromInstance: .modBan
+        case .purgePerson: .adminPurgePerson
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/PieFedGetModlogResponse+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Custom API Models/Extensions/PieFedGetModlogResponse+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  PieFedGetModlogResponse+Extensions.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-03-12.
+//
+
+
+public extension PieFedGetModLogResponse {
+    func toSnapshots() throws(ApiClientError) -> [ModlogEntrySnapshot] {
+        var result = try (removedPosts).map(ModlogEntrySnapshot.init)
+        result += try (lockedPosts).map(ModlogEntrySnapshot.init)
+        result += try (featuredPosts).map(ModlogEntrySnapshot.init)
+        result += try (removedComments).map(ModlogEntrySnapshot.init)
+        result += try (removedCommunities).map(ModlogEntrySnapshot.init)
+        result += try (bannedFromCommunity).map(ModlogEntrySnapshot.init)
+        result += try (banned).map(ModlogEntrySnapshot.init)
+        result += try (addedToCommunity).map(ModlogEntrySnapshot.init)
+        result += try (transferredToCommunity).map(ModlogEntrySnapshot.init)
+        result += try (added).map(ModlogEntrySnapshot.init)
+        result += try (adminPurgedPersons).map(ModlogEntrySnapshot.init)
+        result += try (adminPurgedCommunities).map(ModlogEntrySnapshot.init)
+        result += try (adminPurgedPosts).map(ModlogEntrySnapshot.init)
+        result += try (adminPurgedComments).map(ModlogEntrySnapshot.init)
+        result += try (hiddenCommunities).map(ModlogEntrySnapshot.init)
+        return result
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
@@ -191,7 +191,7 @@ public extension LemmyConnection {
                 communityId: communityId,
                 page: page,
                 limit: limit,
-                type_: type?.apiType,
+                type_: type?.lemmyApiType,
                 otherPersonId: subjectPersonId,
                 postId: postId,
                 commentId: commentId,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Feature.swift
@@ -51,6 +51,8 @@ public extension PieFedConnection {
         case .userNotes, .searchLocalComments, .fetchLinkMetadata:
             version >= .v1_4_0
         case .moderatorSetNsfw: true
+        case .modlog:
+            version >= .v1_6_10
         default: false
         }
     }
@@ -62,6 +64,7 @@ private extension SiteVersion {
     static let v1_2_0: Self = .init("1.2.0")
     static let v1_3_0: Self = .init("1.3.0")
     static let v1_4_0: Self = .init("1.4.0")
+    static let v1_6_10: Self = .init("1.6.10")
 }
 
 private extension PostSortType {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+General.swift
@@ -87,7 +87,18 @@ public extension PieFedConnection {
         commentId: Int? = nil,
         type: ModlogEntryType? = nil
     ) async throws -> [ModlogEntrySnapshot] {
-        throw ApiClientError.featureUnsupported
+        let request = PieFedGetModlogRequest(
+                modPersonId: moderatorId,
+                communityId: communityId,
+                page: page,
+                limit: limit,
+                type_: type?.piefedApiType,
+                otherPersonId: subjectPersonId,
+                postId: postId,
+                commentId: commentId,
+            )
+        let response = try await perform(request)
+        return try response.toSnapshots()
     }
     
     func getPostLink(url: URL) async throws -> PostLink {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
@@ -29,9 +29,9 @@ public enum ModlogEntryContentSnapshot {
     
     case removeComment(
         _ comment: Comment1Snapshot?,
-        creator: Person1Snapshot,
-        post: Post1Snapshot,
-        community: Community1Snapshot,
+        creator: Person1Snapshot?,
+        post: Post1Snapshot?,
+        community: Community1Snapshot?,
         removed: Bool,
         reason: String?
     )

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
@@ -50,12 +50,12 @@ public enum ModlogEntryContentSnapshot {
         reason: String?
     )
     case transferCommunityOwnership(
-        person: Person1Snapshot,
+        person: Person1Snapshot?,
         community: Community1Snapshot
     )
     
     case updatePersonModeratorStatus(
-        person: Person1Snapshot,
+        person: Person1Snapshot?,
         community: Community1Snapshot?,
         appointed: Bool
     )
@@ -64,14 +64,14 @@ public enum ModlogEntryContentSnapshot {
         appointed: Bool
     )
     case banPersonFromCommunity(
-        person: Person1Snapshot,
+        person: Person1Snapshot?,
         community: Community1Snapshot?,
         banned: Bool,
         reason: String?,
         expires: Date?
     )
     case banPersonFromInstance(
-        person: Person1Snapshot,
+        person: Person1Snapshot?,
         banned: Bool,
         reason: String?,
         expires: Date?

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public enum ModlogEntryContentSnapshot {
     case removePost(
-        _ post: Post1Snapshot,
+        _ post: Post1Snapshot?,
         community: Community1Snapshot,
         removed: Bool,
         reason: String?

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
@@ -60,7 +60,7 @@ public enum ModlogEntryContentSnapshot {
         appointed: Bool
     )
     case updatePersonAdminStatus(
-        person: Person1Snapshot,
+        person: Person1Snapshot?,
         appointed: Bool
     )
     case banPersonFromCommunity(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
@@ -28,7 +28,7 @@ public enum ModlogEntryContentSnapshot {
     case purgePost(reason: String?)
     
     case removeComment(
-        _ comment: Comment1Snapshot,
+        _ comment: Comment1Snapshot?,
         creator: Person1Snapshot,
         post: Post1Snapshot,
         community: Community1Snapshot,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
@@ -10,18 +10,18 @@ import Foundation
 public enum ModlogEntryContentSnapshot {
     case removePost(
         _ post: Post1Snapshot?,
-        community: Community1Snapshot,
+        community: Community1Snapshot?,
         removed: Bool,
         reason: String?
     )
     case lockPost(
         _ post: Post1Snapshot?,
-        community: Community1Snapshot,
+        community: Community1Snapshot?,
         locked: Bool
     )
     case pinPost(
         _ post: Post1Snapshot?,
-        community: Community1Snapshot,
+        community: Community1Snapshot?,
         pinned: Bool,
         type: PostFeatureType
     )
@@ -45,7 +45,7 @@ public enum ModlogEntryContentSnapshot {
     case purgeCommunity(reason: String?)
     
     case hideCommunity(
-        _ community: Community1Snapshot,
+        _ community: Community1Snapshot?,
         hidden: Bool,
         reason: String?
     )
@@ -56,7 +56,7 @@ public enum ModlogEntryContentSnapshot {
     
     case updatePersonModeratorStatus(
         person: Person1Snapshot,
-        community: Community1Snapshot,
+        community: Community1Snapshot?,
         appointed: Bool
     )
     case updatePersonAdminStatus(
@@ -65,7 +65,7 @@ public enum ModlogEntryContentSnapshot {
     )
     case banPersonFromCommunity(
         person: Person1Snapshot,
-        community: Community1Snapshot,
+        community: Community1Snapshot?,
         banned: Bool,
         reason: String?,
         expires: Date?

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
@@ -15,12 +15,12 @@ public enum ModlogEntryContentSnapshot {
         reason: String?
     )
     case lockPost(
-        _ post: Post1Snapshot,
+        _ post: Post1Snapshot?,
         community: Community1Snapshot,
         locked: Bool
     )
     case pinPost(
-        _ post: Post1Snapshot,
+        _ post: Post1Snapshot?,
         community: Community1Snapshot,
         pinned: Bool,
         type: PostFeatureType

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Snapshot/ModlogEntry/ModlogEntryContentSnapshot.swift
@@ -38,7 +38,7 @@ public enum ModlogEntryContentSnapshot {
     case purgeComment(reason: String?)
     
     case removeCommunity(
-        _ community: Community1Snapshot,
+        _ community: Community1Snapshot?,
         removed: Bool,
         reason: String?
     )


### PR DESCRIPTION
Closes #2622

PieFed has slightly different behaviour regarding purged content. If a post is removed and then later purged, PieFed still returns an entry for the removed post. Lemmy doesn't do this.

There's some new UI to handle this case:

<img width=50% alt="IMG_2453" src="https://github.com/user-attachments/assets/6cd3034f-3808-48c1-a631-4ba932de766d" />

Tapping the question mark opens this sheet:

<img width=50% alt="IMG_2454" src="https://github.com/user-attachments/assets/93dbe8b2-3a22-4072-98c4-eb4e454a639a" />

The same applies to comments, communities and users.

# Known issues

All comments in the modlog have an empty string for the body. The API is returning empty strings. I've asked the PieFed devs what's going on here, and have opened an issue to track this (#2728). If they confirm that this is intended, I'll add a better UI.