### PR TITLE
Always show controls on tap for videos

### DIFF
--- a/Mlem/App/Views/Pages/ImageViewer.swift
+++ b/Mlem/App/Views/Pages/ImageViewer.swift
@@ -104,7 +104,7 @@ struct ImageViewer: View {
             customDragMoved: dragMoved,
             customDragEnded: dragEnded
         ) {
-            if enableControlTap, showControls != .never {
+            if enableControlTap, (showControls != .never) || controlState.animationAvailable {
                 if controlsShown {
                     hideControls()
                 } else {


### PR DESCRIPTION
Previously, the video scrubbing bar would be inaccessible when the "show controls" setting is set to "never". Now, "never" behaves the same as "when I tap" for videos.