### PR TITLE
Misc bug fixes

### DIFF
--- a/Mlem/App/Actions/MarkReadAction.swift
+++ b/Mlem/App/Actions/MarkReadAction.swift
@@ -50,6 +50,11 @@ extension MarkReadAction {
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {
         guard notification.api.canInteract(appState: environment.appState) else { return .hidden }
+
+        if case let .message(message) = notification.content, message.isOwnMessage {
+            return .hidden
+        }
+
         return .enabled
     }
 }

--- a/Mlem/App/Configuration/User Settings/Settings.swift
+++ b/Mlem/App/Configuration/User Settings/Settings.swift
@@ -60,7 +60,9 @@ class Settings {
     }
     
     static func encoded() throws -> Data {
-        try JSONEncoder().encode(main.values)
+        let encoder = JSONEncoder()
+        encoder.userInfo[.endpointVersion] = LemmyEndpointVersion.v3
+        return try encoder.encode(main.values)
     }
     
     // MARK: - Logic

--- a/Mlem/App/Globals/Definitions/PersistenceRepository.swift
+++ b/Mlem/App/Globals/Definitions/PersistenceRepository.swift
@@ -68,8 +68,6 @@ private enum DiskAccess {
 
 // Enumeration of system-managed settings
 enum SystemSetting {
-    /// v1 settings manually saved by the user
-    case v1_user
     /// v2 settings manually saved by the user
     case v2_user
     /// v2 settings automatically saved by the app
@@ -77,7 +75,6 @@ enum SystemSetting {
     
     var path: String {
         switch self {
-        case .v1_user: "v1"
         case .v2_user: "v2"
         case .v2_system: "v2_system"
         }

--- a/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsView.swift
@@ -17,15 +17,13 @@ struct ImportExportSettingsView: View {
     
     @State var importingSettingsFile: Bool = false
     
-    // these are tracked as state vars so they can be updated as appropriate
-    @State var v1SettingsExist: Bool = false
+    // this is tracked as a state var so they can be updated as appropriate
     @State var v2SettingsExist: Bool = false
     
     var body: some View {
         content
             .withConditionalLabelStyle()
             .onAppear {
-                v1SettingsExist = persistenceRepository.systemSettingsExists(.v1_user)
                 v2SettingsExist = persistenceRepository.systemSettingsExists(.v2_user)
             }
             .fileImporter(

--- a/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ImportExportSettingsView.swift
@@ -71,10 +71,14 @@ struct ImportExportSettingsView: View {
             Section {
                 Button("Export Settings", icon: .general.export) {
                     Task {
-                        let data = try Settings.encoded()
-                        let fileUrl = FileManager.default.temporaryDirectory.appending(path: "settings.json")
-                        try data.write(to: fileUrl, options: .atomic)
-                        navigation.model?.shareInfo = .init(url: fileUrl)
+                        do {
+                            let data = try Settings.encoded()
+                            let fileUrl = FileManager.default.temporaryDirectory.appending(path: "settings.json")
+                            try data.write(to: fileUrl, options: .atomic)
+                            navigation.model?.shareInfo = .init(url: fileUrl)
+                        } catch {
+                            handleError(error)
+                        }
                     }
                 }
                 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Image.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Image.swift
@@ -31,14 +31,16 @@ public extension LemmyConnection {
             auth: token
         )
         
-        let (data, _) = try await restClient.urlSession.upload(
+        let (data, response) = try await restClient.urlSession.upload(
             for: request,
             from: encodedData,
             delegate: ImageUploadDelegate(callback: progressCallback)
         )
-        
+
+        let decoder = JSONDecoder.defaultDecoder
+
         do {
-            let response = try JSONDecoder.defaultDecoder.decode(LemmyPictrsUploadResponse.self, from: data)
+            let response = try decoder.decode(LemmyPictrsUploadResponse.self, from: data)
             guard let file = response.files?.first else { throw ApiClientError.noEntityFound }
             return .init(from: file, baseUrl: baseUrl)
         } catch DecodingError.dataCorrupted {
@@ -47,6 +49,13 @@ public extension LemmyConnection {
                 throw ApiClientError.imageTooLarge
             }
             throw ApiClientError.decoding(data, nil)
+        } catch {
+            if let error = try? decoder.decode(ApiErrorResponse.self, from: data) {
+                let statusCode = (response as? HTTPURLResponse)?.statusCode
+                throw ApiClientError.response(error, statusCode ?? -1)
+            } else {
+                throw error
+            }
         }
     }
     


### PR DESCRIPTION
Closes #2751
Closes #2754

---

Closes #2742

The only way to test this is to uploads lots of images and get rate-limited. Previously you'd get this error:

```
Optional(DecodingError.keyNotFound: Key 'url' not found in keyed decoding container. Debug description: No value associated with key CodingKeys(stringValue: "url", intValue: nil) ("url").) 
```

Now you get:

```
Optional(Response error: rate_limit_error with status 400)
```

---

Also removed some leftover `LegacySettings` code that I missed in #2753