### PR TITLE
`Handle` system

### DIFF
--- a/Mlem/App/Views/Shared/Search/PasteLinkButtonView.swift
+++ b/Mlem/App/Views/Shared/Search/PasteLinkButtonView.swift
@@ -6,43 +6,37 @@
 //
 
 import Dependencies
+import MlemMiddleware
 import SwiftUI
 
 struct PasteLinkButtonView: View {
     @Environment(\.openURL) private var openURL
+    @Environment(AppState.self) private var appState
+    @Environment(NavigationLayer.self) private var navigation
     
     var body: some View {
         Button("Open URL from Clipboard", icon: .general.paste) {
             if let url = UIPasteboard.general.url {
                 openURL(url)
-            } else if let string = UIPasteboard.general.string,
-                      let url = urlFromString(string),
-                      UIApplication.shared.canOpenURL(url) {
-                openURL(url)
-            } else {
-                ToastModel.main.add(.failure("Couldn't read URL"))
+                return
+                }
+
+            if let string = UIPasteboard.general.string {
+                if let handle = try? CommunityHandle(string: string) {
+                    navigation.push(.communityStub(.init(api: appState.firstApi, handle: handle)))
+                    return
+                }
+                if let handle = try? PersonHandle(string: string) {
+                    navigation.push(.personStub(.init(api: appState.firstApi, handle: handle)))
+                    return
+                }
+                if let url = URL(string: string), UIApplication.shared.canOpenURL(url) {
+                    openURL(url)
+                    return
+                }
             }
-        }
-    }
-    
-    func urlFromString(_ string: String) -> URL? {
-        if let url = URL(string: string), UIApplication.shared.canOpenURL(url) {
-            return url
-        }
-        return webfingersToUrl(string)
-    }
-    
-    func webfingersToUrl(_ webfingers: String) -> URL? {
-        do {
-            guard let match = try /[!|@](?<name>[\w_-]+)@(?<host>[\w_-]+\.[\w_\-\.]+)+/.wholeMatch(in: webfingers) else { return nil }
-            
-            let name = match.output.name
-            let host = match.output.host
-            let prefix = webfingers.starts(with: "@") ? "u" : "c"
-            
-            return URL(string: "https://\(host)/\(prefix)/\(name)")
-        } catch {
-            return nil
+
+            ToastModel.main.add(.failure("Couldn't read URL"))
         }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
@@ -32,6 +32,11 @@ public extension ApiClient {
         return await caches.community.getModel(api: self, from: .community2(snapshot))
     }
     
+    func getCommunity(handle: CommunityHandle) async throws -> Community {
+        let snapshot: Community2Snapshot = try await repository.getCommunity(handle: handle)
+        return await caches.community.getModel(api: self, from: .community2(snapshot))
+    }
+    
     func searchCommunities(
         query: String,
         pageInfo: PageInfo,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
@@ -32,6 +32,11 @@ public extension ApiClient {
         return await caches.person.getModel(api: self, from: .person2(snapshot))
     }
     
+    func getPerson(handle: PersonHandle) async throws -> Person {
+        let snapshot: Person2Snapshot = try await repository.getPerson(handle: handle)
+        return await caches.person.getModel(api: self, from: .person2(snapshot))
+    }
+    
     func getPerson(username: String) async throws -> Person {
         let snapshot: Person3Snapshot = try await repository.getPerson(username: username)
         return await caches.person.getModel(api: self, from: .person3(snapshot))

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Community.swift
@@ -20,6 +20,12 @@ extension ApiRepository {
         }
     }
     
+    func getCommunity(handle: CommunityHandle) async throws -> Community2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getCommunity(handle: handle)
+        }
+    }
+    
     func searchCommunities(
         query: String,
         pageInfo: PageInfo,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/API Repository/ApiRepository+Person.swift
@@ -20,6 +20,12 @@ extension ApiRepository {
         }
     }
     
+    func getPerson(handle: PersonHandle) async throws -> Person2Snapshot {
+        try await performingForConnection { connection in
+            try await connection.getPerson(handle: handle)
+        }
+    }
+    
     func getPerson(username: String) async throws -> Person3Snapshot {
         try await performingForConnection { connection in
             try await connection.getPerson(username: username)

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/CommunityStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/CommunityStub.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct CommunityStub: Hashable {
     public var api: ApiClient
 
-    private enum Content: Hashable {
+    private enum Reference: Hashable {
         case url(URL)
         case handle(CommunityHandle)
 
@@ -22,25 +22,25 @@ public struct CommunityStub: Hashable {
         }
     }
 
-    private let content: Content
+    private let reference: Reference
     
     public func asLocal() -> Self {
         .init(
-            api: .getApiClient(url: content.baseUrl, username: nil),
-            content: content
+            api: .getApiClient(url: reference.baseUrl, username: nil),
+            reference: reference
         )
     }
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(content)
+        hasher.combine(reference)
     }
     
     public static func == (lhs: CommunityStub, rhs: CommunityStub) -> Bool {
-        lhs.content == rhs.content
+        lhs.reference == rhs.reference
     }
     
     public func getCommunity() async throws -> Community {
-        switch content {
+        switch reference {
         case let .url(url):
             try await api.getCommunity(url: url)
         case let .handle(handle):
@@ -52,11 +52,11 @@ public struct CommunityStub: Hashable {
 public extension CommunityStub {
     init(api: ApiClient, url: URL) {
         self.api = api
-        self.content = .url(url)
+        self.reference = .url(url)
     }
 
     init(api: ApiClient, handle: CommunityHandle) {
         self.api = api
-        self.content = .handle(handle)
+        self.reference = .handle(handle)
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/CommunityStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Community/CommunityStub.swift
@@ -7,36 +7,56 @@
 
 import Foundation
 
-public struct CommunityStub:  Hashable {
+public struct CommunityStub: Hashable {
     public var api: ApiClient
-    public let url: URL
-    
-    public init(api: ApiClient, url: URL) {
-        self.api = api
-        self.url = url
+
+    private enum Content: Hashable {
+        case url(URL)
+        case handle(CommunityHandle)
+
+        var baseUrl: URL {
+            switch self {
+            case let .url(url): url.removingPathComponents()
+            case let .handle(handle): handle.baseUrl()
+            }
+        }
     }
+
+    private let content: Content
     
     public func asLocal() -> Self {
-        .init(api: .getApiClient(url: url.removingPathComponents(), username: nil), url: url)
+        .init(
+            api: .getApiClient(url: content.baseUrl, username: nil),
+            content: content
+        )
     }
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(url)
+        hasher.combine(content)
     }
     
     public static func == (lhs: CommunityStub, rhs: CommunityStub) -> Bool {
-        lhs.url == rhs.url
+        lhs.content == rhs.content
     }
     
     public func getCommunity() async throws -> Community {
-        try await api.getCommunity(url: url)
+        switch content {
+        case let .url(url):
+            try await api.getCommunity(url: url)
+        case let .handle(handle):
+            try await api.getCommunity(handle: handle)
+        }
     }
 }
 
-// Resolvable conformance
 public extension CommunityStub {
-    var resolvableUrl: URL { url }
-    
-    @inlinable
-    var allResolvableUrls: [URL] { [resolvableUrl] }
+    init(api: ApiClient, url: URL) {
+        self.api = api
+        self.content = .url(url)
+    }
+
+    init(api: ApiClient, handle: CommunityHandle) {
+        self.api = api
+        self.content = .handle(handle)
+    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityHandle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityHandle.swift
@@ -8,19 +8,13 @@
 import Foundation
 
 public struct CommunityHandle: Handle {
+    public static let prefix: String = "!"
+
     public let username: String
     public let host: String
 
     public init(username: String, host: String) {
         self.username = username
         self.host = host
-    }
-
-    public func description(withPrefix: Bool) -> String {
-        if withPrefix {
-            "!\(username)@\(host)"
-        } else {
-            "\(username)@\(host)"
-        }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityHandle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityHandle.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct CommunityHandle {
+public struct CommunityHandle: Handle {
     public let username: String
     public let host: String
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityHandle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityHandle.swift
@@ -1,0 +1,26 @@
+//
+//  CommunityHandle.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-23.
+//
+
+import Foundation
+
+public struct CommunityHandle {
+    public let username: String
+    public let host: String
+
+    public init(username: String, host: String) {
+        self.username = username
+        self.host = host
+    }
+
+    public func description(withPrefix: Bool) -> String {
+        if withPrefix {
+            "!\(username)@\(host)"
+        } else {
+            "\(username)@\(host)"
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityHandle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/CommunityHandle.swift
@@ -8,13 +8,16 @@
 import Foundation
 
 public struct CommunityHandle: Handle {
-    public static let prefix: String = "!"
+    public static let prefix: Character = "!"
 
     public let username: String
     public let host: String
 
-    public init(username: String, host: String) {
+    public init(username: String, host: String) throws(HandleError) {
         self.username = username
         self.host = host
+        guard URL(string: "https://\(host)") != nil else {
+            throw .invalidHost
+        }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Handle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Handle.swift
@@ -5,18 +5,34 @@
 //  Created by Sjmarf on 2026-06-23.
 //
 
+import Foundation
+
 public protocol Handle {
-    static var prefix: String { get }
+    static var prefix: Character { get }
 
     var username: String { get }
     var host: String { get }
 
-    init(username: String, host: String)
+    init(username: String, host: String) throws (HandleError)
 
     func description(withPrefix: Bool) -> String
 }
 
 public extension Handle {
+    init(_ string: String) throws(HandleError) {
+        guard string.first == Self.prefix else { throw .invalidFormat }
+        let parts = string.dropFirst().split(separator: "@", maxSplits: 1)
+        try self.init(
+            username: String(parts[0]),
+            host: String(parts[1])
+        )
+    }
+
+    func baseUrl() -> URL {
+        // Guaranteed to succeed because we validated the host at init time
+        URL(string: "https://\(host)")!
+    }
+
     func description(withPrefix: Bool) -> String {
         if withPrefix {
             "\(Self.prefix)\(username)@\(host)"
@@ -25,3 +41,7 @@ public extension Handle {
         }
     }
 }
+
+public enum HandleError: Error {
+    case invalidFormat, invalidHost
+} 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Handle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Handle.swift
@@ -19,7 +19,7 @@ public protocol Handle: Hashable {
 }
 
 public extension Handle {
-    init(_ string: String) throws(HandleError) {
+    init(string: String) throws(HandleError) {
         guard string.first == Self.prefix else { throw .invalidFormat }
         let parts = string.dropFirst().split(separator: "@", maxSplits: 1)
         try self.init(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Handle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Handle.swift
@@ -6,7 +6,22 @@
 //
 
 public protocol Handle {
+    static var prefix: String { get }
+
+    var username: String { get }
+    var host: String { get }
+
     init(username: String, host: String)
 
     func description(withPrefix: Bool) -> String
+}
+
+public extension Handle {
+    func description(withPrefix: Bool) -> String {
+        if withPrefix {
+            "\(Self.prefix)\(username)@\(host)"
+        } else {
+            "\(username)@\(host)"
+        }
+    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Handle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Handle.swift
@@ -1,0 +1,12 @@
+//
+//  Handle.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-23.
+//
+
+public protocol Handle {
+    init(username: String, host: String)
+
+    func description(withPrefix: Bool) -> String
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Handle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Handle.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol Handle {
+public protocol Handle: Hashable {
     static var prefix: Character { get }
 
     var username: String { get }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/PersonStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/PersonStub.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct PersonStub: Hashable {
     public var api: ApiClient
 
-    private enum Content: Hashable {
+    private enum Reference: Hashable {
         case url(URL)
         case handle(PersonHandle)
 
@@ -22,25 +22,25 @@ public struct PersonStub: Hashable {
         }
     }
 
-    private let content: Content
+    private let reference: Reference
 
     public func asLocal() -> Self {
         .init(
-            api: .getApiClient(url: content.baseUrl, username: nil),
-            content: content
+            api: .getApiClient(url: reference.baseUrl, username: nil),
+            reference: reference
         )
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(content)
+        hasher.combine(reference)
     }
 
     public static func == (lhs: PersonStub, rhs: PersonStub) -> Bool {
-        lhs.content == rhs.content
+        lhs.reference == rhs.reference
     }
 
     public func getPerson() async throws -> Person {
-        switch content {
+        switch reference {
         case let .url(url):
             try await api.getPerson(url: url)
         case let .handle(handle):
@@ -52,11 +52,11 @@ public struct PersonStub: Hashable {
 public extension PersonStub {
     init(api: ApiClient, url: URL) {
         self.api = api
-        self.content = .url(url)
+        self.reference = .url(url)
     }
 
     init(api: ApiClient, handle: PersonHandle) {
         self.api = api
-        self.content = .handle(handle)
+        self.reference = .handle(handle)
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/PersonStub.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/Person/PersonStub.swift
@@ -6,38 +6,57 @@
 //
 
 import Foundation
-import Observation
 
 public struct PersonStub: Hashable {
     public var api: ApiClient
-    public let url: URL
-    
-    public init(api: ApiClient, url: URL) {
-        self.api = api
-        self.url = url
+
+    private enum Content: Hashable {
+        case url(URL)
+        case handle(PersonHandle)
+
+        var baseUrl: URL {
+            switch self {
+            case let .url(url): url.removingPathComponents()
+            case let .handle(handle): handle.baseUrl()
+            }
+        }
     }
-    
+
+    private let content: Content
+
     public func asLocal() -> Self {
-        .init(api: .getApiClient(url: url, username: nil), url: url)
+        .init(
+            api: .getApiClient(url: content.baseUrl, username: nil),
+            content: content
+        )
     }
-    
+
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(url)
+        hasher.combine(content)
     }
-    
+
     public static func == (lhs: PersonStub, rhs: PersonStub) -> Bool {
-        lhs.url == rhs.url
+        lhs.content == rhs.content
     }
-    
+
     public func getPerson() async throws -> Person {
-        try await api.getPerson(url: url)
+        switch content {
+        case let .url(url):
+            try await api.getPerson(url: url)
+        case let .handle(handle):
+            try await api.getPerson(handle: handle)
+        }
     }
 }
 
-// Resolvable conformance
 public extension PersonStub {
-    var resolvableUrl: URL { url }
-    
-    @inlinable
-    var allResolvableUrls: [URL] { [resolvableUrl] }
+    init(api: ApiClient, url: URL) {
+        self.api = api
+        self.content = .url(url)
+    }
+
+    init(api: ApiClient, handle: PersonHandle) {
+        self.api = api
+        self.content = .handle(handle)
+    }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonHandle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonHandle.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct PersonHandle {
+public struct PersonHandle: Handle {
     public let username: String
     public let host: String
 

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonHandle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonHandle.swift
@@ -8,13 +8,16 @@
 import Foundation
 
 public struct PersonHandle: Handle {
-    public static let prefix: String = "@"
+    public static let prefix: Character = "@"
 
     public let username: String
     public let host: String
 
-    public init(username: String, host: String) {
+    public init(username: String, host: String) throws(HandleError) {
         self.username = username
         self.host = host
+        guard URL(string: "https://\(host)") != nil else {
+            throw .invalidHost
+        }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonHandle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonHandle.swift
@@ -1,0 +1,26 @@
+//
+//  PersonHandle.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-06-23.
+//
+
+import Foundation
+
+public struct PersonHandle {
+    public let username: String
+    public let host: String
+
+    public init(username: String, host: String) {
+        self.username = username
+        self.host = host
+    }
+
+    public func description(withPrefix: Bool) -> String {
+        if withPrefix {
+            "@\(username)@\(host)"
+        } else {
+            "\(username)@\(host)"
+        }
+    }
+}

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonHandle.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Content Models/PersonHandle.swift
@@ -8,19 +8,13 @@
 import Foundation
 
 public struct PersonHandle: Handle {
+    public static let prefix: String = "@"
+
     public let username: String
     public let host: String
 
     public init(username: String, host: String) {
         self.username = username
         self.host = host
-    }
-
-    public func description(withPrefix: Bool) -> String {
-        if withPrefix {
-            "@\(username)@\(host)"
-        } else {
-            "\(username)@\(host)"
-        }
     }
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/InstanceConnection.swift
@@ -229,6 +229,7 @@ internal protocol InstanceConnection {
     func getPerson(id: Int) async throws -> Person3Snapshot
     func getPerson(url: URL) async throws -> Person2Snapshot
     func getPerson(username: String) async throws -> Person3Snapshot
+    func getPerson(handle: PersonHandle) async throws -> Person2Snapshot
     
     func searchPeople(
         query: String,
@@ -311,6 +312,7 @@ internal protocol InstanceConnection {
 
     func getCommunity(id: Int) async throws -> Community3Snapshot
     func getCommunity(url: URL) async throws -> Community2Snapshot
+    func getCommunity(handle: CommunityHandle) async throws -> Community2Snapshot
 
     func editCommunityDescription(id: Int, newValue: String?) async throws -> Community2Snapshot 
     

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Community.swift
@@ -24,6 +24,29 @@ internal extension LemmyConnection {
             throw ApiClientError.noEntityFound
         }
     }
+
+    func getCommunity(handle: CommunityHandle) async throws -> Community2Snapshot {
+        if handle.host == self.baseUrl.host() {
+            // Required to fix https://github.com/mlemgroup/mlem/issues/2341
+            let response = try await performingForEndpoint { endpoint in
+                LemmyGetCommunityRequest(
+                    endpoint: endpoint,
+                    id: nil,
+                    name: handle.username
+                )
+            }
+            return try .init(from: response.communityView)
+        }
+        let response = try await performingForEndpoint { endpoint in
+            LemmyResolveObjectRequest(endpoint: endpoint, q: handle.description(withPrefix: true))
+        }
+        switch try ResolvedContent(from: response) {
+        case let .community(community):
+            return community
+        default:
+            throw ApiClientError.noEntityFound
+        }
+    }
     
     func searchCommunities(
         query: String,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/LemmyConnection/LemmyConnection+Person.swift
@@ -49,6 +49,34 @@ internal extension LemmyConnection {
         }
         return try .init(from: response)
     }
+
+    func getPerson(handle: PersonHandle) async throws -> Person2Snapshot {
+        if handle.host == self.baseUrl.host() {
+            // Required to fix https://github.com/mlemgroup/mlem/issues/2341
+            let response = try await performingForEndpoint { endpoint in
+                LemmyReadPersonRequest(
+                    endpoint: endpoint,
+                    personId: nil,
+                    username: handle.username,
+                    sort: nil,
+                    page: 1,
+                    limit: 1,
+                    communityId: nil,
+                    savedOnly: nil
+                )
+            }
+            return try .init(from: response.personView)
+        }
+        let response = try await performingForEndpoint { endpoint in
+            LemmyResolveObjectRequest(endpoint: endpoint, q: handle.description(withPrefix: true))
+        }
+        switch try ResolvedContent(from: response) {
+        case let .person(person):
+            return person
+        default:
+            throw ApiClientError.noEntityFound
+        }
+    }
     
     /// `filter` can be set to `.local` from 0.19.4 onwards.
     func searchPeople(

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Community.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Community.swift
@@ -23,6 +23,15 @@ internal extension PieFedConnection {
         throw ApiClientError.noEntityFound
     }
     
+    func getCommunity(handle: CommunityHandle) async throws -> Community2Snapshot {
+        let request = PieFedResolveObjectRequest(q: handle.description(withPrefix: true))
+        let response = try await perform(request)
+        if let community = response.community {
+            return try .init(from: community)
+        }
+        throw ApiClientError.noEntityFound
+    }
+    
     func searchCommunities(
         query: String,
         pageInfo: PageInfo,

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/InstanceConnection/PiefedConnection/PieFedConnection+Person.swift
@@ -46,6 +46,15 @@ public extension PieFedConnection {
         let response = try await perform(request)
         return try .init(from: response)
     }
+
+    func getPerson(handle: PersonHandle) async throws -> Person2Snapshot {
+        let request = PieFedResolveObjectRequest(q: handle.description(withPrefix: true))
+        let response = try await perform(request)
+        if let person = response.person {
+            return try .init(from: person)
+        }
+        throw ApiClientError.noEntityFound
+    }
     
     /// `filter` can be set to `.local` from 0.19.4 onwards.
     func searchPeople(


### PR DESCRIPTION
Added two new structs to `MlemMiddleware`:

- `PersonHandle`: represents a `"@user@instance.com"` string
- `CommunityHandle`: represents a `"!comm@instance.com"` string

You can resolve a community or person using these types.

This is necessary because converting a handle to a URL isn't guaranteed to work for softwares other than Lemmy or PieFed. For instance, Mbin uses `/m/` rather than `/c/` for communities. Keeping the data in handle form - rather than converting to URL - allows us to support those cases.

I think this work may be necessary for the upcoming Canvas auth work (#2710), which is why it's happening now.