### PR TITLE
Separate error handling system for Lemmy and PieFed

### DIFF
--- a/Mlem/App/Views/Pages/Instance/InstanceCommunityListView.swift
+++ b/Mlem/App/Views/Pages/Instance/InstanceCommunityListView.swift
@@ -62,13 +62,11 @@ struct InstanceCommunityListView: View {
                 return true
             }
 
-            if case let ApiClientError.response(response, _) = error {
-                if response.instanceIsPrivate {
-                    errorDetails?.title = String(localized: "Instance is private")
-                    errorDetails?.body = String(localized: "You cannot view the communities of a private instance.")
-                    errorDetails?.icon = .lemmy.private
-                    errorDetails?.refresh = nil
-                }
+            if case ApiClientError.instanceIsPrivate = error {
+                errorDetails?.title = String(localized: "Instance is private")
+                errorDetails?.body = String(localized: "You cannot view the communities of a private instance.")
+                errorDetails?.icon = .lemmy.private
+                errorDetails?.refresh = nil
             }
 
             self.errorDetails = errorDetails

--- a/Mlem/App/Views/Root/Login/LoginCredentialsView.swift
+++ b/Mlem/App/Views/Root/Login/LoginCredentialsView.swift
@@ -175,7 +175,7 @@ struct LoginCredentialsView: View {
                     }
                 } catch {
                     switch error {
-                    case let ApiClientError.response(response, _) where response.error == "missing_totp_token":
+                    case ApiClientError.missingTotp:
                         navigation.push(.logIn(.totp(client: client, usernameOrEmail: usernameOrEmail, password: password)))
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             authenticating = false

--- a/Mlem/App/Views/Root/Login/LoginCredentialsView.swift
+++ b/Mlem/App/Views/Root/Login/LoginCredentialsView.swift
@@ -180,7 +180,7 @@ struct LoginCredentialsView: View {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             authenticating = false
                         }
-                    case ApiClientError.invalidSession:
+                    case ApiClientError.notLoggedIn:
                         failureReason = .incorrectPassword
                     default:
                         handleError(error, silent: true)

--- a/Mlem/App/Views/Root/Login/SignUpView+EmailConfirmationView.swift
+++ b/Mlem/App/Views/Root/Login/SignUpView+EmailConfirmationView.swift
@@ -64,7 +64,7 @@ extension SignUpView {
                 let account = try await AccountsTracker.main.logIn(username: username, url: api.baseUrl, token: token)
                 navigation.dismissSheet()
                 AppState.main.changeAccount(to: account)
-            } catch let ApiClientError.response(response, _) where response.emailNotVerified || response.registrationApplicationIsPending {
+            } catch ApiClientError.emailNotVerified, ApiClientError.applicationPending {
                 // no-op
             } catch {
                 handleError(error)

--- a/Mlem/App/Views/Root/Tabs/Settings/ChangePasswordView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ChangePasswordView.swift
@@ -116,7 +116,7 @@ struct ChangePasswordView: View {
                 } catch ApiClientError.invalidSession {
                     ToastModel.main.add(.failure("Current password is incorrect"))
                     viewState = .initial
-                } catch let ApiClientError.response(response, _) where response.error == "invalid_password" {
+                } catch ApiClientError.newPasswordInvalid { 
                     ToastModel.main.add(.failure("New password is invalid"))
                     viewState = .initial
                 } catch {

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -8723,6 +8723,9 @@
         }
       }
     },
+    "Taller Collapsed Comments" : {
+
+    },
     "Tap and hold items to add, remove, or rearrange them." : {
       "localizations" : {
         "fr" : {
@@ -8752,6 +8755,9 @@
           }
         }
       }
+    },
+    "Tap to expand" : {
+
     },
     "Tap to show slur filter regex." : {
       "localizations" : {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
@@ -17,9 +17,8 @@ public enum ApiClientError: Error {
     case encoding(Error)
     case networking(Error)
     case serverError(statusCode: Int)
-    case response(LemmyErrorResponse, Int)
+    case response(String, Int)
     case cancelled
-    case notLoggedIn
     case invalidSession
     case decoding(Data, Error?)
     case insufficientPermissions
@@ -35,13 +34,22 @@ public enum ApiClientError: Error {
     case noToken
     case responseMissingRequiredData(_ message: String)
     case unableToDetermineSoftware
+
+    case notLoggedIn
+    case missingTotp
+    case instanceIsPrivate
+    case applicationPending
+    case emailNotVerified
+    case notModOrAdmin
+    case notAdmin
+    case newPasswordInvalid
     
     init(from error: RestError) {
         self = switch error {
         case let .serverError(statusCode):
             .serverError(statusCode: statusCode)
         case let .response(string, statusCode):
-            .response(.init(error: string), statusCode)
+            .response(string, statusCode)
         case let .encoding(error):
             .encoding(error)
         case let .parameterEncoding(error):
@@ -107,6 +115,20 @@ extension ApiClientError: CustomStringConvertible {
             return "An API response was missing required data: \(message)"
         case .unableToDetermineSoftware:
             return "Unable to determine software"
+        case .missingTotp:
+            return "Missing 2FA token"
+        case .instanceIsPrivate:
+            return "Instance is private"
+        case .applicationPending:
+            return "Application pending"
+        case .emailNotVerified:
+            return "Email not verified"
+        case .notModOrAdmin:
+            return "Not mod or admin"
+        case .notAdmin:
+            return "Not admin"
+        case .newPasswordInvalid:
+            return "New password invalid"
         }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
@@ -17,7 +17,7 @@ public enum ApiClientError: Error {
     case encoding(Error)
     case networking(Error)
     case serverError(statusCode: Int)
-    case response(ApiErrorResponse, Int)
+    case response(LemmyErrorResponse, Int)
     case cancelled
     case notLoggedIn
     case invalidSession

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClientError.swift
@@ -82,7 +82,7 @@ extension ApiClientError: CustomStringConvertible {
         case .invalidSession:
             return "Invalid session. There is a token applied to the ApiClient, but it has expired."
         case .notLoggedIn:
-            return "Tried to perform an action that requires authentication on a guest ApiClient."
+            return "Not logged in."
         case .imageTooLarge:
             return "Image too large"
         case let .decoding(data, error):

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/LemmyErrorResponse.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/LemmyErrorResponse.swift
@@ -1,5 +1,5 @@
 //
-//  ApiErrorResponse.swift
+//  LemmyErrorResponse.swift
 //  Mlem
 //
 //  Created by Nicholas Lawson on 06/06/2023.
@@ -9,7 +9,7 @@ import Foundation
 
 // TODO: 0.19 support add all the error types (https://github.com/LemmyNet/lemmy-js-client/blob/b2edfeeaffd189a51150362cc8ead03c65ee2652/src/types/LemmyErrorType.ts)
 
-public struct ApiErrorResponse: Decodable, CustomStringConvertible {
+public struct LemmyErrorResponse: Decodable, CustomStringConvertible {
     public let error: String
     
     public var description: String { error }
@@ -40,7 +40,7 @@ private let couldntFindObjectErrors: Set<String> = [
     "No object found."
 ]
 
-public extension ApiErrorResponse {
+public extension LemmyErrorResponse {
     var requires2FA: Bool { possible2FAErrors.contains(error) }
     var isNotLoggedIn: Bool { possibleAuthenticationErrors.contains(error) }
     var instanceIsPrivate: Bool { error == "instance_is_private" }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/LemmyErrorResponse.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/LemmyErrorResponse.swift
@@ -15,38 +15,3 @@ public struct LemmyErrorResponse: Decodable, CustomStringConvertible {
     public var description: String { error }
 }
 
-private let possibleCredentialErrors: Set<String> = [
-    "incorrect_password",
-    "password_incorrect",
-    "incorrect_login",
-    "couldnt_find_that_username_or_email"
-]
-
-private let possibleAuthenticationErrors: Set<String> = [
-    "incorrect_password",
-    "password_incorrect",
-    "incorrect_login",
-    "not_logged_in"
-]
-
-private let possible2FAErrors: Set<String> = [
-    "missing_totp_token",
-    "incorrect_totp_token"
-]
-
-private let couldntFindObjectErrors: Set<String> = [
-    "couldnt_find_person",
-    "couldnt_find_object",
-    "No object found."
-]
-
-public extension LemmyErrorResponse {
-    var requires2FA: Bool { possible2FAErrors.contains(error) }
-    var isNotLoggedIn: Bool { possibleAuthenticationErrors.contains(error) }
-    var instanceIsPrivate: Bool { error == "instance_is_private" }
-    var registrationApplicationIsPending: Bool { error == "registration_application_is_pending" }
-    var emailNotVerified: Bool { error == "email_not_verified" }
-    var couldntFindObject: Bool { couldntFindObjectErrors.contains(error) }
-    var notModOrAdmin: Bool { error == "not_a_mod_or_admin" }
-    var notAdmin: Bool { error == "not_an_admin" }
-}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/PieFedErrorResponse.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/PieFedErrorResponse.swift
@@ -1,0 +1,19 @@
+//
+//  PieFedErrorResponse.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-01.
+//
+
+import Foundation
+
+// https://codeberg.org/rimu/pyfedi/src/commit/6378bd77b84681d4e646860183598bb7a5bf17be/app/api/alpha/__init__.py#L91
+
+public struct PieFedErrorResponse: Decodable, CustomStringConvertible {
+    public let code: Int
+    public let status: String // String version of the `code`, e.g. "Bad Request"
+
+    public let message: String
+    
+    public var description: String { message }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
@@ -55,32 +55,6 @@ class ApiRepository {
         token = newToken
     }
     
-    func perform<Request: RestRequest>(
-        _ request: Request,
-        tokenOverride: String? = nil,
-        requiresToken: Bool = true // This should be `true` for the vast majority of requests, even GET requests
-    ) async throws -> Request.Response {
-        guard !requiresToken || username == nil || token != nil else {
-            throw ApiClientError.noToken
-        }
-        
-        let token = tokenOverride ?? token
-        do throws(RestError) {
-            return try await restClient.perform(baseUrl: baseUrl, request, token: token)
-        } catch {
-            switch error {
-            case let RestError.response(response, statusCode: _):
-                if LemmyErrorResponse(error: response).isNotLoggedIn {
-                    throw token == nil ? ApiClientError.notLoggedIn : ApiClientError.invalidSession // (self)
-                } else {
-                    throw ApiClientError(from: error)
-                }
-            default:
-                throw ApiClientError(from: error)
-            }
-        }
-    }
-    
     func getConnection() async throws -> any InstanceConnection {
         try await connectionMultiplexer.getConnection {
             _ = try await getMyInstance()

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository.swift
@@ -24,7 +24,7 @@ class ApiRepository {
     let username: String?
     private var connectionMultiplexer: ConnectionMultiplexer<ConnectionWrapper>!
     
-    let restClient = RestClient(errorType: ApiErrorResponse.self)
+    let restClient = RestClient(errorType: LemmyErrorResponse.self)
     var token: String?
     
     var connection: (any InstanceConnection)? {
@@ -70,7 +70,7 @@ class ApiRepository {
         } catch {
             switch error {
             case let RestError.response(response, statusCode: _):
-                if ApiErrorResponse(error: response).isNotLoggedIn {
+                if LemmyErrorResponse(error: response).isNotLoggedIn {
                     throw token == nil ? ApiClientError.notLoggedIn : ApiClientError.invalidSession // (self)
                 } else {
                     throw ApiClientError(from: error)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/ApiClientError+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/ApiClientError+Lemmy.swift
@@ -1,0 +1,42 @@
+//
+//  ApiClientError+Lemmy.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-01.
+//
+
+import Foundation
+
+extension ApiClientError {
+    init(lemmyMessage: String, statusCode: Int) {
+        self = switch lemmyMessage {
+        case "incorrect_password",
+             "password_incorrect",
+             "incorrect_login",
+             "not_logged_in",
+             "couldnt_find_that_username_or_email":
+            .notLoggedIn
+        case "missing_totp_token",
+             "incorrect_totp_token":
+            .missingTotp
+        case "couldnt_find_person",
+             "couldnt_find_object",
+             "No object found.":
+            .noEntityFound
+        case "instance_is_private":
+            .instanceIsPrivate
+        case "registration_application_is_pending":
+            .applicationPending
+        case "email_not_verified":
+            .emailNotVerified
+        case "not_mod_or_admin":
+            .notModOrAdmin
+        case "not_admin":
+            .notAdmin
+        case "invalid_password":
+            .newPasswordInvalid
+        default:
+            .response(lemmyMessage, statusCode)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ApiClientError+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ApiClientError+PieFed.swift
@@ -1,0 +1,17 @@
+//
+//  ApiClientError+PieFed.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-01.
+//
+
+import Foundation
+
+extension ApiClientError {
+    init(piefedMessage: String, statusCode: Int) {
+        self = switch piefedMessage {
+        default:
+            .response(piefedMessage, statusCode)
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ApiClientError+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/ApiClientError+PieFed.swift
@@ -10,6 +10,8 @@ import Foundation
 extension ApiClientError {
     init(piefedMessage: String, statusCode: Int) {
         self = switch piefedMessage {
+        case "incorrect_login":
+            .notLoggedIn
         default:
             .response(piefedMessage, statusCode)
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Post1Snapshot+PieFed.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PieFedExtensions/Post1Snapshot+PieFed.swift
@@ -29,7 +29,7 @@ public extension Post1Snapshot {
             deleted: post.removed ? false : post.deleted,
             removed: post.removed,
             pinnedCommunity: post.sticky,
-            pinnedInstance: false,
+            pinnedInstance: post.instanceSticky ?? false,
             locked: post.locked
         )
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -112,7 +112,7 @@ public final class UnreadCount {
                     taskGroup.addTask {
                         do {
                             return try await self.api.repository.getReportCount(communityId: nil).unreadCountDictionary
-                        } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
+                        } catch ApiClientError.notModOrAdmin {
                             return [:]
                         }
                     }
@@ -122,7 +122,7 @@ public final class UnreadCount {
                     taskGroup.addTask {
                         do {
                             return try await [.registrationApplication: self.api.getRegistrationApplicationCount()]
-                        } catch let ApiClientError.response(response, _) where response.notAdmin {
+                        } catch ApiClientError.notAdmin {
                             return [:]
                         }
                     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ApplicationChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ApplicationChildFeedLoader.swift
@@ -17,7 +17,7 @@ public class ApplicationChildFeedLoader: ModMailChildFeedLoader {
                     prevCursor: nil,
                     nextCursor: nil
                 )
-            } catch let ApiClientError.response(response, _) where response.notAdmin {
+            } catch ApiClientError.notAdmin {
                 return .init(items: .init(), prevCursor: nil, nextCursor: nil)
             }
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/CommentReportChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/CommentReportChildFeedLoader.swift
@@ -15,7 +15,7 @@ public class CommentReportChildFeedLoader: ModMailChildFeedLoader {
                     prevCursor: nil,
                     nextCursor: nil
                 )
-            } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
+            } catch ApiClientError.notModOrAdmin {
                 return .init(items: .init(), prevCursor: nil, nextCursor: nil)
             }
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/MessageReportChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/MessageReportChildFeedLoader.swift
@@ -17,7 +17,7 @@ public class MessageReportChildFeedLoader: ModMailChildFeedLoader {
                     prevCursor: nil,
                     nextCursor: nil
                 )
-            } catch let ApiClientError.response(response, _) where response.notAdmin {
+            } catch ApiClientError.notAdmin {
                 return .init(items: .init(), prevCursor: nil, nextCursor: nil)
             }
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/PostReportChildFeedLoader.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/PostReportChildFeedLoader.swift
@@ -15,7 +15,7 @@ public class PostReportChildFeedLoader: ModMailChildFeedLoader {
                     prevCursor: nil,
                     nextCursor: nil
                 )
-            } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
+            } catch ApiClientError.notModOrAdmin {
                 return .init(items: .init(), prevCursor: nil, nextCursor: nil)
             }
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Comment.swift
@@ -16,15 +16,11 @@ public extension LemmyConnection {
     }
     
     func getComment(url: URL) async throws -> Comment2Snapshot {
-        do {
-            let result = try await resolve(url: url)
-            switch result {
-            case let .comment(comment):
-                return comment
-            default:
-                throw ApiClientError.noEntityFound
-            }
-        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
+        let result = try await resolve(url: url)
+        switch result {
+        case let .comment(comment):
+            return comment
+        default:
             throw ApiClientError.noEntityFound
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Community.swift
@@ -16,15 +16,11 @@ public extension LemmyConnection {
     }
     
     func getCommunity(url: URL) async throws -> Community2Snapshot {
-        do {
-            let result = try await resolve(url: url)
-            switch result {
-            case let .community(community):
-                return community
-            default:
-                throw ApiClientError.noEntityFound
-            }
-        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
+        let result = try await resolve(url: url)
+        switch result {
+        case let .community(community):
+            return community
+        default:
             throw ApiClientError.noEntityFound
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
@@ -27,10 +27,10 @@ public extension LemmyConnection {
         // I suspect that `registrationCreated` and `verifyEmailSent` can only be true for the `LemmyLoginResponse`
         // that is returned when signing in. Nevertheless, I've included this just in case.
         if response.registrationCreated {
-            throw ApiClientError.response(.init(error: "registration_application_is_pending"), 200)
+            throw ApiClientError.applicationPending
         }
         if response.verifyEmailSent {
-            throw ApiClientError.response(.init(error: "email_not_verified"), 200)
+            throw ApiClientError.emailNotVerified
         }
         
         guard let jwt = response.jwt else {
@@ -122,42 +122,38 @@ public extension LemmyConnection {
     }
     
     func resolve(url: URL) async throws -> ResolvedContent {
-        do {
-            // Fix for https://github.com/mlemgroup/mlem/issues/2341
-            let components = url.pathComponents
-            if url.host == baseUrl.host(), components.count > 2 {
-                switch components[1] {
-                case "c":
-                    let response = try await performingForEndpoint { endpoint in
-                        LemmyGetCommunityRequest(endpoint: endpoint, id: nil, name: components[2])
-                    }
-                    return try .community(.init(from: response.communityView))
-                case "u":
-                    let response = try await performingForEndpoint { endpoint in
-                        LemmyReadPersonRequest(
-                            endpoint: endpoint,
-                            personId: nil,
-                            username: components[2],
-                            sort: nil,
-                            page: 1,
-                            limit: 1,
-                            communityId: nil,
-                            savedOnly: nil
-                        )
-                    }
-                    return try .person(.init(from: response.personView))
-                default:
-                    break
+        // Fix for https://github.com/mlemgroup/mlem/issues/2341
+        let components = url.pathComponents
+        if url.host == baseUrl.host(), components.count > 2 {
+            switch components[1] {
+            case "c":
+                let response = try await performingForEndpoint { endpoint in
+                    LemmyGetCommunityRequest(endpoint: endpoint, id: nil, name: components[2])
                 }
+                return try .community(.init(from: response.communityView))
+            case "u":
+                let response = try await performingForEndpoint { endpoint in
+                    LemmyReadPersonRequest(
+                        endpoint: endpoint,
+                        personId: nil,
+                        username: components[2],
+                        sort: nil,
+                        page: 1,
+                        limit: 1,
+                        communityId: nil,
+                        savedOnly: nil
+                    )
+                }
+                return try .person(.init(from: response.personView))
+            default:
+                break
             }
-            
-            let response = try await performingForEndpoint { endpoint in
-                LemmyResolveObjectRequest(endpoint: endpoint, q: url.absoluteString)
-            }
-            return try .init(from: response)
-        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
-            throw ApiClientError.noEntityFound
         }
+
+        let response = try await performingForEndpoint { endpoint in
+            LemmyResolveObjectRequest(endpoint: endpoint, q: url.absoluteString)
+        }
+        return try .init(from: response)
     }
     
     func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [Instance1Snapshot]) {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Image.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Image.swift
@@ -57,7 +57,7 @@ public extension LemmyConnection {
         let response = try await restClient.execute(request)
         if let response = response.1 as? HTTPURLResponse {
             if response.statusCode != 204 {
-                throw ApiClientError.response(.init(error: "Unexpected status code"), response.statusCode)
+                throw ApiClientError.response("Unexpected status code", response.statusCode)
             }
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Image.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Image.swift
@@ -50,9 +50,9 @@ public extension LemmyConnection {
             }
             throw ApiClientError.decoding(data, nil)
         } catch {
-            if let error = try? decoder.decode(ApiErrorResponse.self, from: data) {
+            if let error = try? decoder.decode(LemmyErrorResponse.self, from: data) {
                 let statusCode = (response as? HTTPURLResponse)?.statusCode
-                throw ApiClientError.response(error, statusCode ?? -1)
+                throw ApiClientError.response(error.error, statusCode ?? -1)
             } else {
                 throw error
             }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
@@ -25,37 +25,29 @@ public extension LemmyConnection {
     }
     
     func getPerson(url: URL) async throws -> Person2Snapshot {
-        do {
-            let result = try await resolve(url: url)
-            switch result {
-            case let .person(person):
-                return person
-            default:
-                throw ApiClientError.noEntityFound
-            }
-        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
+        let result = try await resolve(url: url)
+        switch result {
+        case let .person(person):
+            return person
+        default:
             throw ApiClientError.noEntityFound
         }
     }
     
     func getPerson(username: String) async throws -> Person3Snapshot {
-        do {
-            let response = try await performingForEndpoint { endpoint in
-                LemmyReadPersonRequest(
-                    endpoint: endpoint,
-                    personId: nil,
-                    username: username,
-                    sort: nil,
-                    page: nil,
-                    limit: nil,
-                    communityId: nil,
-                    savedOnly: nil
-                )
-            }
-            return try .init(from: response)
-        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
-            throw ApiClientError.noEntityFound
+        let response = try await performingForEndpoint { endpoint in
+            LemmyReadPersonRequest(
+                endpoint: endpoint,
+                personId: nil,
+                username: username,
+                sort: nil,
+                page: nil,
+                limit: nil,
+                communityId: nil,
+                savedOnly: nil
+            )
         }
+        return try .init(from: response)
     }
     
     /// `filter` can be set to `.local` from 0.19.4 onwards.

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Post.swift
@@ -213,15 +213,11 @@ public extension LemmyConnection {
     }
     
     func getPost(url: URL) async throws -> Post2Snapshot {
-        do {
-            let result = try await resolve(url: url)
-            switch result {
-            case let .post(post):
-                return post
-            default:
-                throw ApiClientError.noEntityFound
-            }
-        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
+        let result = try await resolve(url: url)
+        switch result {
+        case let .post(post):
+            return post
+        default:
             throw ApiClientError.noEntityFound
         }
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection.swift
@@ -13,10 +13,6 @@ public class LemmyConnection: InstanceConnection {
     
     let restClient = RestClient(errorType: LemmyErrorResponse.self)
     
-    enum LemmyConnectionError: Error {
-        case invalidSession
-    }
-    
     struct Context {
         let siteVersion: SiteVersion
         let myPersonId: Int?
@@ -93,16 +89,8 @@ public class LemmyConnection: InstanceConnection {
             )
         } catch {
             switch error {
-            case let RestError.response(response, statusCode: _):
-                if LemmyErrorResponse(error: response).isNotLoggedIn {
-                    if token == nil {
-                        throw ApiClientError.notLoggedIn
-                    } else {
-                        throw LemmyConnectionError.invalidSession
-                    }
-                } else {
-                    throw ApiClientError(from: error)
-                }
+            case let RestError.response(response, statusCode: code):
+                throw ApiClientError(lemmyMessage: response, statusCode: code)
             default:
                 throw ApiClientError(from: error)
             }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection.swift
@@ -11,7 +11,7 @@ import Rest
 public class LemmyConnection: InstanceConnection {
     public static let softwareType: SiteSoftwareType = .lemmy
     
-    let restClient = RestClient(errorType: ApiErrorResponse.self)
+    let restClient = RestClient(errorType: LemmyErrorResponse.self)
     
     enum LemmyConnectionError: Error {
         case invalidSession
@@ -94,7 +94,7 @@ public class LemmyConnection: InstanceConnection {
         } catch {
             switch error {
             case let RestError.response(response, statusCode: _):
-                if ApiErrorResponse(error: response).isNotLoggedIn {
+                if LemmyErrorResponse(error: response).isNotLoggedIn {
                     if token == nil {
                         throw ApiClientError.notLoggedIn
                     } else {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Comment.swift
@@ -15,14 +15,10 @@ public extension PieFedConnection {
     }
     
     func getComment(url: URL) async throws -> Comment2Snapshot {
-        do {
-            let request = PieFedResolveObjectRequest(q: url.absoluteString)
-            let response = try await perform(request)
-            if let comment = response.comment {
-                return try .init(from: comment)
-            }
-        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
-            throw ApiClientError.noEntityFound
+        let request = PieFedResolveObjectRequest(q: url.absoluteString)
+        let response = try await perform(request)
+        if let comment = response.comment {
+            return try .init(from: comment)
         }
         throw ApiClientError.noEntityFound
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Community.swift
@@ -15,14 +15,10 @@ public extension PieFedConnection {
     }
     
     func getCommunity(url: URL) async throws -> Community2Snapshot {
-        do {
-            let request = PieFedResolveObjectRequest(q: url.absoluteString)
-            let response = try await perform(request)
-            if let community = response.community {
-                return try .init(from: community)
-            }
-        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
-            throw ApiClientError.noEntityFound
+        let request = PieFedResolveObjectRequest(q: url.absoluteString)
+        let response = try await perform(request)
+        if let community = response.community {
+            return try .init(from: community)
         }
         throw ApiClientError.noEntityFound
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
@@ -24,14 +24,10 @@ public extension PieFedConnection {
     }
     
     func getPerson(url: URL) async throws -> Person2Snapshot {
-        do {
-            let request = PieFedResolveObjectRequest(q: url.absoluteString)
-            let response = try await perform(request)
-            if let person = response.person {
-                return try .init(from: person)
-            }
-        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
-            throw ApiClientError.noEntityFound
+        let request = PieFedResolveObjectRequest(q: url.absoluteString)
+        let response = try await perform(request)
+        if let person = response.person {
+            return try .init(from: person)
         }
         throw ApiClientError.noEntityFound
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Post.swift
@@ -127,14 +127,10 @@ public extension PieFedConnection {
     }
     
     func getPost(url: URL) async throws -> Post2Snapshot {
-        do {
-            let request = PieFedResolveObjectRequest(q: url.absoluteString)
-            let response = try await perform(request)
-            if let post = response.post {
-                return try .init(from: post)
-            }
-        } catch let ApiClientError.response(response, _) where response.couldntFindObject {
-            throw ApiClientError.noEntityFound
+        let request = PieFedResolveObjectRequest(q: url.absoluteString)
+        let response = try await perform(request)
+        if let post = response.post {
+            return try .init(from: post)
         }
         throw ApiClientError.noEntityFound
     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection.swift
@@ -11,7 +11,7 @@ import Rest
 public class PieFedConnection: InstanceConnection {
     public static let softwareType: SiteSoftwareType = .pieFed
     
-    let restClient = RestClient(errorType: LemmyErrorResponse.self)
+    let restClient = RestClient(errorType: PieFedErrorResponse.self)
     
     enum PieFedConnectionError: Error {
         case invalidSession

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection.swift
@@ -74,16 +74,8 @@ public class PieFedConnection: InstanceConnection {
             return try await restClient.perform(baseUrl: baseUrl, request, token: token)
         } catch {
             switch error {
-            case let RestError.response(response, statusCode: _):
-                if LemmyErrorResponse(error: response).isNotLoggedIn {
-                    if token == nil {
-                        throw ApiClientError.notLoggedIn
-                    } else {
-                        throw PieFedConnectionError.invalidSession
-                    }
-                } else {
-                    throw ApiClientError(from: error)
-                }
+            case let RestError.response(response, statusCode: code):
+                throw ApiClientError(piefedMessage: response, statusCode: code)
             default:
                 throw ApiClientError(from: error)
             }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection.swift
@@ -11,7 +11,7 @@ import Rest
 public class PieFedConnection: InstanceConnection {
     public static let softwareType: SiteSoftwareType = .pieFed
     
-    let restClient = RestClient(errorType: ApiErrorResponse.self)
+    let restClient = RestClient(errorType: LemmyErrorResponse.self)
     
     enum PieFedConnectionError: Error {
         case invalidSession
@@ -75,7 +75,7 @@ public class PieFedConnection: InstanceConnection {
         } catch {
             switch error {
             case let RestError.response(response, statusCode: _):
-                if ApiErrorResponse(error: response).isNotLoggedIn {
+                if LemmyErrorResponse(error: response).isNotLoggedIn {
                     if token == nil {
                         throw ApiClientError.notLoggedIn
                     } else {


### PR DESCRIPTION
`PieFedConnection` was incorrectly using the Lemmy error response schema. It now uses its own PieFed schema.

Fixes #2599

Also fixed instance-pinned posts not showing as pinned on PieFed (closes #2563)