### PR TITLE
Block list fixes

### DIFF
--- a/Mlem/App/Actions/ContextMenu+Instance.swift
+++ b/Mlem/App/Actions/ContextMenu+Instance.swift
@@ -71,6 +71,19 @@ extension InstanceSummary: @retroactive Blockable {}
 extension InstanceSummary: InstanceActionProviding {
     public var actorId: ActorIdentifier { instanceStub.actorId }
     public func url() -> URL { actorId.url }
-    public var blocked: any RealizedValueProviding<Bool> { RealizedValue(false) }
+    public var blocked: any RealizedValueProviding<Bool> {
+        let value = AppState.main.firstSession.api.blocks?.contains(instanceActorId: actorId) ?? false
+        return RealizedValue(value)
+    }
+    public var updateBlocked: ((Bool, ((Bool) -> Void)?) -> Void)? { nil }
+}
+
+extension InstanceStub: @retroactive Blockable {}
+extension InstanceStub: InstanceActionProviding {
+    public var instanceStub: InstanceStub { self }
+    public var blocked: any RealizedValueProviding<Bool> {
+        let value = AppState.main.firstSession.api.blocks?.contains(instanceActorId: actorId) ?? false
+        return RealizedValue(value)
+    }
     public var updateBlocked: ((Bool, ((Bool) -> Void)?) -> Void)? { nil }
 }

--- a/Mlem/App/Models/MlemStats/MlemStats.swift
+++ b/Mlem/App/Models/MlemStats/MlemStats.swift
@@ -93,4 +93,14 @@ class MlemStats {
             return !blocks.contains(instanceActorId: actorId)
         }
     }
+
+    func findInstances(stubs: [InstanceStub]) -> [InstanceSummary]? {
+        let hosts = Set(stubs.map(\.host))
+
+        let result = self.instances?
+            .filter { hosts.contains($0.host) }
+            .sorted { $0.name < $1.name }
+
+        return result?.count == stubs.count ? result : nil
+    }
 }

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -29,7 +29,7 @@ struct BlockListView: View {
     @State var selectedTab: Tab = .people
     @State var people: [Person] = []
     @State var communities: [Community] = []
-    @State var instances: [Instance] = []
+    @State var instances: [InstanceStub] = []
     
     var body: some View {
         FancyScrollView {
@@ -54,8 +54,10 @@ struct BlockListView: View {
                     CommunityListRow(community, showBlockStatus: false)
                 }
             case .instances:
-                SearchResultsView(results: instances.filter(\.blocked_.realizedValue)) { instance in
-                    InstanceListRow(instance, showBlockStatus: false)
+                ForEach(instances, id: \.self) { instance in
+                    InstanceRow(instance: instance)
+                        .padding(.horizontal, Constants.main.standardSpacing)
+                        .padding(.bottom, Constants.main.halfSpacing)
                 }
             }
         }
@@ -83,3 +85,15 @@ struct BlockListView: View {
         return output
     }
 }
+
+private struct InstanceRow: View {
+    let instance: InstanceStub
+
+    var body: some View {
+        Text(instance.actorId.host)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+    }
+} 

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -54,7 +54,7 @@ struct BlockListView: View {
                     CommunityListRow(community, showBlockStatus: false)
                 }
             case .instances:
-                ForEach(instances, id: \.self) { instance in
+                ForEach(instances.filter { $0.blocked.realizedValue }, id: \.self) { instance in
                     InstanceRow(instance: instance)
                         .padding(.horizontal, Constants.main.standardSpacing)
                         .padding(.bottom, Constants.main.halfSpacing)
@@ -92,8 +92,9 @@ private struct InstanceRow: View {
     var body: some View {
         Text(instance.actorId.host)
             .padding(.horizontal, 16)
-            .padding(.vertical, 8)
+            .padding(.vertical, 12)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
+            .contextMenu(instance: instance)
     }
 } 

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -81,8 +81,10 @@ struct BlockListView: View {
                     .padding(.horizontal, Constants.main.standardSpacing)
                     .padding(.bottom, Constants.main.halfSpacing)
             }
-        case .summaries:
-            EmptyView()
+        case let .summaries(summaries):
+            SearchResultsView(results: summaries.filter { $0.blocked.realizedValue }) { community in
+                InstanceListRow(community, showBlockStatus: false)
+            }
         }
     }
 
@@ -91,7 +93,11 @@ struct BlockListView: View {
             let result = try await appState.firstApi.getBlocked()
             people = result.people
             communities = result.communities
-            instances = .stubs(result.instances)
+            if let summaries = MlemStats.main.findInstances(stubs: result.instances) {
+                instances = .summaries(summaries)
+            } else {
+                instances = .stubs(result.instances)
+            }
         } catch {
             handleError(error)
         }

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -54,27 +54,36 @@ struct BlockListView: View {
                     CommunityListRow(community, showBlockStatus: false)
                 }
             case .instances:
-                ForEach(instances.filter { $0.blocked.realizedValue }, id: \.self) { instance in
-                    InstanceRow(instance: instance)
-                        .padding(.horizontal, Constants.main.standardSpacing)
-                        .padding(.bottom, Constants.main.halfSpacing)
-                }
+                instancesView
             }
         }
         .themedGroupedBackground()
         .onAppear {
             Task { @MainActor in
-                do {
-                    let result = try await appState.firstApi.getBlocked()
-                    people = result.people
-                    communities = result.communities
-                    instances = result.instances
-                } catch {
-                    handleError(error)
-                }
+                await refresh()
             }
         }
         .navigationTitle("Block List")
