### PR TITLE
Option for taller collapsed comments

### DIFF
--- a/Mlem/App/Configuration/User Settings/SettingsValues.swift
+++ b/Mlem/App/Configuration/User Settings/SettingsValues.swift
@@ -41,6 +41,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
     var behavior_infiniteScroll: Bool
     var comment_behaviors_collapseChildren: Bool
     var comment_compact: Bool
+    var comment_tallerCollapsed: Bool
     var comment_defaultSort: LemmyCommentSortType
     var comment_gestures_tapToCollapse: Bool
     var comment_jumpButton: CommentJumpButtonLocation
@@ -169,6 +170,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.behavior_infiniteScroll = try container.decodeIfPresent(Bool.self, forKey: ._behavior_infiniteScroll) ?? true
         self.comment_behaviors_collapseChildren = try container.decodeIfPresent(Bool.self, forKey: ._comment_behaviors_collapseChildren) ?? false
         self.comment_compact = try container.decodeIfPresent(Bool.self, forKey: ._comment_compact) ?? false
+        self.comment_tallerCollapsed = try container.decodeIfPresent(Bool.self, forKey: ._comment_tallerCollapsed) ?? false
         self.comment_defaultSort = try container.decodeIfPresent(LemmyCommentSortType.self, forKey: ._comment_defaultSort) ?? .hot
         self.comment_gestures_tapToCollapse = try container.decodeIfPresent(Bool.self, forKey: ._comment_gestures_tapToCollapse) ?? true
         self.comment_jumpButton = try container.decodeIfPresent(CommentJumpButtonLocation.self, forKey: ._comment_jumpButton) ?? .bottomTrailing
@@ -427,6 +429,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         case _behavior_infiniteScroll = "behavior_infiniteScroll"
         case _comment_behaviors_collapseChildren = "comment_behaviors_collapseChildren"
         case _comment_compact = "comment_compact"
+        case _comment_tallerCollapsed = "comment_taller_collapsed"
         case _comment_defaultSort = "comment_defaultSort"
         case _comment_gestures_tapToCollapse = "comment_gestures_tapToCollapse"
         case _comment_jumpButton = "comment_jumpButton"
@@ -549,6 +552,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.behavior_infiniteScroll = settings.infiniteScroll
         self.comment_behaviors_collapseChildren = false // Replaced by comment_maxDepth in 2.0
         self.comment_compact = settings.compactComments
+        self.comment_tallerCollapsed = false // Added in 2.5
         self.comment_defaultSort = settings.commentSort
         self.comment_gestures_tapToCollapse = settings.tapCommentsToCollapse
         self.comment_jumpButton = settings.jumpButton

--- a/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
@@ -13,6 +13,7 @@ struct CommentSettingsView: View {
     @Setting(\.comment_maxDepth) var maxCommentDepth
     @Setting(\.comment_jumpButton) var jumpButton
     @Setting(\.comment_showDownvotesCompact) var showDownvotesCompact
+    @Setting(\.comment_tallerCollapsed) var tallerCollapsed
     @Setting(\.interactionBar_comment) var commentInteractionBar
 
     var body: some View {
@@ -51,6 +52,7 @@ struct CommentSettingsView: View {
             }
             Section {
                 Toggle("Tap to Collapse", icon: .general.collapse, isOn: $tapCommentsToCollapse)
+                Toggle("Taller Collapsed Comments", icon: .general.expand, isOn: $tallerCollapsed)
             }
         }
         .withConditionalLabelStyle()

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -18,6 +18,7 @@ struct CommentView<EmbeddedContent: View>: View {
     @Environment(\.palette) private var palette
     
     @Setting(\.comment_compact) var compactComments
+    @Setting(\.comment_tallerCollapsed) var tallerCollapsed
     @Setting(\.comment_showDownvotesCompact) var showDownvotesCompact
     @Setting(\.menus_modActionGrouping) var moderatorActionGrouping
     @Setting(\.interactionBar_comment) var commentInteractionBar
@@ -83,14 +84,18 @@ struct CommentView<EmbeddedContent: View>: View {
                         if !inFeed {
                             authorAndMenu.padding(.top, Constants.main.standardSpacing)
                         }
-                        
+
                         if !collapsed {
                             CommentBodyView(comment: comment)
                                 .padding(.trailing, 2)
                             embeddedContent
+                        } else if tallerCollapsed {
+                            Text("Tap to expand")
+                                .foregroundStyle(.themedSecondary)
+                                .italic()
                         }
                         
-                        if compact, !collapsed {
+                        if (compact && !collapsed) || (collapsed && tallerCollapsed) {
                             InfoStackView(
                                 comment: comment,
                                 readouts: compactReadouts,
@@ -148,7 +153,7 @@ struct CommentView<EmbeddedContent: View>: View {
             }
             Spacer()
             Group {
-                if collapsed {
+                if collapsed, !tallerCollapsed {
                     if let saved = comment.saved.value, let votes = comment.votes.value {
                         Group {
                             postTag(active: saved, icon: .lemmy.saved.representingState(active: true), color: .themedSave) +
@@ -158,7 +163,7 @@ struct CommentView<EmbeddedContent: View>: View {
                         .lineLimit(1)
                         .font(.caption)
                     }
-                    
+
                     Image(icon: .general.expand)
                         .frame(height: 10)
                         .imageScale(.small)


### PR DESCRIPTION
Closes #2734 

Settings -> Comments -> Taller Collapsed Comments

<img width="1206" height="359" alt="IMG_2457" src="https://github.com/user-attachments/assets/c2f1a636-e5f8-464a-8f29-13936261f6d1" />
