### PR TITLE
Edit button in block list

### DIFF
--- a/Mlem/App/Utility/Extensions/QuickSwipeAction+Actions.swift
+++ b/Mlem/App/Utility/Extensions/QuickSwipeAction+Actions.swift
@@ -60,4 +60,18 @@ extension View {
             leadingBuffer: leadingBuffer
         ))
     }
+
+    @ViewBuilder
+    func quickSwipes(
+        entity: Any,
+        leading: [ActionSeed] = [],
+        trailing: [ActionSeed] = [],
+        leadingBuffer: SwipeBuffer
+    ) -> some View {
+        quickSwipes(
+            leading: leading.compactMap { $0.createAction(entity) },
+            trailing: trailing.compactMap { $0.createAction(entity) },
+            leadingBuffer: leadingBuffer
+        )
+    }
 }

--- a/Mlem/App/Utility/Extensions/Views/View Modifiers/View+QuickSwipes.swift
+++ b/Mlem/App/Utility/Extensions/Views/View Modifiers/View+QuickSwipes.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 2025-08-23.
 //
 
+import Actions
 import MlemMiddleware
 import QuickSwipes
 import SwiftUI

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -93,8 +93,8 @@ struct BlockListView: View {
             ForEach(stubs.filter { $0.blocked.realizedValue }, id: \.self) { instance in
                 deleteButton(entity: instance) {
                     InstanceRow(instance: instance)
-                        .padding(.horizontal, Constants.main.standardSpacing)
                 }
+                .padding(.horizontal, Constants.main.standardSpacing)
                 .padding(.bottom, Constants.main.halfSpacing)
             }
         case let .summaries(summaries):
@@ -116,7 +116,11 @@ struct BlockListView: View {
             if isEditing {
                 Button("Unblock", icon: .lemmy.unblock) {
                     withAnimation {
-                        entity.updateBlocked?(false, nil)
+                        if entity is any InstanceActionProviding, let session = (appState.firstSession as? UserSession) {
+                            session.updateInstanceBlock(actorId: entity.actorId, shouldBlock: false) 
+                        } else {
+                            entity.updateBlocked?(false, nil)
+                        }
                         hapticManager.play(haptic: .lightSuccess, tier: .low)
                     }
                 }

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -5,6 +5,7 @@
 //  Created by Sjmarf on 2024-11-09.
 //
 
+import Actions
 import MlemBackend
 import MlemMiddleware
 import SwiftUI
@@ -54,10 +55,20 @@ struct BlockListView: View {
             case .people:
                 SearchResultsView(results: people.filter(\.blocked_.realizedValue)) { person in
                     PersonListRow(person, showBlockStatus: false)
+                        .quickSwipes(
+                            entity: person,
+                            trailing: [ActionSeed.block],
+                            leadingBuffer: .standard
+                        )
                 }
             case .communities:
                 SearchResultsView(results: communities.filter(\.blocked_.realizedValue)) { community in
                     CommunityListRow(community, showBlockStatus: false)
+                        .quickSwipes(
+                            entity: community,
+                            trailing: [ActionSeed.block],
+                            leadingBuffer: .standard
+                        )
                 }
             case .instances:
                 instancesView
@@ -78,12 +89,22 @@ struct BlockListView: View {
         case let .stubs(stubs):
             ForEach(stubs.filter { $0.blocked.realizedValue }, id: \.self) { instance in
                 InstanceRow(instance: instance)
+                    .quickSwipes(
+                        entity: instance,
+                        trailing: [ActionSeed.block],
+                        leadingBuffer: .standard
+                    )
                     .padding(.horizontal, Constants.main.standardSpacing)
                     .padding(.bottom, Constants.main.halfSpacing)
             }
         case let .summaries(summaries):
-            SearchResultsView(results: summaries.filter { $0.blocked.realizedValue }) { community in
-                InstanceListRow(community, showBlockStatus: false)
+            SearchResultsView(results: summaries.filter { $0.blocked.realizedValue }) { instance in
+                InstanceListRow(instance, showBlockStatus: false)
+                    .quickSwipes(
+                        entity: instance,
+                        trailing: [ActionSeed.block],
+                        leadingBuffer: .standard
+                    )
             }
         }
     }

--- a/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/BlockListView.swift
@@ -6,6 +6,7 @@
 //
 
 import Actions
+import Haptics
 import MlemBackend
 import MlemMiddleware
 import SwiftUI
@@ -13,6 +14,7 @@ import Theming
 
 struct BlockListView: View {
     @Environment(AppState.self) var appState
+    @Environment(HapticManager.self) var hapticManager
     
     enum Tab: CaseIterable, Identifiable {
         case people, communities, instances
@@ -37,6 +39,8 @@ struct BlockListView: View {
     @State var people: [Person] = []
     @State var communities: [Community] = []
     @State var instances: InstanceInfo = .stubs([])
+
+    @State var isEditing: Bool = false
     
     var body: some View {
         FancyScrollView {
@@ -54,27 +58,26 @@ struct BlockListView: View {
             switch selectedTab {
             case .people:
                 SearchResultsView(results: people.filter(\.blocked_.realizedValue)) { person in
-                    PersonListRow(person, showBlockStatus: false)
-                        .quickSwipes(
-                            entity: person,
-                            trailing: [ActionSeed.block],
-                            leadingBuffer: .standard
-                        )
+                    deleteButton(entity: person) {
+                        PersonListRow(person, showBlockStatus: false)
+                    }
                 }
             case .communities:
                 SearchResultsView(results: communities.filter(\.blocked_.realizedValue)) { community in
-                    CommunityListRow(community, showBlockStatus: false)
-                        .quickSwipes(
-                            entity: community,
-                            trailing: [ActionSeed.block],
-                            leadingBuffer: .standard
-                        )
+                    deleteButton(entity: community) {
+                        CommunityListRow(community, showBlockStatus: false)
+                    }
                 }
             case .instances:
                 instancesView
             }
         }
         .themedGroupedBackground()
+        .toolbar {
+            Button(isEditing ? "Done" : "Edit") {
+                isEditing.toggle()
+            }
+        }
         .onAppear {
             Task { @MainActor in
                 await refresh()
@@ -88,25 +91,41 @@ struct BlockListView: View {
         switch instances {
         case let .stubs(stubs):
             ForEach(stubs.filter { $0.blocked.realizedValue }, id: \.self) { instance in
-                InstanceRow(instance: instance)
-                    .quickSwipes(
-                        entity: instance,
-                        trailing: [ActionSeed.block],
-                        leadingBuffer: .standard
-                    )
-                    .padding(.horizontal, Constants.main.standardSpacing)
-                    .padding(.bottom, Constants.main.halfSpacing)
+                deleteButton(entity: instance) {
+                    InstanceRow(instance: instance)
+                        .padding(.horizontal, Constants.main.standardSpacing)
+                }
+                .padding(.bottom, Constants.main.halfSpacing)
             }
         case let .summaries(summaries):
             SearchResultsView(results: summaries.filter { $0.blocked.realizedValue }) { instance in
-                InstanceListRow(instance, showBlockStatus: false)
-                    .quickSwipes(
-                        entity: instance,
-                        trailing: [ActionSeed.block],
-                        leadingBuffer: .standard
-                    )
+                deleteButton(entity: instance) {
+                    InstanceListRow(instance, showBlockStatus: false)
+                }
             }
         }
+    }
+
+    @ViewBuilder
+    func deleteButton(
+        entity: any Blockable,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        HStack {
+            content()
+            if isEditing {
+                Button("Unblock", icon: .lemmy.unblock) {
+                    withAnimation {
+                        entity.updateBlocked?(false, nil)
+                        hapticManager.play(haptic: .lightSuccess, tier: .low)
+                    }
+                }
+                .labelStyle(.iconOnly)
+                .foregroundStyle(.themedNegative)
+                .padding(.horizontal, Constants.main.halfSpacing)
+            }
+        }
+        .animation(.default, value: isEditing)
     }
 
     func refresh() async {

--- a/Mlem/App/Views/Shared/Search/SearchView+Views.swift
+++ b/Mlem/App/Views/Shared/Search/SearchView+Views.swift
@@ -333,7 +333,7 @@ extension SearchView {
                 }
             }
             .labelStyle(.iconOnly)
-            .foregroundStyle(palette.negative)
+            .foregroundStyle(.themedNegative)
             .padding(.horizontal, Constants.main.halfSpacing)
         }
     }

--- a/Mlem/Packages/QuickSwipes/Sources/QuickSwipes/QuickSwipesViewModifier.swift
+++ b/Mlem/Packages/QuickSwipes/Sources/QuickSwipes/QuickSwipesViewModifier.swift
@@ -68,6 +68,7 @@ struct QuickSwipeViewModifier: ViewModifier {
                     }
                     Button("Cancel", role: .cancel) {}
                 }
+                .environment(\.quickSwipesEnabled, false)
         } else {
             content
                 .clipShape(.rect(cornerRadius: cornerRadius)) // clip entire view


### PR DESCRIPTION
~The block list now has a single trailing swipe action: "unblock". It ignores the user's swipe action configuration (unless they've got swipe actions completely off, in which case it's disabled)~

The block list now has an "edit" button

Closes #2760