### PR TITLE
Invert Layout Direction Setting

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -473,6 +473,8 @@
 		CD1DF63E2D387E8500F7851E /* MediaView+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1DF63D2D387E8300F7851E /* MediaView+Views.swift */; };
 		CD24CAFC2D5568FE0032B5E8 /* DiscussionLanguageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD24CAFB2D5568F90032B5E8 /* DiscussionLanguageSettingsView.swift */; };
 		CD27839A2D9B366000DD4C69 /* ZoomableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2783992D9B365D00DD4C69 /* ZoomableImageView.swift */; };
+		CD2BBE0B300439E000865794 /* NSLocale+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2BBE0A300439DB00865794 /* NSLocale+Extensions.swift */; };
+		CD2BBE0D30043C0500865794 /* LayoutDirection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2BBE0C30043C0000865794 /* LayoutDirection+Extensions.swift */; };
 		CD2C86542D5556C00034CD8A /* MlemError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2C86532D5556BE0034CD8A /* MlemError.swift */; };
 		CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */; };
 		CD332D792CA7175500A53988 /* PlayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD332D782CA7175200A53988 /* PlayButton.swift */; };
@@ -1095,6 +1097,8 @@
 		CD1DF63D2D387E8300F7851E /* MediaView+Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaView+Views.swift"; sourceTree = "<group>"; };
 		CD24CAFB2D5568F90032B5E8 /* DiscussionLanguageSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionLanguageSettingsView.swift; sourceTree = "<group>"; };
 		CD2783992D9B365D00DD4C69 /* ZoomableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableImageView.swift; sourceTree = "<group>"; };
+		CD2BBE0A300439DB00865794 /* NSLocale+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLocale+Extensions.swift"; sourceTree = "<group>"; };
+		CD2BBE0C30043C0000865794 /* LayoutDirection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LayoutDirection+Extensions.swift"; sourceTree = "<group>"; };
 		CD2C86532D5556BE0034CD8A /* MlemError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlemError.swift; sourceTree = "<group>"; };
 		CD3153062C38421B00BC5FBE /* View+LoadFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+LoadFeed.swift"; sourceTree = "<group>"; };
 		CD332D782CA7175200A53988 /* PlayButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayButton.swift; sourceTree = "<group>"; };
@@ -2163,6 +2167,8 @@
 		CD4D58C22B86DC5800B82964 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				CD2BBE0C30043C0000865794 /* LayoutDirection+Extensions.swift */,
+				CD2BBE0A300439DB00865794 /* NSLocale+Extensions.swift */,
 				031DBA672F9A65DC00B4BAE4 /* BackendClient+Extensions.swift */,
 				CD737FB92F771BF100E46411 /* InstanceSummarySoftware+Extensions.swift */,
 				CD03B5BD2F3BA16100AEF786 /* Blockable+Extensions.swift */,
@@ -3082,6 +3088,7 @@
 				CD4B66DA2DCE809D00D28EB4 /* InstanceUptimeView+Views.swift in Sources */,
 				03631B572FE94BAE0060CA5A /* AuthHandoffView.swift in Sources */,
 				0311ADBF2E4F68D000EC3120 /* TopPeopleListView.swift in Sources */,
+				CD2BBE0D30043C0500865794 /* LayoutDirection+Extensions.swift in Sources */,
 				CD3153072C38421B00BC5FBE /* View+LoadFeed.swift in Sources */,
 				0302A8802F9BC379000A127A /* SearchHomeCategoryLabelStyle.swift in Sources */,
 				039F588F2C7B599800C61658 /* ThemeLabel.swift in Sources */,
@@ -3220,6 +3227,7 @@
 				CDFB8C692C7796020070845F /* View+DynamicBlur.swift in Sources */,
 				CD5CAA0C2D41AE57008E20F2 /* EmbeddingSettingsView.swift in Sources */,
 				03B25B372CC4478600EB6DF5 /* FediseerInfoView.swift in Sources */,