+    }
+
+    @ViewBuilder
+    var instancesView: some View {
+        ForEach(instances.filter { $0.blocked.realizedValue }, id: \.self) { instance in
+            InstanceRow(instance: instance)
+                .padding(.horizontal, Constants.main.standardSpacing)
+                .padding(.bottom, Constants.main.halfSpacing)
+        }
+    }
+
+    func refresh() async {
+        do {
+            let result = try await appState.firstApi.getBlocked()
+            people = result.people
+            communities = result.communities
+            instances = result.instances
+        } catch {
+            handleError(error)
+        }
     }
 }
 

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -87,6 +87,8 @@ struct BlockListView: View {
 }
 
 private struct InstanceRow: View {
+    @Environment(NavigationLayer.self) var navigation
+
     let instance: InstanceStub
 
     var body: some View {
@@ -96,5 +98,8 @@ private struct InstanceRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(.themedSecondaryGroupedBackground, in: .rect(cornerRadius: Constants.main.standardSpacing))
             .contextMenu(instance: instance)
+            .onTapGesture {
+                navigation.push(.instanceStub(instance))
+            }
     }
 } 

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 2024-11-09.
 //
 
+import MlemBackend
 import MlemMiddleware
 import SwiftUI
 import Theming
@@ -25,11 +26,16 @@ struct BlockListView: View {
             }
         }
     }
+
+    enum InstanceInfo {
+        case stubs([InstanceStub])
+        case summaries([InstanceSummary])
+    }
     
     @State var selectedTab: Tab = .people
     @State var people: [Person] = []
     @State var communities: [Community] = []
