### PR TITLE
Sort favourites list deterministically instead of random Set order

### DIFF
--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SubscriptionList.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/SubscriptionList.swift
@@ -93,7 +93,7 @@ public class SubscriptionList {
         }
         self.instanceSections = instanceSections
         
-        favorites = communities.filter { favoriteIDs.contains($0.id) }
+        favorites = communities.filter { favoriteIDs.contains($0.id) }.sorted(by: self.sortPredicate)
     }
     
     func updateCommunitySubscription(community: Community) {


### PR DESCRIPTION
## Issues

- closes #2763

## Description

The favourites list could appear in a random order rather than alphabetically like the other sections. This sorts the rebuilt favourites array so it is deterministic and alphabetical.

## Implementation Notes

In `SubscriptionList.updateCommunities(with:)`, `favorites` was rebuilt with:

```swift
favorites = communities.filter { favoriteIDs.contains($0.id) }
```

Because `communities` is a `Set<Community>`, iteration order is unspecified, so the resulting array order was non-deterministic. Every other section in that method (`alphabeticSections`, `instanceSections`, `otherSection`) is run through `.sorted(by: self.sortPredicate)`, and the incremental favourite paths in `updateCommunitySubscription`/`addCommunity` use `favorites.sortedInsert(community, by: self.sortPredicate)`. The bulk rebuild was the one path that skipped the predicate.

The fix appends the same predicate so the bulk rebuild matches the alphabetical ordering already used everywhere else:

```swift
favorites = communities.filter { favoriteIDs.contains($0.id) }.sorted(by: self.sortPredicate)
```

One-line change, no public API or behaviour change beyond making the order deterministic.
