### PR TITLE
Fix too many parents being shown for comment

### DIFF
--- a/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/CommentTreeTracker.swift
@@ -77,7 +77,7 @@ class CommentTreeTracker: Hashable {
             if let ensuredComment {
                 let comment = try await ensuredComment.asComment()
                 let api = root.wrappedValue.api
-                if !nodesKeyedByActorId.keys.contains(comment.actorId) {
+                if !nodesKeyedByActorId.keys.contains(comment.actorId), !newComments.contains(where: { $0.actorId == comment.actorId }) {
                     // Find the first parent of the ensured comment that isn't in `newComments`.
                     // This will be the starting point for the second page of comments to load.
                     let idsToSearch = comment.parentCommentIds + [comment.id]

--- a/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
+++ b/Mlem/App/Views/Shared/ExpandedPost/ExpandedPostView.swift
@@ -129,22 +129,20 @@ struct ExpandedPostView<Content: View>: View {
                             ErrorView(errorDetails)
                                 .frame(maxWidth: .infinity)
                         } else if hasNoComments {
-                            noCommentsView
-                                .padding(.top, Constants.main.doubleSpacing)
-                        } else {
-                            switch tracker.loadingState {
-                            case .done:
-                                LazyVStack(spacing: 0) {
-                                    commentTree(tracker: tracker, scrollProxy: proxy)
-                                }
-                                .geometryGroup()
-                            default:
+                            if tracker.loadingState == .loading {
                                 ProgressView()
                                     .tint(.themedSecondary)
                                     .padding(.top, 50)
                                     // This prevents the tab bar going transparent whilst the comments are loading
                                     .padding(.bottom, 500)
                                     .frame(maxWidth: .infinity)
+                            } else {
+                                noCommentsView
+                                    .padding(.top, Constants.main.doubleSpacing)
+                            }
+                        } else {
+                            LazyVStack(spacing: 0) {
+                                commentTree(tracker: tracker, scrollProxy: proxy)
                             }
                         }
                     }


### PR DESCRIPTION
Closes #2800

I thought I had got this right in #2741, but it seems I was wrong. Example comment: 

https://lemmy.ml/comment/26240544

When you open a comment page, it should now always shown exactly one parent, and the "show parent" button should show parents one at a time.