### PR TITLE
Customisable user and instance swipe actions

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 		03B25B372CC4478600EB6DF5 /* FediseerInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B362CC4478600EB6DF5 /* FediseerInfoView.swift */; };
 		03B25B3B2CC44FFF00EB6DF5 /* UploadConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B3A2CC44FFF00EB6DF5 /* UploadConfirmationView.swift */; };
 		03B2ECE12FC9908D00C36011 /* PersonActionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2ECE02FC9908D00C36011 /* PersonActionConfiguration.swift */; };
+		03B2F09D2FC9958600C36011 /* PersonSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2F09C2FC9958600C36011 /* PersonSettingsView.swift */; };
 		03B431B42C4481C3001A1EB5 /* MarkdownTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B32C4481C3001A1EB5 /* MarkdownTextEditor.swift */; };
 		03B431B62C454D49001A1EB5 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */; };
 		03B431BC2C455838001A1EB5 /* LargePostBodyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431BB2C455838001A1EB5 /* LargePostBodyView.swift */; };
@@ -939,6 +940,7 @@
 		03B25B362CC4478600EB6DF5 /* FediseerInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FediseerInfoView.swift; sourceTree = "<group>"; };
 		03B25B3A2CC44FFF00EB6DF5 /* UploadConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadConfirmationView.swift; sourceTree = "<group>"; };
 		03B2ECE02FC9908D00C36011 /* PersonActionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonActionConfiguration.swift; sourceTree = "<group>"; };
+		03B2F09C2FC9958600C36011 /* PersonSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonSettingsView.swift; sourceTree = "<group>"; };
 		03B431B12C44409D001A1EB5 /* CommentEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentEditorView.swift; sourceTree = "<group>"; };
 		03B431B32C4481C3001A1EB5 /* MarkdownTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextEditor.swift; sourceTree = "<group>"; };
 		03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
@@ -1356,6 +1358,7 @@
 				03BF11C42D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift */,
 				CDBFCB692C04EFFE008CD468 /* PostSettingsView.swift */,
 				038E1AC92F59C18100D30F01 /* CommunitySettingsView.swift */,
+				03B2F09C2FC9958600C36011 /* PersonSettingsView.swift */,
 				037F783E2D3BD05500D4E180 /* PostSettingsView+PostSizePicker.swift */,
 				037F78442D3C25AB00D4E180 /* PostSubscriptionIndicatorSettingsView.swift */,
 				037F78422D3C129B00D4E180 /* PostThumbnailSettingsView.swift */,
@@ -2866,6 +2869,7 @@
 				CD13CC592C583C7A001AF428 /* WebsitePreviewView.swift in Sources */,
 				CDA67A9F2D9B32A100E5D17B /* CGPoint+Extensions.swift in Sources */,
 				03BF11C52D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift in Sources */,
+				03B2F09D2FC9958600C36011 /* PersonSettingsView.swift in Sources */,
 				CD869FCE2C15F90C00FC8B5B /* ChildSizeReader.swift in Sources */,
 				035EDEF12C2DE94B00F51144 /* DefaultTextInputType.swift in Sources */,
 				039F588C2C7B574E00C61658 /* AdvancedSettingsView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		03B25B3B2CC44FFF00EB6DF5 /* UploadConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B3A2CC44FFF00EB6DF5 /* UploadConfirmationView.swift */; };
 		03B2ECE12FC9908D00C36011 /* PersonActionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2ECE02FC9908D00C36011 /* PersonActionConfiguration.swift */; };
 		03B2F09D2FC9958600C36011 /* PersonSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2F09C2FC9958600C36011 /* PersonSettingsView.swift */; };
+		03B2F09F2FC998B300C36011 /* InstanceActionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2F09E2FC998B300C36011 /* InstanceActionConfiguration.swift */; };
 		03B431B42C4481C3001A1EB5 /* MarkdownTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B32C4481C3001A1EB5 /* MarkdownTextEditor.swift */; };
 		03B431B62C454D49001A1EB5 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */; };
 		03B431BC2C455838001A1EB5 /* LargePostBodyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431BB2C455838001A1EB5 /* LargePostBodyView.swift */; };
@@ -941,6 +942,7 @@
 		03B25B3A2CC44FFF00EB6DF5 /* UploadConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadConfirmationView.swift; sourceTree = "<group>"; };
 		03B2ECE02FC9908D00C36011 /* PersonActionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonActionConfiguration.swift; sourceTree = "<group>"; };
 		03B2F09C2FC9958600C36011 /* PersonSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonSettingsView.swift; sourceTree = "<group>"; };
+		03B2F09E2FC998B300C36011 /* InstanceActionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceActionConfiguration.swift; sourceTree = "<group>"; };
 		03B431B12C44409D001A1EB5 /* CommentEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentEditorView.swift; sourceTree = "<group>"; };
 		03B431B32C4481C3001A1EB5 /* MarkdownTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextEditor.swift; sourceTree = "<group>"; };
 		03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
@@ -1717,6 +1719,7 @@
 				0381F7132F670F95008A7731 /* SwipeActionConfiguration.swift */,
 				038E62DF2F6F0FC600C54DEB /* ContextMenuConfiguration.swift */,
 				038E1ABB2F58B9EF00D30F01 /* CommunityActionConfiguration.swift */,
+				03B2F09E2FC998B300C36011 /* InstanceActionConfiguration.swift */,
 				0397D49B2C6EA73C002C6CDC /* InteractionBarConfiguration.swift */,
 				03AF91E42C1C61FA00E56644 /* PostBarConfiguration.swift */,
 				0381F7152F671427008A7731 /* PostBarConfiguration+Types.swift */,
