### PR TITLE
Silence network errors

### DIFF
--- a/Mlem/App/Logic/HandleError.swift
+++ b/Mlem/App/Logic/HandleError.swift
@@ -71,11 +71,10 @@ private func _handleError(
     case ApiClientError.cancelled, is CancellationError:
         print("Cancellation error")
         return true
+    case let error as NSError where [NSURLErrorCancelled, NSURLErrorTimedOut, NSURLErrorNetworkConnectionLost].contains(error.code):
+        print("Network error")
+        return true
     default:
-        if (error as NSError).code == NSURLErrorCancelled {
-            print("Timeout error")
-            return true
-        }
         return false
     }
 }


### PR DESCRIPTION
Closes #2839

If the app is moved to the background while a request is ongoing, these errors can appear. I kept getting these popups when returning to the app.

I've silenced those errors. They still appear in the error log and `ErrorView`.

The downside is that they won't appear in cases where we _did_ get a legitimate timeout, but I think it's worth that trade-off.