### PR TITLE
Infer image type from image data when file extension unavailable

### DIFF
--- a/Mlem/App/Logic/ImageFunctions.swift
+++ b/Mlem/App/Logic/ImageFunctions.swift
@@ -6,10 +6,12 @@
 //
 
 import Foundation
+import ImageIO
 import MlemMiddleware
 import Nuke
 import Photos
 import SwiftUI
+import UniformTypeIdentifiers
 
 func saveMedia(url: URL) async {
     do {
@@ -68,29 +70,33 @@ func fullSizeUrl(url: URL?) -> URL? {
 func downloadImageToFileSystem(url: URL) async -> URL? {
     do {
         let (data, _) = try await ImagePipeline.shared.data(url: url)
-        var fileName: String
-        
-        // image proxies that use url query param don't have pathExtension so we extract it from the embedded url
-        if url.pathExtension.isEmpty,
-           let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-           let queryItems = components.queryItems,
-           let baseUrlString = queryItems.first(where: { $0.name == "url" })?.value,
-           let baseUrl = URL(string: baseUrlString) {
-            fileName = baseUrl.lastPathComponent
-        } else {
-            fileName = url.lastPathComponent
-        }
-        
-        if fileName.isEmpty {
-            assertionFailure("Empty fileName!")
-            return nil
-        }
-        
+        let fileName = try getFileName(url: url, data: data)
         return try data.writeToTempFile(fileName: fileName)
     } catch {
         handleError(error)
         return nil
     }
+}
+
+private func getFileName(url: URL, data: Data) throws(FileDownloadError) -> String {
+    let url = url.unwrapProxy()
+
+    if !url.pathExtension.isEmpty {
+        return url.pathExtension
+    }
+
+    // Infer file type from the image data
+    if let source = CGImageSourceCreateWithData(data as CFData, nil),
+       let typeIdentifier = CGImageSourceGetType(source),
+       let ext = UTType(typeIdentifier as String)?.preferredFilenameExtension {
+        return "\(String(localized: "image")).\(ext)"
+    }
+
+    throw .couldNotDetermineFileType
+}
+
+enum FileDownloadError: Error {
+    case couldNotDetermineFileType
 }
 
 func downloadTextToFileSystem(fileName: String, text: String) async -> URL? {

--- a/Mlem/Packages/Media/Sources/Media/Resources/Core/MediaLoader.swift
+++ b/Mlem/Packages/Media/Sources/Media/Resources/Core/MediaLoader.swift
@@ -73,7 +73,7 @@ public class MediaLoader {
             self.processors = .init()
         }
         
-        self.proxyBypass = computeProxyBypass(for: url)
+        self.proxyBypass = url?.proxiedUrl()
         
         if let cachedImage = retrieveCachedImage(for: url, with: processors) {
             self.mediaType = cachedImage
@@ -98,7 +98,7 @@ public class MediaLoader {
         await setLoading(.loading)
         await setError(nil)
         
-        proxyBypass = computeProxyBypass(for: url)
+        proxyBypass = url?.proxiedUrl()
         
         // easy case: nil url
         guard let url else {
@@ -160,15 +160,6 @@ func retrieveCachedImage(for url: URL?, with processors: [ImageProcessing]) -> M
            processors: processors
        )) {
         return container.animatedMediaType
-    }
-    return nil
-}
-
-func computeProxyBypass(for url: URL?) -> URL? {
-    if let url,
-       let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-       let base = components.queryItems?.first(where: { $0.name == "url" })?.value {
-        return .init(string: base)
     }
     return nil
 }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
@@ -108,18 +108,29 @@ public extension URL {
         }
         return nil
     }
+
+    func proxiedUrl() -> URL? {
+        if let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
+            let queryItems = components.queryItems,
+            let baseUrlString = queryItems.first(where: { $0.name == "url" })?.value,
+            let baseUrl = URL(string: baseUrlString) {
+            baseUrl
+        } else {
+            nil
+        }
+    }
+
+    func unwrapProxy() -> URL {
+        proxiedUrl() ?? self
+    }
     
     /// Path extension of this URL, taking into account image proxy behavior
     var proxyAwarePathExtension: String? {
         var ret = pathExtension
         
         // image proxies that use url query param don't have pathExtension so we extract it from the embedded url
-        if ret.isEmpty,
-           let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
-           let queryItems = components.queryItems,
-           let baseUrlString = queryItems.first(where: { $0.name == "url" })?.value,
-           let baseUrl = URL(string: baseUrlString) {
-            ret = baseUrl.pathExtension
+        if ret.isEmpty {
+            ret = unwrapProxy().pathExtension
         }
         
         return ret.isEmpty ? nil : ret.lowercased()


### PR DESCRIPTION
Closes #2875

My original plan was to read the MIME type from the response, but we only get the `URLResponse` if the image was fetched directly. It's unavailable if the image was cached.