### PR TITLE
Fix 2.4 -> 2.5 Settings decoding error

### DIFF
--- a/Mlem/App/Configuration/User Settings/SettingsValues.swift
+++ b/Mlem/App/Configuration/User Settings/SettingsValues.swift
@@ -196,7 +196,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.feed_markReadOnScroll = try container.decodeIfPresent(Bool.self, forKey: ._feed_markReadOnScroll) ?? false
         self.feed_showRead = try container.decodeIfPresent(Bool.self, forKey: ._feed_showRead) ?? true
         
-        if let types = try container.decodeIfPresent(Set<InboxItemType>.self, forKey: ._tab_inbox_badgeIncludedTypes) {
+        if let types = try? container.decodeIfPresent(Set<InboxItemType>.self, forKey: ._tab_inbox_badgeIncludedTypes) {
             self.tab_inbox_badgeIncludedTypes = types
         } else if let types = try? container.decodeIfPresent(Set<LegacyInboxItemType>.self, forKey: ._tab_inbox_badgeIncludedTypes) {
             self._tab_inbox_badgeIncludedTypes = .init(legacyTypes: types)


### PR DESCRIPTION
When installing 2.5 after configuring settings with 2.4, InboxItemType decoder would throw an error instead of falling through the LegacyInboxItemType