@@ -3024,6 +3027,7 @@
 				CD45CB0D2D1880E8008BC729 /* FiltersSettingsView.swift in Sources */,
 				038028FF2CB72AC90091A8A2 /* ReasonShortcutView.swift in Sources */,
 				03A6316D2D4E3D24009A47A6 /* ModeratorActionSeparationSettingsView.swift in Sources */,
+				03B2F09F2FC998B300C36011 /* InstanceActionConfiguration.swift in Sources */,
 				03D2A6422C011F4A00ED4FF2 /* AccountListRowBody.swift in Sources */,
 				03134A5A2BEC2253002662CC /* AvatarStackView.swift in Sources */,
 				03AB48572CBC0DFC00567FF9 /* AccountSignInSettingsView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		03B2ECE12FC9908D00C36011 /* PersonActionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2ECE02FC9908D00C36011 /* PersonActionConfiguration.swift */; };
 		03B2F09D2FC9958600C36011 /* PersonSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2F09C2FC9958600C36011 /* PersonSettingsView.swift */; };
 		03B2F09F2FC998B300C36011 /* InstanceActionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2F09E2FC998B300C36011 /* InstanceActionConfiguration.swift */; };
+		03B2F0A72FC99B2100C36011 /* InstanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2F0A62FC99B2100C36011 /* InstanceSettingsView.swift */; };
 		03B431B42C4481C3001A1EB5 /* MarkdownTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B32C4481C3001A1EB5 /* MarkdownTextEditor.swift */; };
 		03B431B62C454D49001A1EB5 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */; };
 		03B431BC2C455838001A1EB5 /* LargePostBodyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431BB2C455838001A1EB5 /* LargePostBodyView.swift */; };
@@ -943,6 +944,7 @@
 		03B2ECE02FC9908D00C36011 /* PersonActionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonActionConfiguration.swift; sourceTree = "<group>"; };
 		03B2F09C2FC9958600C36011 /* PersonSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonSettingsView.swift; sourceTree = "<group>"; };
 		03B2F09E2FC998B300C36011 /* InstanceActionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceActionConfiguration.swift; sourceTree = "<group>"; };
+		03B2F0A62FC99B2100C36011 /* InstanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceSettingsView.swift; sourceTree = "<group>"; };
 		03B431B12C44409D001A1EB5 /* CommentEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentEditorView.swift; sourceTree = "<group>"; };
 		03B431B32C4481C3001A1EB5 /* MarkdownTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextEditor.swift; sourceTree = "<group>"; };
 		03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
@@ -1361,6 +1363,7 @@
 				CDBFCB692C04EFFE008CD468 /* PostSettingsView.swift */,
 				038E1AC92F59C18100D30F01 /* CommunitySettingsView.swift */,
 				03B2F09C2FC9958600C36011 /* PersonSettingsView.swift */,
+				03B2F0A62FC99B2100C36011 /* InstanceSettingsView.swift */,
 				037F783E2D3BD05500D4E180 /* PostSettingsView+PostSizePicker.swift */,
 				037F78442D3C25AB00D4E180 /* PostSubscriptionIndicatorSettingsView.swift */,
 				037F78422D3C129B00D4E180 /* PostThumbnailSettingsView.swift */,
@@ -3027,6 +3030,7 @@
 				CD45CB0D2D1880E8008BC729 /* FiltersSettingsView.swift in Sources */,
 				038028FF2CB72AC90091A8A2 /* ReasonShortcutView.swift in Sources */,
 				03A6316D2D4E3D24009A47A6 /* ModeratorActionSeparationSettingsView.swift in Sources */,
+				03B2F0A72FC99B2100C36011 /* InstanceSettingsView.swift in Sources */,
 				03B2F09F2FC998B300C36011 /* InstanceActionConfiguration.swift in Sources */,
 				03D2A6422C011F4A00ED4FF2 /* AccountListRowBody.swift in Sources */,
 				03134A5A2BEC2253002662CC /* AvatarStackView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		03B25B352CC4446400EB6DF5 /* FediseerOpinionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B342CC4446400EB6DF5 /* FediseerOpinionListView.swift */; };
 		03B25B372CC4478600EB6DF5 /* FediseerInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B362CC4478600EB6DF5 /* FediseerInfoView.swift */; };
 		03B25B3B2CC44FFF00EB6DF5 /* UploadConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B25B3A2CC44FFF00EB6DF5 /* UploadConfirmationView.swift */; };
+		03B2ECE12FC9908D00C36011 /* PersonActionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2ECE02FC9908D00C36011 /* PersonActionConfiguration.swift */; };
 		03B431B42C4481C3001A1EB5 /* MarkdownTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B32C4481C3001A1EB5 /* MarkdownTextEditor.swift */; };
 		03B431B62C454D49001A1EB5 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */; };
 		03B431BC2C455838001A1EB5 /* LargePostBodyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B431BB2C455838001A1EB5 /* LargePostBodyView.swift */; };
@@ -937,6 +938,7 @@
 		03B25B342CC4446400EB6DF5 /* FediseerOpinionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FediseerOpinionListView.swift; sourceTree = "<group>"; };
 		03B25B362CC4478600EB6DF5 /* FediseerInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FediseerInfoView.swift; sourceTree = "<group>"; };
 		03B25B3A2CC44FFF00EB6DF5 /* UploadConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadConfirmationView.swift; sourceTree = "<group>"; };
+		03B2ECE02FC9908D00C36011 /* PersonActionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonActionConfiguration.swift; sourceTree = "<group>"; };
 		03B431B12C44409D001A1EB5 /* CommentEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentEditorView.swift; sourceTree = "<group>"; };
 		03B431B32C4481C3001A1EB5 /* MarkdownTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextEditor.swift; sourceTree = "<group>"; };
 		03B431B52C454D49001A1EB5 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
@@ -1720,6 +1722,7 @@
 				032C32172C36F70300595286 /* ReplyBarConfiguration.swift */,
 				0381F7272F6724D3008A7731 /* ReplyBarConfiguration+Types.swift */,
 				03D662A42F5377630041ADAF /* ActionSeedSections.swift */,
