### PR TITLE
Fix unexpandable comment

### DIFF
--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Views.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView+Views.swift
@@ -49,7 +49,7 @@ extension ExpandedPostView {
             depthOffset: depthOffset
         )
         .onTapGesture {
-            if tapCommentsToCollapse {
+            if tapCommentsToCollapse || node.collapsed {
                 withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .default) {
                     node.collapsed.toggle()
                 }


### PR DESCRIPTION

<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2738 

## Description

When "tap to collapse" is off comments are unexpandable, this change allows tap to expand if the node is currently collapsed.

## Implementation Notes

<!-- Any information about the code that would be helpful for reviewing -->