+				CD2BBE0B300439E000865794 /* NSLocale+Extensions.swift in Sources */,
 				032A22012EB2A4D100E8B346 /* PersonContentFeedLoader+Extensions.swift in Sources */,
 				03B62B772CE295530077E9C8 /* RulesListView.swift in Sources */,
 				03500C2B2BF7F1B100CAA076 /* ToastOverlayView.swift in Sources */,

--- a/Mlem/App/Configuration/User Settings/SettingsValues.swift
+++ b/Mlem/App/Configuration/User Settings/SettingsValues.swift
@@ -117,7 +117,6 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
     var filters_keywords: Set<String>
     var filters_literalFilterEnabled: Bool
     var filters_literals: Set<String>
-    
     var interactionBar_post: PostBarConfiguration
     var interactionBar_comment: CommentBarConfiguration
     var interactionBar_reply: ReplyBarConfiguration
@@ -127,8 +126,8 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
     var interactionBar_postReport: PostBarConfiguration
     var interactionBar_commentReport: CommentBarConfiguration
     var interactionBar_alternateReportLayout: Bool
-
     var events_showEvents: Bool
+    var layout_invertDirection: Bool
     
     // These are included in the encoding, but are synthesized into tab_inbox_badgeIncludedTypes at decoding
     @ObservationIgnored var inbox_badge_includeApplications: Bool = false
@@ -270,8 +269,8 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.interactionBar_postReport = try container.decodeIfPresent(PostBarConfiguration.self, forKey: ._interactionBar_postReport) ?? .reportDefault_
         self.interactionBar_commentReport = try container.decodeIfPresent(CommentBarConfiguration.self, forKey: ._interactionBar_commentReport) ?? .reportDefault_
         self.interactionBar_alternateReportLayout = try container.decodeIfPresent(Bool.self, forKey: ._interactionBar_alternateReportLayout) ?? false
-
         self.events_showEvents = try container.decodeIfPresent(Bool.self, forKey: ._events_showEvents) ?? true
