### PR TITLE
Simplify `InteractionBarConfiguration` generics

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		0315B1C62C754802006D4F82 /* PostEditorView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0315B1C52C754802006D4F82 /* PostEditorView+Logic.swift */; };
 		0316CD642C382A6A009EA8EA /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0316CD632C382A6A009EA8EA /* MessageView.swift */; };
 		0316D3F1300CC2A2003CB1BD /* ReadoutType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0316D3F0300CC2A2003CB1BD /* ReadoutType.swift */; };
+		0316D3F5300CC4E1003CB1BD /* CounterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0316D3F4300CC4E1003CB1BD /* CounterType.swift */; };
 		0318BA9F2D72405F006CA71F /* PostSortType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0318BA9E2D72405F006CA71F /* PostSortType+Extensions.swift */; };
 		031CA0D92E4FBFD800CF0C0F /* MarkAllAsReadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031CA0D82E4FBFD800CF0C0F /* MarkAllAsReadButton.swift */; };
 		031CA4AE2E58A84E00CF0C0F /* View+WithSheetSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031CA4AD2E58A84E00CF0C0F /* View+WithSheetSearch.swift */; };
@@ -684,6 +685,7 @@
 		0315B1C52C754802006D4F82 /* PostEditorView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+Logic.swift"; sourceTree = "<group>"; };
 		0316CD632C382A6A009EA8EA /* MessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageView.swift; sourceTree = "<group>"; };
 		0316D3F0300CC2A2003CB1BD /* ReadoutType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadoutType.swift; sourceTree = "<group>"; };
+		0316D3F4300CC4E1003CB1BD /* CounterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterType.swift; sourceTree = "<group>"; };
 		0318BA9E2D72405F006CA71F /* PostSortType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostSortType+Extensions.swift"; sourceTree = "<group>"; };
 		031CA0D82E4FBFD800CF0C0F /* MarkAllAsReadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkAllAsReadButton.swift; sourceTree = "<group>"; };
 		031CA4AD2E58A84E00CF0C0F /* View+WithSheetSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+WithSheetSearch.swift"; sourceTree = "<group>"; };
@@ -1759,6 +1761,7 @@
 			isa = PBXGroup;
 			children = (
 				0316D3F0300CC2A2003CB1BD /* ReadoutType.swift */,
+				0316D3F4300CC4E1003CB1BD /* CounterType.swift */,
 				0381F7132F670F95008A7731 /* SwipeActionConfiguration.swift */,
 				038E62DF2F6F0FC600C54DEB /* ContextMenuConfiguration.swift */,
 				038E1ABB2F58B9EF00D30F01 /* CommunityActionConfiguration.swift */,
@@ -3345,6 +3348,7 @@
 				035EDF012C2ECFE000F51144 /* Searchable.swift in Sources */,
 				CD756A982ED7669C0031D7D1 /* ExportableCommentEditorView.swift in Sources */,
 				CD7743892C20EDEE0085BB43 /* VotesModel+Extensions.swift in Sources */,
+				0316D3F5300CC4E1003CB1BD /* CounterType.swift in Sources */,
 				CD4D58AD2B86BE7100B82964 /* QuickSwitcherView.swift in Sources */,
 				0397D4642C676CA8002C6CDC /* FeedSortPicker.swift in Sources */,
 				0355F9462C150B2300605248 /* ExternalApiInfoView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		0315B1C12C74C71A006D4F82 /* CommentEditorView+Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0315B1C02C74C71A006D4F82 /* CommentEditorView+Context.swift */; };
 		0315B1C62C754802006D4F82 /* PostEditorView+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0315B1C52C754802006D4F82 /* PostEditorView+Logic.swift */; };
 		0316CD642C382A6A009EA8EA /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0316CD632C382A6A009EA8EA /* MessageView.swift */; };
+		0316D3F1300CC2A2003CB1BD /* ReadoutType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0316D3F0300CC2A2003CB1BD /* ReadoutType.swift */; };
 		0318BA9F2D72405F006CA71F /* PostSortType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0318BA9E2D72405F006CA71F /* PostSortType+Extensions.swift */; };
 		031CA0D92E4FBFD800CF0C0F /* MarkAllAsReadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031CA0D82E4FBFD800CF0C0F /* MarkAllAsReadButton.swift */; };
 		031CA4AE2E58A84E00CF0C0F /* View+WithSheetSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031CA4AD2E58A84E00CF0C0F /* View+WithSheetSearch.swift */; };
