### PR TITLE
Inbox lock

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -34,17 +34,19 @@ public extension ApiClient {
         limit: Int,
         unreadOnly: Bool
     ) async throws -> (notifications: [InboxNotification], cursor: String?) {
-        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
-        let response = try await repository.getReplyNotifications(
-            page: page,
-            cursor: cursor,
-            limit: limit,
-            unreadOnly: unreadOnly
-        )
-        return await (
-            notifications: caches.notification.getModels(api: self, from: response.notifications, myPersonId: myPersonId),
-            cursor: response.cursor
-        )
+        try await inboxLock.withLock {
+            guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+            let response = try await repository.getReplyNotifications(
+                page: page,
+                cursor: cursor,
+                limit: limit,
+                unreadOnly: unreadOnly
+            )
+            return await (
+                notifications: caches.notification.getModels(api: self, from: response.notifications, myPersonId: myPersonId),
+                cursor: response.cursor
+            )
+        }
     }
     
     func getMentionNotifications(
@@ -53,17 +55,19 @@ public extension ApiClient {
         limit: Int,
         unreadOnly: Bool
     ) async throws -> (notifications: [InboxNotification], cursor: String?) {
-        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
-        let response = try await repository.getMentionNotifications(
-            page: page,
-            cursor: cursor,
-            limit: limit,
-            unreadOnly: unreadOnly
-        )
-        return await (
-            notifications: caches.notification.getModels(api: self, from: response.notifications, myPersonId: myPersonId),
-            cursor: response.cursor
-        )
+        try await inboxLock.withLock {
+            guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+            let response = try await repository.getMentionNotifications(
+                page: page,
+                cursor: cursor,
+                limit: limit,
+                unreadOnly: unreadOnly
+            )
+            return await (
+                notifications: caches.notification.getModels(api: self, from: response.notifications, myPersonId: myPersonId),
+                cursor: response.cursor
+            )
+        }
     }
 
     func getMessageNotifications(
@@ -72,37 +76,43 @@ public extension ApiClient {
         limit: Int,
         unreadOnly: Bool
     ) async throws -> (notifications: [InboxNotification], cursor: String?) {
-        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
-        let response = try await repository.getMessageNotifications(
-            page: page,
-            cursor: cursor,
-            limit: limit,
-            unreadOnly: unreadOnly
-        )
-        return await (
-            notifications: caches.notification.getModels(api: self, from: response.notifications, myPersonId: myPersonId),
-            cursor: response.cursor
-        )
+        try await inboxLock.withLock {
+            guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+            let response = try await repository.getMessageNotifications(
+                page: page,
+                cursor: cursor,
+                limit: limit,
+                unreadOnly: unreadOnly
+            )
+            return await (
+                notifications: caches.notification.getModels(api: self, from: response.notifications, myPersonId: myPersonId),
+                cursor: response.cursor
+            )
+        }
     }
 
     func markAllAsRead() async throws {
-        try await repository.markAllAsRead()
-        _ = await Task { @MainActor in
-            for notification in caches.notification.itemCache.value.values {
-                notification.content?.read = true
-            }
-        }.result
-        unreadCount?.clear(.personal)
+        try await inboxLock.withLock {
+            try await repository.markAllAsRead()
+            _ = await Task { @MainActor in
+                for notification in caches.notification.itemCache.value.values {
+                    notification.content?.read = true
+                }
+            }.result
+            unreadCount?.clear(.personal)
+        }
     }
     
     /// Get an ``UnreadCount`` object that continues to be updated by the ``ApiClient`` whenever an inbox item is marked read/unread.
     func getUnreadCount(alwaysMakeCalls: Bool = false) async throws -> UnreadCount {
-        let unreadCount = unreadCount ?? .init(api: self)
-        try await unreadCount.refresh(alwaysMakeCalls: alwaysMakeCalls)
-        self.unreadCount = unreadCount
-        return unreadCount
+        try await inboxLock.withLock {
+            let unreadCount = unreadCount ?? .init(api: self)
+            try await unreadCount.refresh(alwaysMakeCalls: alwaysMakeCalls)
+            self.unreadCount = unreadCount
+            return unreadCount
+        }
     }
-    
+
     func createMessage(personId: Int, content: String) async throws -> Message2 {
         let snapshot = try await repository.createMessage(personId: personId, content: content)
         guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -23,6 +23,9 @@ public class ApiClient {
     public internal(set) weak var subscriptions: SubscriptionList?
     public internal(set) weak var blocks: BlockList?
     public internal(set) weak var unreadCount: UnreadCount?
+
+    /// This prevents the unread count getting desynced if requests are performed at the same time.
+    internal let inboxLock = LockActor()
     
     /// Stores the IDs of posts that are queued to be marked read.
     var markReadQueue: MarkReadQueue = .init()

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Helpers/LockActor.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/Helpers/LockActor.swift
@@ -1,0 +1,12 @@
+//
+//  LockActor.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-05-29.
+//
+
+actor LockActor {
+    func withLock<T>(_ body: () async throws -> T) async rethrows -> T {
+        try await body()
+    }
+}


### PR DESCRIPTION
Added a lock to the `ApiClient` methods that affect the inbox count.

In theory, this should prevent very occasional notification count desyncs caused by multiple requests running at the same time. 

Additionally, this work may become necessary for #2710. Authenticating to Canvas may require sending and receiving DMs with a bot account, and we'll want to do this seamlessly in the background without the user's inbox count updating.

Using actors allows for nested locks acquisition. For instance, this won't cause a deadlock:

```swift
try await inboxLock.withLock {
    try await inboxLock.withLock {
        // ...
    }
}
```