### PR TITLE
Fix `CommentTreeTracker` bugs

### DIFF
--- a/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
@@ -73,6 +73,7 @@ class CommentTreeTracker: Hashable {
         loadingState = .loading
         do {
             var newComments = try await fetchComments(page: 1)
+
             if let ensuredComment {
                 let comment = try await ensuredComment.asComment()
                 let api = root.wrappedValue.api
@@ -80,7 +81,7 @@ class CommentTreeTracker: Hashable {
                     // Find the first parent of the ensured comment that isn't in `newComments`.
                     // This will be the starting point for the second page of comments to load.
                     let idsToSearch = comment.parentCommentIds + [comment.id]
-                    let firstAbsentParentId = idsToSearch.first(
+                    let firstAbsentParentId = idsToSearch.last(
                         where: { id in !newComments.contains(where: { $0.id == id }) }
                     )
                     if let firstAbsentParentId {
@@ -187,6 +188,7 @@ class CommentTreeTracker: Hashable {
         var commentsKeyedByActorId: [ActorIdentifier: CommentTreeNode] = clear ? [:] : nodesKeyedByActorId
 
         let sortedComments = newComments.sorted { $0.depth < $1.depth }
+        let firstDepth = sortedComments.first?.depth ?? 0
         
         for comment in sortedComments {
             if commentsKeyedByActorId.keys.contains(comment.actorId) {
@@ -196,7 +198,7 @@ class CommentTreeTracker: Hashable {
             let wrapper: CommentTreeNode = .init(comment)
             commentsKeyedById[comment.id] = wrapper
             commentsKeyedByActorId[comment.actorId] = wrapper
-            if let parentId = comment.parentCommentIds.last, comment.depth > root.depth {
+            if let parentId = comment.parentCommentIds.last, comment.depth > firstDepth {
                 if let parent = commentsKeyedById[parentId] {
                     parent.addChild(wrapper)
                 }

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Logic.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Logic.swift
@@ -98,8 +98,15 @@ extension ExpandedPostView {
         let comment = node.comment
         if comment.shouldHideInFeed { return [] }
         if node.collapsed { return [.comment(node)] }
-        var output: [CommentTreeViewType] = node.children.reduce([.comment(node)]) { $0 + generateViewTree(for: $1) }
-        let directChildCount = node.children.reduce(comment.commentCount.value_ ?? 0) { $0 - ($1.comment.commentCount.value_ ?? 0) }
+
+        var output: [CommentTreeViewType] = node.children.reduce([.comment(node)]) {
+            $0 + generateViewTree(for: $1)
+        }
+
+        let directChildCount = node.children.reduce(comment.commentCount.value_ ?? 0) {
+            $0 - ($1.comment.commentCount.value_ ?? 0)
+        }
+
         if node.children.count < directChildCount {
             output.append(.unloadedComments(comment: node, count: (comment.commentCount.value_ ?? 0) - output.count))
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Comment/Comment.swift
@@ -332,6 +332,12 @@ public extension Comment {
     }
 }
 
+extension Comment: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        "Comment(\(self.id), \"\(self.content.prefix(25))\")"
+    }
+}
+
 // MARK: Shim
 
 public extension Comment {


### PR DESCRIPTION
There were two issues that affected `CommentPage` (the one with the "view all button"), specifically in cases where the focused comment had a depth of > 2.

In such cases, the intent is to load the parent of the focused comment, and all of its children. However, it was actually loading _all_ of that comment's parents, which was unintended.

Also, the check for determining whether a comment should be considered "top-level" in the current view incorrectly counted all children as being top-level, which messed up the tree structure. This caused "more replies" buttons to show where they shouldn't have done.

Closes #2739