@@ -682,6 +683,7 @@
 		0315B1C02C74C71A006D4F82 /* CommentEditorView+Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentEditorView+Context.swift"; sourceTree = "<group>"; };
 		0315B1C52C754802006D4F82 /* PostEditorView+Logic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditorView+Logic.swift"; sourceTree = "<group>"; };
 		0316CD632C382A6A009EA8EA /* MessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageView.swift; sourceTree = "<group>"; };
+		0316D3F0300CC2A2003CB1BD /* ReadoutType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadoutType.swift; sourceTree = "<group>"; };
 		0318BA9E2D72405F006CA71F /* PostSortType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostSortType+Extensions.swift"; sourceTree = "<group>"; };
 		031CA0D82E4FBFD800CF0C0F /* MarkAllAsReadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkAllAsReadButton.swift; sourceTree = "<group>"; };
 		031CA4AD2E58A84E00CF0C0F /* View+WithSheetSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+WithSheetSearch.swift"; sourceTree = "<group>"; };
@@ -1756,6 +1758,7 @@
 		03AF91E62C1C65AE00E56644 /* Interaction */ = {
 			isa = PBXGroup;
 			children = (
+				0316D3F0300CC2A2003CB1BD /* ReadoutType.swift */,
 				0381F7132F670F95008A7731 /* SwipeActionConfiguration.swift */,
 				038E62DF2F6F0FC600C54DEB /* ContextMenuConfiguration.swift */,
 				038E1ABB2F58B9EF00D30F01 /* CommunityActionConfiguration.swift */,
@@ -2847,6 +2850,7 @@
 				0325092A2FD57DE5006F8394 /* ActiveUserTimeRange+Extensions.swift in Sources */,
 				031CA5B52E590B0D00CF0C0F /* QuickSwipeAction+Extensions.swift in Sources */,
 				030056A42D7DB05A00EB0BA3 /* SharingLinksSettingsView.swift in Sources */,
+				0316D3F1300CC2A2003CB1BD /* ReadoutType.swift in Sources */,
 				0315B1C12C74C71A006D4F82 /* CommentEditorView+Context.swift in Sources */,
 				03D283FE2D25EEC500A6659B /* SearchView+Views.swift in Sources */,
 				03AFD0DF2C3B2E000054B8AD /* PersonListRow.swift in Sources */,

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration+Types.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration+Types.swift
@@ -89,33 +89,4 @@ extension CommentBarConfiguration {
             }
         }
     }
-    
-    enum CounterType: String, CounterTypeProviding {
-        typealias Configuration = CommentBarConfiguration // swiftlint:disable:this nesting
-        
-        case score
-        case upvote
-        case downvote
-        case reply
-        
-        static var defaultWidgets: [CounterType] { allCases }
-        
-        var appearance: CounterAppearance {
-            switch self {
-            case .score: .score()
-            case .upvote: .upvote()
-            case .downvote: .downvote()
-            case .reply: .reply()
-            }
-        }
-        
-        func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
-            switch self {
-            case .score: [.upvote, .downvote, .score]
-            case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
-            case .downvote: context.votes.value?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
-            case .reply: []
-            }
-        }
-    }
 }

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration+Types.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration+Types.swift
@@ -61,7 +61,7 @@ extension CommentBarConfiguration {
             }
         }
         
-        func associatedReadouts(context: any InteractableProviding) -> Set<Configuration.ReadoutType> {
+        func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
             switch self {
             case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
             case .downvote: context.votes.value?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
@@ -109,7 +109,7 @@ extension CommentBarConfiguration {
             }
         }
         
-        func associatedReadouts(context: any InteractableProviding) -> Set<Configuration.ReadoutType> {
+        func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
             switch self {
             case .score: [.upvote, .downvote, .score]
             case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
@@ -118,33 +118,4 @@ extension CommentBarConfiguration {
             }
         }
     }
-    
-    enum ReadoutType: String, ReadoutTypeProviding {
-        case created
-        case score
-        case upvote
-        case downvote
-        case comment
-        case saved
-        
-        var appearance: MockReadoutAppearance {
-            switch self {
-            case .created: .init(icon: .general.time, label: "18h")
-            case .score: .init(icon: .lemmy.votes, label: "7")
-            case .upvote: .init(icon: .lemmy.upvoted, label: "9")
-            case .downvote: .init(icon: .lemmy.downvoted, label: "2")
-            case .comment: .init(icon: .lemmy.replies, label: "1")
-            case .saved: .init(icon: .lemmy.saved, label: "")
-            }
-        }
-        
-        func compatibleWith(otherReadouts: Set<Self>) -> Bool {
-            switch self {
-            case .score: otherReadouts.isDisjoint(with: [.upvote, .downvote])
-            case .upvote, .downvote: !otherReadouts.contains(.score)
-            default: true
-            }
-        }
-    }
-
 }

