### PR TITLE
Fix subscription list navigation in windowed mode on iPad

### DIFF
--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListNavigationButton.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListNavigationButton.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct SubscriptionListNavigationButton<Content: View>: View {
     @Environment(NavigationLayer.self) var navigation
+
     let destination: NavigationPage
     @ViewBuilder var label: () -> Content
     
@@ -19,14 +20,16 @@ struct SubscriptionListNavigationButton<Content: View>: View {
     }
     
     var body: some View {
-        MultiplatformView(phone: {
-            NavigationLink(destination, label: label)
-        }, pad: {
-            Button(action: {
-                navigation.popToRoot()
-                navigation.replace(destination)
-            }, label: label)
-                .buttonStyle(.empty)
-        })
+        Button {
+            navigation.popToRoot()
+            navigation.replace(destination)
+        } label: {
+            if horizontalSizeClass == .compact {
+                FormChevron { label() }
+            } else {
+                label()
+            }
+        }
+        .buttonStyle(.empty)
     }
 }

--- a/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListNavigationButton.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/SubscriptionListNavigationButton.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct SubscriptionListNavigationButton<Content: View>: View {
     @Environment(NavigationLayer.self) var navigation
+    @Environment(\.sidebarPresentationMode) var sidebarPresentationMode
 
     let destination: NavigationPage
     @ViewBuilder var label: () -> Content
@@ -24,7 +25,7 @@ struct SubscriptionListNavigationButton<Content: View>: View {
             navigation.popToRoot()
             navigation.replace(destination)
         } label: {
-            if horizontalSizeClass == .compact {
+            if sidebarPresentationMode == .single {
                 FormChevron { label() }
             } else {
                 label()

--- a/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationLayerView.swift
@@ -24,6 +24,7 @@ struct NavigationLayerView: View {
             if layer.hasNavigationStack {
                 NavigationStack(path: $layer.path) {
                     rootView()
+                        .id(layer.root.updateCountHash)
                         .environment(\.isRootView, true)
                         .navigationDestination(for: NavigationFrame.self) {
                             NavigationFrameView(frame: $0)

--- a/Mlem/App/Views/Shared/Navigation/NavigationRootView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationRootView.swift
@@ -30,6 +30,7 @@ struct NavigationSplitRootView: View {
             preferredCompactColumn: $preferredColumn,
             sidebar: {
                 sidebar.view()
+                    .environment(\.sidebarPresentationMode, preferredColumn == .sidebar ? .single : .double)
             },
             detail: {
                 NavigationLayerView(layer: layer, hasSheetModifiers: false)
@@ -41,4 +42,12 @@ struct NavigationSplitRootView: View {
             preferredColumn = .detail
         }
     }
+}
+
+extension EnvironmentValues {
+    @Entry var sidebarPresentationMode: SidebarPresentationMode = .single
+}
+
+enum SidebarPresentationMode {
+    case single, double
 }

--- a/Mlem/App/Views/Shared/Navigation/NavigationRootView.swift
+++ b/Mlem/App/Views/Shared/Navigation/NavigationRootView.swift
@@ -12,11 +12,12 @@ struct NavigationSplitRootView: View {
     let sidebar: NavigationPage
     
     @State var columnVisibility: NavigationSplitViewVisibility = .all
+
+    @State private var preferredColumn = NavigationSplitViewColumn.detail
     
     init(sidebar: NavigationPage, root: NavigationPage) {
         self._layer = .init(wrappedValue: .init(
-            root: UIDevice.isPad ? root : sidebar,
-            path: UIDevice.isPad ? [] : [root],
+            root: root,
             model: .main
         ))
         self.sidebar = sidebar
@@ -24,24 +25,20 @@ struct NavigationSplitRootView: View {
     }
     
     var body: some View {
-        MultiplatformView(
-            phone: {
-                NavigationLayerView(layer: layer, hasSheetModifiers: false)
+        NavigationSplitView(
+            columnVisibility: $columnVisibility,
+            preferredCompactColumn: $preferredColumn,
+            sidebar: {
+                sidebar.view()
             },
-            pad: {
-                NavigationSplitView(
-                    columnVisibility: $columnVisibility,
-                    sidebar: {
-                        sidebar.view()
-                    },
-                    detail: {
-                        NavigationLayerView(layer: layer, hasSheetModifiers: false)
-                            .id(layer.root.updateCountHash)
-                    }
-                )
-                .modifier(HandleThreadiverseLinksModifier())
+            detail: {
+                NavigationLayerView(layer: layer, hasSheetModifiers: false)
             }
         )
+        .modifier(HandleThreadiverseLinksModifier())
         .environment(layer)
+        .onChange(of: layer.root.updateCountHash) {
+            preferredColumn = .detail
+        }
     }
 }


### PR DESCRIPTION
Closes #2484

We're now using `NavigationSplitView` on iPhone, too. This simplifies some code and may become necessary if Apple releases a foldable

Also added a nice transition when switching pages in split-view mode on iPad.