+        self.layout_invertDirection = try container.decodeIfPresent(Bool.self, forKey: ._layout_invertDirection) ?? false
     }
 
     init() {
@@ -386,6 +385,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         self.interactionBar_commentReport = .reportDefault_
         self.interactionBar_alternateReportLayout = false
         self.events_showEvents = true
+        self.layout_invertDirection = false
     }
     
     func reinit(from otherValues: SettingsValues) {
@@ -499,6 +499,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         inbox_badge_includeMessageReports = otherValues.inbox_badge_includeMessageReports
         inbox_badge_includeMod = otherValues.inbox_badge_includeMod
         inbox_badge_includePersonal = otherValues.inbox_badge_includePersonal
+        layout_invertDirection = otherValues.layout_invertDirection
     }
     
     enum CodingKeys: String, CodingKey {
@@ -613,6 +614,7 @@ class SettingsValues: Codable { // swiftlint:disable:this type_body_length
         case _interactionBar_commentReport = "interactionBar_commentReport"
         case _interactionBar_alternateReportLayout = "interactionBar_alternateReportLayout"
         case _events_showEvents = "events_showEvents"
+        case _layout_invertDirection = "layout_invertDirection"
 
         case inbox_badge_includeApplications
         case inbox_badge_includeMessageReports

--- a/Mlem/App/Utility/Extensions/LayoutDirection+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/LayoutDirection+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  LayoutDirection+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2026-07-12.
+//
+
+import SwiftUI
+
+extension LayoutDirection {
+    var inverted: LayoutDirection {
+        switch self {
+        case .leftToRight:
+            return .rightToLeft
+        case .rightToLeft:
+            return .leftToRight
+        default:
+            assertionFailure("Unknown LayoutDirection!")
+            return .leftToRight
+        }
+    }
+}

--- a/Mlem/App/Utility/Extensions/NSLocale+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/NSLocale+Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  NSLocale+Extensions.swift
+//  Mlem
+//
+//  Created by Eric Andrews on 2026-07-12.
+//
+
+import Foundation
+import SwiftUI
+
+extension NSLocale.LanguageDirection {
+    var layoutDirection: LayoutDirection {
+        switch self {
+        case .unknown, .leftToRight, .topToBottom, .bottomToTop:
+            return .leftToRight
+        case .rightToLeft:
+            return .rightToLeft
+        default:
+            assertionFailure("Unrecognized NSLocale.LayoutDirection!")
+            return .leftToRight
+        }
+    }
+}

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -127,6 +127,7 @@ struct ContentView: View {
                 .hapticConfiguration(maximumHapticTier: hapticLevel, errorHandler: handleHapticError)
                 .environment(AppState.main)
                 .onOpenURL(perform: self.handleIncomingDeeplink)
+                .environment(\.layoutDirection, .rightToLeft)
         }
     }
     

--- a/Mlem/App/Views/Root/ContentView.swift
+++ b/Mlem/App/Views/Root/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
     @Setting(\.dev_developerMode) var developerMode
     @Setting(\.behavior_hapticLevel) var hapticLevel
     @Setting(\.behavior_enableQuickSwipes) var quickSwipesEnabled
+    @Setting(\.layout_invertDirection) var invertLayoutDirection
 
     let cacheCleanTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
     let unreadCountTimer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
@@ -47,6 +48,10 @@ struct ContentView: View {
     
     @State var expandedPostHistoryTracker: ExpandedPostHistoryTracker = .init()
     @State var eventsTracker: EventsTracker = .init()
+    
+    var localizedLayoutDirection: LayoutDirection {
+        Locale.current.language.characterDirection.layoutDirection
+    }
     
     var body: some View {
         if appState.appRefreshToggle {
@@ -127,7 +132,7 @@ struct ContentView: View {
                 .hapticConfiguration(maximumHapticTier: hapticLevel, errorHandler: handleHapticError)
                 .environment(AppState.main)
                 .onOpenURL(perform: self.handleIncomingDeeplink)
-                .environment(\.layoutDirection, .rightToLeft)
+                .environment(\.layoutDirection, invertLayoutDirection ? localizedLayoutDirection.inverted : localizedLayoutDirection)
         }
     }
     

--- a/Mlem/App/Views/Root/Tabs/Settings/AdvancedSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/AdvancedSettingsView.swift
@@ -13,8 +13,8 @@ struct AdvancedSettingsView: View {
     @Environment(ErrorsTracker.self) var errorsTracker
 
     @Setting(\.dev_errorTimeout) var errorToastTimeout
-
     @Setting(\.dev_developerMode) var developerMode
+    @Setting(\.layout_invertDirection) var invertLayoutDirection
     
     @State var backendStatus: BackendHealthCheck?
     @State var lastBackendStatusCheck: Date?
@@ -57,6 +57,12 @@ struct AdvancedSettingsView: View {
                     fallbackValue: "",
                     destination: .settings(.errorToastTimeout)
                 )
+            }
+            
+            Section {
+                Toggle("Invert Layout Direction", isOn: $invertLayoutDirection)
+            } footer: {
+                Text("Reverses the horizontal layout of Mlem. This may cause some unexpected element arrangements.")
             }
 
             backendStatusSection

--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -4848,6 +4848,9 @@
         }
       }
     },
+    "Invert Layout Direction" : {
+
+    },
     "It's turtles all the way down" : {
       "localizations" : {
         "fr" : {
@@ -7870,6 +7873,9 @@
           }
         }
       }
+    },
+    "Reverses the horizontal layout of Mlem. This may cause some unexpected element arrangements." : {
+
     },
     "Right" : {
       "localizations" : {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #1948

## Description

Adds a layout inversion toggle. Currently several known bugs:
- Toggling the layout _back_ inverts just the character direction without changing the layout direction until the view is re-rendered (switching accounts or relaunching does the trick)
- Bubble picker coordinate logic is very broken
- Swipe actions are inverted