--- a/Mlem/App/Enums/Interaction/CounterType.swift
+++ b/Mlem/App/Enums/Interaction/CounterType.swift
@@ -1,0 +1,36 @@
+//
+//  CounterType.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-07-19.
+//
+
+import Foundation
+import MlemMiddleware
+    
+enum CounterType: String, Codable, CaseIterable, Hashable {
+    case score
+    case upvote
+    case downvote
+    case reply
+        
+    static var defaultWidgets: [CounterType] { allCases }
+        
+    var appearance: CounterAppearance {
+        switch self {
+        case .score: .score()
+        case .upvote: .upvote()
+        case .downvote: .downvote()
+        case .reply: .reply()
+        }
+    }
+        
+    func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
+        switch self {
+        case .score: [.upvote, .downvote, .score]
+        case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
+        case .downvote: context.votes.value?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
+        case .reply: []
+        }
+    }
+}

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -114,17 +114,9 @@ enum InteractionConfigurationItem<
     func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
         switch self {
         case let .action(actionType):
-            guard let ret = actionType.associatedReadouts(context: context) as? Set<ReadoutType> else {
-                assertionFailure("Could not cast to ReadoutType")
-                return []
-            }
-            return ret
+            actionType.associatedReadouts(context: context)
         case let .counter(counterType):
-            guard let ret = counterType.associatedReadouts(context: context) as? Set<ReadoutType> else {
-                assertionFailure("Could not cast to ReadoutType")
-                return []
-            }
-            return ret
+            counterType.associatedReadouts(context: context)
         }
     }
 }

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -149,12 +149,6 @@ protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable
     func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType>
 }
 
