### PR TITLE
Community/Person description tweaks

### DIFF
--- a/Mlem/App/Actions/ContextMenu+Person.swift
+++ b/Mlem/App/Actions/ContextMenu+Person.swift
@@ -12,6 +12,7 @@ import SwiftUI
 private let seeds: [ActionSeed] = [
     .goToInstance,
     .copyName,
+    .selectText,
     .share,
     .sendMessage,
     .block,

--- a/Mlem/App/Actions/SelectTextAction.swift
+++ b/Mlem/App/Actions/SelectTextAction.swift
@@ -28,6 +28,10 @@ extension ActionSeed {
             SelectTextAction(text: entity.content)
         case let entity as Post:
             SelectTextAction(text: entity.selectableContent ?? "")
+        case let entity as Person:
+            SelectTextAction(text: entity.displayName + "\n\n" + (entity.description ?? ""))
+        case let entity as Community:
+            SelectTextAction(text: entity.displayName + "\n\n" + (entity.description ?? ""))
         default:
             nil
         }

--- a/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
@@ -18,6 +18,7 @@ struct CommunityActionConfiguration: Codable, SwipeActionConfiguration {
                 .favorite,
                 .goToInstance,
                 .copyName,
+                .selectText,
                 .share
             ],
             [

--- a/Mlem/App/Views/Pages/Community/CommunityAboutView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityAboutView.swift
@@ -50,8 +50,8 @@ struct CommunityAboutView: View {
                 .padding(.horizontal, Constants.main.standardSpacing)
                 Divider()
             }
-            Markdown(description, configuration: .default(palette: palette))
-            .padding(.horizontal, Constants.main.standardSpacing)
+            MarkdownWithLinkList(description)
+                .padding(.horizontal, Constants.main.standardSpacing)
         }
         .padding(.vertical, Constants.main.standardSpacing)
         .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))

--- a/Mlem/App/Views/Pages/Person/PersonView.swift
+++ b/Mlem/App/Views/Pages/Person/PersonView.swift
@@ -138,13 +138,13 @@ struct PersonView: View {
         if let bio = person.description {
             VStack(spacing: Constants.main.standardSpacing) {
                 let blocks: [BlockNode] = .init(bio)
-                if blocks.isSimpleParagraphs, bio.count < 300 {
+                if blocks.isSimpleParagraphs, bio.count < 300, blocks.links.isEmpty {
                     MarkdownText(blocks, configuration: .default(palette: palette))
                         .multilineTextAlignment(.center)
                     dateLabel(person: person)
                         .frame(maxWidth: .infinity, alignment: .center)
                 } else {
-                    Markdown(blocks, configuration: .default(palette: palette))
+                    MarkdownWithLinkList(blocks)
                     dateLabel(person: person)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }


### PR DESCRIPTION
- Link footers are now shown in community/person descriptions (closes #2608)
- `Community` and `Person` now have the "Select Text" action (closes #2607)