### PR TITLE
Fix `NavigationLayer.replace` stuttering

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -357,6 +357,8 @@
 		03B72B672C2888EE0023A6C4 /* View+ContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B72B662C2888EE0023A6C4 /* View+ContextMenu.swift */; };
 		03B72B6B2C28A0190023A6C4 /* SubscriptionListSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B72B6A2C28A0190023A6C4 /* SubscriptionListSettingsView.swift */; };
 		03B7F3352EEEC70F00B00F6A /* NoteEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B7F3342EEEC70F00B00F6A /* NoteEditorView.swift */; };
+		03BEF4802FF84AB600D75A16 /* NavigationFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BEF47E2FF84AB600D75A16 /* NavigationFrame.swift */; };
+		03BEF4812FF84AB600D75A16 /* NavigationFrameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BEF47F2FF84AB600D75A16 /* NavigationFrameView.swift */; };
 		03BF11C32D3D135D00CC1F66 /* SearchView+CreatorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BF11C22D3D135D00CC1F66 /* SearchView+CreatorPicker.swift */; };
 		03BF11C52D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BF11C42D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift */; };
 		03BF11C72D3D634A00CC1F66 /* AccessibilitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BF11C62D3D634A00CC1F66 /* AccessibilitySettingsView.swift */; };
@@ -982,6 +984,8 @@
 		03B72B662C2888EE0023A6C4 /* View+ContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ContextMenu.swift"; sourceTree = "<group>"; };
 		03B72B6A2C28A0190023A6C4 /* SubscriptionListSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionListSettingsView.swift; sourceTree = "<group>"; };
 		03B7F3342EEEC70F00B00F6A /* NoteEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEditorView.swift; sourceTree = "<group>"; };
+		03BEF47E2FF84AB600D75A16 /* NavigationFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationFrame.swift; sourceTree = "<group>"; };
+		03BEF47F2FF84AB600D75A16 /* NavigationFrameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationFrameView.swift; sourceTree = "<group>"; };
 		03BF11C22D3D135D00CC1F66 /* SearchView+CreatorPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchView+CreatorPicker.swift"; sourceTree = "<group>"; };
 		03BF11C42D3D3AFB00CC1F66 /* PostReadIndicatorSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReadIndicatorSettingsView.swift; sourceTree = "<group>"; };
 		03BF11C62D3D634A00CC1F66 /* AccessibilitySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySettingsView.swift; sourceTree = "<group>"; };
@@ -1570,6 +1574,8 @@
 				035BE08A2BDD903100F77D73 /* NavigationModel.swift */,
 				035BE08E2BDE911900F77D73 /* NavigationLayer.swift */,
 				035BE0882BDD901B00F77D73 /* NavigationPage.swift */,
+				03BEF47E2FF84AB600D75A16 /* NavigationFrame.swift */,
+				03BEF47F2FF84AB600D75A16 /* NavigationFrameView.swift */,
 				03D001DC2EC53A97001BF97D /* NavigationPage+PresentationDetents.swift */,
 				0320B6642C91DBD500D38548 /* NavigationPage+View.swift */,
 				03531EF42C2DA610004A3464 /* NavigationSearchType.swift */,
@@ -2985,6 +2991,8 @@
 				03ECD71F2C864DB700D48BF6 /* ImageUploadManager.swift in Sources */,
 				CD1446272A5B36DA00610EF1 /* EULA.swift in Sources */,
 				036A84D82D99531400E95D50 /* View+ConditionalNavigationTitle.swift in Sources */,
+				03BEF4802FF84AB600D75A16 /* NavigationFrame.swift in Sources */,
+				03BEF4812FF84AB600D75A16 /* NavigationFrameView.swift in Sources */,
 				CD79281F2C73B52A00FA712D /* EndOfFeedView.swift in Sources */,
 				CDE1F19C2C63E2EB008AF042 /* SettingPropertyWrapper.swift in Sources */,
 				0368F3692D7349D8007DEB70 /* LanguageListRowBody.swift in Sources */,

--- a/Mlem/App/Actions/CrosspostAction.swift
+++ b/Mlem/App/Actions/CrosspostAction.swift
@@ -64,7 +64,7 @@ extension CrosspostAction {
             content: crossPostContent,
             type: entity.type,
             nsfw: entity.nsfw,
-            feedLoader: .init(wrappedValue: nil)
+            feedLoader: nil
         ))
     }
 }

