### PR TITLE
Show warning when version is unsupported

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		0325B93A2D3A9E8100E28B97 /* InboxBadgeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325B9392D3A9E8100E28B97 /* InboxBadgeSettingsView.swift */; };
 		0325B93C2D3AA62500E28B97 /* InboxItemType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325B93B2D3AA62500E28B97 /* InboxItemType+Extensions.swift */; };
 		0325B93E2D3AAE9E00E28B97 /* SettingsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325B93D2D3AAE9E00E28B97 /* SettingsHeaderView.swift */; };
+		0325FF302FD40CB4006F8394 /* LoginVersionWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325FF2F2FD40CB4006F8394 /* LoginVersionWarningView.swift */; };
 		03267D822BED489C009D6268 /* AvatarBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03267D812BED489C009D6268 /* AvatarBannerView.swift */; };
 		03267D842BED49CE009D6268 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03267D832BED49CE009D6268 /* AccountSettingsView.swift */; };
 		032A22012EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032A22002EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift */; };
@@ -695,6 +696,7 @@
 		0325B9392D3A9E8100E28B97 /* InboxBadgeSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxBadgeSettingsView.swift; sourceTree = "<group>"; };
 		0325B93B2D3AA62500E28B97 /* InboxItemType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InboxItemType+Extensions.swift"; sourceTree = "<group>"; };
 		0325B93D2D3AAE9E00E28B97 /* SettingsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderView.swift; sourceTree = "<group>"; };
+		0325FF2F2FD40CB4006F8394 /* LoginVersionWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVersionWarningView.swift; sourceTree = "<group>"; };
 		03267D812BED489C009D6268 /* AvatarBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarBannerView.swift; sourceTree = "<group>"; };
 		03267D832BED49CE009D6268 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
 		032A22002EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonContentFeedLoader+Extensions.swift"; sourceTree = "<group>"; };
@@ -2367,6 +2369,7 @@
 				0320B6572C8BB3C400D38548 /* SignUpView+Views.swift */,
 				0320B6662C93504600D38548 /* SignUpView+Logic.swift */,
 				0320B6592C8CBB0D00D38548 /* SignUpView+EmailConfirmationView.swift */,
+				0325FF2F2FD40CB4006F8394 /* LoginVersionWarningView.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -3227,6 +3230,7 @@
 				030050D32D109B7E002B1E99 /* ReportView.swift in Sources */,
 				0397D49A2C6EA6EE002C6CDC /* InteractionBarEditorView.swift in Sources */,
 				03F6BDAF2D516636006A425E /* CommunityMockType.swift in Sources */,
+				0325FF302FD40CB4006F8394 /* LoginVersionWarningView.swift in Sources */,
 				0300309D2C4163C9009A65FF /* CommentTreeTracker.swift in Sources */,
 				03A631CC2D4FD18C009A47A6 /* Post+Mock.swift in Sources */,
 				03FE14082BF94FFB00A8377F /* ErrorView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		0325B93C2D3AA62500E28B97 /* InboxItemType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325B93B2D3AA62500E28B97 /* InboxItemType+Extensions.swift */; };
 		0325B93E2D3AAE9E00E28B97 /* SettingsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325B93D2D3AAE9E00E28B97 /* SettingsHeaderView.swift */; };
 		0325FF302FD40CB4006F8394 /* LoginVersionWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325FF2F2FD40CB4006F8394 /* LoginVersionWarningView.swift */; };
+		0325FF322FD41D58006F8394 /* LoginVersionWarningView+Content.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325FF312FD41D58006F8394 /* LoginVersionWarningView+Content.swift */; };
 		03267D822BED489C009D6268 /* AvatarBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03267D812BED489C009D6268 /* AvatarBannerView.swift */; };
 		03267D842BED49CE009D6268 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03267D832BED49CE009D6268 /* AccountSettingsView.swift */; };
 		032A22012EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032A22002EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift */; };
@@ -697,6 +698,7 @@
 		0325B93B2D3AA62500E28B97 /* InboxItemType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InboxItemType+Extensions.swift"; sourceTree = "<group>"; };
 		0325B93D2D3AAE9E00E28B97 /* SettingsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderView.swift; sourceTree = "<group>"; };
 		0325FF2F2FD40CB4006F8394 /* LoginVersionWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVersionWarningView.swift; sourceTree = "<group>"; };
+		0325FF312FD41D58006F8394 /* LoginVersionWarningView+Content.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginVersionWarningView+Content.swift"; sourceTree = "<group>"; };
 		03267D812BED489C009D6268 /* AvatarBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarBannerView.swift; sourceTree = "<group>"; };
 		03267D832BED49CE009D6268 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
 		032A22002EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonContentFeedLoader+Extensions.swift"; sourceTree = "<group>"; };
@@ -2370,6 +2372,7 @@
 				0320B6662C93504600D38548 /* SignUpView+Logic.swift */,
 				0320B6592C8CBB0D00D38548 /* SignUpView+EmailConfirmationView.swift */,
 				0325FF2F2FD40CB4006F8394 /* LoginVersionWarningView.swift */,
+				0325FF312FD41D58006F8394 /* LoginVersionWarningView+Content.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -2856,6 +2859,7 @@
 				0389DDC52C38917A0005B808 /* InboxItemProviding+Extensions.swift in Sources */,
 				036ED67B2D0B004D0018E5EA /* AdvancedSortView+SortButton.swift in Sources */,
 				CD13CC5B2C588B34001AF428 /* WebView.swift in Sources */,
+				0325FF322FD41D58006F8394 /* LoginVersionWarningView+Content.swift in Sources */,
 				0372EC202D370F0200257095 /* RegistrationApplicationDenialEditorView.swift in Sources */,
 				039EFEC32BEEBEE0003AC372 /* LoginInstancePickerView.swift in Sources */,
 				03AB484F2CBAE33500567FF9 /* MarkdownWithLinkList.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		0325FF302FD40CB4006F8394 /* LoginVersionWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325FF2F2FD40CB4006F8394 /* LoginVersionWarningView.swift */; };
 		0325FF322FD41D58006F8394 /* LoginVersionWarningView+Content.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325FF312FD41D58006F8394 /* LoginVersionWarningView+Content.swift */; };
 		0325FF342FD43068006F8394 /* UnsupportedVersionWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325FF332FD43068006F8394 /* UnsupportedVersionWarningView.swift */; };
+		0325FF362FD433EB006F8394 /* UnsupportedVersionDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325FF352FD433EB006F8394 /* UnsupportedVersionDescriptionView.swift */; };
 		03267D822BED489C009D6268 /* AvatarBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03267D812BED489C009D6268 /* AvatarBannerView.swift */; };
 		03267D842BED49CE009D6268 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03267D832BED49CE009D6268 /* AccountSettingsView.swift */; };
 		032A22012EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032A22002EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift */; };
@@ -701,6 +702,7 @@
 		0325FF2F2FD40CB4006F8394 /* LoginVersionWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVersionWarningView.swift; sourceTree = "<group>"; };
 		0325FF312FD41D58006F8394 /* LoginVersionWarningView+Content.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginVersionWarningView+Content.swift"; sourceTree = "<group>"; };
 		0325FF332FD43068006F8394 /* UnsupportedVersionWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedVersionWarningView.swift; sourceTree = "<group>"; };
+		0325FF352FD433EB006F8394 /* UnsupportedVersionDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedVersionDescriptionView.swift; sourceTree = "<group>"; };
 		03267D812BED489C009D6268 /* AvatarBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarBannerView.swift; sourceTree = "<group>"; };
 		03267D832BED49CE009D6268 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
 		032A22002EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonContentFeedLoader+Extensions.swift"; sourceTree = "<group>"; };
@@ -2045,6 +2047,7 @@
 			isa = PBXGroup;
 			children = (
 				0325FF332FD43068006F8394 /* UnsupportedVersionWarningView.swift */,
+				0325FF352FD433EB006F8394 /* UnsupportedVersionDescriptionView.swift */,
 				03B431C32C45BA45001A1EB5 /* AccountPickerMenu.swift */,
 				CD635E1A2C94DACD00864F75 /* BypassProxyWarningSheet.swift */,
 				0397D45F2C66113F002C6CDC /* CommentBodyView.swift */,
@@ -2924,6 +2927,7 @@
 				CDD4A0A02C8B985D0001AD1A /* ImportExportSettingsView.swift in Sources */,
 				03B431B62C454D49001A1EB5 /* UIImage+Extensions.swift in Sources */,
 				03EC86462E9E9D4D004698BB /* PopupAnchorModel.swift in Sources */,