-protocol ReadoutTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
-    var appearance: MockReadoutAppearance { get }
-    
-    func compatibleWith(otherReadouts: Set<Self>) -> Bool
-}
-
 struct InteractionBarConfigurations: Codable {
     var post: PostBarConfiguration
     var comment: CommentBarConfiguration

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -16,9 +16,8 @@ import SwiftUI
 protocol InteractionBarConfiguration: Codable, Equatable, SwipeActionConfiguration, ContextMenuConfiguration {
     associatedtype ActionType: ActionTypeProviding
     associatedtype CounterType: CounterTypeProviding
-    associatedtype ReadoutType: ReadoutTypeProviding
     
-    typealias Item = InteractionConfigurationItem<ActionType, CounterType, ReadoutType>
+    typealias Item = InteractionConfigurationItem<ActionType, CounterType>
     
     var leading: [Item] { get set }
     var trailing: [Item] { get set }
@@ -74,8 +73,7 @@ enum InteractionBarConfigurationConversionType {
 
 enum InteractionConfigurationItem<
     ActionType: ActionTypeProviding,
-    CounterType: CounterTypeProviding,
-    ReadoutType: ReadoutTypeProviding
+    CounterType: CounterTypeProviding
 >: Codable, Hashable {
     case action(ActionType)
     case counter(CounterType)
@@ -86,9 +84,8 @@ enum InteractionConfigurationItem<
     
     fileprivate func convert<
         A: ActionTypeProviding,
-        C: CounterTypeProviding,
-        R: ReadoutTypeProviding
-    >() -> InteractionConfigurationItem<A, C, R>? {
+        C: CounterTypeProviding
+    >() -> InteractionConfigurationItem<A, C>? {
         switch self {
         case let .action(action):
             if let value = A(rawValue: action.rawValue) {
@@ -139,7 +136,7 @@ protocol ActionTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable 
     
     static var defaultWidgets: [Self] { get }
     
-    func associatedReadouts(context: any InteractableProviding) -> Set<Configuration.ReadoutType>
+    func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType>
 }
 
 protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
@@ -149,7 +146,7 @@ protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable
     
     static var defaultWidgets: [Self] { get }
     
-    func associatedReadouts(context: any InteractableProviding) -> Set<Configuration.ReadoutType>
+    func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType>
 }
 
 protocol ReadoutTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -15,9 +15,8 @@ import SwiftUI
 
 protocol InteractionBarConfiguration: Codable, Equatable, SwipeActionConfiguration, ContextMenuConfiguration {
     associatedtype ActionType: ActionTypeProviding
-    associatedtype CounterType: CounterTypeProviding
     
-    typealias Item = InteractionConfigurationItem<ActionType, CounterType>
+    typealias Item = InteractionConfigurationItem<ActionType>
     
     var leading: [Item] { get set }
     var trailing: [Item] { get set }
@@ -71,10 +70,7 @@ enum InteractionBarConfigurationConversionType {
     case swipe, bar, contextMenu
 }
 
-enum InteractionConfigurationItem<
-    ActionType: ActionTypeProviding,
-    CounterType: CounterTypeProviding
->: Codable, Hashable {
+enum InteractionConfigurationItem<ActionType: ActionTypeProviding>: Codable, Hashable {
     case action(ActionType)
     case counter(CounterType)
     
@@ -82,10 +78,7 @@ enum InteractionConfigurationItem<
         CounterType.allCases.map { .counter($0) } + ActionType.allCases.map { .action($0) }
     }
     
-    fileprivate func convert<
-        A: ActionTypeProviding,
-        C: CounterTypeProviding
-    >() -> InteractionConfigurationItem<A, C>? {
+    fileprivate func convert<A: ActionTypeProviding>() -> InteractionConfigurationItem<A>? {
         switch self {
         case let .action(action):
             if let value = A(rawValue: action.rawValue) {
@@ -94,7 +87,7 @@ enum InteractionConfigurationItem<
                 return nil
             }
         case let .counter(counter):
-            if let value = C(rawValue: counter.rawValue) {
+            if let value = CounterType(rawValue: counter.rawValue) {
                 return .counter(value)
             } else {
                 return nil
@@ -125,16 +118,6 @@ protocol ActionTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable 
     associatedtype Configuration: InteractionBarConfiguration
     
     var appearance: ActionAppearance { get }
-    
-    static var defaultWidgets: [Self] { get }
-    
-    func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType>
-}
-
-protocol CounterTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
-    associatedtype Configuration: InteractionBarConfiguration
-    
-    var appearance: CounterAppearance { get }
     
     static var defaultWidgets: [Self] { get }
     

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -50,7 +50,7 @@ extension InteractionBarConfiguration {
             leading: types.contains(.bar) ? other.leading.compactMap { $0.convert() } : leading,
             trailing: types.contains(.bar) ? other.trailing.compactMap { $0.convert() } : trailing,
             savedSwipes: types.contains(.swipe) ? other.savedSwipes?.filter(allowed: Self.availableActions.all) : savedSwipes,
-            readouts: types.contains(.bar) ? other.readouts.compactMap { .init(rawValue: $0.rawValue) } : readouts,
+            readouts: types.contains(.bar) ? other.readouts : readouts,
             availableWidgets: types.contains(.bar) ? .init(other.availableWidgets.compactMap { $0.convert() }) : availableWidgets,
             savedContextMenu: types.contains(.contextMenu) ? other.savedContextMenu.map { $0.filter { Self.availableActions.all.contains($0) } } : savedContextMenu
         )
@@ -87,11 +87,7 @@ enum InteractionConfigurationItem<ActionType: ActionTypeProviding>: Codable, Has
                 return nil
             }
         case let .counter(counter):
-            if let value = CounterType(rawValue: counter.rawValue) {
-                return .counter(value)
-            } else {
-                return nil
-            }
+            return .counter(counter)
         }
     }
     

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration+Types.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration+Types.swift
@@ -69,16 +69,7 @@ extension PostBarConfiguration {
             }
         }
         
-        func associatedReadouts(context: any InteractableProviding) -> Set<PostBarConfiguration.ReadoutType> {
-            switch self {
-            case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
-            case .downvote: context.votes.value?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
-            case .save: [.saved]
-            case .reply, .share, .selectText, .postDetails, .hide, .block, .report, .crossPost, .lock, .pin, .resolve, .remove, .ban: []
-            }
-        }
-        
-        func associatedReadouts(context: Post) -> Set<PostBarConfiguration.ReadoutType> {
+        func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
             switch self {
             case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
             case .downvote: context.votes.value?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
@@ -128,16 +119,7 @@ extension PostBarConfiguration {
             }
         }
         
-        func associatedReadouts(context: any InteractableProviding) -> Set<PostBarConfiguration.ReadoutType> {
-            switch self {
-            case .score: [.upvote, .downvote, .score]
-            case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
-            case .downvote: context.votes.value?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
-            case .reply: []
-            }
-        }
-        
-        func associatedReadouts(context: Post) -> Set<PostBarConfiguration.ReadoutType> {
+        func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
             switch self {
             case .score: [.upvote, .downvote, .score]
             case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
@@ -146,33 +128,4 @@ extension PostBarConfiguration {
             }
         }
     }
-    
-    enum ReadoutType: String, ReadoutTypeProviding {
-        case created
-        case score
-        case upvote
-        case downvote
-        case comment
-        case saved
-        
-        var appearance: MockReadoutAppearance {
-            switch self {
-            case .created: .init(icon: .general.time, label: "18h")
-            case .score: .init(icon: .lemmy.votes, label: "7")
-            case .upvote: .init(icon: .lemmy.upvoted, label: "9")
-            case .downvote: .init(icon: .lemmy.downvoted, label: "2")
-            case .comment: .init(icon: .lemmy.replies, label: "1")
-            case .saved: .init(icon: .lemmy.saved, label: "")
-            }
-        }
-        
-        func compatibleWith(otherReadouts: Set<Self>) -> Bool {
-            switch self {
-            case .score: otherReadouts.isDisjoint(with: [.upvote, .downvote])
-            case .upvote, .downvote: !otherReadouts.contains(.score)
-            default: true
-            }
-        }
-    }
-
 }

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration+Types.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration+Types.swift
@@ -99,33 +99,4 @@ extension PostBarConfiguration {
             }
         }
     }
-    
-    enum CounterType: String, CounterTypeProviding {
-        typealias Configuration = PostBarConfiguration // swiftlint:disable:this nesting
-        
-        case score
-        case upvote
-        case downvote
-        case reply
-        
-        static var defaultWidgets: [CounterType] { allCases }
-        
-        var appearance: CounterAppearance {
-            switch self {
-            case .score: .score()
-            case .upvote: .upvote()
-            case .downvote: .downvote()
-            case .reply: .reply()
-            }
-        }
-        
-        func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
-            switch self {
-            case .score: [.upvote, .downvote, .score]
-            case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
-            case .downvote: context.votes.value?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
-            case .reply: []
-            }
-        }
-    }
 }

--- a/Mlem/App/Enums/Interaction/ReadoutType.swift
+++ b/Mlem/App/Enums/Interaction/ReadoutType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum ReadoutType: String, ReadoutTypeProviding {
+enum ReadoutType: String, Codable, CaseIterable, Hashable {
     case created
     case score
     case upvote

--- a/Mlem/App/Enums/Interaction/ReadoutType.swift
+++ b/Mlem/App/Enums/Interaction/ReadoutType.swift
@@ -1,0 +1,36 @@
+//
+//  ReadoutType.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-07-19.
+//
+
+import Foundation
+
+enum ReadoutType: String, ReadoutTypeProviding {
+    case created
+    case score
+    case upvote
+    case downvote
+    case comment
+    case saved
+        
+    var appearance: MockReadoutAppearance {
+        switch self {
+        case .created: .init(icon: .general.time, label: "18h")
+        case .score: .init(icon: .lemmy.votes, label: "7")
+        case .upvote: .init(icon: .lemmy.upvoted, label: "9")
+        case .downvote: .init(icon: .lemmy.downvoted, label: "2")
+        case .comment: .init(icon: .lemmy.replies, label: "1")
+        case .saved: .init(icon: .lemmy.saved, label: "")
+        }
+    }
+        
+    func compatibleWith(otherReadouts: Set<Self>) -> Bool {
+        switch self {
+        case .score: otherReadouts.isDisjoint(with: [.upvote, .downvote])
+        case .upvote, .downvote: !otherReadouts.contains(.score)
+        default: true
+        }
+    }
+}

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration+Types.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration+Types.swift
@@ -42,7 +42,7 @@ extension ReplyBarConfiguration {
             }
         }
         
-        func associatedReadouts(context: any InteractableProviding) -> Set<ReplyBarConfiguration.ReadoutType> {
+        func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
             switch self {
             case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
             case .downvote: context.votes.value?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
@@ -83,40 +83,12 @@ extension ReplyBarConfiguration {
             }
         }
         
-        func associatedReadouts(context: any InteractableProviding) -> Set<ReplyBarConfiguration.ReadoutType> {
+        func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
             switch self {
             case .score: [.upvote, .downvote, .score]
             case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
             case .downvote: context.votes.value?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
             case .reply: []
-            }
-        }
-    }
-    
-    enum ReadoutType: String, ReadoutTypeProviding {
-        case created
-        case score
-        case upvote
-        case downvote
-        case comment
-        case saved
-        
-        var appearance: MockReadoutAppearance {
-            switch self {
-            case .created: .init(icon: .general.time, label: "18h")
-            case .score: .init(icon: .lemmy.votes, label: "7")
-            case .upvote: .init(icon: .lemmy.upvoted, label: "9")
-            case .downvote: .init(icon: .lemmy.downvoted, label: "2")
-            case .comment: .init(icon: .lemmy.replies, label: "1")
-            case .saved: .init(icon: .lemmy.saved, label: "")
-            }
-        }
-        
-        func compatibleWith(otherReadouts: Set<Self>) -> Bool {
-            switch self {
-            case .score: otherReadouts.isDisjoint(with: [.upvote, .downvote])
-            case .upvote, .downvote: !otherReadouts.contains(.score)
-            default: true
             }
         }
     }

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration+Types.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration+Types.swift
@@ -63,33 +63,4 @@ extension ReplyBarConfiguration {
             }
         }
     }
-    
-    enum CounterType: String, CounterTypeProviding {
-        typealias Configuration = ReplyBarConfiguration // swiftlint:disable:this nesting
-        
-        case score
-        case upvote
-        case downvote
-        case reply
-        
-        static var defaultWidgets: [CounterType] { allCases }
-        
-        var appearance: CounterAppearance {
-            switch self {
-            case .score: .score()
-            case .upvote: .upvote()
-            case .downvote: .downvote()
-            case .reply: .reply()
-            }
-        }
-        
-        func associatedReadouts(context: any InteractableProviding) -> Set<ReadoutType> {
-            switch self {
-            case .score: [.upvote, .downvote, .score]
-            case .upvote: context.votes.value?.myVote ?? .none == .upvote ? [.upvote, .score] : [.upvote]
-            case .downvote: context.votes.value?.myVote ?? .none == .downvote ? [.downvote, .score] : [.downvote]
-            case .reply: []
-            }
-        }
-    }
 }

--- a/Mlem/App/Utility/Extensions/Content Models/Comment/Comment+Actions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment/Comment+Actions.swift
@@ -13,7 +13,7 @@ import SwiftUI
 extension Comment {
     // MARK: - Readouts
     
-    func readout(type: CommentBarConfiguration.ReadoutType, showColor: Bool) -> Readout? {
+    func readout(type: ReadoutType, showColor: Bool) -> Readout? {
         switch type {
         case .created: createdReadout
         // swiftlint:disable:next void_function_in_ternary
@@ -25,18 +25,6 @@ extension Comment {
         }
     }
 
-    func readout(type: ReplyBarConfiguration.ReadoutType, showColor: Bool) -> Readout? {
-        switch type {
-        case .created: createdReadout
-        // swiftlint:disable:next void_function_in_ternary
-        case .score: downvotesEnabled ? scoreReadout(showColor: showColor) : upvoteReadout(showColor: showColor)
-        case .upvote: upvoteReadout(showColor: showColor)
-        case .downvote: downvotesEnabled ? downvoteReadout(showColor: showColor) : nil
-        case .comment: commentReadout
-        case .saved: savedReadout(showColor: showColor)
-        }
-    }
-    
     // MARK: - Counters
     
     func counter(

--- a/Mlem/App/Utility/Extensions/Content Models/Comment/Comment+Actions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Comment/Comment+Actions.swift
@@ -29,7 +29,7 @@ extension Comment {
     
     func counter(
         appState: AppState,
-        type: CommentBarConfiguration.CounterType,
+        type: CounterType,
         commentTreeTracker: CommentTreeTracker? = nil
     ) -> Counter? {
         switch type {
@@ -40,19 +40,6 @@ extension Comment {
         }
     }
 
-    func counter(
-        appState: AppState,
-        type: ReplyBarConfiguration.CounterType,
-        commentTreeTracker: CommentTreeTracker? = nil
-    ) -> Counter? {
-        switch type {
-        case .score: scoreCounter(appState: appState, downvotesEnabled: downvotesEnabled)
-        case .upvote: upvoteCounter(appState: appState)
-        case .downvote: downvotesEnabled ? downvoteCounter(appState: appState, downvotesEnabled: downvotesEnabled) : nil
-        case .reply: replyCounter(appState: appState, commentTreeTracker: commentTreeTracker)
-        }
-    }
-    
     // MARK: - Actions
     
     func createImageAction(navigation: NavigationLayer, commentTreeTracker: CommentTreeTracker?) -> BasicAction {

--- a/Mlem/App/Utility/Extensions/Content Models/Post/Post+Actions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post/Post+Actions.swift
@@ -313,7 +313,7 @@ extension Post {
     
     func counter(
         appState: AppState,
-        type: PostBarConfiguration.CounterType,
+        type: CounterType,
         commentTreeTracker: CommentTreeTracker? = nil
     ) -> Counter? {
         switch type {

--- a/Mlem/App/Utility/Extensions/Content Models/Post/Post+Actions.swift
+++ b/Mlem/App/Utility/Extensions/Content Models/Post/Post+Actions.swift
@@ -297,7 +297,7 @@ extension Post {
         return nil
     }
     
-    func readout(type: PostBarConfiguration.ReadoutType, showColor: Bool) -> Readout? {
+    func readout(type: ReadoutType, showColor: Bool) -> Readout? {
         switch type {
         case .created: createdReadout
         // swiftlint:disable:next void_function_in_ternary

--- a/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
+++ b/Mlem/App/Views/Root/Tabs/Feeds/Feed Posts/CompactPostView.swift
@@ -23,8 +23,8 @@ struct CompactPostView: View {
     let post: Post
     var requireConsistentHeight: Bool = false
     
-    var readouts: [PostBarConfiguration.ReadoutType] {
-        var readouts: [PostBarConfiguration.ReadoutType] = [.created]
+    var readouts: [ReadoutType] {
+        var readouts: [ReadoutType] = [.created]
         readouts.append(contentsOf: showDownvotesCompact ? [.upvote, .downvote, .comment] : [.score, .comment])
         readouts.appendIfPresent(post.saved.value ?? false ? .saved : nil)
         return readouts
@@ -97,7 +97,7 @@ struct CompactPostView: View {
                 } else {
                     titleAndHostView
                 }
-                InfoStackView(post: post, readouts: readouts, coloredReadouts: .init(PostBarConfiguration.ReadoutType.allCases))
+                InfoStackView(post: post, readouts: readouts, coloredReadouts: .init(ReadoutType.allCases))
             }
             .frame(maxWidth: .infinity)
             

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Views.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarEditorView+Views.swift
@@ -194,7 +194,7 @@ extension InteractionBarEditorView {
     @ViewBuilder
     var readoutSelectors: some View {
         HFlow(spacing: Constants.main.standardSpacing) {
-            ForEach(Array(Configuration.ReadoutType.allCases.enumerated()), id: \.offset) { _, readout in
+            ForEach(Array(ReadoutType.allCases.enumerated()), id: \.offset) { _, readout in
                 let isActive = configuration.readouts.contains(readout)
                 let disabled = !readout.compatibleWith(otherReadouts: Set(configuration.readouts))
                 Button {
@@ -205,7 +205,7 @@ extension InteractionBarEditorView {
                     } else {
                         // Insert and sort the new `ReadoutType`. In future these could be re-arrangable too
                         // but I need to think about how the UI would work
-                        configuration.readouts = Configuration.ReadoutType.allCases.filter {
+                        configuration.readouts = ReadoutType.allCases.filter {
                             configuration.readouts.contains($0) || $0 == readout
                         }
                     }

--- a/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/InteractionBarEditor/InteractionBarWidgetPickerView.swift
@@ -28,7 +28,7 @@ struct InteractionBarWidgetPickerView<Configuration: InteractionBarConfiguration
             }
             
             Section("Counters") {
-                ForEach(Array(Configuration.CounterType.allCases), id: \.self) { item in
+                ForEach(Array(CounterType.allCases), id: \.self) { item in
                     widgetButton(.counter(item))
                 }
             }

--- a/Mlem/App/Views/Shared/CommentView.swift
+++ b/Mlem/App/Views/Shared/CommentView.swift
@@ -37,8 +37,8 @@ struct CommentView<EmbeddedContent: View>: View {
     let highlight: Bool
     let depthOffset: Int
     
-    var compactReadouts: [CommentBarConfiguration.ReadoutType] {
-        var readouts: [CommentBarConfiguration.ReadoutType] = [.created]
+    var compactReadouts: [ReadoutType] {
+        var readouts: [ReadoutType] = [.created]
         readouts.append(contentsOf: showDownvotesCompact ? [.upvote, .downvote, .comment] : [.score, .comment])
         readouts.appendIfPresent(comment.saved.value ?? false ? .saved : nil)
         return readouts
@@ -100,7 +100,7 @@ struct CommentView<EmbeddedContent: View>: View {
                             InfoStackView(
                                 comment: comment,
                                 readouts: compactReadouts,
-                                coloredReadouts: .init(CommentBarConfiguration.ReadoutType.allCases)
+                                coloredReadouts: .init(ReadoutType.allCases)
                             )
                             .layoutPriority(1)
                         }

--- a/Mlem/App/Views/Shared/ExportableViews/ExportableCommentView.swift
+++ b/Mlem/App/Views/Shared/ExportableViews/ExportableCommentView.swift
@@ -23,7 +23,7 @@ struct ExportableCommentView: View {
     let appState: AppState
     let colorScheme: ColorScheme
     
-    let infoStackReadouts: [CommentBarConfiguration.ReadoutType] = [.upvote, .downvote, .created, .comment]
+    let infoStackReadouts: [ReadoutType] = [.upvote, .downvote, .created, .comment]
     
     var showBars: Bool { showPost || comments.count > 1 }
     

--- a/Mlem/App/Views/Shared/ExportableViews/ExportablePostView.swift
+++ b/Mlem/App/Views/Shared/ExportableViews/ExportablePostView.swift
@@ -20,7 +20,7 @@ struct ExportablePostView: View {
     let appState: AppState
     let colorScheme: ColorScheme
     
-    let infoStackReadouts: [PostBarConfiguration.ReadoutType] = [.upvote, .downvote, .created, .comment]
+    let infoStackReadouts: [ReadoutType] = [.upvote, .downvote, .created, .comment]
     
     var animationHashValue: Int {
         var hasher = Hasher()

--- a/Mlem/App/Views/Shared/InfoStackView.swift
+++ b/Mlem/App/Views/Shared/InfoStackView.swift
@@ -52,14 +52,14 @@ struct ReadoutView: View {
 }
 
 extension InfoStackView {
-    init(post: Post, readouts: [PostBarConfiguration.ReadoutType], coloredReadouts: Set<PostBarConfiguration.ReadoutType>) {
+    init(post: Post, readouts: [ReadoutType], coloredReadouts: Set<ReadoutType>) {
         self.readouts = readouts.compactMap { post.readout(type: $0, showColor: coloredReadouts.contains($0)) }
     }
     
     init(
         comment: Comment,
-        readouts: [CommentBarConfiguration.ReadoutType],
-        coloredReadouts: Set<CommentBarConfiguration.ReadoutType>
+        readouts: [ReadoutType],
+        coloredReadouts: Set<ReadoutType>
     ) {
         self.readouts = readouts.compactMap { comment.readout(type: $0, showColor: coloredReadouts.contains($0)) }
     }

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarView.swift
@@ -50,7 +50,7 @@ struct InteractionBarView: View {
             reportContext: reportContext
         )
         
-        let associatedReadouts = configuration.all.reduce(into: Set<PostBarConfiguration.ReadoutType>()) { result, widget in
+        let associatedReadouts = configuration.all.reduce(into: Set<ReadoutType>()) { result, widget in
             result.formUnion(widget.associatedReadouts(context: post))
         }
         self.readouts = configuration.readouts.compactMap { readout in
@@ -85,7 +85,7 @@ struct InteractionBarView: View {
             communityContext: communityContext,
             reportContext: reportContext
         )
-        let associatedReadouts = configuration.all.reduce(into: Set<CommentBarConfiguration.ReadoutType>()) { result, widget in
+        let associatedReadouts = configuration.all.reduce(into: Set<ReadoutType>()) { result, widget in
             result.formUnion(widget.associatedReadouts(context: comment))
         }
         self.readouts = configuration.readouts.compactMap { readout in
@@ -114,7 +114,7 @@ struct InteractionBarView: View {
             notification: notification,
             items: configuration.trailing
         )
-        let associatedReadouts = configuration.all.reduce(into: Set<ReplyBarConfiguration.ReadoutType>()) { result, widget in
+        let associatedReadouts = configuration.all.reduce(into: Set<ReadoutType>()) { result, widget in
             result.formUnion(widget.associatedReadouts(context: comment))
         }
         self.readouts = configuration.readouts.compactMap { readout in


### PR DESCRIPTION
No functional changes; refactor only.

Previously, `InteractionBarConfiguration` had three associated types:

``` swift
associatedtype ActionType: ActionTypeProviding
associatedtype CounterType: CounterTypeProviding
associatedtype ReadoutType: ReadoutTypeProviding
```

In this PR, I've made `CounterType` and `ReadoutType` into concrete types, rather than being associated types. Now, there is only one associated type.

``` swift
associatedtype ActionType: ActionTypeProviding
// CounterType and ReadoutType are now concrete
```

This is only possible because all three interaction bar configurations (post, comment, inbox) have identical options for counters and readouts.

# Downsides

It's now impossible to implement readouts or counters that are _specific_ to one of the three types (e.g. #2290).

# Motivation

This change will make it significantly easier to switch the interaction bar system over to the new action system, which I'll be doing soon.

Once the new action system is in, I'd like to make the readout/counter system more flexible again. I'm imagining a system similar to `ActionSeed`, to avoid the need for generics. But for now, I just want to get rid of the old action system ASAP lol