-    @State var instances: [InstanceStub] = []
+    @State var instances: InstanceInfo = .stubs([])
     
     var body: some View {
         FancyScrollView {
@@ -68,10 +74,15 @@ struct BlockListView: View {
 
     @ViewBuilder
     var instancesView: some View {
-        ForEach(instances.filter { $0.blocked.realizedValue }, id: \.self) { instance in
-            InstanceRow(instance: instance)
-                .padding(.horizontal, Constants.main.standardSpacing)
-                .padding(.bottom, Constants.main.halfSpacing)
+        switch instances {
+        case let .stubs(stubs):
+            ForEach(stubs.filter { $0.blocked.realizedValue }, id: \.self) { instance in
+                InstanceRow(instance: instance)
+                    .padding(.horizontal, Constants.main.standardSpacing)
+                    .padding(.bottom, Constants.main.halfSpacing)
+            }
+        case .summaries:
+            EmptyView()
         }
     }
 
@@ -80,7 +91,7 @@ struct BlockListView: View {
             let result = try await appState.firstApi.getBlocked()
             people = result.people
             communities = result.communities
-            instances = result.instances
+            instances = .stubs(result.instances)
         } catch {
             handleError(error)
         }

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -33,7 +33,7 @@ struct BlockListView: View {
     
     var body: some View {
         FancyScrollView {
-            BubblePicker(availableTabs, selected: $selectedTab, label: \.label, value: { tab in
+            BubblePicker(Tab.allCases, selected: $selectedTab, label: \.label, value: { tab in
                 guard let blockList = (appState.firstSession as? UserSession)?.blocks else { return 0 }
                 switch tab {
                 case .people:
@@ -75,14 +75,6 @@ struct BlockListView: View {
             }
         }
         .navigationTitle("Block List")
-    }
-    
-    var availableTabs: [Tab] {
-        var output: [Tab] = [.people, .communities]
-        if appState.firstApi.supports(.viewInstanceBlockList, defaultValue: false) {
-            output.append(.instances)
-        }
-        return output
     }
 }
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -117,12 +117,12 @@ public extension ApiClient {
         }
     }
     
-    func getBlocked() async throws -> (people: [Person], communities: [Community], instances: [Instance]) {
+    func getBlocked() async throws -> (people: [Person], communities: [Community], instances: [InstanceStub]) {
         let snapshots = try await repository.getBlocked()
         return await (
             people: caches.person.getModels(api: self, from: snapshots.people.map { .person1($0) }),
             communities: caches.community.getModels(api: self, from: snapshots.communities.map { .community1($0) }),
-            instances: caches.instance.getModels(api: self, from: snapshots.instances.map { .instance1($0) })
+            instances: snapshots.instances.map { .init(api: self, actorId: .instance(host: $0)) }
         )
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+General.swift
@@ -81,7 +81,7 @@ extension ApiRepository {
         }
     }
     
-    func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [Instance1Snapshot]) {
+    func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [String]) {
         try await performingForConnection { connection in
             try await connection.getBlocked()
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Feature.swift
@@ -60,7 +60,6 @@ public enum Feature: Hashable {
     case autoMarkPostReadOnInteract
     
     case blockInstances
-    case viewInstanceBlockList
     case moderatorSetNsfw
     
     case fetchLinkMetadata

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/InstanceStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Instance/InstanceStub.swift
@@ -13,12 +13,12 @@ public enum InstanceUpgradeError: Error {
     case noSiteReturned
 }
 
-public struct InstanceStub: Hashable {
+public struct InstanceStub: Hashable, ActorIdentifiable {
     public var api: ApiClient
     public let actorId: ActorIdentifier
     
     public var local: Bool { actorId.url == api.baseUrl }
-    
+
     public init(api: ApiClient, actorId: ActorIdentifier) {
         self.api = api
         self.actorId = actorId
@@ -50,5 +50,11 @@ public struct InstanceStub: Hashable {
             throw InstanceUpgradeError.noSiteReturned
         }
         return instance
+    }
+}
+
+extension InstanceStub: Sharable {
+    public func url() -> URL {
+        actorId.url
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -390,7 +390,7 @@ public protocol InstanceConnection {
     
     func resolve(url: URL) async throws -> ResolvedContent
     
-    func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [Instance1Snapshot])
+    func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [String])
     
     func getModlog(
         page: Int,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Feature.swift
@@ -44,7 +44,7 @@ public extension LemmyConnection {
              .banFromCommunity, .editModeratorList, .commentSearch, .undeletePrivateMessages, .searchLocalPeople,
              .hidePosts, .editDisplayName, .editProfile, .autoMarkPostReadOnInteract, .blockInstances,
              .fetchLinkMetadata, .unbanWithReason, .customPostThumbnail, .banFromNonLocalCommunity, .editCommunityDescription,
-             .searchLocalComments, .viewInstanceBlockList:
+             .searchLocalComments:
             true
         case .moderatorSetNsfw, .userNotes, .toggleNotifications:
             false

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
@@ -164,17 +164,26 @@ public extension LemmyConnection {
         return try .init(from: response)
     }
     
-    func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [Instance1Snapshot]) {
+    func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [String]) {
         let response = try await performingForEndpoint { endpoint in
             LemmyGetSiteRequest(endpoint: endpoint)
         }
         
         guard let myUser = response.myUser else { return ([], [], []) }
+
+        let instances: [String]
+        if let blocks = myUser.instanceCommunitiesBlocks {
+            instances = blocks.map(\.domain)
+        } else if let blocks = myUser.instanceBlocks {
+            instances = blocks.map(\.instance.domain)
+        } else {
+            throw ApiClientError.responseMissingRequiredData("Lemmy getBlocked instances")
+        }
         
         return try (
             people: myUser.personBlocks.map { try .init(from: $0.person) },
             communities: myUser.communityBlocks.map { try .init(from: $0.community) },
-            instances: myUser.instanceBlocks?.compactMap(\.site).map { try .init(from: $0) } ?? [] // TODO: Lemmy 1.0
+            instances: instances
         )
     }
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+General.swift
@@ -165,11 +165,20 @@ public extension LemmyConnection {
     }
     
     func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [String]) {
-        let response = try await performingForEndpoint { endpoint in
-            LemmyGetSiteRequest(endpoint: endpoint)
+        let myUser = try await processingForEndpoint { endpoint in
+            switch endpoint {
+            case .v3:
+                let request = LemmyGetSiteRequest(endpoint: .v3)
+                let response = try await self.perform(request, endpoint: .v3)
+                return response.myUser
+            case .v4:
+                let request = LemmyGetMyUserRequest()
+                let response = try await self.perform(request, endpoint: .v4)
+                return response
+            }
         }
         
-        guard let myUser = response.myUser else { return ([], [], []) }
+        guard let myUser else { return ([], [], []) }
 
         let instances: [String]
         if let blocks = myUser.instanceCommunitiesBlocks {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+General.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+General.swift
@@ -71,7 +71,7 @@ public extension PieFedConnection {
         return try .init(from: response)
     }
     
-    func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [Instance1Snapshot]) {
+    func getBlocked() async throws -> (people: [Person1Snapshot], communities: [Community1Snapshot], instances: [String]) {
         let request = PieFedGetSiteRequest()
         let response = try await perform(request)
         guard let myUser = response.myUser else { return ([], [], []) }
@@ -79,7 +79,7 @@ public extension PieFedConnection {
         return try (
             people: myUser.personBlocks.map { try .init(from: $0.target) },
             communities: myUser.communityBlocks.map { try .init(from: $0.community) },
-            instances: myUser.instanceBlocks.compactMap(\.site).map { try .init(from: $0) }
+            instances: myUser.instanceBlocks.map(\.instance.domain)
         )
     }
     


### PR DESCRIPTION
- Fixed the block list being empty on Lemmy 1.0 (closes #2179)
- Enabled "Instances" tab in the block list on PieFed (closes #2486)

On both Lemmy 1.0 and PieFed, the block list endpoint does not return full instance information. To make support possible, I've changed the UI to only show the domain name:

<img width=50% alt="IMG_2533" src="https://github.com/user-attachments/assets/923b1a84-135b-4f5e-9d74-c24367e81b62" />

Previously, it looked like this:

<img width=50% alt="IMG_2534" src="https://github.com/user-attachments/assets/96f38ab9-bcc2-4814-ba29-ccdbb8da39a5" />