+				0325FF362FD433EB006F8394 /* UnsupportedVersionDescriptionView.swift in Sources */,
 				CD93420B2DCD069800945333 /* InstanceUptimeView+Logic.swift in Sources */,
 				CD1446212A5B328E00610EF1 /* Privacy Policy.swift in Sources */,
 				03AFD0E32C3C0C540054B8AD /* InstanceView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		0325B93E2D3AAE9E00E28B97 /* SettingsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325B93D2D3AAE9E00E28B97 /* SettingsHeaderView.swift */; };
 		0325FF302FD40CB4006F8394 /* LoginVersionWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325FF2F2FD40CB4006F8394 /* LoginVersionWarningView.swift */; };
 		0325FF322FD41D58006F8394 /* LoginVersionWarningView+Content.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325FF312FD41D58006F8394 /* LoginVersionWarningView+Content.swift */; };
+		0325FF342FD43068006F8394 /* UnsupportedVersionWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0325FF332FD43068006F8394 /* UnsupportedVersionWarningView.swift */; };
 		03267D822BED489C009D6268 /* AvatarBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03267D812BED489C009D6268 /* AvatarBannerView.swift */; };
 		03267D842BED49CE009D6268 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03267D832BED49CE009D6268 /* AccountSettingsView.swift */; };
 		032A22012EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032A22002EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift */; };
@@ -699,6 +700,7 @@
 		0325B93D2D3AAE9E00E28B97 /* SettingsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderView.swift; sourceTree = "<group>"; };
 		0325FF2F2FD40CB4006F8394 /* LoginVersionWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVersionWarningView.swift; sourceTree = "<group>"; };
 		0325FF312FD41D58006F8394 /* LoginVersionWarningView+Content.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginVersionWarningView+Content.swift"; sourceTree = "<group>"; };
+		0325FF332FD43068006F8394 /* UnsupportedVersionWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedVersionWarningView.swift; sourceTree = "<group>"; };
 		03267D812BED489C009D6268 /* AvatarBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarBannerView.swift; sourceTree = "<group>"; };
 		03267D832BED49CE009D6268 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
 		032A22002EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonContentFeedLoader+Extensions.swift"; sourceTree = "<group>"; };
@@ -2042,6 +2044,7 @@
 		CD4D58A82B86BE4C00B82964 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				0325FF332FD43068006F8394 /* UnsupportedVersionWarningView.swift */,
 				03B431C32C45BA45001A1EB5 /* AccountPickerMenu.swift */,
 				CD635E1A2C94DACD00864F75 /* BypassProxyWarningSheet.swift */,
 				0397D45F2C66113F002C6CDC /* CommentBodyView.swift */,
@@ -2789,6 +2792,7 @@
 				035DF9112EB2AA160021DE8C /* PersonContentGridView+FeedLoaderType.swift in Sources */,
 				03E0EF452CA74036002CB66C /* CommentPage.swift in Sources */,
 				030BCB1B2C3EA5FD0037680F /* InstanceDetailsView.swift in Sources */,
+				0325FF342FD43068006F8394 /* UnsupportedVersionWarningView.swift in Sources */,
 				03134A582BEC1C46002662CC /* AccountListSettingsView.swift in Sources */,
 				CDCC1BA72D99BDB7006579DF /* GestureRecognizers.swift in Sources */,
 				03E614E52C0BCCAA00F692A4 /* PostSize.swift in Sources */,

--- a/Mlem/App/Globals/Definitions/AccountsTracker.swift
+++ b/Mlem/App/Globals/Definitions/AccountsTracker.swift
@@ -150,6 +150,7 @@ class AccountsTracker {
             }
             let software = try await authenticatedApiClient.software
             let account = UserAccount(person: person, siteSoftware: software)
+            account.versionWarningIgnored = software.version
             addAccount(account: account)
             return account
         }

--- a/Mlem/App/Models/Account/Account.swift
+++ b/Mlem/App/Models/Account/Account.swift
@@ -19,6 +19,7 @@ protocol Account: AnyObject, Codable, ActorIdentifiable, ProfileProviding, Hasha
     var avatar: URL? { get }
     var activityState: AccountActivityState { get set }
     var accountType: AccountType { get }
+    var versionWarningIgnored: SiteVersion? { get }
     
     // Computed
     var nickname: String { get }

--- a/Mlem/App/Models/Account/Account.swift
+++ b/Mlem/App/Models/Account/Account.swift
@@ -30,7 +30,7 @@ protocol Account: AnyObject, Codable, ActorIdentifiable, ProfileProviding, Hasha
     
     func setNickname(_ newValue: String)
     func updateSoftware(_ software: SiteSoftware)
-    func ignoreVersionWarning()
+    func ignoreVersionWarning(_ ignore: Bool)
 }
 
 enum AccountActivityState: Codable, Hashable {

--- a/Mlem/App/Models/Account/Account.swift
+++ b/Mlem/App/Models/Account/Account.swift
@@ -29,6 +29,7 @@ protocol Account: AnyObject, Codable, ActorIdentifiable, ProfileProviding, Hasha
     var uniqueStringId: String { get }
     
     func setNickname(_ newValue: String)
+    func updateSoftware(_ software: SiteSoftware)
 }
 
 enum AccountActivityState: Codable, Hashable {

--- a/Mlem/App/Models/Account/Account.swift
+++ b/Mlem/App/Models/Account/Account.swift
@@ -30,6 +30,7 @@ protocol Account: AnyObject, Codable, ActorIdentifiable, ProfileProviding, Hasha
     
     func setNickname(_ newValue: String)
     func updateSoftware(_ software: SiteSoftware)
+    func ignoreVersionWarning()
 }
 
 enum AccountActivityState: Codable, Hashable {

--- a/Mlem/App/Models/Account/Account.swift
+++ b/Mlem/App/Models/Account/Account.swift
@@ -74,4 +74,13 @@ extension Account {
     }
     
     var nickname: String { storedNickname ?? name }
+
+    var shouldShowVersionWarning: Bool {
+        guard let siteSoftware, !siteSoftware.isSupported else { return false }
+        if let versionWarningIgnored {
+            return versionWarningIgnored != siteSoftware.version
+        } else {
+            return true
+        }
+    }
 }