--- a/Mlem/App/Actions/ReplyAction.swift
+++ b/Mlem/App/Actions/ReplyAction.swift
@@ -53,7 +53,7 @@ extension ReplyAction {
         guard content.value.api.canInteract(appState: environment.appState) else { return .hidden }
 
         // Don't show the reply action for messages in the message feed
-        if case .message = self.content, case .messageFeed = environment.navigation?.path.last {
+        if case .message = self.content, case .messageFeed = environment.navigation?.path.last?.page {
             return .hidden
         }
 

--- a/Mlem/App/Logic/HandleError.swift
+++ b/Mlem/App/Logic/HandleError.swift
@@ -83,7 +83,9 @@ private func _handleError(
 @MainActor
 private func showReauthSheet() {
     if let user = AppState.main.firstSession.account as? UserAccount,
-       !NavigationModel.main.layers.contains(where: { $0.root.page == .logIn(.reauth(user)) }) {
+        !NavigationModel.main.layers.contains(where: {
+            if case .logIn(.reauth(user)) = $0.root.page { true } else { false }
+        }) {
         NavigationModel.main.openSheet(.logIn(.reauth(user)))
     }
 }

--- a/Mlem/App/Logic/HandleError.swift
+++ b/Mlem/App/Logic/HandleError.swift
@@ -83,7 +83,7 @@ private func _handleError(
 @MainActor
 private func showReauthSheet() {
     if let user = AppState.main.firstSession.account as? UserAccount,
-       !NavigationModel.main.layers.contains(where: { $0.root == .logIn(.reauth(user)) }) {
+       !NavigationModel.main.layers.contains(where: { $0.root.page == .logIn(.reauth(user)) }) {
         NavigationModel.main.openSheet(.logIn(.reauth(user)))
     }
 }

--- a/Mlem/App/Models/ErrorDetails.swift
+++ b/Mlem/App/Models/ErrorDetails.swift
@@ -68,7 +68,7 @@ struct ErrorDetails: Hashable {
     }
     
     func errorText(includingLocation: Bool = true) -> String {
-        var output = String(describing: error)
+        var output: String = error.map(String.init(describing:)) ?? "nil"
         if includingLocation, let location {
             output += " (\(location))"
         }

--- a/Mlem/App/Utility/Extensions/Content Models/Post/Post+Actions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post/Post+Actions.swift
@@ -83,7 +83,7 @@ extension Post {
                     content: crossPostContent,
                     type: self.type,
                     nsfw: self.nsfw,
-                    feedLoader: .init(wrappedValue: nil)
+                    feedLoader: nil
                 ))
             }
         )

--- a/Mlem/App/Utility/Extensions/Views/NavigationLink+NavigationPage.swift
+++ b/Mlem/App/Utility/Extensions/Views/NavigationLink+NavigationPage.swift
@@ -10,11 +10,11 @@ import SwiftUI
 
 extension NavigationLink where Destination == Never {
     init(_ value: NavigationPage, @ViewBuilder label: () -> Label) {
-        self.init(value: value, label: label)
+        self.init(value: NavigationFrame(page: value), label: label)
     }
     
     init(_ titleKey: LocalizedStringResource, destination: NavigationPage) where Label == Text {
-        self.init(value: destination) { Text(titleKey) }
+        self.init(value: NavigationFrame(page: destination)) { Text(titleKey) }
     }
     
     init(
@@ -36,7 +36,7 @@ extension NavigationLink where Destination == Never {
     
     @_disfavoredOverload
     init(_ title: String, destination: NavigationPage) where Label == Text {
-        self.init(value: destination) { Text(title) }
+        self.init(value: NavigationFrame(page: destination)) { Text(title) }
     }
     
     init(
@@ -44,7 +44,9 @@ extension NavigationLink where Destination == Never {
         icon: Icon,
         destination: NavigationPage
     ) where Label == SwiftUI.Label<Text, Image> {
-        self.init(value: destination) { Label(String(localized: titleKey), icon: icon) }
+        self.init(value: NavigationFrame(page: destination)) {
+            Label(String(localized: titleKey), icon: icon)
+        }
     }
 }
 

--- a/Mlem/App/Views/Root/Tabs/Feeds/Components/UpdateBannerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Components/UpdateBannerView.swift
@@ -61,7 +61,7 @@ struct UpdateBannerView: View {
             }
         }
         .onChange(of: navigation.path) {
-            if case .post(let post, _, _, _) = navigation.path.last,
+            if case .post(let post, _, _, _) = navigation.path.last?.page,
                post.allResolvableUrls.contains(url) {
                 dismiss()
             }

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListNavigationButton.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListNavigationButton.swift
@@ -23,8 +23,8 @@ struct SubscriptionListNavigationButton<Content: View>: View {
             NavigationLink(destination, label: label)
         }, pad: {
             Button(action: {
-                navigation.path = []
-                navigation.root = destination
+                navigation.popToRoot()
+                navigation.replace(destination)
             }, label: label)
                 .buttonStyle(.empty)
         })

--- a/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
+++ b/Mlem/App/Views/Shared/Images/Core/MediaView+Views.swift
@@ -91,7 +91,7 @@ extension MediaView {
                         Button("Load directly from \(proxyBypass.host() ?? "unknown host")") {
                             if !bypassImageProxyShown {
                                 bypassImageProxyShown = true
-                                navigation.openSheet(.bypassImageProxyWarning {
+                                navigation.openSheet(.bypassImageProxy {
                                     Task {
                                         await loader.load(proxyBypass)
                                     }

--- a/Mlem/App/Views/Shared/Navigation/NavigationFrame.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationFrame.swift
@@ -1,0 +1,28 @@
+//
+//  NavigationFrame.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-07-03.
+//
+
+import Foundation
+
+// This exists to fix the following issue:
+// https://github.com/mlemgroup/mlem/issues/2533
+
+@Observable
+class NavigationFrame: Hashable {
+    var page: NavigationPage
+
+    init(page: NavigationPage) {
+        self.page = page
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: NavigationFrame, rhs: NavigationFrame) -> Bool {
+        lhs === rhs
+    }
+}

--- a/Mlem/App/Views/Shared/Navigation/NavigationFrameView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationFrameView.swift
@@ -1,0 +1,20 @@
+//
+//  NavigationFrameView.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-07-03.
+//
+
+import SwiftUI
+
+// This struct exists to restrict the scope of view updates when
+// `frame.page` changes. This can happen when `NavigationLayer.replace`
+// is called.
+
+struct NavigationFrameView: View {
+    let frame: NavigationFrame
+
+    var body: some View {
+        frame.page.view()
+    }
+}

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayer.swift
@@ -16,8 +16,8 @@ class NavigationLayer: Identifiable {
     weak var model: NavigationModel?
     var index: Int
     
-    var root: NavigationPage
-    var path: [NavigationPage]
+    var root: NavigationFrame
+    var path: [NavigationFrame]
     var hasNavigationStack: Bool
     var isFullScreenCover: Bool
     var canDisplayToasts: Bool
@@ -38,8 +38,8 @@ class NavigationLayer: Identifiable {
     ) {
         self.model = model
         self.index = index
-        self.root = root
-        self.path = path
+        self.root = .init(page: root)
+        self.path = path.map { .init(page: $0) }
         self.hasNavigationStack = hasNavigationStack
         self.isFullScreenCover = isFullScreenCover
         self.canDisplayToasts = canDisplayToasts
@@ -51,7 +51,7 @@ class NavigationLayer: Identifiable {
         if hasNavigationStack {
             // This prevents keyboard animation glitches when navigating whilst the keyboard is open
             UIApplication.shared.firstKeyWindow?.endEditing(true)
-            path.append(page)
+            path.append(.init(page: page))
         } else {
             openSheet(page)
         }
@@ -65,9 +65,9 @@ class NavigationLayer: Identifiable {
             // This prevents keyboard animation glitches when navigating whilst the keyboard is open
             UIApplication.shared.firstKeyWindow?.endEditing(true)
             if path.isEmpty {
-                root = page
+                root.page = page
             } else {
-                path[path.count - 1] = page
+                path[path.count - 1].page = page
             }
         } else {
             openSheet(page)
@@ -115,7 +115,7 @@ class NavigationLayer: Identifiable {
             return
         }
         rootChangePending = true
-        if case .actionSheet = root {
+        if case .actionSheet = root.page {
             withAnimation {
                 if let detentsConfiguration = page.presentationDetentConfiguration {
                     if detentsConfiguration.detents.contains(.large), self.rootViewPresentationDetent != .large {
@@ -128,7 +128,7 @@ class NavigationLayer: Identifiable {
                 }
             } completion: {
                 withAnimation(.easeOut(duration: 0.3)) {
-                    self.root = page
+                    self.root = .init(page: page)
                     self.hasNavigationStack = page.hasNavigationStack
                 }
             }
@@ -262,7 +262,7 @@ class NavigationLayer: Identifiable {
 
     @MainActor
     func dismissingActionSheet(_ callback: @escaping () -> Void) {
-        if case .actionSheet = root {
+        if case .actionSheet = root.page {
             dismissSheet()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 callback()
@@ -278,7 +278,7 @@ class NavigationLayer: Identifiable {
     var isAlive: Bool { model != nil }
     
     var isImageViewer: Bool {
-        switch root {
+        switch root.page {
         case .imageViewer: true
         default: false
         }

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
@@ -25,8 +25,8 @@ struct NavigationLayerView: View {
                 NavigationStack(path: $layer.path) {
                     rootView()
                         .environment(\.isRootView, true)
-                        .navigationDestination(for: NavigationPage.self) {
-                            $0.view()
+                        .navigationDestination(for: NavigationFrame.self) {
+                            NavigationFrameView(frame: $0)
                                 .environment(\.isRootView, false)
                         }
                 }
@@ -84,9 +84,9 @@ struct NavigationLayerView: View {
     @ViewBuilder
     private func innerRootView() -> some View {
         if let selectedDetent {
-            layer.root.sheetView(selectedDetent: selectedDetent)
+            layer.root.page.sheetView(selectedDetent: selectedDetent)
         } else {
-            layer.root.view()
+            layer.root.page.view()
         }
     }
     

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage+View.swift
@@ -11,7 +11,6 @@ import MlemMiddleware
 import SwiftUI
 
 extension NavigationPage {
-
     @MainActor @ViewBuilder
     func sheetView(selectedDetent: Binding<PresentationDetent>) -> some View {
         if let presentationDetentConfiguration {
@@ -30,7 +29,7 @@ extension NavigationPage {
         case let .selectText(string):
             SelectTextView(text: string)
         case let .shareInstancePicker(sharable):
-            ShareInstancePickerView(entity: sharable.wrappedValue)
+            ShareInstancePickerView(entity: sharable)
         case let .settings(page):
             page.view()
         case let .logIn(page):
@@ -68,11 +67,11 @@ extension NavigationPage {
         case .quickSwitcher:
             QuickSwitcherView()
         case let .report(target, community):
-            ReportEditorView(target: target.wrappedValue, community: community)
+            ReportEditorView(target: target, community: community)
         case let .remove(target):
-            ContentRemovalEditorView(target: target.wrappedValue)
+            ContentRemovalEditorView(target: target)
         case let .purge(target):
-            ContentPurgeEditorView(target: target.wrappedValue)
+            ContentPurgeEditorView(target: target)
         case let .ban(person, isBannedFromCommunity: isBannedFromCommunity, shouldBan: shouldBan, community: community):
             PersonBanEditorView(
                 person: person,
@@ -139,7 +138,7 @@ extension NavigationPage {
                 content: content,
                 type: type,
                 nsfw: nsfw,
-                feedLoader: feedLoader.wrappedValue
+                feedLoader: feedLoader
             ) {
                 view
             } else {
@@ -150,7 +149,7 @@ extension NavigationPage {
         case let .communityPicker(api: api, callback: callback):
             SearchSheetView(api: api) { (community: Community, navigation: NavigationLayer) in
                 Button {
-                    callback.wrappedValue(community, navigation)
+                    callback(community, navigation)
                 } label: {
                     CommunityListRowBody(community, readout: .subscribers)
                         .tint(.themedPrimary)
@@ -161,7 +160,7 @@ extension NavigationPage {
         case let .personPicker(api: api, filter: filter, callback: callback):
             SearchSheetView(api: api, filter: filter) { (person: Person, navigation: NavigationLayer) in
                 Button {
-                    callback.wrappedValue(person, navigation)
+                    callback(person, navigation)
                 } label: {
                     PersonListRowBody(person)
                         .tint(.themedPrimary)
@@ -172,7 +171,7 @@ extension NavigationPage {
         case let .instancePicker(callback: callback, requiredFeature: requiredFeature):
             SearchSheetView { (instance: InstanceSummary, navigation: NavigationLayer) in
                 Button {
-                    callback.wrappedValue(instance, navigation)
+                    callback(instance, navigation)
                 } label: {
                     InstanceListRowBody(instance)
                         .tint(.themedPrimary)
@@ -195,11 +194,11 @@ extension NavigationPage {
                 }
             }
         case let .languagePicker(selectedLanguages: selectedLanguages, callback: callback):
-            LanguagePickerSheetView(selectedLanguages: selectedLanguages, callback: callback.wrappedValue)
+            LanguagePickerSheetView(selectedLanguages: selectedLanguages, callback: callback)
         case let .instance(instance, visitContext):
             InstanceView(instance: instance, visitContext: visitContext)
         case let .instanceStub(instance, targetPage):
-            InstanceStubResolutionPage(stub: instance, targetPage: targetPage.wrappedValue)
+            InstanceStubResolutionPage(stub: instance, targetPage: targetPage)
         case let .instanceOpinionList(instance: instance, opinionType: opinionType, data: data):
             FediseerOpinionListView(instance: instance, opinionType: opinionType, fediseerData: data)
         case .fediseerInfo:
@@ -209,7 +208,7 @@ extension NavigationPage {
         case let .deleteAccount(account):
             DeleteAccountView(account: account)
         case let .bypassImageProxy(callback):
-            BypassProxyWarningSheet(callback: callback.wrappedValue)
+            BypassProxyWarningSheet(callback: callback)
         case let .confirmUpload(imageData: imageData, fileExtension: fileExtension, imageManager: imageManager, uploadApi: uploadApi):
             UploadConfirmationView(
                 imageData: imageData,
@@ -218,11 +217,11 @@ extension NavigationPage {
                 uploadApi: uploadApi
             )
         case let .rulesList(model, callback):
-            RulesPickerView(model: model.wrappedValue, callback: callback.wrappedValue)
+            RulesPickerView(model: model, callback: callback)
         case .blockList:
             BlockListView()
         case let .advancedSorting(sort):
-            AdvancedSortView(selectedSort: sort.wrappedValue)
+            AdvancedSortView(selectedSort: sort)
         case let .votesList(target):
             VotesListView(target: target)
         case let .messageFeed(person, messageContent: messageContent, focusTextField: focusTextField, editing: editing):
@@ -230,7 +229,7 @@ extension NavigationPage {
                 person: person,
                 messageContent: messageContent,
                 focusTextField: focusTextField,
-                editing: editing?.wrappedValue
+                editing: editing
             )
         case let .modlog(target, targetPerson, moderatorPerson):
             ModlogView(initialTarget: target, targetPerson: targetPerson, moderatorPerson: moderatorPerson)
@@ -242,14 +241,14 @@ extension NavigationPage {
             ExportableCommentEditorView(comment: comment, commentTreeTracker: tracker)
         case let .actionSheet(sections, environment, configuration):
             ActionSheet(
-                sections: sections.wrappedValue,
-                environment: environment.wrappedValue,
+                sections: sections,
+                environment: environment,
                 configuration: configuration
             )
         case .unavailableContentInfo:
             UnavailableContentInfoView()
         case let .unsupportedVersion(account):
-            UnsupportedVersionWarningView(account: account.wrappedValue)
+            UnsupportedVersionWarningView(account: account)
         case let .authHandoff(session: session, personHandle: personHandle, defaultAccount: defaultAccount):
             AuthHandoffView(
                 session: session,

--- a/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationPage.swift
@@ -10,9 +10,7 @@ import MlemBackend
 import MlemMiddleware
 import SwiftUI
 
-// swiftlint:disable file_length
-// swiftlint:disable:next type_body_length
-enum NavigationPage: Hashable {
+enum NavigationPage {
     case settings(_ page: SettingsPage = .root)
     case logIn(_ page: LoginPage = .pickInstance)
     case signUp(_ instance: Instance)
@@ -49,65 +47,76 @@ enum NavigationPage: Hashable {
     case person(_ person: Person, visitContext: VisitHistory.VisitContext = .other)
     case personStub(_ personStub: PersonStub, visitContext: VisitHistory.VisitContext = .other)
     case instance(_ instance: Instance, visitContext: VisitHistory.VisitContext = .other)
-    case instanceStub(_ instanceStub: InstanceStub, targetPage: HashWrapper<(Instance) -> NavigationPage>)
+    case instanceStub(_ instanceStub: InstanceStub, targetPage: (Instance) -> NavigationPage)
     case instanceOpinionList(instance: Instance, opinionType: FediseerOpinionType, data: FediseerData)
-    case messageFeed(_ person: Person, messageContent: String, focusTextField: Bool, editing: MessageHashWrapper?)
+    case messageFeed(
+        _ person: Person,
+        messageContent: String = "",
+        focusTextField: Bool = false,
+        editing: (any Message1Providing)? = nil
+    )
     case fediseerInfo
     case instanceUptime(_ instance: Instance, uptimeData: UptimeData)
     case externalApiInfo(api: ApiClient, actorId: ActorIdentifier)
     case imageViewer(_ url: URL)
-    case communityPicker(api: ApiClient?, callback: HashWrapper<(Community, NavigationLayer) -> Void>)
-    case personPicker(api: ApiClient?, filter: ListingType, callback: HashWrapper<(Person, NavigationLayer) -> Void>)
-    case instancePicker(callback: HashWrapper<(InstanceSummary, NavigationLayer) -> Void>, requiredFeature: Feature? = nil)
-    case languagePicker(selectedLanguages: Set<Locale.Language>, callback: HashWrapper<(Locale.Language) -> Void>)
+    case communityPicker(
+        api: ApiClient? = nil,
+        callback: (Community, NavigationLayer) -> Void
+    )
+    case personPicker(
+        api: ApiClient? = nil,
+        filter: ListingType = .all,
+        callback: (Person, NavigationLayer) -> Void
+    )
+    case instancePicker(
+        callback: (InstanceSummary, NavigationLayer) -> Void,
+        requiredFeature: Feature? = nil
+    )
+    case languagePicker(selectedLanguages: Set<Locale.Language>, callback: (Locale.Language) -> Void)
     case selectText(_ string: String)
-    case shareInstancePicker(_ sharable: SharableHashWrapper)
+    case shareInstancePicker(_ sharable: any Sharable & ContentModel)
     case subscriptionList
     case createComment(_ context: CommentEditorView.Context, commentTreeTracker: CommentTreeTracker? = nil)
     case editComment(_ comment: Comment, context: CommentEditorView.Context?)
     case editCommunity(_ community: Community)
     case editNote(_ person: Person)
-    case report(_ interactable: ReportableHashWrapper, community: Community? = nil)
-    case remove(_ removable: RemovableHashWrapper)
-    case purge(_ purgable: PurgableHashWrapper)
+    case report(_ interactable: any ReportableProviding, community: Community? = nil)
+    case remove(_ removable: any RemovableProviding)
+    case purge(_ purgable: any PurgableProviding)
     case ban(_ person: Person, isBannedFromCommunity: Bool, shouldBan: Bool, community: Community?)
     case createPost(
-        community: Community?,
-        title: String,
-        content: String?,
-        type: PostType?,
-        nsfw: Bool,
-        feedLoader: HashWrapper<(any FeedLoading)?>
+        community: Community? = nil,
+        title: String = "",
+        content: String? = nil,
+        type: PostType? = nil,
+        nsfw: Bool = false,
+        feedLoader: (any FeedLoading)? = nil
     )
     case editPost(_ post: Post)
     case deleteAccount(_ account: UserAccount)
-    case bypassImageProxy(callback: HashWrapper<() -> Void>)
+    case bypassImageProxy(callback: () -> Void)
     case confirmUpload(imageData: Data, fileExtension: String, imageManager: ImageUploadManager, uploadApi: ApiClient)
-    case rulesList(_ model: Profile2HashWrapper, callback: HashWrapper<(String) -> Void>)
+    case rulesList(_ model: any ProfileProviding, callback: (String) -> Void)
     case blockList
-    case advancedSorting(_ sort: HashWrapper<Binding<PostSortType>>)
+    case advancedSorting(_ sort: Binding<PostSortType>)
     case votesList(_ target: VotesListView.Target)
     case modlog(ModlogView.InitialTarget, targetPerson: Person?, moderatorPerson: Person?)
     case denyApplication(RegistrationApplication)
     case exportPostImage(_ post: Post)
     case exportCommentImage(_ comment: Comment, tracker: CommentTreeTracker?)
     case unavailableContentInfo
-    case unsupportedVersion(_ account: AccountHashWrapper)
+    case unsupportedVersion(_ account: any Account)
     case postDetails(_ post: Post)
     case authHandoff(session: String, personHandle: PersonHandle, defaultAccount: UserAccount)
 
     // If `configuration` is specified, show a "customise" button in the sheet for editing that configuration.
     // Otherwise, no "customise" button is shown.
     case actionSheet(
-        _ actions: HashWrapper<[ActionSheetSection]>,
-        environment: HashWrapper<EnvironmentValues>,
+        _ actions: [ActionSheetSection],
+        environment: EnvironmentValues,
         configuration: ContextMenuSettingsPage?
     )
 
-    static func shareInstancePicker(_ sharable: any Sharable & ContentModel) -> NavigationPage {
-        shareInstancePicker(.init(wrappedValue: sharable))
-    }
-    
     static func modlog(
         community: Community,
         targetPerson: Person? = nil,
@@ -131,32 +140,10 @@ enum NavigationPage: Hashable {
         modlog(.currentInstance, targetPerson: targetPerson, moderatorPerson: moderatorPerson)
     }
     
-    static func messageFeed(
-        _ person: Person,
-        messageContent: String = "",
-        focusTextField: Bool = false,
-        editing: (any Message1Providing)? = nil
-    ) -> NavigationPage {
-        var editingWrapper: MessageHashWrapper?
-        if let editing {
-            editingWrapper = .init(wrappedValue: editing)
-        }
-        return messageFeed(
-            person,
-            messageContent: messageContent,
-            focusTextField: focusTextField,
-            editing: editingWrapper
-        )
-    }
-    
     static func instanceStub(_ stub: InstanceStub, visitContext: VisitHistory.VisitContext = .other) -> NavigationPage {
-        .instanceStub(stub, targetPage: .init(wrappedValue: { .instance($0, visitContext: visitContext) }))
+        .instanceStub(stub, targetPage: { .instance($0, visitContext: visitContext) })
     }
-    
-    static func instanceStub(_ stub: InstanceStub, targetPage: @escaping (Instance) -> NavigationPage) -> NavigationPage {
-        .instanceStub(stub, targetPage: .init(wrappedValue: targetPage))
-    }
-    
+
     static func hostInstance(
         of entity: any ActorIdentifiable,
         visitContext: VisitHistory.VisitContext = .other
@@ -172,35 +159,6 @@ enum NavigationPage: Hashable {
         return .instanceStub(.init(api: AppState.main.firstApi, actorId: .instance(host: entity.actorId.host)))
     }
     
-    static func communityPicker(
-        api: ApiClient? = nil,
-        callback: @escaping (Community, NavigationLayer) -> Void
-    ) -> NavigationPage {
-        communityPicker(api: api, callback: .init(wrappedValue: callback))
-    }
-    
-    static func personPicker(
-        api: ApiClient? = nil,
-        filter: ListingType = .all,
-        callback: @escaping (Person, NavigationLayer) -> Void
-    ) -> NavigationPage {
-        personPicker(api: api, filter: filter, callback: .init(wrappedValue: callback))
-    }
-    
-    static func instancePicker(
-        callback: @escaping (InstanceSummary, NavigationLayer) -> Void,
-        requiredFeature: Feature? = nil
-    ) -> NavigationPage {
-        instancePicker(callback: .init(wrappedValue: callback), requiredFeature: requiredFeature)
-    }
-    
-    static func languagePicker(
-        selectedLanguages: Set<Locale.Language>,
-        callback: @escaping (Locale.Language) -> Void
-    ) -> NavigationPage {
-        languagePicker(selectedLanguages: selectedLanguages, callback: .init(wrappedValue: callback))
-    }
-    
     static func signUp() -> NavigationPage {
         .instancePicker(callback: { instance, navigation in
             Task { @MainActor in
@@ -210,19 +168,19 @@ enum NavigationPage: Hashable {
     }
     
     static func signUp(_ stub: InstanceStub) -> NavigationPage {
-        .instanceStub(stub, targetPage: .init(wrappedValue: { .signUp($0) }))
+        .instanceStub(stub, targetPage: { .signUp($0) })
     }
     
     static func communityPicker(
         api: ApiClient? = nil,
         callback: @escaping (Community) -> Void
     ) -> NavigationPage {
-        communityPicker(api: api, callback: .init(wrappedValue: { value, navigation in
+        communityPicker(api: api, callback: { value, navigation in
             Task { @MainActor in
                 navigation.dismissSheet()
                 callback(value)
             }
-        }))
+        })
     }
     
     static func personPicker(
@@ -230,80 +188,37 @@ enum NavigationPage: Hashable {
         filter: ListingType = .all,
         callback: @escaping (Person) -> Void
     ) -> NavigationPage {
-        personPicker(api: api, filter: filter, callback: .init(wrappedValue: { value, navigation in
+        personPicker(api: api, filter: filter, callback: { value, navigation in
             Task { @MainActor in
                 navigation.dismissSheet()
                 callback(value)
             }
-        }))
+        })
     }
     
     static func instancePicker(
         callback: @escaping (InstanceSummary) -> Void,
         requiredFeature: Feature? = nil
     ) -> NavigationPage {
-        instancePicker(callback: .init(wrappedValue: { value, navigation in
-            Task { @MainActor in
-                navigation.dismissSheet()
-                callback(value)
-            }
-        }), requiredFeature: requiredFeature)
-    }
-    
-    static func createPost(
-        community: Community?,
-        title: String = "",
-        content: String? = nil,
-        type: PostType?,
-        nsfw: Bool = false,
-        feedLoader: (any FeedLoading)?
-    ) -> NavigationPage {
-        return createPost(
-            community: community,
-            title: title,
-            content: content,
-            type: type,
-            nsfw: nsfw,
-            feedLoader: .init(wrappedValue: feedLoader)
+        instancePicker(
+            callback: { value, navigation in
+                Task { @MainActor in
+                    navigation.dismissSheet()
+                    callback(value)
+                }
+            },
+            requiredFeature: requiredFeature
         )
     }
-
-    static func report(_ interactable: any ReportableProviding, community: Community?) -> NavigationPage {
-        return report(.init(wrappedValue: interactable), community: community)
-    }
     
-    static func remove(_ interactable: any RemovableProviding) -> NavigationPage {
-        remove(.init(wrappedValue: interactable))
-    }
-    
-    static func purge(_ purgable: any PurgableProviding) -> NavigationPage {
-        purge(.init(wrappedValue: purgable))
-    }
-    
-    static func bypassImageProxyWarning(callback: @escaping () -> Void) -> NavigationPage {
-        bypassImageProxy(callback: .init(wrappedValue: callback))
-    }
-    
-    static func rulesList(_ model: any ProfileProviding, callback: @escaping (String) -> Void) -> NavigationPage {
-        rulesList(.init(wrappedValue: model), callback: .init(wrappedValue: callback))
-    }
-    
-    static func advancedSorting(_ sort: Binding<PostSortType>) -> NavigationPage {
-        advancedSorting(.init(wrappedValue: sort))
-    }
-
-    static func unsupportedVersion(_ account: any Account) -> NavigationPage {
-        unsupportedVersion(.init(wrappedValue: account))
-    }
-
     static func actionSheet(
         _ actions: [ActionSheetSection],
         environment: EnvironmentValues,
         configuration: ReferenceWritableKeyPath<SettingsValues, some ContextMenuConfiguration>? = nil
     ) -> NavigationPage {
         actionSheet(
-            .init(wrappedValue: actions),
-            environment: .init(wrappedValue: environment),
+            actions,
+            environment: environment,
             configuration: configuration.map(ContextMenuSettingsPage.init)
         )
     }
@@ -327,102 +242,3 @@ enum NavigationPage: Hashable {
         }
     }
 }
-
-struct HashWrapper<Value>: Hashable, Identifiable {
-    let wrappedValue: Value
-    let id = UUID()
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-    
-    static func == (lhs: HashWrapper, rhs: HashWrapper) -> Bool {
-        lhs.id == rhs.id
-    }
-}
-
-struct AccountHashWrapper: Hashable {
-    var wrappedValue: any Account
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(wrappedValue.hashValue)
-    }
-    
-    static func == (lhs: AccountHashWrapper, rhs: AccountHashWrapper) -> Bool {
-        lhs.hashValue == rhs.hashValue
-    }
-}
-
-struct ReportableHashWrapper: Hashable {
-    var wrappedValue: any ReportableProviding
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(wrappedValue.hashValue)
-    }
-    
-    static func == (lhs: ReportableHashWrapper, rhs: ReportableHashWrapper) -> Bool {
-        lhs.hashValue == rhs.hashValue
-    }
-}
-
-struct SharableHashWrapper: Hashable {
-    var wrappedValue: any Sharable & ContentModel
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(wrappedValue.hashValue)
-    }
-    
-    static func == (lhs: SharableHashWrapper, rhs: SharableHashWrapper) -> Bool {
-        lhs.hashValue == rhs.hashValue
-    }
-}
-
-struct RemovableHashWrapper: Hashable {
-    var wrappedValue: any RemovableProviding
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(wrappedValue.hashValue)
-    }
-    
-    static func == (lhs: RemovableHashWrapper, rhs: RemovableHashWrapper) -> Bool {
-        lhs.hashValue == rhs.hashValue
-    }
-}
-
-struct PurgableHashWrapper: Hashable {
-    var wrappedValue: any PurgableProviding
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(wrappedValue.hashValue)
-    }
-    
-    static func == (lhs: PurgableHashWrapper, rhs: PurgableHashWrapper) -> Bool {
-        lhs.hashValue == rhs.hashValue
-    }
-}
-
-struct Profile2HashWrapper: Hashable {
-    var wrappedValue: any ProfileProviding
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(wrappedValue.actorId)
-    }
-    
-    static func == (lhs: Profile2HashWrapper, rhs: Profile2HashWrapper) -> Bool {
-        lhs.hashValue == rhs.hashValue
-    }
-}
-
-struct MessageHashWrapper: Hashable {
-    var wrappedValue: any Message1Providing
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(wrappedValue.actorId)
-    }
-    
-    static func == (lhs: MessageHashWrapper, rhs: MessageHashWrapper) -> Bool {
-        lhs.hashValue == rhs.hashValue
-    }
-}
-
-// swiftlint:enable file_length

--- a/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
+++ b/Mlem/App/Views/Shared/Navigation/SettingsPage.swift
@@ -9,12 +9,12 @@ import LemmyMarkdownUI
 import SwiftUI
 
 // swiftlint:disable:next type_body_length
-enum SettingsPage: Hashable {
-    enum ContentActionType: Hashable {
+enum SettingsPage {
+    enum ContentActionType {
         case post, comment, inboxNotification, postReport, commentReport
     }
 
-    enum SwipeActionSettingType: Hashable {
+    enum SwipeActionSettingType {
         case post, comment, inboxNotification, postReport, commentReport, community, person, instance
     }
 
@@ -41,11 +41,11 @@ enum SettingsPage: Hashable {
     case interactionBar(ContentActionType)
     case swipeActions(SwipeActionSettingType)
     case contextMenu(ContextMenuSettingsPage)
-    case postBarWidgetPicker(HashWrapper<Binding<PostBarConfiguration>>)
-    case commentBarWidgetPicker(HashWrapper<Binding<CommentBarConfiguration>>)
-    case replyBarWidgetPicker(HashWrapper<Binding<ReplyBarConfiguration>>)
-    case postReportBarWidgetPicker(HashWrapper<Binding<PostBarConfiguration>>)
-    case commentReportBarWidgetPicker(HashWrapper<Binding<CommentBarConfiguration>>)
+    case postBarWidgetPicker(Binding<PostBarConfiguration>)
+    case commentBarWidgetPicker(Binding<CommentBarConfiguration>)
+    case replyBarWidgetPicker(Binding<ReplyBarConfiguration>)
+    case postReportBarWidgetPicker(Binding<PostBarConfiguration>)
+    case commentReportBarWidgetPicker(Binding<CommentBarConfiguration>)
     case moderation
     case modMailInteractionBar
     case separateModeratorActions
@@ -268,15 +268,15 @@ enum SettingsPage: Hashable {
                 InteractionBarEditorView(setting: \.interactionBar_commentReport, isReport: true)
             }
         case let .postBarWidgetPicker(configuration):
-            InteractionBarWidgetPickerView<PostBarConfiguration>(configuration: configuration.wrappedValue)
+            InteractionBarWidgetPickerView<PostBarConfiguration>(configuration: configuration)
         case let .commentBarWidgetPicker(configuration):
-            InteractionBarWidgetPickerView<CommentBarConfiguration>(configuration: configuration.wrappedValue)
+            InteractionBarWidgetPickerView<CommentBarConfiguration>(configuration: configuration)
         case let .replyBarWidgetPicker(configuration):
-            InteractionBarWidgetPickerView<ReplyBarConfiguration>(configuration: configuration.wrappedValue)
+            InteractionBarWidgetPickerView<ReplyBarConfiguration>(configuration: configuration)
         case let .postReportBarWidgetPicker(configuration):
-            InteractionBarWidgetPickerView<PostBarConfiguration>(configuration: configuration.wrappedValue)
+            InteractionBarWidgetPickerView<PostBarConfiguration>(configuration: configuration)
         case let .commentReportBarWidgetPicker(configuration):
-            InteractionBarWidgetPickerView<CommentBarConfiguration>(configuration: configuration.wrappedValue)
+            InteractionBarWidgetPickerView<CommentBarConfiguration>(configuration: configuration)
         case let .document(doc):
             SimpleMarkdownPage(doc: doc)
         case .licences:
@@ -295,28 +295,8 @@ enum SettingsPage: Hashable {
         #endif
         }
     }
-    
-    static func postBarWidgetPicker(_ configuration: Binding<PostBarConfiguration>) -> SettingsPage {
-        .postBarWidgetPicker(.init(wrappedValue: configuration))
-    }
-    
-    static func commentBarWidgetPicker(_ configuration: Binding<CommentBarConfiguration>) -> SettingsPage {
-        .commentBarWidgetPicker(.init(wrappedValue: configuration))
-    }
-    
-    static func replyBarWidgetPicker(_ configuration: Binding<ReplyBarConfiguration>) -> SettingsPage {
-        .replyBarWidgetPicker(.init(wrappedValue: configuration))
-    }
-    
-    static func postReportBarWidgetPicker(_ configuration: Binding<PostBarConfiguration>) -> SettingsPage {
-        .postReportBarWidgetPicker(.init(wrappedValue: configuration))
-    }
-    
-    static func commentReportBarWidgetPicker(_ configuration: Binding<CommentBarConfiguration>) -> SettingsPage {
-        .commentReportBarWidgetPicker(.init(wrappedValue: configuration))
-    }
 }
-
+    
 private struct SimpleMarkdownPage: View {
     @Environment(\.palette) var palette
     


### PR DESCRIPTION
Closes #2533. I couldn't repro it after this change, but can't be 100% sure.

Previously, we fed the`navigationDestination` with the `NavigationPage`:

``` swift
.navigationDestination(for: NavigationPage.self) {
    $0.view()
        .environment(\.isRootView, false)
}
```

I fixed the issue by introducing a new wrapper type, `NavigationFrame`, which is an `@Observable` class that wraps a `NavigationPage`, and has a unique `hashValue`.

``` swift
@Observable
class NavigationFrame: Hashable {
    var page: NavigationPage

    init(page: NavigationPage) {
        self.page = page
    }

    func hash(into hasher: inout Hasher) {
        hasher.combine(ObjectIdentifier(self))
    }

    public static func == (lhs: NavigationFrame, rhs: NavigationFrame) -> Bool {
        lhs === rhs
    }
}
```

`navigationDestination` now uses that wrapper type:

``` swift
.navigationDestination(for: NavigationFrame.self) {
    NavigationFrameView(frame: $0)
        .environment(\.isRootView, false)
}
```

When `NavigationLayer.replace` is called, it updates the `NavigationPage` _inside_ of the top frame, rather than the whole frame.

This shifts responsibility for view updates from the `navigationDestination` down into `NavigationFrameView`, which is a simple wrapper view.

``` swift
struct NavigationFrameView: View {
    let frame: NavigationFrame

    var body: some View {
        frame.page.view()
    }
}
```

One convenient consequence of this change is that `NavigationPage` no longer needs to be `Hashable`, so I've removed that conformance. This cleans up the `HashWrapper` mess.