+				03B2ECE02FC9908D00C36011 /* PersonActionConfiguration.swift */,
 			);
 			path = Interaction;
 			sourceTree = "<group>";
@@ -3105,6 +3108,7 @@
 				03CBD18D2C6120F600E870BC /* PersonFlair.swift in Sources */,
 				03EC83252E916C51004698BB /* View+SafeAreaBar.swift in Sources */,
 				033FCB3E2C5E7FA9007B7CD1 /* View+OutdatedFeedPopup.swift in Sources */,
+				03B2ECE12FC9908D00C36011 /* PersonActionConfiguration.swift in Sources */,
 				CD10FA772C7A8622008985AD /* ImageSaver.swift in Sources */,
 				03267D822BED489C009D6268 /* AvatarBannerView.swift in Sources */,
 				031CA5752E5900C800CF0C0F /* SwipeConfiguration+Extensions.swift in Sources */,

--- a/Mlem/App/Actions/ContextMenu+Instance.swift
+++ b/Mlem/App/Actions/ContextMenu+Instance.swift
@@ -10,22 +10,13 @@ import MlemMiddleware
 import SwiftUI
 import MlemBackend
 
-private let seeds: [ActionSeed] = [
-    .visit,
-    .logIn,
-    .signUp,
-    .openInBrowser,
-    .share,
-    .block
-]
-
 extension View {
     @ViewBuilder
     func contextMenu(instance: (any InstanceActionProviding)?) -> some View {
         if let instance {
             contextMenu {
                 ActionButtons { _ in
-                    seeds.compactMap { $0.createAction(instance) }
+                    InstanceActionConfiguration.availableActions.all.compactMap { $0.createAction(instance) }
                 }
             }
         } else {
@@ -38,7 +29,7 @@ extension ToolbarEllipsisMenu {
     init(instance: any InstanceActionProviding) where Content == ActionButtons {
         self.init {
             ActionButtons { _ in
-                seeds.compactMap { $0.createAction(instance) }
+                InstanceActionConfiguration.availableActions.all.compactMap { $0.createAction(instance) }
             }
         }
     }
@@ -49,7 +40,7 @@ extension View {
     func contextMenu(instance: any InstanceActionProviding) -> some View {
         contextMenu {
             ActionButtons { _ in
-                seeds.compactMap { $0.createAction(instance) }
+                InstanceActionConfiguration.availableActions.all.compactMap { $0.createAction(instance) }
             }
         }
     }

--- a/Mlem/App/Actions/ContextMenu+Instance.swift
+++ b/Mlem/App/Actions/ContextMenu+Instance.swift
@@ -31,11 +31,15 @@ extension View {
         configuration: InstanceActionConfiguration,
         leadingBuffer: SwipeBuffer
     ) -> some View {
-        quickSwipes(
-            leading: configuration.swipes.leading.compactMap { $0.createAction(instance) },
-            trailing: configuration.swipes.trailing.compactMap { $0.createAction(instance) },
-            leadingBuffer: leadingBuffer
-        )
+        if let instance {
+            quickSwipes(
+                leading: configuration.swipes.leading.compactMap { $0.createAction(instance) },
+                trailing: configuration.swipes.trailing.compactMap { $0.createAction(instance) },
+                leadingBuffer: leadingBuffer
+            )
+        } else {
+            quickSwipes(.init())
+        }
     }
 }
 

--- a/Mlem/App/Actions/ContextMenu+Instance.swift
+++ b/Mlem/App/Actions/ContextMenu+Instance.swift
@@ -9,6 +9,7 @@ import Actions
 import MlemMiddleware
 import SwiftUI
 import MlemBackend
+import QuickSwipes
 
 extension View {
     @ViewBuilder
@@ -22,6 +23,19 @@ extension View {
         } else {
             self
         }
+    }
+
+    @ViewBuilder
+    func quickSwipes(
+        instance: (any InstanceActionProviding)?,
+        configuration: InstanceActionConfiguration,
+        leadingBuffer: SwipeBuffer
+    ) -> some View {
+        quickSwipes(
+            leading: configuration.swipes.leading.compactMap { $0.createAction(instance) },
+            trailing: configuration.swipes.trailing.compactMap { $0.createAction(instance) },
+            leadingBuffer: leadingBuffer
+        )
     }
 }
 

--- a/Mlem/App/Actions/ContextMenu+Person.swift
+++ b/Mlem/App/Actions/ContextMenu+Person.swift
@@ -8,6 +8,7 @@
 import Actions
 import MlemMiddleware
 import SwiftUI
+import QuickSwipes
 
 extension ActionButtons {
     init(person: Person) {
@@ -22,5 +23,14 @@ extension View {
         contextMenu {
             ActionButtons(person: person)
         }
+    }
+
+    @ViewBuilder
+    func quickSwipes(person: Person, configuration: PersonActionConfiguration, leadingBuffer: SwipeBuffer) -> some View {
+        quickSwipes(
+            leading: configuration.swipes.leading.compactMap { $0.createAction(person) },
+            trailing: configuration.swipes.trailing.compactMap { $0.createAction(person) },
+            leadingBuffer: leadingBuffer
+        )
     }
 }

--- a/Mlem/App/Actions/ContextMenu+Person.swift
+++ b/Mlem/App/Actions/ContextMenu+Person.swift
@@ -9,25 +9,10 @@ import Actions
 import MlemMiddleware
 import SwiftUI
 
-private let seeds: [ActionSeed] = [
-    .goToInstance,
-    .copyName,
-    .selectText,
-    .share,
-    .sendMessage,
-    .block,
-    .editNote,
-    .openModlog,
-    .ban,
-    .purge,
-    .appointModerator,
-    .appointAdmin
-]
-
 extension ActionButtons {
     init(person: Person) {
         self.init { _ in
-            seeds.compactMap { $0.createAction(person) }
+            PersonActionConfiguration.availableActions.all.compactMap { $0.createAction(person) }
         }
     }
 }

--- a/Mlem/App/Actions/GoToInstanceAction.swift
+++ b/Mlem/App/Actions/GoToInstanceAction.swift
@@ -30,7 +30,7 @@ extension GoToInstanceAction {
     static let label: ActionLabel = .init(
         "Go to Instance",
         icon: .lemmy.instance,
-        color: .themedColorfulAccent(1)
+        color: .themedInstanceAccent
     )
 
     func createLabel(environment: EnvironmentValues) -> ActionLabel {

--- a/Mlem/App/Configuration/User Settings/SettingsValues.swift
+++ b/Mlem/App/Configuration/User Settings/SettingsValues.swift
@@ -122,6 +122,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
     var interactionBar_comment: CommentBarConfiguration
     var interactionBar_reply: ReplyBarConfiguration
     var interactionBar_community: CommunityActionConfiguration
+    var interactionBar_person: PersonActionConfiguration
     var interactionBar_postReport: PostBarConfiguration
     var interactionBar_commentReport: CommentBarConfiguration
     var interactionBar_alternateReportLayout: Bool
@@ -277,6 +278,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.interactionBar_comment = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: ._interactionBar_comment) ?? .default
         self.interactionBar_reply = try container.decodeIfPresent(ReplyBarConfiguration.self, forKey: ._interactionBar_reply) ?? .default
         self.interactionBar_community = try container.decodeIfPresent(CommunityActionConfiguration.self, forKey: ._interactionBar_community) ?? .init()
+        self.interactionBar_person = try container.decodeIfPresent(PersonActionConfiguration.self, forKey: ._interactionBar_person) ?? .init()
         self.interactionBar_postReport = try container.decodeIfPresent(PostBarConfiguration.self, forKey: ._interactionBar_postReport) ?? .reportDefault_
         self.interactionBar_commentReport = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: ._interactionBar_commentReport) ?? .reportDefault_
         self.interactionBar_alternateReportLayout = try container.decodeIfPresent(Bool.self, forKey: ._interactionBar_alternateReportLayout) ?? false
@@ -390,6 +392,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.interactionBar_comment = .default
         self.interactionBar_reply = .default
         self.interactionBar_community = .init()
+        self.interactionBar_person = .init()
         self.interactionBar_postReport = .reportDefault_
         self.interactionBar_commentReport = .reportDefault_
         self.interactionBar_alternateReportLayout = false
@@ -498,6 +501,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         interactionBar_comment = otherValues.interactionBar_comment
         interactionBar_reply = otherValues.interactionBar_reply
         interactionBar_community = otherValues.interactionBar_community
+        interactionBar_person = otherValues.interactionBar_person
         interactionBar_postReport = otherValues.interactionBar_postReport
         interactionBar_commentReport = otherValues.interactionBar_commentReport
         interactionBar_alternateReportLayout = otherValues.interactionBar_alternateReportLayout
@@ -613,6 +617,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         case _interactionBar_comment = "interactionBar_comment"
         case _interactionBar_reply = "interactionBar_reply"
         case _interactionBar_community = "interactionBar_community"
+        case _interactionBar_person = "interactionBar_person"
         case _interactionBar_postReport = "interactionBar_postReport"
         case _interactionBar_commentReport = "interactionBar_commentReport"
         case _interactionBar_alternateReportLayout = "interactionBar_alternateReportLayout"

--- a/Mlem/App/Configuration/User Settings/SettingsValues.swift
+++ b/Mlem/App/Configuration/User Settings/SettingsValues.swift
@@ -123,6 +123,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
     var interactionBar_reply: ReplyBarConfiguration
     var interactionBar_community: CommunityActionConfiguration
     var interactionBar_person: PersonActionConfiguration
+    var interactionBar_instance: InstanceActionConfiguration
     var interactionBar_postReport: PostBarConfiguration
     var interactionBar_commentReport: CommentBarConfiguration
     var interactionBar_alternateReportLayout: Bool
@@ -279,6 +280,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.interactionBar_reply = try container.decodeIfPresent(ReplyBarConfiguration.self, forKey: ._interactionBar_reply) ?? .default
         self.interactionBar_community = try container.decodeIfPresent(CommunityActionConfiguration.self, forKey: ._interactionBar_community) ?? .init()
         self.interactionBar_person = try container.decodeIfPresent(PersonActionConfiguration.self, forKey: ._interactionBar_person) ?? .init()
+        self.interactionBar_instance = try container.decodeIfPresent(InstanceActionConfiguration.self, forKey: ._interactionBar_instance) ?? .init()
         self.interactionBar_postReport = try container.decodeIfPresent(PostBarConfiguration.self, forKey: ._interactionBar_postReport) ?? .reportDefault_
         self.interactionBar_commentReport = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: ._interactionBar_commentReport) ?? .reportDefault_
         self.interactionBar_alternateReportLayout = try container.decodeIfPresent(Bool.self, forKey: ._interactionBar_alternateReportLayout) ?? false
@@ -393,6 +395,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.interactionBar_reply = .default
         self.interactionBar_community = .init()
         self.interactionBar_person = .init()
+        self.interactionBar_instance = .init()
         self.interactionBar_postReport = .reportDefault_
         self.interactionBar_commentReport = .reportDefault_
         self.interactionBar_alternateReportLayout = false
@@ -502,6 +505,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         interactionBar_reply = otherValues.interactionBar_reply
         interactionBar_community = otherValues.interactionBar_community
         interactionBar_person = otherValues.interactionBar_person
+        interactionBar_instance = otherValues.interactionBar_instance
         interactionBar_postReport = otherValues.interactionBar_postReport
         interactionBar_commentReport = otherValues.interactionBar_commentReport
         interactionBar_alternateReportLayout = otherValues.interactionBar_alternateReportLayout
@@ -618,6 +622,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         case _interactionBar_reply = "interactionBar_reply"
         case _interactionBar_community = "interactionBar_community"
         case _interactionBar_person = "interactionBar_person"
+        case _interactionBar_instance = "interactionBar_instance"
         case _interactionBar_postReport = "interactionBar_postReport"
         case _interactionBar_commentReport = "interactionBar_commentReport"
         case _interactionBar_alternateReportLayout = "interactionBar_alternateReportLayout"

--- a/Mlem/App/Enums/Interaction/InstanceActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InstanceActionConfiguration.swift
@@ -1,0 +1,55 @@
+//
+//  InstanceActionConfiguration.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-05-29.
+//
+
+import Actions
+import Foundation
+
+struct InstanceActionConfiguration: Codable, SwipeActionConfiguration {
+    var savedSwipes: ActionSeedSwipeConfiguration?
+
+    static var availableActions: ActionSeedSections { .init(sections: [
+            [
+                .visit,
+                .logIn,
+                .signUp,
+                .openInBrowser,
+                .share,
+                .block
+            ]
+        ])
+    }
+
+    static var defaultSwipes: ActionSeedSwipeConfiguration {
+        .init(leading: [], trailing: [])
+    }
+
+    enum CodingKeys: CodingKey {
+        case swipes
+    }
+
+    init() {
+        self.savedSwipes = nil
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let swipeConfigurationContainer = try? container.nestedContainer(
+            keyedBy: ActionSeedSwipeConfiguration.CodingKeys.self,
+            forKey: .swipes
+        )
+        if let swipeConfigurationContainer {
+            self.savedSwipes = try .init(from: swipeConfigurationContainer, availableActions: Self.availableActions.all)
+        } else {
+            self.savedSwipes = nil
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.savedSwipes, forKey: .swipes)
+    }
+}

--- a/Mlem/App/Enums/Interaction/PersonActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PersonActionConfiguration.swift
@@ -1,0 +1,63 @@
+//
+//  PersonActionConfiguration.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-05-29.
+//
+
+import Actions
+import Foundation
+
+struct PersonActionConfiguration: Codable, SwipeActionConfiguration {
+    var savedSwipes: ActionSeedSwipeConfiguration?
+
+    static var availableActions: ActionSeedSections { .init(sections: [
+            [
+                .goToInstance,
+                .copyName,
+                .selectText,
+                .share,
+                .sendMessage,
+                .block,
+                .editNote,
+                .openModlog
+            ],
+            [
+                .ban,
+                .purge,
+                .appointModerator,
+                .appointAdmin
+            ]
+        ])
+    }
+
+    static var defaultSwipes: ActionSeedSwipeConfiguration {
+        .init(leading: [], trailing: [])
+    }
+
+    enum CodingKeys: CodingKey {
+        case swipes
+    }
+
+    init() {
+        self.savedSwipes = nil
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let swipeConfigurationContainer = try? container.nestedContainer(
+            keyedBy: ActionSeedSwipeConfiguration.CodingKeys.self,
+            forKey: .swipes
+        )
+        if let swipeConfigurationContainer {
+            self.savedSwipes = try .init(from: swipeConfigurationContainer, availableActions: Self.availableActions.all)
+        } else {
+            self.savedSwipes = nil
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.savedSwipes, forKey: .swipes)
+    }
+}

--- a/Mlem/App/Enums/Interaction/SwipeActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/SwipeActionConfiguration.swift
@@ -25,4 +25,8 @@ extension SwipeActionConfiguration {
         }
     }
 
+    mutating func applySwipes<Configuration: SwipeActionConfiguration>(other: Configuration) {
+        let swipes = other.savedSwipes ?? Configuration.defaultSwipes
+        self.savedSwipes = swipes.filter(allowed: Self.availableActions.all)
+    }
 }

--- a/Mlem/App/Views/Pages/Community/CommunityView.swift
+++ b/Mlem/App/Views/Pages/Community/CommunityView.swift
@@ -39,6 +39,7 @@ struct CommunityView: View {
     @Setting(\.post_size) var postSize
     @Setting(\.feed_showRead) var showRead
     @Setting(\.safety_enableNsfwCommunityWarning) var showNsfwCommunityWarning
+    @Setting(\.interactionBar_person) var personActionConfiguration
     @Setting(\.safety_blurNsfw) var blurNsfw
     
     @ObservationIgnored @Dependency(\.persistenceRepository) private var persistenceRepository
@@ -149,7 +150,7 @@ struct CommunityView: View {
                 guard !showRead else { return }
                 let now = Date()
                 if let lastRefresh = lastRefreshDate,
-                   now.timeIntervalSince(lastRefresh) < 5 {
+                    now.timeIntervalSince(lastRefresh) < 5 {
                     showHiddenReadBanner = true
                 }
                 lastRefreshDate = now
@@ -202,8 +203,12 @@ struct CommunityView: View {
             VStack(spacing: Constants.main.halfSpacing) {
                 // ExpectedView causes rendering issues here
                 ForEach(community.moderators.value ?? []) { person in
-                    PersonListRow(person)
-                        .quickSwipes(moderatorQuickSwipes(community: community, person: person))
+                    if personActionConfiguration.swipes.trailing.isEmpty {
+                        PersonListRow(person)
+                            .quickSwipes(moderatorQuickSwipes(community: community, person: person))
+                    } else {
+                        PersonListRow(person)
+                    }
                 }
             }
             

--- a/Mlem/App/Views/Root/Tabs/Settings/InstanceSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InstanceSettingsView.swift
@@ -15,7 +15,7 @@ struct InstanceSettingsView: View {
                 description: "Customize the appearance of instances.",
                 icon: .lemmy.instance
             )
-            .gradientTint(.themedColorfulAccent(1))
+            .gradientTint(.themedInstanceAccent)
             Section {
                 NavigationLink("Swipe Actions", destination: .settings(.swipeActions(.instance)))
             }

--- a/Mlem/App/Views/Root/Tabs/Settings/InstanceSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InstanceSettingsView.swift
@@ -1,0 +1,27 @@
+//
+//  InstanceSettingsView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-05-29.
+//
+
+import SwiftUI
+
+struct InstanceSettingsView: View {
+    var body: some View {
+        Form {
+            SettingsHeaderView(
+                title: "Instances",
+                description: "Customize the appearance of instances.",
+                icon: .lemmy.instance
+            )
+            .gradientTint(.themedColorfulAccent(1))
+            Section {
+                NavigationLink("Swipe Actions", destination: .settings(.swipeActions(.instance)))
+            }
+        }
+        .withConditionalLabelStyle()
+        .contentMargins(.top, 16)
+        .hiddenNavigationTitle("Instances")
+    }
+}

--- a/Mlem/App/Views/Root/Tabs/Settings/PersonSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PersonSettingsView.swift
@@ -1,0 +1,43 @@
+//
+//  PersonSettingsView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-05-29.
+//
+
+import SwiftUI
+
+struct PersonSettingsView: View {
+    @Setting(\.person_showAvatar) var showPersonAvatar
+    @Setting(\.person_ageVisibility) var accountAgeVisibility
+
+    var body: some View {
+        Form {
+            SettingsHeaderView(
+                title: "Users",
+                description: "Customize the appearance of users.",
+                icon: .lemmy.person
+            )
+            .gradientTint(.themedPersonAccent)
+            Section {
+                NavigationLink("Swipe Actions", destination: .settings(.swipeActions(.person)))
+                NavigationLink(
+                    "Show Account Age",
+                    value: .init(localized: accountAgeVisibility.label),
+                    fallbackValue: "",
+                    icon: .lemmy.newAccountFlair,
+                    destination: .settings(.accountAgeVisibility)
+                )
+            }
+            Section {
+                Toggle("User Avatar", icon: .lemmy.person, isOn: $showPersonAvatar)
+                    .symbolVariant(.circle)
+            } footer: {
+                Text("Choose whether to show user avatars on posts.")
+            }
+        }
+        .withConditionalLabelStyle()
+        .contentMargins(.top, 16)
+        .hiddenNavigationTitle("Users")
+    }
+}

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -93,7 +93,7 @@ struct SettingsView: View {
                 NavigationLink("Users", icon: .lemmy.person, destination: .settings(.person))
                     .gradientTint(.themedPersonAccent)
                 NavigationLink("Instances", icon: .lemmy.instance, destination: .settings(.instance))
-                    .gradientTint(.themedColorfulAccent(1))
+                    .gradientTint(.themedInstanceAccent)
                 NavigationLink("Tab Bar", icon: .settings.tabBar, destination: .settings(.tabBar))
                     .gradientTint(.themedColorfulAccent(5))
             }

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -92,6 +92,8 @@ struct SettingsView: View {
                     .gradientTint(.themedCommunityAccent)
                 NavigationLink("Users", icon: .lemmy.person, destination: .settings(.person))
                     .gradientTint(.themedPersonAccent)
+                NavigationLink("Instances", icon: .lemmy.instance, destination: .settings(.instance))
+                    .gradientTint(.themedColorfulAccent(1))
                 NavigationLink("Tab Bar", icon: .settings.tabBar, destination: .settings(.tabBar))
                     .gradientTint(.themedColorfulAccent(5))
             }

--- a/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SettingsView.swift
@@ -90,6 +90,8 @@ struct SettingsView: View {
                     .gradientTint(.themedInbox)
                 NavigationLink("Communities", icon: .lemmy.community, destination: .settings(.community))
                     .gradientTint(.themedCommunityAccent)
+                NavigationLink("Users", icon: .lemmy.person, destination: .settings(.person))
+                    .gradientTint(.themedPersonAccent)
                 NavigationLink("Tab Bar", icon: .settings.tabBar, destination: .settings(.tabBar))
                     .gradientTint(.themedColorfulAccent(5))
             }

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -221,11 +221,32 @@ enum SettingsPage: Hashable {
                     }
                 })
             case .community:
-                SwipeActionEditorView(\.interactionBar_community)
+                SwipeActionEditorView(\.interactionBar_community, onApplyToAll: { configuration in
+                    Settings.mutate(\.interactionBar_instance) {
+                        $0.applySwipes(other: configuration)
+                    }
+                    Settings.mutate(\.interactionBar_community) {
+                        $0.applySwipes(other: configuration)
+                    }
+                })
             case .person:
-                SwipeActionEditorView(\.interactionBar_person)
+                SwipeActionEditorView(\.interactionBar_person, onApplyToAll: { configuration in
+                    Settings.mutate(\.interactionBar_instance) {
+                        $0.applySwipes(other: configuration)
+                    }
+                    Settings.mutate(\.interactionBar_community) {
+                        $0.applySwipes(other: configuration)
+                    }
+                })
             case .instance:
-                SwipeActionEditorView(\.interactionBar_instance)
+                SwipeActionEditorView(\.interactionBar_instance, onApplyToAll: { configuration in
+                    Settings.mutate(\.interactionBar_person) {
+                        $0.applySwipes(other: configuration)
+                    }
+                    Settings.mutate(\.interactionBar_community) {
+                        $0.applySwipes(other: configuration)
+                    }
+                })
             }
         case let .contextMenu(page):
             page.view

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -15,7 +15,7 @@ enum SettingsPage: Hashable {
     }
 
     enum SwipeActionSettingType: Hashable {
-        case post, comment, inboxNotification, postReport, commentReport, community
+        case post, comment, inboxNotification, postReport, commentReport, community, person
     }
 
     case root
@@ -32,7 +32,7 @@ enum SettingsPage: Hashable {
     case externalLinks, sharingLinks, tappableLinks
     case importExportSettings
     case theme, icon
-    case post, comment, inbox, community, subscriptionList
+    case post, comment, inbox, community, person, subscriptionList
     case tabBar, longPressAction
     case postThumbnail, postSubscriptionIndicator, postReadIndicator
     case commentMaximumDepth, commentJumpButton
@@ -125,6 +125,8 @@ enum SettingsPage: Hashable {
             PostSettingsView()
         case .community:
             CommunitySettingsView()
+        case .person:
+            PersonSettingsView()
         case .postThumbnail:
             PostThumbnailSettingsView()
         case .postSubscriptionIndicator:
@@ -218,6 +220,8 @@ enum SettingsPage: Hashable {
                 })
             case .community:
                 SwipeActionEditorView(\.interactionBar_community)
+            case .person:
+                SwipeActionEditorView(\.interactionBar_person)
             }
         case let .contextMenu(page):
             page.view

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -15,7 +15,7 @@ enum SettingsPage: Hashable {
     }
 
     enum SwipeActionSettingType: Hashable {
-        case post, comment, inboxNotification, postReport, commentReport, community, person
+        case post, comment, inboxNotification, postReport, commentReport, community, person, instance
     }
 
     case root
@@ -32,7 +32,7 @@ enum SettingsPage: Hashable {
     case externalLinks, sharingLinks, tappableLinks
     case importExportSettings
     case theme, icon
-    case post, comment, inbox, community, person, subscriptionList
+    case post, comment, inbox, community, person, instance, subscriptionList
     case tabBar, longPressAction
     case postThumbnail, postSubscriptionIndicator, postReadIndicator
     case commentMaximumDepth, commentJumpButton
@@ -127,6 +127,8 @@ enum SettingsPage: Hashable {
             CommunitySettingsView()
         case .person:
             PersonSettingsView()
+        case .instance:
+            InstanceSettingsView()
         case .postThumbnail:
             PostThumbnailSettingsView()
         case .postSubscriptionIndicator:
@@ -222,6 +224,8 @@ enum SettingsPage: Hashable {
                 SwipeActionEditorView(\.interactionBar_community)
             case .person:
                 SwipeActionEditorView(\.interactionBar_person)
+            case .instance:
+                SwipeActionEditorView(\.interactionBar_instance)
             }
         case let .contextMenu(page):
             page.view

--- a/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
+++ b/Mlem/App/Views/Shared/Search/Home/SearchHomeView.swift
@@ -102,7 +102,7 @@ struct SearchHomeView: View {
             if !UIDevice.isPad { Spacer() }
 
             NavigationLink("Instances", icon: .lemmy.instance, destination: .topInstances)
-                .tint(.themedColorfulAccent(1))
+                .tint(.themedInstanceAccent)
         }
         .labelStyle(SearchHomeCategoryLabelStyle())
         .buttonStyle(.empty)
@@ -115,7 +115,7 @@ struct SearchHomeView: View {
             GridButton(title: "Top Communities", color: .themedCommunityAccent)
             GridButton(title: "Trending Communities", color: .themedColorfulAccent(0))
             GridButton(title: "Users", color: .themedPersonAccent)
-            GridButton(title: "Instances", color: .themedColorfulAccent(1))
+            GridButton(title: "Instances", color: .themedInstanceAccent)
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, -4)

--- a/Mlem/App/Views/Shared/Search/Results/InstanceListRow.swift
+++ b/Mlem/App/Views/Shared/Search/Results/InstanceListRow.swift
@@ -15,6 +15,7 @@ struct InstanceListRow<Content2: View>: View {
     
     @Environment(AppState.self) var appState
     @Environment(NavigationLayer.self) var navigation
+    @Setting(\.interactionBar_instance) var instanceActionConfiguration
     
     let instance: any InstanceActionProviding
     let content: Content
@@ -60,6 +61,7 @@ struct InstanceListRow<Content2: View>: View {
         .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu(instance: instance)
+        .quickSwipes(instance: instance, configuration: instanceActionConfiguration, leadingBuffer: .standard)
         .popupAnchor()
         .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }

--- a/Mlem/App/Views/Shared/Search/Results/PersonListRow.swift
+++ b/Mlem/App/Views/Shared/Search/Results/PersonListRow.swift
@@ -15,6 +15,7 @@ struct PersonListRow<Content2: View>: View {
     @Environment(AppState.self) var appState
     @Environment(NavigationLayer.self) var navigation
     @Environment(\.communityContext) var communityContext
+    @Setting(\.interactionBar_person) var personActionConfiguration
     
     let person: Person
     let content: Content
@@ -56,6 +57,7 @@ struct PersonListRow<Content2: View>: View {
         .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
         .contentShape(.contextMenuPreview, .rect(cornerRadius: Constants.main.standardSpacing))
         .contextMenu(person: person)
+        .quickSwipes(person: person, configuration: personActionConfiguration, leadingBuffer: .standard)
         .popupAnchor()
         .paletteBorder(cornerRadius: Constants.main.standardSpacing)
     }

--- a/Mlem/Packages/Icons/Sources/Icons/Icon+General.swift
+++ b/Mlem/Packages/Icons/Sources/Icons/Icon+General.swift
@@ -68,7 +68,7 @@ public extension Icon {
         public let signOut: Icon = .init("minus.circle")
         public let attachment: Icon = .init("paperclip")
         public let refresh: Icon = .init("arrow.clockwise")
-        public let select: Icon = .init("selection.pin.in.out")
+        public let select: Icon = .baseOnly("selection.pin.in.out")
         
         public let chooseFile: Icon = .init("folder")
         public let chooseImage: Icon = .init("photo")

--- a/Mlem/Packages/Icons/Sources/Icons/Icon+Lemmy.swift
+++ b/Mlem/Packages/Icons/Sources/Icons/Icon+Lemmy.swift
@@ -211,9 +211,14 @@ public extension Icon {
         public let switchAccount: Icon = .init("arrow.left.arrow.right")
         public let switchAccountAndReload: Icon = .init("arrow.2.circlepath")
         public let switchAccountAndKeepPlace: Icon = .init("checkmark.diamond")
-        public let visitInstance: Icon = .init("arrow.right")
+        public let visitInstance: Icon = .applyCircle("arrow.right")
         public let logIn: Icon = .init("person.text.rectangle")
-        public let signUp: Icon = .init("pencil.and.list.clipboard")
+        public let signUp: Icon = .custom { variant in
+            switch variant {
+            case .active: "list.clipboard.fill"
+            default: "pencil.and.list.clipboard"
+            }
+        }
         
         public let jumpButton: Icon = .init("chevron.down")
         public let jumpToLastPositionButton: Icon = .init("chevron.down.2")

--- a/Mlem/Packages/Icons/Sources/Icons/Icon+Lemmy.swift
+++ b/Mlem/Packages/Icons/Sources/Icons/Icon+Lemmy.swift
@@ -84,7 +84,7 @@ public extension Icon {
         // MARK: - Purge
         
         @inlinable public var purged: Icon { purge }
-        public let purge: Icon = .init("burn")
+        public let purge: Icon = .baseOnly("burn")
         
         // MARK: - Ban
 
@@ -205,7 +205,7 @@ public extension Icon {
 
         public let noContent: Icon = .init("binoculars")
         public let note: Icon = .init("note.text")
-        public let editNote: Icon = .init("square.and.pencil")
+        public let editNote: Icon = .applyCircle("square.and.pencil")
         public let openAccountSwitcher: Icon = .init("person.crop.rectangle.stack.fill")
         public let groupAccountSort: Icon = .init("square.stack.3d.up.fill")
         public let switchAccount: Icon = .init("arrow.left.arrow.right")

--- a/Mlem/Packages/Icons/Sources/Icons/Icon.swift
+++ b/Mlem/Packages/Icons/Sources/Icons/Icon.swift
@@ -18,6 +18,7 @@ public struct Icon: Hashable {
     
     public enum VariantApplicationStrategy {
         case baseOnly(name: String)
+        case fillable(name: String)
         case applySquare(name: String)
         case applyCircle(name: String)
         case custom((Variant?) -> String)
@@ -26,6 +27,8 @@ public struct Icon: Hashable {
         func computeImageName(variant: Variant?) -> String {
             switch self {
             case let .baseOnly(name):
+                name
+            case let .fillable(name):
                 switch variant {
                 case .active: "\(name).fill"
                 default: name
@@ -60,11 +63,15 @@ public struct Icon: Hashable {
     }
     
     public init(_ name: String, source: Source = .system) {
-        self.init(.baseOnly(name: name), source: source)
+        self.init(.fillable(name: name), source: source)
     }
     
     public func computeImageName() -> String {
         variantApplicationStrategy.computeImageName(variant: appliedVariant)
+    }
+
+    public static func baseOnly(_ name: String) -> Self {
+        self.init(.baseOnly(name: name))
     }
     
     public static func applySquare(_ name: String) -> Self {

--- a/Mlem/Packages/Theming/Sources/Theming/ThemedColor.swift
+++ b/Mlem/Packages/Theming/Sources/Theming/ThemedColor.swift
@@ -200,6 +200,7 @@ public extension ShapeStyle where Self == ThemedColor {
     static var themedCommentAccent: ThemedColor { themedColorfulAccent(0) }
     static var themedPostAccent: ThemedColor { themedColorfulAccent(1) }
     static var themedPersonAccent: ThemedColor { themedColorfulAccent(2) }
+    static var themedInstanceAccent: ThemedColor { themedColorfulAccent(1) }
     static var themedCommunityAccent: ThemedColor { themedColorfulAccent(3) }
     static var themedLockAccent: ThemedColor { themedColorfulAccent(0) }
     


### PR DESCRIPTION
Closes #2617

Settings -> Users
Settings -> Instances

---

The root settings page is getting rather long; I think we should find a better way to arrange this in future. Maybe all of the content types ("Posts", "Comments", etc) could go under a new settings page called "Content"?