--- a/Mlem/App/Models/Account/GuestAccount.swift
+++ b/Mlem/App/Models/Account/GuestAccount.swift
@@ -18,7 +18,7 @@ class GuestAccount: Account {
     var avatar: URL?
     var activityState: AccountActivityState
     let accountType: AccountType = .guest
-    let versionWarningIgnored: SiteVersion?
+    var versionWarningIgnored: SiteVersion?
     
     fileprivate init(url: URL) throws {
         guard let host = url.host() else { throw DecodingError.invalidHost }
@@ -89,6 +89,7 @@ class GuestAccount: Account {
         try container.encode(avatar, forKey: .avatarUrl)
         try container.encode(activityState, forKey: .activityState)
         try container.encode(api.baseUrl, forKey: .instanceLink)
+        try container.encode(versionWarningIgnored, forKey: .versionWarningIgnored)
     }
     
     @MainActor
@@ -112,6 +113,11 @@ class GuestAccount: Account {
             self.siteSoftware = software
             AccountsTracker.main.saveAccounts(ofType: .guest)
         }
+    }
+
+    func ignoreVersionWarning() {
+        self.versionWarningIgnored = self.siteSoftware?.version
+        AccountsTracker.main.saveAccounts(ofType: .guest)
     }
 
     var name: String { actorId.host }

--- a/Mlem/App/Models/Account/GuestAccount.swift
+++ b/Mlem/App/Models/Account/GuestAccount.swift
@@ -18,12 +18,14 @@ class GuestAccount: Account {
     var avatar: URL?
     var activityState: AccountActivityState
     let accountType: AccountType = .guest
+    let versionWarningIgnored: SiteVersion?
     
     fileprivate init(url: URL) throws {
         guard let host = url.host() else { throw DecodingError.invalidHost }
         self.actorId = .instance(host: host)
         self.activityState = .inactive(lastUsed: nil)
         self.api = .getApiClient(url: url, username: nil)
+        self.versionWarningIgnored = nil
     }
   
     // TODO: updated mocks
@@ -43,7 +45,7 @@ class GuestAccount: Account {
     
     enum CodingKeys: String, CodingKey {
         // Keys are named this way to be consistent with the `UserAccount.CodingKey` cases
-        case storedNickname, instanceLink, siteVersion, avatarUrl, lastUsed, activityState, siteSoftware
+        case storedNickname, instanceLink, siteVersion, avatarUrl, lastUsed, activityState, siteSoftware, versionWarningIgnored
     }
     
     enum DecodingError: Error {
@@ -71,6 +73,8 @@ class GuestAccount: Account {
             let lastUsed = try values.decodeIfPresent(Date?.self, forKey: .lastUsed) ?? nil
             self.activityState = .inactive(lastUsed: lastUsed)
         }
+
+        self.versionWarningIgnored = try values.decodeIfPresent(SiteVersion?.self, forKey: .versionWarningIgnored) ?? nil
 
         let actorId = try values.decode(ActorIdentifier.self, forKey: .instanceLink)
         self.actorId = actorId

--- a/Mlem/App/Models/Account/GuestAccount.swift
+++ b/Mlem/App/Models/Account/GuestAccount.swift
@@ -106,7 +106,14 @@ class GuestAccount: Account {
             AccountsTracker.main.saveAccounts(ofType: .guest)
         }
     }
-    
+
+    func updateSoftware(_ software: SiteSoftware) {
+        if self.siteSoftware != software {
+            self.siteSoftware = software
+            AccountsTracker.main.saveAccounts(ofType: .guest)
+        }
+    }
+
     var name: String { actorId.host }
     
     var isActive: Bool { AppState.main.guestSession === self }

--- a/Mlem/App/Models/Account/GuestAccount.swift
+++ b/Mlem/App/Models/Account/GuestAccount.swift
@@ -115,8 +115,8 @@ class GuestAccount: Account {
         }
     }
 
-    func ignoreVersionWarning() {
-        self.versionWarningIgnored = self.siteSoftware?.version
+    func ignoreVersionWarning(_ ignore: Bool) {
+        self.versionWarningIgnored = ignore ? self.siteSoftware?.version : nil
         AccountsTracker.main.saveAccounts(ofType: .guest)
     }
 

--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -192,6 +192,13 @@ class UserAccount: Account, CommunityOrPerson {
             AccountsTracker.main.saveAccounts(ofType: .user)
         }
     }
+
+    func updateSoftware(_ software: SiteSoftware) {
+        if self.siteSoftware != software {
+            self.siteSoftware = software
+            AccountsTracker.main.saveAccounts(ofType: .user)
+        }
+    }
     
     func updateToken(_ newToken: String) {
         api.updateToken(newToken)

--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -141,6 +141,7 @@ class UserAccount: Account, CommunityOrPerson {
         try container.encode(banner, forKey: .banner)
         try container.encode(created, forKey: .created)
         try container.encode(updated, forKey: .updated)
+        try container.encode(versionWarningIgnored, forKey: .versionWarningIgnored)
     }
     
     var keychainId: String {
@@ -198,6 +199,11 @@ class UserAccount: Account, CommunityOrPerson {
             self.siteSoftware = software
             AccountsTracker.main.saveAccounts(ofType: .user)
         }
+    }
+
+    func ignoreVersionWarning() {
+        self.versionWarningIgnored = self.siteSoftware?.version
+        AccountsTracker.main.saveAccounts(ofType: .user)
     }
     
     func updateToken(_ newToken: String) {

--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -24,6 +24,7 @@ class UserAccount: Account, CommunityOrPerson {
     var favorites: Set<Int>
     var visitHistoryEnabled: Bool
     var accountType: AccountType
+    var versionWarningIgnored: SiteVersion?
     var description: String?
     var banner: URL?
     var created: Date?
@@ -41,6 +42,7 @@ class UserAccount: Account, CommunityOrPerson {
         self.favorites = []
         self.visitHistoryEnabled = true
         self.accountType = (person.moderatedCommunities.value_?.isEmpty ?? true) ? .user : .moderator
+        self.versionWarningIgnored = nil
         self.description = person.description
         self.banner = person.banner
         self.created = person.created
@@ -49,7 +51,7 @@ class UserAccount: Account, CommunityOrPerson {
     
     enum CodingKeys: String, CodingKey {
         // These key names don't match the identifiers of their corresponding properties - this is because these key names must match the property names used in SavedAccount pre-1.3 in order to maintain compatibility
-        case id, username, storedNickname, instanceLink, siteVersion, avatarUrl
+        case id, username, storedNickname, instanceLink, siteVersion, avatarUrl, versionWarningIgnored
         case lastUsed, favorites, accountType, visitHistoryEnabled, activityState
         case siteSoftware
         case description, banner, created, updated
@@ -86,6 +88,8 @@ class UserAccount: Account, CommunityOrPerson {
         self.favorites = try values.decodeIfPresent(Set<Int>.self, forKey: .favorites) ?? []
         self.visitHistoryEnabled = try values.decodeIfPresent(Bool.self, forKey: .visitHistoryEnabled) ?? true
         self.accountType = try values.decodeIfPresent(AccountType.self, forKey: .accountType) ?? .user
+
+        self.versionWarningIgnored = try values.decodeIfPresent(SiteVersion?.self, forKey: .versionWarningIgnored) ?? nil
 
         // parse instance link
         let instanceLink = try values.decode(URL.self, forKey: .instanceLink)

--- a/Mlem/App/Models/Account/UserAccount.swift
+++ b/Mlem/App/Models/Account/UserAccount.swift
@@ -201,8 +201,8 @@ class UserAccount: Account, CommunityOrPerson {
         }
     }
 
-    func ignoreVersionWarning() {
-        self.versionWarningIgnored = self.siteSoftware?.version
+    func ignoreVersionWarning(_ ignore: Bool) {
+        self.versionWarningIgnored = ignore ? self.siteSoftware?.version : nil
         AccountsTracker.main.saveAccounts(ofType: .user)
     }
     

--- a/Mlem/App/Models/Session/UserSession.swift
+++ b/Mlem/App/Models/Session/UserSession.swift
@@ -48,6 +48,9 @@ class UserSession: Session {
                 self.blocks = blocks
                 self.instance = instance
             } catch {
+                if let software = try? await self.api.getSoftwareFallback() {
+                    self.account.updateSoftware(software)
+                }
                 handleError(error)
             }
             

--- a/Mlem/App/Utility/Extensions/Content Models/SiteSoftware+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/SiteSoftware+Extensions.swift
@@ -23,13 +23,8 @@ extension SiteSoftware {
     var label: String {
         "\(String(localized: type.label)) \(version)"
     }
-}
 
-extension SiteSoftwareType {
-    var label: LocalizedStringResource {
-        switch self {
-        case .lemmy: "Lemmy"
-        case .pieFed: "PieFed"
-        }
+    var isSupported: Bool {
+        version >= type.minimumSupportedVersion
     }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/SiteSoftwareType+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/SiteSoftwareType+Extensions.swift
@@ -9,6 +9,13 @@ import Foundation
 import MlemMiddleware
 
 extension SiteSoftwareType {
+    var label: LocalizedStringResource {
+        switch self {
+        case .lemmy: "Lemmy"
+        case .pieFed: "PieFed"
+        }
+    }
+
     var minimumSupportedVersion: SiteVersion {
         switch self {
         case .lemmy: .init("0.19.0")

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -104,6 +104,11 @@ struct ContentView: View {
                         }
                     }
                 }
+                .onChange(of: appState.firstAccount.shouldShowVersionWarning, initial: true) {
+                    if appState.firstAccount.shouldShowVersionWarning, navigationModel.layers.isEmpty {
+                        navigationModel.openSheet(.unsupportedVersion(appState.firstAccount))
+                    }
+                }
                 .onChange(of: scenePhase) {
                     if scenePhase == .active {
                         eventsTracker.refreshIfStale()

--- a/Mlem/App/Views/Root/Login/LoginInstancePickerView.swift
+++ b/Mlem/App/Views/Root/Login/LoginInstancePickerView.swift
@@ -182,16 +182,25 @@ struct LoginInstancePickerView: View {
     func connectionTask(url: URL) async {
         let apiClient = ApiClient.getApiClient(url: url, username: nil)
         do {
-            let instance = try await apiClient.getMyInstance()
-
-            let software = try instance.software.tryValue
             let page: LoginPage
 
-            if software.isSupported {
-                page = .instance(instance)
-            } else {
-                page = .unsupportedVersion(host: instance.host, software: software)
+            do {
+                let instance = try await apiClient.getMyInstance()
+                let software = try instance.software.tryValue
+
+                if software.isSupported {
+                    page = .instance(instance)
+                } else {
+                    page = .unsupportedVersion(host: instance.host, software: software)
+                }
+            } catch {
+                if let software = try? await apiClient.getSoftwareFallback(), !software.isSupported, let host = url.host() {
+                    page = .unsupportedVersion(host: host, software: software)
+                } else {
+                    throw error
+                }
             }
+
             navigation.push(.logIn(page))
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 connecting = false

--- a/Mlem/App/Views/Root/Login/LoginInstancePickerView.swift
+++ b/Mlem/App/Views/Root/Login/LoginInstancePickerView.swift
@@ -183,7 +183,16 @@ struct LoginInstancePickerView: View {
         let apiClient = ApiClient.getApiClient(url: url, username: nil)
         do {
             let instance = try await apiClient.getMyInstance()
-            navigation.push(.logIn(.instance(instance)))
+
+            let software = try instance.software.tryValue
+            let page: LoginPage
+
+            if software.isSupported {
+                page = .instance(instance)
+            } else {
+                page = .unsupportedVersion(host: instance.host, software: software)
+            }
+            navigation.push(.logIn(page))
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 connecting = false
             }

--- a/Mlem/App/Views/Root/Login/LoginInstancePickerView.swift
+++ b/Mlem/App/Views/Root/Login/LoginInstancePickerView.swift
@@ -159,6 +159,7 @@ struct LoginInstancePickerView: View {
         return Color.clear
     }
     
+    @MainActor
     func attemptToConnect() {
         guard !connecting else { return }
         var domain = domain
@@ -169,27 +170,27 @@ struct LoginInstancePickerView: View {
             focused = false
             connecting = true
             let fetchTask = Task {
-                let apiClient = ApiClient.getApiClient(url: url, username: nil)
-                do {
-                    let instance = try await apiClient.getMyInstance()
-                    Task { @MainActor in
-                        navigation.push(.logIn(.instance(instance)))
-                    }
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        connecting = false
-                    }
-                } catch {
-                    handleError(error, silent: true)
-                    Task { @MainActor in
-                        connecting = false
-                        invalidInstance = true
-                    }
-                }
+                await connectionTask(url: url)
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
                 fetchTask.cancel()
                 invalidInstance = true
             }
+        }
+    }
+
+    func connectionTask(url: URL) async {
+        let apiClient = ApiClient.getApiClient(url: url, username: nil)
+        do {
+            let instance = try await apiClient.getMyInstance()
+            navigation.push(.logIn(.instance(instance)))
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                connecting = false
+            }
+        } catch {
+            handleError(error, silent: true)
+            connecting = false
+            invalidInstance = true
         }
     }
     

--- a/Mlem/App/Views/Root/Login/LoginInstancePickerView.swift
+++ b/Mlem/App/Views/Root/Login/LoginInstancePickerView.swift
@@ -191,11 +191,11 @@ struct LoginInstancePickerView: View {
                 if software.isSupported {
                     page = .instance(instance)
                 } else {
-                    page = .unsupportedVersion(host: instance.host, software: software)
+                    page = .unsupportedVersion(.resolvedInstance(instance))
                 }
             } catch {
                 if let software = try? await apiClient.getSoftwareFallback(), !software.isSupported, let host = url.host() {
-                    page = .unsupportedVersion(host: host, software: software)
+                    page = .unsupportedVersion(.unresolvedInstance(host: host, software: software))
                 } else {
                     throw error
                 }

--- a/Mlem/App/Views/Root/Login/LoginVersionWarningView+Content.swift
+++ b/Mlem/App/Views/Root/Login/LoginVersionWarningView+Content.swift
@@ -26,5 +26,12 @@ extension LoginVersionWarningView {
             case let .unresolvedInstance(host: _, software: software): software
             }
         }
+
+        var instance: Instance? {
+            switch self {
+            case let .resolvedInstance(instance): instance
+            case .unresolvedInstance: nil
+            }
+        }
     }
 }

--- a/Mlem/App/Views/Root/Login/LoginVersionWarningView+Content.swift
+++ b/Mlem/App/Views/Root/Login/LoginVersionWarningView+Content.swift
@@ -1,0 +1,30 @@
+//
+//  LoginVersionWarningView+Context.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-06.
+//
+
+import MlemMiddleware
+import SwiftUI
+
+extension LoginVersionWarningView {
+    enum Content: Hashable {
+        case resolvedInstance(Instance)
+        case unresolvedInstance(host: String, software: SiteSoftware)
+
+        var host: String {
+            switch self {
+            case let .resolvedInstance(instance): instance.host
+            case let .unresolvedInstance(host: host, software: _): host
+            }
+        }
+
+        var software: SiteSoftware? {
+            switch self {
+            case let .resolvedInstance(instance): instance.software.value
+            case let .unresolvedInstance(host: _, software: software): software
+            }
+        }
+    }
+}

--- a/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
+++ b/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
@@ -28,15 +28,7 @@ struct LoginVersionWarningView: View {
                     .fontWeight(.semibold)
                     .padding(.bottom, 5)
 
-                Text(
-                    """
-                    \(host) is running \(software.label), and Mlem requires \(minimumSoftware.label) or later.
-
-                    Consider choosing another instance, or asking your server administrators to upgrade.
-
-                    You can choose to continue anyway, but some features may not work on this version.
-                    """
-                )
+                Text(bodyText)
             }
             .padding(.horizontal, 16)
         }
@@ -47,6 +39,16 @@ struct LoginVersionWarningView: View {
                 Button("Continue Anyway") {}
             }
         }
+    }
+
+    var bodyText: String {
+        """
+        \(host) is running \(software.label), and Mlem requires \(minimumSoftware.label) or later.
+
+        Consider choosing another instance, or asking your server administrators to upgrade.
+
+        You can choose to continue anyway, but some features may not work on this version.
+        """
     }
 
     var minimumSoftware: SiteSoftware {

--- a/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
+++ b/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
@@ -14,18 +14,23 @@ struct LoginVersionWarningView: View {
 
     var body: some View {
         ScrollView {
-            VStack {
-                Image(icon: .lemmy.versionSort)
+            VStack(alignment: .leading) {
+                Image(systemName: "xmark")
                     .resizable()
+                    .symbolVariant(.square.fill)
                     .aspectRatio(contentMode: .fit)
-                    .frame(height: 100)
+                    .frame(height: 70)
+                    .foregroundStyle(.themedColorfulAccent(5))
+                    .padding(.top, 16)
 
                 Text("\(host) is unsupported")
                     .font(.title)
+                    .fontWeight(.semibold)
+                    .padding(.bottom, 5)
 
                 Text(
                     """
-                     \(host) is running \(software.label), and Mlem requires \(minimumSoftware.label) or later.
+                    \(host) is running \(software.label), and Mlem requires \(minimumSoftware.label) or later.
 
                     Consider choosing another instance, or asking your server administrators to upgrade.
 
@@ -33,8 +38,10 @@ struct LoginVersionWarningView: View {
                     """
                 )
             }
+            .padding(.horizontal, 16)
         }
-        .background(.themedSecondaryGroupedBackground)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.themedGroupedBackground)
         .toolbar {
             ToolbarItem(placement: .bottomBar) {
                 Button("Continue Anyway") {}

--- a/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
+++ b/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
@@ -15,24 +15,11 @@ struct LoginVersionWarningView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading) {
-                Image(systemName: "xmark")
-                    .resizable()
-                    .symbolVariant(.square.fill)
-                    .aspectRatio(contentMode: .fit)
-                    .frame(height: 70)
-                    .foregroundStyle(.themedColorfulAccent(5))
-                    .padding(.top, 16)
-
-                Text("\(content.host) is unsupported")
-                    .font(.title)
-                    .fontWeight(.semibold)
-                    .padding(.bottom, 5)
-                if let software = content.software {
-                    Text(bodyText(software: software))
-                }
-            }
-            .padding(.horizontal, 16)
+            UnsupportedVersionDescriptionView(
+                host: content.host,
+                software: content.software,
+                offerContinuation: content.instance != nil
+            )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.themedGroupedBackground)
@@ -45,26 +32,5 @@ struct LoginVersionWarningView: View {
                 }
             }
         }
-    }
-
-    func bodyText(software: SiteSoftware) -> String {
-        var result = String(localized: """
-                                       \(content.host) is running \(software.label), \
-                                       and Mlem requires \(minimumSoftware(type: software.type).label) or later.
-                                       """)
-        result += "\n\n"
-        result += .init(localized: "Consider choosing another instance, or asking your server administrators to upgrade.")
-        if content.instance != nil {
-            result += "\n\n"
-            result += .init(localized: "You can choose to continue anyway, but some features may not work on this version.")
-        }
-        return result
-    }
-
-    func minimumSoftware(type: SiteSoftwareType) -> SiteSoftware {
-        .init(
-            type: type,
-            version: type.minimumSupportedVersion
-        )
     }
 }

--- a/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
+++ b/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
@@ -9,6 +9,8 @@ import MlemMiddleware
 import SwiftUI
 
 struct LoginVersionWarningView: View {
+    @Environment(\.navigation) var navigation
+
     let content: Content
 
     var body: some View {
@@ -35,18 +37,27 @@ struct LoginVersionWarningView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.themedGroupedBackground)
         .toolbar {
-            ToolbarItem(placement: .bottomBar) {
-                Button("Continue Anyway") {}
+            if let instance = content.instance {
+                ToolbarItem(placement: .bottomBar) {
+                    Button("Continue Anyway") {
+                        navigation?.push(.logIn(.instance(instance)))
+                    }
+                }
             }
         }
     }
 
     func bodyText(software: SiteSoftware) -> String {
-        var result = String(localized: "\(content.host) is running \(software.label), and Mlem requires \(minimumSoftware(type: software.type).label) or later.")
+        var result = String(localized: """
+                                       \(content.host) is running \(software.label), \
+                                       and Mlem requires \(minimumSoftware(type: software.type).label) or later.
+                                       """)
         result += "\n\n"
         result += .init(localized: "Consider choosing another instance, or asking your server administrators to upgrade.")
-        result += "\n\n"
-        result += .init(localized: "You can choose to continue anyway, but some features may not work on this version.")
+        if content.instance != nil {
+            result += "\n\n"
+            result += .init(localized: "You can choose to continue anyway, but some features may not work on this version.")
+        }
         return result
     }
 

--- a/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
+++ b/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
@@ -1,0 +1,51 @@
+//
+//  LoginVersionWarningView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-06.
+//
+
+import MlemMiddleware
+import SwiftUI
+
+struct LoginVersionWarningView: View {
+    let host: String
+    let software: SiteSoftware
+
+    var body: some View {
+        ScrollView {
+            VStack {
+                Image(icon: .lemmy.versionSort)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 100)
+
+                Text("\(host) is unsupported")
+                    .font(.title)
+
+                Text(
+                    """
+                     \(host) is running \(software.label), and Mlem requires \(minimumSoftware.label) or later.
+
+                    Consider choosing another instance, or asking your server administrators to upgrade.
+
+                    You can choose to continue anyway, but some features may not work on this version.
+                    """
+                )
+            }
+        }
+        .background(.themedSecondaryGroupedBackground)
+        .toolbar {
+            ToolbarItem(placement: .bottomBar) {
+                Button("Continue Anyway") {}
+            }
+        }
+    }
+
+    var minimumSoftware: SiteSoftware {
+        .init(
+            type: software.type,
+            version: software.type.minimumSupportedVersion
+        )
+    }
+}

--- a/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
+++ b/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
@@ -20,6 +20,7 @@ struct LoginVersionWarningView: View {
                 software: content.software,
                 offerContinuation: content.instance != nil
             )
+            .padding(16)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.themedGroupedBackground)

--- a/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
+++ b/Mlem/App/Views/Root/Login/LoginVersionWarningView.swift
@@ -9,8 +9,7 @@ import MlemMiddleware
 import SwiftUI
 
 struct LoginVersionWarningView: View {
-    let host: String
-    let software: SiteSoftware
+    let content: Content
 
     var body: some View {
         ScrollView {
@@ -23,12 +22,13 @@ struct LoginVersionWarningView: View {
                     .foregroundStyle(.themedColorfulAccent(5))
                     .padding(.top, 16)
 
-                Text("\(host) is unsupported")
+                Text("\(content.host) is unsupported")
                     .font(.title)
                     .fontWeight(.semibold)
                     .padding(.bottom, 5)
-
-                Text(bodyText)
+                if let software = content.software {
+                    Text(bodyText(software: software))
+                }
             }
             .padding(.horizontal, 16)
         }
@@ -41,20 +41,19 @@ struct LoginVersionWarningView: View {
         }
     }
 
-    var bodyText: String {
-        """
-        \(host) is running \(software.label), and Mlem requires \(minimumSoftware.label) or later.
-
-        Consider choosing another instance, or asking your server administrators to upgrade.
-
-        You can choose to continue anyway, but some features may not work on this version.
-        """
+    func bodyText(software: SiteSoftware) -> String {
+        var result = String(localized: "\(content.host) is running \(software.label), and Mlem requires \(minimumSoftware(type: software.type).label) or later.")
+        result += "\n\n"
+        result += .init(localized: "Consider choosing another instance, or asking your server administrators to upgrade.")
+        result += "\n\n"
+        result += .init(localized: "You can choose to continue anyway, but some features may not work on this version.")
+        return result
     }
 
-    var minimumSoftware: SiteSoftware {
+    func minimumSoftware(type: SiteSoftwareType) -> SiteSoftware {
         .init(
-            type: software.type,
-            version: software.type.minimumSupportedVersion
+            type: type,
+            version: type.minimumSupportedVersion
         )
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/DeveloperSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/DeveloperSettingsView.swift
@@ -16,6 +16,7 @@ import Theming
 // be burdening translators with these when they'll never be used
 
 struct DeveloperSettingsView: View {
+    @Environment(AppState.self) var appState
     @Environment(BackendClient.self) var backendClient
     @Environment(EventsTracker.self) var eventsTracker
     
@@ -93,6 +94,10 @@ struct DeveloperSettingsView: View {
                     
                     Button(String("Reset Feed TestFlight Banner")) {
                         lastTestFlightUpdate = nil
+                    }
+
+                    Button(String("Reset Version Warning")) {
+                        appState.firstAccount.ignoreVersionWarning(false)
                     }
                 
                     Button(String("Create Error")) {

--- a/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
@@ -151,13 +151,27 @@ extension AccountListView {
     func fetchUnreadCounts() {
         for account in accountsTracker.allAccounts {
             Task {
-                let startTime = Date.now
-                let unreadCount = try? await account.api.getUnreadCount(alwaysMakeCalls: true)
-                self.unreadCountResponses[account.actorId] = .init(
-                    unreadCount: unreadCount,
-                    responseTime: Date.now.timeIntervalSince(startTime)
-                )
+                do {
+                    async let response = fetchVersionNumber(account: account)
+                    let unreadCount = try await account.api.getUnreadCount(alwaysMakeCalls: true)
+                    let (software, responseTime) = try await response
+                    account.updateSoftware(software)
+
+                    self.unreadCountResponses[account.actorId] = .init(
+                        unreadCount: unreadCount,
+                        responseTime: responseTime
+                    )
+                } catch {
+                    handleError(error, silent: true)
+                }
             }
         }
+    }
+
+    func fetchVersionNumber(account: any Account) async throws -> (SiteSoftware, TimeInterval) {
+        let startTime = Date.now
+        let software = try await account.api.getSoftwareFallback()
+        let interval = Date.now.timeIntervalSince(startTime)
+        return (software, interval)
     }
 }

--- a/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
@@ -153,7 +153,7 @@ extension AccountListView {
             Task {
                 do {
                     async let response = fetchVersionNumber(account: account)
-                    let unreadCount = try await account.api.getUnreadCount(alwaysMakeCalls: true)
+                    let unreadCount = try? await account.api.getUnreadCount()
                     let (software, responseTime) = try await response
                     account.updateSoftware(software)
 
@@ -162,7 +162,7 @@ extension AccountListView {
                         responseTime: responseTime
                     )
                 } catch {
-                    handleError(error, silent: true)
+                    handleError(error)
                 }
             }
         }

--- a/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
+++ b/Mlem/App/Views/Shared/Accounts/AccountListView+Logic.swift
@@ -162,7 +162,7 @@ extension AccountListView {
                         responseTime: responseTime
                     )
                 } catch {
-                    handleError(error)
+                    handleError(error, silent: true)
                 }
             }
         }

--- a/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
@@ -80,7 +80,7 @@ struct AccountListRowBody: View {
 
         // The unreadCount check ensures that we are not showing stale data.
         // Once the unread count has been fetched, the version will have been updated.
-        if let software = account.siteSoftware, !software.isSupported, unreadCount != nil {
+        if let software = account.siteSoftware, !software.isSupported, responseTime != nil {
             var str = AttributedString(localized: "Unsupported")
             str.foregroundColor = ThemedColor.themedWarning.resolve(with: palette)
             output.append(str)

--- a/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
@@ -66,18 +66,18 @@ struct AccountListRowBody: View {
         }
     }
     
-    var captionText: String? {
-        var output: [String] = []
+    var captionText: AttributedString? {
+        var output: [AttributedString] = []
         if complications.contains(.instance) {
             if account is GuestAccount {
                 output.append(.init(localized: "Guest"))
             } else {
-                output.append("@\(account.api.host)")
+                output.append(.init("@\(account.api.host)"))
             }
         }
         if complications.contains(.lastUsed), let timeText {
             if (account as? GuestAccount)?.isSaved ?? true {
-                output.append(timeText)
+                output.append(.init(timeText))
             } else {
                 output.append(.init(localized: "Temporary"))
             }
@@ -87,9 +87,17 @@ struct AccountListRowBody: View {
             let formatter = MeasurementFormatter()
             formatter.unitOptions = .providedUnit
             formatter.unitStyle = .short
-            output.append(formatter.string(from: measurement))
+            output.append(.init(formatter.string(from: measurement)))
         }
-        return output.joined(separator: " • ")
+
+        var result = AttributedString()
+        for (index, item) in output.enumerated() {
+            result += item
+            if index < output.count - 1 {
+                result += AttributedString(" • ")
+            }
+        }
+        return result
     }
 }
 

--- a/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
@@ -78,7 +78,7 @@ struct AccountListRowBody: View {
             }
         }
 
-        // The unreadCount check ensures that we are not showing stale data.
+        // The responseTime check ensures that we are not showing stale data.
         // Once the unread count has been fetched, the version will have been updated.
         if let software = account.siteSoftware, !software.isSupported, responseTime != nil {
             var str = AttributedString(localized: "Unsupported")

--- a/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
@@ -7,9 +7,11 @@
 
 import NukeUI
 import SwiftUI
+import Theming
 
 struct AccountListRowBody: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.palette) var palette
     
     enum Complication: CaseIterable {
         case instance, lastUsed, responseTime, isActive, unreadCount
@@ -75,19 +77,26 @@ struct AccountListRowBody: View {
                 output.append(.init("@\(account.api.host)"))
             }
         }
-        if complications.contains(.lastUsed), let timeText {
-            if (account as? GuestAccount)?.isSaved ?? true {
-                output.append(.init(timeText))
-            } else {
-                output.append(.init(localized: "Temporary"))
+
+        if let software = account.siteSoftware, !software.isSupported {
+            var str = AttributedString(localized: "Unsupported")
+            str.foregroundColor = ThemedColor.themedWarning.resolve(with: palette)
+            output.append(str)
+        } else {
+            if complications.contains(.lastUsed), let timeText {
+                if (account as? GuestAccount)?.isSaved ?? true {
+                    output.append(.init(timeText))
+                } else {
+                    output.append(.init(localized: "Temporary"))
+                }
             }
-        }
-        if complications.contains(.responseTime), let responseTime {
-            let measurement = Measurement(value: Double(Int(responseTime * 1000)), unit: UnitDuration.milliseconds)
-            let formatter = MeasurementFormatter()
-            formatter.unitOptions = .providedUnit
-            formatter.unitStyle = .short
-            output.append(.init(formatter.string(from: measurement)))
+            if complications.contains(.responseTime), let responseTime {
+                let measurement = Measurement(value: Double(Int(responseTime * 1000)), unit: UnitDuration.milliseconds)
+                let formatter = MeasurementFormatter()
+                formatter.unitOptions = .providedUnit
+                formatter.unitStyle = .short
+                output.append(.init(formatter.string(from: measurement)))
+            }
         }
 
         var result = AttributedString()

--- a/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
+++ b/Mlem/App/Views/Shared/ListRow/AccountListRowBody.swift
@@ -78,7 +78,9 @@ struct AccountListRowBody: View {
             }
         }
 
-        if let software = account.siteSoftware, !software.isSupported {
+        // The unreadCount check ensures that we are not showing stale data.
+        // Once the unread count has been fetched, the version will have been updated.
+        if let software = account.siteSoftware, !software.isSupported, unreadCount != nil {
             var str = AttributedString(localized: "Unsupported")
             str.foregroundColor = ThemedColor.themedWarning.resolve(with: palette)
             output.append(str)

--- a/Mlem/App/Views/Shared/Navigation/LoginPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/LoginPage.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 enum LoginPage: Hashable {
     case pickInstance
+    case unsupportedVersion(host: String, software: SiteSoftware)
     case instance(_ instance: Instance)
     case reauth(_ account: UserAccount)
     case totp(client: ApiClient, usernameOrEmail: String, password: String)
@@ -19,6 +20,8 @@ enum LoginPage: Hashable {
         switch self {
         case .pickInstance:
             LoginInstancePickerView()
+        case let .unsupportedVersion(host: host, software: software):
+            Text(host)
         case let .instance(instance):
             LoginCredentialsView(instance: instance)
         case let .reauth(account):
@@ -45,6 +48,10 @@ enum LoginPage: Hashable {
     
     func hash(into hasher: inout Hasher) {
         switch self {
+        case let .unsupportedVersion(host: host, software: software):
+            hasher.combine("unsupported version")
+            hasher.combine(host)
+            hasher.combine(software)
         case .pickInstance:
             hasher.combine("pickInstance")
         case .totp:

--- a/Mlem/App/Views/Shared/Navigation/LoginPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/LoginPage.swift
@@ -15,7 +15,7 @@ enum LoginPage: Hashable {
     case reauth(_ account: UserAccount)
     case totp(client: ApiClient, usernameOrEmail: String, password: String)
     
-    @ViewBuilder
+    @MainActor @ViewBuilder
     func view() -> some View {
         switch self {
         case .pickInstance:

--- a/Mlem/App/Views/Shared/Navigation/LoginPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/LoginPage.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 enum LoginPage: Hashable {
     case pickInstance
-    case unsupportedVersion(host: String, software: SiteSoftware)
+    case unsupportedVersion(LoginVersionWarningView.Content)
     case instance(_ instance: Instance)
     case reauth(_ account: UserAccount)
     case totp(client: ApiClient, usernameOrEmail: String, password: String)
@@ -20,8 +20,8 @@ enum LoginPage: Hashable {
         switch self {
         case .pickInstance:
             LoginInstancePickerView()
-        case let .unsupportedVersion(host: host, software: software):
-            LoginVersionWarningView(host: host, software: software)
+        case let .unsupportedVersion(content):
+            LoginVersionWarningView(content: content)
         case let .instance(instance):
             LoginCredentialsView(instance: instance)
         case let .reauth(account):
@@ -48,10 +48,9 @@ enum LoginPage: Hashable {
     
     func hash(into hasher: inout Hasher) {
         switch self {
-        case let .unsupportedVersion(host: host, software: software):
+        case let .unsupportedVersion(content):
             hasher.combine("unsupported version")
-            hasher.combine(host)
-            hasher.combine(software)
+            hasher.combine(content)
         case .pickInstance:
             hasher.combine("pickInstance")
         case .totp:

--- a/Mlem/App/Views/Shared/Navigation/LoginPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/LoginPage.swift
@@ -21,7 +21,7 @@ enum LoginPage: Hashable {
         case .pickInstance:
             LoginInstancePickerView()
         case let .unsupportedVersion(host: host, software: software):
-            Text(host)
+            LoginVersionWarningView(host: host, software: software)
         case let .instance(instance):
             LoginCredentialsView(instance: instance)
         case let .reauth(account):

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 extension NavigationPage {
 
-    @ViewBuilder
+    @MainActor @ViewBuilder
     func sheetView(selectedDetent: Binding<PresentationDetent>) -> some View {
         if let presentationDetentConfiguration {
             view()
@@ -23,7 +23,7 @@ extension NavigationPage {
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
-    @ViewBuilder func view() -> some View {
+    @MainActor @ViewBuilder func view() -> some View {
         switch self {
         case .subscriptionList:
             SubscriptionListView()

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -246,6 +246,8 @@ extension NavigationPage {
             )
         case .unavailableContentInfo:
             UnavailableContentInfoView()
+        case let .unsupportedVersion(account):
+            UnsupportedVersionWarningView(account: account.wrappedValue)
         }
     }
 }

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -92,6 +92,7 @@ enum NavigationPage: Hashable {
     case exportPostImage(_ post: Post)
     case exportCommentImage(_ comment: Comment, tracker: CommentTreeTracker?)
     case unavailableContentInfo
+    case unsupportedVersion(_ account: AccountHashWrapper)
 
     // If `configuration` is specified, show a "customise" button in the sheet for editing that configuration.
     // Otherwise, no "customise" button is shown.
@@ -289,6 +290,10 @@ enum NavigationPage: Hashable {
         advancedSorting(.init(wrappedValue: sort))
     }
 
+    static func unsupportedVersion(_ account: any Account) -> NavigationPage {
+        unsupportedVersion(.init(wrappedValue: account))
+    }
+
     static func actionSheet(
         _ actions: [ActionSheetSection],
         environment: EnvironmentValues,
@@ -331,6 +336,18 @@ struct HashWrapper<Value>: Hashable, Identifiable {
     
     static func == (lhs: HashWrapper, rhs: HashWrapper) -> Bool {
         lhs.id == rhs.id
+    }
+}
+
+struct AccountHashWrapper: Hashable {
+    var wrappedValue: any Account
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(wrappedValue.hashValue)
+    }
+    
+    static func == (lhs: AccountHashWrapper, rhs: AccountHashWrapper) -> Bool {
+        lhs.hashValue == rhs.hashValue
     }
 }
 

--- a/Mlem/App/Views/Shared/UnsupportedVersionDescriptionView.swift
+++ b/Mlem/App/Views/Shared/UnsupportedVersionDescriptionView.swift
@@ -21,7 +21,6 @@ struct UnsupportedVersionDescriptionView: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(height: 70)
                 .foregroundStyle(.themedColorfulAccent(5))
-                .padding(.top, 16)
 
             Text("\(host) is unsupported")
                 .font(.title)
@@ -31,7 +30,6 @@ struct UnsupportedVersionDescriptionView: View {
                 Text(bodyText(software: software))
             }
         }
-        .padding(.horizontal, 16)
     }
 
     func bodyText(software: SiteSoftware) -> String {

--- a/Mlem/App/Views/Shared/UnsupportedVersionDescriptionView.swift
+++ b/Mlem/App/Views/Shared/UnsupportedVersionDescriptionView.swift
@@ -1,0 +1,57 @@
+//
+//  UnsupportedVersionDescriptionView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-06.
+//
+
+import MlemMiddleware
+import SwiftUI
+
+struct UnsupportedVersionDescriptionView: View {
+    let host: String
+    let software: SiteSoftware?
+    let offerContinuation: Bool
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Image(systemName: "xmark")
+                .resizable()
+                .symbolVariant(.square.fill)
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 70)
+                .foregroundStyle(.themedColorfulAccent(5))
+                .padding(.top, 16)
+
+            Text("\(host) is unsupported")
+                .font(.title)
+                .fontWeight(.semibold)
+                .padding(.bottom, 5)
+            if let software {
+                Text(bodyText(software: software))
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+
+    func bodyText(software: SiteSoftware) -> String {
+        var result = String(localized: """
+                                       \(host) is running \(software.label), \
+                                       and Mlem requires \(minimumSoftware(type: software.type).label) or later.
+                                       """)
+        result += "\n\n"
+        result += .init(localized: "Consider choosing another instance, or asking your server administrators to upgrade.")
+        if offerContinuation {
+            result += "\n\n"
+            result += .init(localized: "You can choose to continue anyway, but some features may not work on this version.")
+        }
+        return result
+    }
+
+    func minimumSoftware(type: SiteSoftwareType) -> SiteSoftware {
+        .init(
+            type: type,
+            version: type.minimumSupportedVersion
+        )
+    }
+}

--- a/Mlem/App/Views/Shared/UnsupportedVersionWarningView.swift
+++ b/Mlem/App/Views/Shared/UnsupportedVersionWarningView.swift
@@ -15,7 +15,7 @@ struct UnsupportedVersionWarningView: View {
             Text("Unsupported")
         }
         .onDisappear {
-            account.ignoreVersionWarning()
+            account.ignoreVersionWarning(true)
         }
     }
 }

--- a/Mlem/App/Views/Shared/UnsupportedVersionWarningView.swift
+++ b/Mlem/App/Views/Shared/UnsupportedVersionWarningView.swift
@@ -11,6 +11,11 @@ struct UnsupportedVersionWarningView: View {
     let account: any Account
 
     var body: some View {
-        Text("Unsupported")
+        VStack {
+            Text("Unsupported")
+        }
+        .onDisappear {
+            account.ignoreVersionWarning()
+        }
     }
 }

--- a/Mlem/App/Views/Shared/UnsupportedVersionWarningView.swift
+++ b/Mlem/App/Views/Shared/UnsupportedVersionWarningView.swift
@@ -5,24 +5,41 @@
 //  Created by Sjmarf on 2026-06-06.
 //
 
+import ComponentViews
 import MlemMiddleware
 import SwiftUI
 
 struct UnsupportedVersionWarningView: View {
+    @Environment(\.dismiss) var dismiss
+
     let account: any Account
 
     var body: some View {
         ScrollView {
-            UnsupportedVersionDescriptionView(
-                host: account.host,
-                software: account.siteSoftware,
-                offerContinuation: true
-            )
+            VStack(alignment: .leading) {
+                UnsupportedVersionDescriptionView(
+                    host: account.host,
+                    software: account.siteSoftware,
+                    offerContinuation: true
+                )
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Continue")
+                        .padding(.horizontal, 15)
+                        .padding(.vertical, 5)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding(16)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.themedGroupedBackground)
         .onDisappear {
             account.ignoreVersionWarning(true)
+        }
+        .toolbar {
+            CloseButtonToolbarItem(ios18Label: .xmark)
         }
     }
 }

--- a/Mlem/App/Views/Shared/UnsupportedVersionWarningView.swift
+++ b/Mlem/App/Views/Shared/UnsupportedVersionWarningView.swift
@@ -5,15 +5,22 @@
 //  Created by Sjmarf on 2026-06-06.
 //
 
+import MlemMiddleware
 import SwiftUI
 
 struct UnsupportedVersionWarningView: View {
     let account: any Account
 
     var body: some View {
-        VStack {
-            Text("Unsupported")
+        ScrollView {
+            UnsupportedVersionDescriptionView(
+                host: account.host,
+                software: account.siteSoftware,
+                offerContinuation: true
+            )
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.themedGroupedBackground)
         .onDisappear {
             account.ignoreVersionWarning(true)
         }

--- a/Mlem/App/Views/Shared/UnsupportedVersionWarningView.swift
+++ b/Mlem/App/Views/Shared/UnsupportedVersionWarningView.swift
@@ -1,0 +1,16 @@
+//
+//  UnsupportedVersionWarningView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-06.
+//
+
+import SwiftUI
+
+struct UnsupportedVersionWarningView: View {
+    let account: any Account
+
+    var body: some View {
+        Text("Unsupported")
+    }
+}

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -195,6 +195,19 @@
         }
       }
     },
+    "%@ is running %@, and Mlem requires %@ or later.\n\nConsider choosing another instance, or asking your server administrators to upgrade.\n\nYou can choose to continue anyway, but some features may not work on this version." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ is running %2$@, and Mlem requires %3$@ or later.\n\nConsider choosing another instance, or asking your server administrators to upgrade.\n\nYou can choose to continue anyway, but some features may not work on this version."
+          }
+        }
+      }
+    },
+    "%@ is unsupported" : {
+
+    },
     "%@ locked a post" : {
       "localizations" : {
         "fr" : {
@@ -2110,6 +2123,9 @@
     "Choose whether to show community avatars on posts." : {
 
     },
+    "Choose whether to show user avatars on posts." : {
+
+    },
     "Choose whether to use alternate interaction bar and swipe action layouts for post and comment reports in Mod Mail." : {
       "localizations" : {
         "fr" : {
@@ -2631,6 +2647,9 @@
         }
       }
     },
+    "Continue Anyway" : {
+
+    },
     "Contrast" : {
       "localizations" : {
         "fr" : {
@@ -2930,6 +2949,9 @@
         }
       }
     },
+    "Customize the appearance of instances." : {
+
+    },
     "Customize the appearance of the tab bar." : {
       "localizations" : {
         "en-GB" : {
@@ -2939,6 +2961,9 @@
           }
         }
       }
+    },
+    "Customize the appearance of users." : {
+
     },
     "Customize the image viewer's buttons and gestures." : {
       "localizations" : {
@@ -7513,6 +7538,9 @@
           }
         }
       }
+    },
+    "Requires Invitation" : {
+
     },
     "Reset" : {
       "localizations" : {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -22,6 +22,10 @@ public extension ApiClient {
         }
         return myAdminIndex < targetAdminIndex
     }
+
+    func getSoftwareFallback() async throws -> SiteSoftware {
+        try await repository.getSoftwareFallback()
+    }
     
     func getAccountToken(usernameOrEmail: String, password: String, totpToken: String?) async throws -> String {
         try await repository.getAccountToken(usernameOrEmail: usernameOrEmail, password: password, totpToken: totpToken)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -104,10 +104,10 @@ public extension ApiClient {
     }
     
     /// Get an ``UnreadCount`` object that continues to be updated by the ``ApiClient`` whenever an inbox item is marked read/unread.
-    func getUnreadCount(alwaysMakeCalls: Bool = false) async throws -> UnreadCount {
+    func getUnreadCount() async throws -> UnreadCount {
         try await inboxLock.withLock {
             let unreadCount = unreadCount ?? .init(api: self)
-            try await unreadCount.refresh(alwaysMakeCalls: alwaysMakeCalls)
+            try await unreadCount.refresh()
             self.unreadCount = unreadCount
             return unreadCount
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+General.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 extension ApiRepository {
+    func getSoftwareFallback() async throws -> SiteSoftware {
+        try await performingForConnection { connection in
+            let version = try await connection.getVersionFallback()
+            return SiteSoftware(type: type(of: connection).softwareType, version: version)
+        }
+    }
+
     func getAccountToken(usernameOrEmail: String, password: String, totpToken: String?) async throws -> String {
         try await performingForConnection { connection in
             try await connection.getAccountToken(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteSoftware/SiteSoftware.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteSoftware/SiteSoftware.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct SiteSoftware: Codable, Hashable {
+public struct SiteSoftware: Codable, Hashable, Sendable {
     public let type: SiteSoftwareType
     public let version: SiteVersion
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Internal/SiteVersion/SiteVersion.swift
@@ -6,7 +6,7 @@
 //
 import Foundation
 
-public enum SiteVersion: Equatable, Hashable {
+public enum SiteVersion: Equatable, Hashable, Sendable {
     case release(major: Int, minor: Int, patch: Int)
     case other(String)
     case zero

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/ApiClientError+Lemmy.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/LemmyExtensions/ApiClientError+Lemmy.swift
@@ -31,7 +31,8 @@ extension ApiClientError {
             .emailNotVerified
         case "not_mod_or_admin":
             .notModOrAdmin
-        case "not_admin":
+        case "not_admin",
+             "not_an_admin":
             .notAdmin
         case "invalid_password":
             .newPasswordInvalid

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Shared/ValueProviding/ExpectedValue.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Shared/ValueProviding/ExpectedValue.swift
@@ -24,6 +24,16 @@ public struct ExpectedValue<T>: ValueProviding {
         }
         return nil
     }
+
+    public var tryValue: T {
+        get throws(ExpectedValueError) {
+            if let value_ {
+                return value_
+            } else {
+                throw .init()
+            }
+        }
+    }
     
     /// Callback expected to update value_
     let provideValue: () async throws -> Void
@@ -38,4 +48,8 @@ func dummyExpectedValue<T>(_ value: T?) -> ExpectedValue<T> {
     .init(
         value: value,
         provideValue: { assertionFailure("Dummy function! This should not be called") })
+}
+
+public struct ExpectedValueError: Error, CustomStringConvertible {
+    public let description: String = "Called `.tryValue` and the value was not present."
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -90,10 +90,7 @@ public final class UnreadCount {
         (verifiedCount[type] ?? 0) + (unverifiedCount[type] ?? 0)
     }
     
-    // If `alwaysMakeCalls` is `false`, `UnreadCount` will avoid making calls it doesn't need to (e.g. checking for
-    // moderation notifications if the user does not moderate any communities). You might want to set this to
-    // `true` if you are using this function to measure the response time of the server.
-    public func refresh(alwaysMakeCalls: Bool = false) async throws {
+    public func refresh() async throws {
         let values: [InboxItemType: Int] = try await withThrowingTaskGroup(
             of: [InboxItemType: Int].self,
             returning: [InboxItemType: Int].self
@@ -101,14 +98,14 @@ public final class UnreadCount {
             taskGroup.addTask {
                 try await self.api.repository.getPersonalUnreadCount().unreadCountDictionary
             }
-            if !alwaysMakeCalls, self.api.username != nil, self.api.myPerson == nil || self.api.myInstance == nil {
+            if  self.api.username != nil, self.api.myPerson == nil || self.api.myInstance == nil {
                 // The theoretical solution to this is to store the moderated
                 // community IDs in `ApiClient.Context` and `await` them here.
                 log.warning("ApiClient.myPerson or ApiClient.myInstance is nil at UnreadCount refresh - this may lead to unneeded API calls")
             }
             
             if try await self.api.supports(.viewReports) {
-                if alwaysMakeCalls || !(self.api.myPerson?.moderatedCommunities.value_?.isEmpty ?? false) || self.api.isAdmin {
+                if !(self.api.myPerson?.moderatedCommunities.value_?.isEmpty ?? false) || self.api.isAdmin {
                     taskGroup.addTask {
                         do {
                             return try await self.api.repository.getReportCount(communityId: nil).unreadCountDictionary
@@ -118,7 +115,7 @@ public final class UnreadCount {
                     }
                 }
                 // Don't use `api.isAdmin` here; it falls back to `false` and we need to fallback to `true`
-                if alwaysMakeCalls || api.myInstance?.administrators.value?.contains(where: { $0.id == api.myPerson?.id }) ?? true {
+                if api.myInstance?.administrators.value?.contains(where: { $0.id == api.myPerson?.id }) ?? true {
                     taskGroup.addTask {
                         do {
                             return try await [.registrationApplication: self.api.getRegistrationApplicationCount()]

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -23,6 +23,11 @@ public protocol InstanceConnection {
     var myPersonId: Int? { get async throws }
     func ensureContextPresence() async throws
 
+    // This should do the minimum work required to retrieve the version,
+    // and should be compatible with as many versions as possible (including
+    // those outside Mlem's supported version range).
+    func getVersionFallback() async throws -> SiteVersion
+
     // MARK: - Post
     
     func getPosts(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 public extension LemmyConnection {
+    func getVersionFallback() async throws -> SiteVersion {
+        let response = try await performingForEndpoint { endpoint in
+            LemmyFallbackGetVersionRequest(endpoint: endpoint)
+        }
+        return response.version
+    }
+
     func getAccountToken(
         usernameOrEmail: String,
         password: String,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyFallbackGetVersionRequest.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyFallbackGetVersionRequest.swift
@@ -1,0 +1,25 @@
+//
+//  LemmyFallbackGetVersionRequest.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-05.
+//
+
+import Rest
+
+public struct LemmyFallbackGetVersionRequest: GetRequest {
+    public typealias Parameters = Int
+
+    public struct Response: Decodable {
+        let version: SiteVersion
+    }
+    
+    public let path: String
+    public let parameters: Parameters? = nil
+    
+    init(
+      endpoint: LemmyEndpointVersion
+    ) {
+        self.path = endpoint == .v4 ? "api/v4/site" : "api/v3/site"
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+General.swift
@@ -8,6 +8,12 @@
 import Foundation
 
 public extension PieFedConnection {
+    func getVersionFallback() async throws -> SiteVersion {
+        let request = PieFedFallbackGetVersionRequest()
+        let response = try await perform(request)
+        return response.version
+    }
+
     func getAccountToken(
         usernameOrEmail: String,
         password: String,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedFallbackGetVersionRequest.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedFallbackGetVersionRequest.swift
@@ -1,0 +1,19 @@
+//
+//  PieFedFallbackGetVersionRequest.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-05.
+//
+
+import Rest
+
+public struct PieFedFallbackGetVersionRequest: GetRequest {
+    public typealias Parameters = Int
+
+    public struct Response: Decodable {
+        let version: SiteVersion
+    }
+    
+    public let path: String = "api/alpha/site"
+    public let parameters: Parameters? = nil
+}


### PR DESCRIPTION
Closes #113

I will shortly be removing support for some of the older PieFed versions, so I thought now would be a good time to do this. The easiest way to test this is to change the minimum version in `Mlem/App/Utility/Extensions/Content Models/SiteSoftwareType+Extensions.swift`.

When an instance is unsupported, a warning is shown in the account switcher:

<img width=50% alt="IMG_2520" src="https://github.com/user-attachments/assets/63cb1a0a-e857-4bef-b375-ad40c2969665" />

When you open the account, this warning is shown:

<img width=50% alt="IMG_2519" src="https://github.com/user-attachments/assets/1e6a428e-398a-49cd-8cee-06a8147ac7fc" />

The warning will only be shown once for that account. If the instance is upgraded, and later falls outside of the support window for a _second_ time, the warning will be shown again. For testing purposes, you can use the "Reset Version Warning" button in Developer settings to see the warning a second time.

A similar warning is shown in the log in sheet, if the user chooses an unsupported instance:

<img width=50% alt="IMG_2517" src="https://github.com/user-attachments/assets/4020765d-d0be-4ca9-abfd-347c51bd656a" />


