### PR TITLE
More context menu customisation

### DIFF
--- a/Mlem/App/Actions/ContextMenu+Community.swift
+++ b/Mlem/App/Actions/ContextMenu+Community.swift
@@ -21,7 +21,11 @@ extension ActionButtons {
 extension View {
     func contextMenu(community: Community) -> some View {
         contextMenu {
-            ActionButtons(community: community)
+            CustomizableActionMenu(
+                entity: community,
+                configuration: \.interactionBar_community,
+                customizable: true
+            )
         }
     }
 

--- a/Mlem/App/Actions/ContextMenu+Instance.swift
+++ b/Mlem/App/Actions/ContextMenu+Instance.swift
@@ -16,9 +16,11 @@ extension View {
     func contextMenu(instance: (any InstanceActionProviding)?) -> some View {
         if let instance {
             contextMenu {
-                ActionButtons { _ in
-                    InstanceActionConfiguration.availableActions.all.compactMap { $0.createAction(instance) }
-                }
+                CustomizableActionMenu(
+                    entity: instance,
+                    configuration: \.interactionBar_instance,
+                    customizable: true
+                )
             }
         } else {
             self
@@ -46,17 +48,6 @@ extension View {
 extension ToolbarEllipsisMenu {
     init(instance: any InstanceActionProviding) where Content == ActionButtons {
         self.init {
-            ActionButtons { _ in
-                InstanceActionConfiguration.availableActions.all.compactMap { $0.createAction(instance) }
-            }
-        }
-    }
-}
-
-extension View {
-    @ViewBuilder
-    func contextMenu(instance: any InstanceActionProviding) -> some View {
-        contextMenu {
             ActionButtons { _ in
                 InstanceActionConfiguration.availableActions.all.compactMap { $0.createAction(instance) }
             }

--- a/Mlem/App/Actions/ContextMenu+Person.swift
+++ b/Mlem/App/Actions/ContextMenu+Person.swift
@@ -21,7 +21,11 @@ extension ActionButtons {
 extension View {
     func contextMenu(person: Person) -> some View {
         contextMenu {
-            ActionButtons(person: person)
+            CustomizableActionMenu(
+                entity: person,
+                configuration: \.interactionBar_person,
+                customizable: true
+            )
         }
     }
 

--- a/Mlem/App/Actions/RemoveAction.swift
+++ b/Mlem/App/Actions/RemoveAction.swift
@@ -55,6 +55,10 @@ extension RemoveAction {
         guard let myPerson = entity.api.myPerson else { return .hidden }
         guard entity.canModerate else { return .hidden }
 
+        if entity is Community {
+            guard entity.api.isAdmin else { return .hidden }
+        }
+
         if let entity = entity as? any OwnershipProviding {
             guard !entity.isOwnContent(myPersonId: myPerson.id) else { return .hidden }
         }

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 import MlemMiddleware
 import SwiftUI
 
-struct CommentBarConfiguration: InteractionBarConfiguration, SwipeActionConfiguration {
+struct CommentBarConfiguration: InteractionBarConfiguration {
     var leading: [Item]
     var trailing: [Item]
     var readouts: [ReadoutType]

--- a/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
@@ -39,7 +39,7 @@ struct CommunityActionConfiguration: Codable, ContextMenuConfiguration, SwipeAct
             .newPost,
             .subscribe,
             .favorite,
-            .goToInstance,
+            .copyName,
             .share,
             .block,
             .remove,

--- a/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/CommunityActionConfiguration.swift
@@ -8,8 +8,9 @@
 import Actions
 import Foundation
 
-struct CommunityActionConfiguration: Codable, SwipeActionConfiguration {
+struct CommunityActionConfiguration: Codable, ContextMenuConfiguration, SwipeActionConfiguration {
     var savedSwipes: ActionSeedSwipeConfiguration?
+    var savedContextMenu: [ActionSeed]?
 
     static var availableActions: ActionSeedSections { .init(sections: [
             [
@@ -31,6 +32,19 @@ struct CommunityActionConfiguration: Codable, SwipeActionConfiguration {
 
     static var defaultSwipes: ActionSeedSwipeConfiguration {
         .init(leading: [], trailing: [.subscribe, .favorite])
+    }
+
+    static var defaultContextMenu: [ActionSeed] {
+        [
+            .newPost,
+            .subscribe,
+            .favorite,
+            .goToInstance,
+            .share,
+            .block,
+            .remove,
+            .purge
+        ]
     }
 
     enum CodingKeys: CodingKey {

--- a/Mlem/App/Enums/Interaction/InstanceActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InstanceActionConfiguration.swift
@@ -8,8 +8,9 @@
 import Actions
 import Foundation
 
-struct InstanceActionConfiguration: Codable, SwipeActionConfiguration {
+struct InstanceActionConfiguration: Codable, ContextMenuConfiguration, SwipeActionConfiguration {
     var savedSwipes: ActionSeedSwipeConfiguration?
+    var savedContextMenu: [ActionSeed]?
 
     static var availableActions: ActionSeedSections { .init(sections: [
             [
@@ -25,6 +26,16 @@ struct InstanceActionConfiguration: Codable, SwipeActionConfiguration {
 
     static var defaultSwipes: ActionSeedSwipeConfiguration {
         .init(leading: [], trailing: [])
+    }
+
+    static var defaultContextMenu: [ActionSeed] {
+        [
+            .visit,
+            .logIn,
+            .signUp,
+            .share,
+            .block
+        ]
     }
 
     enum CodingKeys: CodingKey {

--- a/Mlem/App/Enums/Interaction/PersonActionConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PersonActionConfiguration.swift
@@ -8,8 +8,9 @@
 import Actions
 import Foundation
 
-struct PersonActionConfiguration: Codable, SwipeActionConfiguration {
+struct PersonActionConfiguration: Codable, ContextMenuConfiguration, SwipeActionConfiguration {
     var savedSwipes: ActionSeedSwipeConfiguration?
+    var savedContextMenu: [ActionSeed]?
 
     static var availableActions: ActionSeedSections { .init(sections: [
             [
@@ -33,6 +34,17 @@ struct PersonActionConfiguration: Codable, SwipeActionConfiguration {
 
     static var defaultSwipes: ActionSeedSwipeConfiguration {
         .init(leading: [], trailing: [])
+    }
+
+    static var defaultContextMenu: [ActionSeed] {
+        [
+            .copyName,
+            .share,
+            .block,
+            .editNote,
+            .ban,
+            .purge
+        ]
     }
 
     enum CodingKeys: CodingKey {

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 import MlemMiddleware
 import SwiftUI
 
-struct PostBarConfiguration: InteractionBarConfiguration, SwipeActionConfiguration {
+struct PostBarConfiguration: InteractionBarConfiguration {
     var leading: [Item]
     var trailing: [Item]
     var readouts: [ReadoutType]

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 import MlemMiddleware
 import SwiftUI
 
-struct ReplyBarConfiguration: InteractionBarConfiguration, SwipeActionConfiguration {
+struct ReplyBarConfiguration: InteractionBarConfiguration {
     var leading: [Item]
     var trailing: [Item]
     var readouts: [ReadoutType]

--- a/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/CommentSettingsView.swift
@@ -29,6 +29,7 @@ struct CommentSettingsView: View {
                     SettingsInteractionBarSummaryView(configuration: commentInteractionBar)
                 }
                 NavigationLink("Swipe Actions", destination: .settings(.swipeActions(.comment)))
+                NavigationLink("Context Menu", destination: .settings(.contextMenu(\.interactionBar_comment)))
             }
             Section {
                 NavigationLink(

--- a/Mlem/App/Views/Root/Tabs/Settings/CommunitySettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/CommunitySettingsView.swift
@@ -19,8 +19,11 @@ struct CommunitySettingsView: View {
             )
             .gradientTint(.themedCommunityAccent)
             Section {
-                NavigationLink("Subscription List", destination: .settings(.subscriptionList))
                 NavigationLink("Swipe Actions", destination: .settings(.swipeActions(.community)))
+                NavigationLink("Context Menu", destination: .settings(.contextMenu(\.interactionBar_community)))
+            }
+            Section {
+                NavigationLink("Subscription List", destination: .settings(.subscriptionList))
             }
             Section {
                 Toggle("Community Avatar", icon: .lemmy.community, isOn: $showCommunityAvatar)

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -10,6 +10,7 @@ import Actions
 import SwiftUI
 
 struct ContextMenuSettingsView<Configuration: ContextMenuConfiguration>: View {
+    @Environment(NavigationLayer.self) var navigation
     @Binding var configuration: [ActionSeed]
 
     var body: some View {
@@ -29,7 +30,9 @@ struct ContextMenuSettingsView<Configuration: ContextMenuConfiguration>: View {
             }
         }
         .toolbar {
-            CloseButtonToolbarItem(ios18Label: .xmark)
+            if navigation.isInsideSheet {
+                CloseButtonToolbarItem(ios18Label: .xmark)
+            }
         }
         .navigationTitle("Customize Context Menu")
         .navigationBarTitleDisplayMode(.inline)

--- a/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InboxSettingsView.swift
@@ -26,6 +26,7 @@ struct InboxSettingsView: View {
                     SettingsInteractionBarSummaryView(configuration: replyInteractionBar)
                 }
                 NavigationLink("Swipe Actions", destination: .settings(.swipeActions(.inboxNotification)))
+                NavigationLink("Context Menu", destination: .settings(.contextMenu(\.interactionBar_reply)))
             }
             if AccountsTracker.main.highestLevelAccountType >= .moderator {
                 Section {

--- a/Mlem/App/Views/Root/Tabs/Settings/InstanceSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InstanceSettingsView.swift
@@ -18,6 +18,7 @@ struct InstanceSettingsView: View {
             .gradientTint(.themedInstanceAccent)
             Section {
                 NavigationLink("Swipe Actions", destination: .settings(.swipeActions(.instance)))
+                NavigationLink("Context Menu", destination: .settings(.contextMenu(\.interactionBar_instance)))
             }
         }
         .withConditionalLabelStyle()

--- a/Mlem/App/Views/Root/Tabs/Settings/PersonSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PersonSettingsView.swift
@@ -21,6 +21,9 @@ struct PersonSettingsView: View {
             .gradientTint(.themedPersonAccent)
             Section {
                 NavigationLink("Swipe Actions", destination: .settings(.swipeActions(.person)))
+                NavigationLink("Context Menu", destination: .settings(.contextMenu(\.interactionBar_person)))
+            }
+            Section {
                 NavigationLink(
                     "Show Account Age",
                     value: .init(localized: accountAgeVisibility.label),

--- a/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/PostSettingsView.swift
@@ -36,6 +36,7 @@ struct PostSettingsView: View {
                     SettingsInteractionBarSummaryView(configuration: postInteractionBar)
                 }
                 NavigationLink("Swipe Actions", destination: .settings(.swipeActions(.post)))
+                NavigationLink("Context Menu", destination: .settings(.contextMenu(\.interactionBar_post)))
             }
             
             Section {


### PR DESCRIPTION
- Context menus for communities, users and instances are now customisable
- You can now open the context menu editor from settings (See the "Posts" page, etc)

Closes #1642

I've removed some of the actions from the default context menus, but I'm not sure this is the right choice. Does this sacrifice usability? Would appreciate your opinion. One option is to put _all_ of the options in the default context menu, and hiding the "more" button by default (#2770). That would keep the same default behavior we have now, while still making it customisable.