### PR TITLE
More specific action labelling system

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -279,8 +279,8 @@
 		0397D4932C6CE87E002C6CDC /* PostEditorTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0397D4922C6CE87E002C6CDC /* PostEditorTargetView.swift */; };
 		0397D49A2C6EA6EE002C6CDC /* InteractionBarEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0397D4992C6EA6EE002C6CDC /* InteractionBarEditorView.swift */; };
 		0397D49C2C6EA73C002C6CDC /* InteractionBarConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0397D49B2C6EA73C002C6CDC /* InteractionBarConfiguration.swift */; };
-		0397D4A22C6EB035002C6CDC /* ActionAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0397D4A12C6EB035002C6CDC /* ActionAppearance.swift */; };
-		0397D4A42C6FBC04002C6CDC /* ActionAppearance+StaticValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0397D4A32C6FBC04002C6CDC /* ActionAppearance+StaticValues.swift */; };
+		0397D4A22C6EB035002C6CDC /* LegacyActionAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0397D4A12C6EB035002C6CDC /* LegacyActionAppearance.swift */; };
+		0397D4A42C6FBC04002C6CDC /* LegacyActionAppearance+StaticValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0397D4A32C6FBC04002C6CDC /* LegacyActionAppearance+StaticValues.swift */; };
 		039D75642C4EEE69004F24C2 /* DeletableProviding+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D75632C4EEE69004F24C2 /* DeletableProviding+Extensions.swift */; };
 		039EFEC32BEEBEE0003AC372 /* LoginInstancePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039EFEC22BEEBEE0003AC372 /* LoginInstancePickerView.swift */; };
 		039F58812C7A7E5900C61658 /* JumpButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039F58802C7A7E5900C61658 /* JumpButtonView.swift */; };
@@ -906,8 +906,8 @@
 		0397D4922C6CE87E002C6CDC /* PostEditorTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditorTargetView.swift; sourceTree = "<group>"; };
 		0397D4992C6EA6EE002C6CDC /* InteractionBarEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionBarEditorView.swift; sourceTree = "<group>"; };
 		0397D49B2C6EA73C002C6CDC /* InteractionBarConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionBarConfiguration.swift; sourceTree = "<group>"; };
-		0397D4A12C6EB035002C6CDC /* ActionAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionAppearance.swift; sourceTree = "<group>"; };
-		0397D4A32C6FBC04002C6CDC /* ActionAppearance+StaticValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ActionAppearance+StaticValues.swift"; sourceTree = "<group>"; };
+		0397D4A12C6EB035002C6CDC /* LegacyActionAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyActionAppearance.swift; sourceTree = "<group>"; };
+		0397D4A32C6FBC04002C6CDC /* LegacyActionAppearance+StaticValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LegacyActionAppearance+StaticValues.swift"; sourceTree = "<group>"; };
 		039D75632C4EEE69004F24C2 /* DeletableProviding+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeletableProviding+Extensions.swift"; sourceTree = "<group>"; };
 		039EFEC22BEEBEE0003AC372 /* LoginInstancePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginInstancePickerView.swift; sourceTree = "<group>"; };
 		039F58802C7A7E5900C61658 /* JumpButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpButtonView.swift; sourceTree = "<group>"; };
@@ -1816,8 +1816,8 @@
 				03AF91E92C1CE96600E56644 /* Counter.swift */,
 				0324FA762C1F0AE100F6247D /* Readout.swift */,
 				03D3A1D32BB88EF1009DE55E /* Action.swift */,
-				0397D4A12C6EB035002C6CDC /* ActionAppearance.swift */,
-				0397D4A32C6FBC04002C6CDC /* ActionAppearance+StaticValues.swift */,
+				0397D4A12C6EB035002C6CDC /* LegacyActionAppearance.swift */,
+				0397D4A32C6FBC04002C6CDC /* LegacyActionAppearance+StaticValues.swift */,
 				03036C732C71408700C6DA1D /* CounterAppearance.swift */,
 				03D3A1F02BB9D48E009DE55E /* BasicAction.swift */,
 				03D3A1F22BB9D49B009DE55E /* ActionGroup.swift */,
@@ -3235,7 +3235,7 @@
 				03D3A1E52BB8B7A3009DE55E /* ActionType.swift in Sources */,
 				0348F98D2DDBB526006639CD /* OnboardingView.swift in Sources */,
 				0320B6542C8B65EB00D38548 /* Captcha+Extensions.swift in Sources */,
-				0397D4A42C6FBC04002C6CDC /* ActionAppearance+StaticValues.swift in Sources */,
+				0397D4A42C6FBC04002C6CDC /* LegacyActionAppearance+StaticValues.swift in Sources */,
 				03B431C02C45ABFB001A1EB5 /* UITextView+Extensions.swift in Sources */,
 				CDF8C1912D5D502400295CBA /* InteractionBarWidgetPickerView.swift in Sources */,
 				034B947F2C091EDD00039AF4 /* ProfileHeaderView.swift in Sources */,
@@ -3245,7 +3245,7 @@
 				037FC0702E4A6B16009E3E63 /* InstanceView+About.swift in Sources */,
 				CDBEC30F2E84C9F800F30B00 /* ExportablePostView.swift in Sources */,
 				0368F3432D72796B007DEB70 /* LanguagePickerSheetView.swift in Sources */,
-				0397D4A22C6EB035002C6CDC /* ActionAppearance.swift in Sources */,
+				0397D4A22C6EB035002C6CDC /* LegacyActionAppearance.swift in Sources */,
 				035394952CA1AE6300795AA5 /* InstanceUptimeView.swift in Sources */,
 				CDB2EC862BFADD7C00DBC0EF /* FullyQualifiedLabelView.swift in Sources */,
 				CD7DB9712C49C17200DCC542 /* PersonContentGridView.swift in Sources */,

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -99,7 +99,7 @@ private struct ActionSheetButton: View {
     let dismiss: DismissAction
 
     var body: some View {
-        Button(appearance) {
+        Button(appearance, describing: .stateTransition) {
             action.execute(environment: environment)
             if !navigation.rootChangePending, popupAnchorModel.data == nil {
                 dismiss()

--- a/Mlem/App/Actions/ActionSheet/ActionSheet.swift
+++ b/Mlem/App/Actions/ActionSheet/ActionSheet.swift
@@ -66,9 +66,9 @@ struct ActionSheet: View {
 
     private func frames(for actions: [any Actions.Action]) -> [ActionFrame] {
         actions.compactMap {
-            let label = $0.createLabel(environment: environment)
-            if label.visibility == .hidden { return nil }
-            return .init(action: $0, label: label)
+            let appearance = $0.createAppearance(environment: environment)
+            if appearance.visibility == .hidden { return nil }
+            return .init(action: $0, appearance: appearance)
         }
     }
 
@@ -78,7 +78,7 @@ struct ActionSheet: View {
             Divider()
                 .padding(.horizontal, 15)
         }
-        ActionSheetButton(action: frame.action, label: frame.label, dismiss: dismiss)
+        ActionSheetButton(action: frame.action, appearance: frame.appearance, dismiss: dismiss)
             .popupAnchor(model: popupAnchorModel)
             .environment(\.isRootView, isRootView)
             .environment(navigation)
@@ -93,25 +93,25 @@ private struct ActionSheetButton: View {
 
     let action: any Actions.Action
 
-    // Lable passed separately for performance reasons
-    let label: ActionLabel
+    // Appearance passed separately for performance reasons
+    let appearance: ActionAppearance
 
     let dismiss: DismissAction
 
     var body: some View {
-        Button(label) {
+        Button(appearance) {
             action.execute(environment: environment)
             if !navigation.rootChangePending, popupAnchorModel.data == nil {
                 dismiss()
             }
         }
-        .disabled(label.visibility == .disabled)
+        .disabled(appearance.visibility == .disabled)
     }
 }
 
 private struct ActionFrame {
     let action: any Actions.Action
-    let label: ActionLabel
+    let appearance: ActionAppearance
 }
 
 private struct ActionSheetButtonStyle: ButtonStyle {

--- a/Mlem/App/Actions/AppointAdminAction.swift
+++ b/Mlem/App/Actions/AppointAdminAction.swift
@@ -16,7 +16,7 @@ struct AppointAdminAction: Actions.Action {
 // MARK: - Configurability
 
 extension ActionSeed {
-    static let appointAdmin = ActionSeed("appointAdmin", label: AppointAdminAction.appointLabel) { entity in
+    static let appointAdmin = ActionSeed("appointAdmin", appearance: AppointAdminAction.appointAppearance) { entity in
         switch entity {
         case let entity as Person:
             AppointAdminAction(entity: entity)
@@ -29,29 +29,22 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension AppointAdminAction {
-    static let appointLabel: ActionLabel = .init(
+    static let appointAppearance: ActionAppearance = .init(
         "Appoint Administrator",
         icon: .lemmy.addAdministrator,
         color: .themedPositive
     )
 
-    static let demoteLabel: ActionLabel = .init(
+    static let demoteAppearance: ActionAppearance = .init(
         "Remove Administrator",
         icon: .lemmy.removeAdministrator,
         color: .themedNegative
     )
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        guard let isAdmin = entity.isAdmin.value else { return Self.demoteLabel.withVisibility(.hidden) }
-        let label: ActionLabel
-
-        if isAdmin {
-            label = Self.demoteLabel
-        } else {
-            label = Self.appointLabel
-        }
-
-        return label.withVisibility(visibility(environment))
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        guard let isAdmin = entity.isAdmin.value else { return Self.demoteAppearance.withVisibility(.hidden) }
+        let base = isAdmin ? Self.demoteAppearance : Self.appointAppearance
+        return base.withVisibility(visibility(environment))
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/AppointModeratorAction.swift
+++ b/Mlem/App/Actions/AppointModeratorAction.swift
@@ -16,7 +16,7 @@ struct AppointModeratorAction: Actions.Action {
 // MARK: - Configurability
 
 extension ActionSeed {
-    static let appointModerator = ActionSeed("appointModerator", label: AppointModeratorAction.appointLabel) { entity in
+    static let appointModerator = ActionSeed("appointModerator", appearance: AppointModeratorAction.appointAppearance) { entity in
         switch entity {
         case let entity as Person:
             AppointModeratorAction(entity: entity)
@@ -29,28 +29,21 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension AppointModeratorAction {
-    static let appointLabel: ActionLabel = .init(
+    static let appointAppearance: ActionAppearance = .init(
         "Appoint Moderator",
         icon: .lemmy.addModerator,
         color: .themedPositive
     )
 
-    static let demoteLabel: ActionLabel = .init(
+    static let demoteAppearance: ActionAppearance = .init(
         "Remove Moderator",
         icon: .lemmy.removeModerator,
         color: .themedNegative
     )
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        let label: ActionLabel
-
-        if isModerator(environment: environment) ?? false {
-            label = Self.demoteLabel
-        } else {
-            label = Self.appointLabel
-        }
-
-        return label.withVisibility(visibility(environment))
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        let base = isModerator(environment: environment) ?? false ? Self.demoteAppearance : Self.appointAppearance
+        return base.withVisibility(visibility(environment))
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/BanAction.swift
+++ b/Mlem/App/Actions/BanAction.swift
@@ -117,7 +117,8 @@ extension BanAction {
             base = .init(
                 currentStateLabel: .init("Banned", icon: .lemmy.bannedFromInstance.representingState(active: true)),
                 stateTransitionLabel: .init("Unban", icon: .lemmy.unbanFromInstance),
-                color: .themedPositive
+                color: .themedPositive,
+                prominent: true
             )
 
         case (bannedFrom: .instanceOnly, canBanFrom: .both),
@@ -133,7 +134,8 @@ extension BanAction {
             base = .init(
                 currentStateLabel: .init("Banned", icon: .lemmy.bannedFromCommunity.representingState(active: true)),
                 stateTransitionLabel: .init("Unban", icon: .lemmy.unbanFromCommunity),
-                color: .themedPositive
+                color: .themedPositive,
+                prominent: true
             )
 
         case (bannedFrom: .anyNotContaining(.community), canBanFrom: .communityOnly):

--- a/Mlem/App/Actions/BanAction.swift
+++ b/Mlem/App/Actions/BanAction.swift
@@ -91,8 +91,8 @@ extension ActionSeed {
 
 extension BanAction {
     static let appearance: ActionAppearance = .init(
-        "Ban",
-        icon: .lemmy.banFromCommunity,
+        currentStateLabel: .init("Unbanned", icon: .lemmy.bannedFromCommunity.representingState(active: false)),
+        stateTransitionLabel: .init("Ban", icon: .lemmy.banFromCommunity),
         color: .themedNegative,
         isDestructive: true
     )
@@ -106,8 +106,8 @@ extension BanAction {
         case (bannedFrom: .none, canBanFrom: .both),
              (bannedFrom: .anyNotContaining(.instance), canBanFrom: .instanceOnly):
             base = .init(
-                "Ban",
-                icon: .lemmy.banFromInstance,
+                currentStateLabel: .init("Unbanned", icon: .lemmy.bannedFromInstance.representingState(active: false)),
+                stateTransitionLabel: .init("Ban", icon: .lemmy.banFromInstance),
                 color: .themedNegative,
                 isDestructive: true
             )
@@ -115,8 +115,8 @@ extension BanAction {
         case (bannedFrom: .anyContaining(.instance), canBanFrom: .instanceOnly),
              (bannedFrom: .both, canBanFrom: .both):
             base = .init(
-                "Unban",
-                icon: .lemmy.unbanFromInstance,
+                currentStateLabel: .init("Banned", icon: .lemmy.bannedFromInstance.representingState(active: true)),
+                stateTransitionLabel: .init("Unban", icon: .lemmy.unbanFromInstance),
                 color: .themedPositive
             )
 
@@ -131,8 +131,8 @@ extension BanAction {
 
         case (bannedFrom: .anyContaining(.community), canBanFrom: .communityOnly):
             base = .init(
-                "Unban",
-                icon: .lemmy.unbanFromCommunity,
+                currentStateLabel: .init("Banned", icon: .lemmy.bannedFromCommunity.representingState(active: true)),
+                stateTransitionLabel: .init("Unban", icon: .lemmy.unbanFromCommunity),
                 color: .themedPositive
             )
 

--- a/Mlem/App/Actions/BanAction.swift
+++ b/Mlem/App/Actions/BanAction.swift
@@ -90,23 +90,22 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension BanAction {
-    static let label: ActionLabel = .init(
+    static let appearance: ActionAppearance = .init(
         "Ban",
         icon: .lemmy.banFromCommunity,
         color: .themedNegative,
         isDestructive: true
     )
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        let label: ActionLabel
-
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         let appliedBanScopes = getAppliedBanScopes(environment: environment)
         let actionableBanScopes = getActionableBanScopes(environment: environment)
+        let base: ActionAppearance
 
         switch (bannedFrom: appliedBanScopes, canBanFrom: actionableBanScopes) {
         case (bannedFrom: .none, canBanFrom: .both),
              (bannedFrom: .anyNotContaining(.instance), canBanFrom: .instanceOnly):
-            label = .init(
+            base = .init(
                 "Ban",
                 icon: .lemmy.banFromInstance,
                 color: .themedNegative,
@@ -115,7 +114,7 @@ extension BanAction {
 
         case (bannedFrom: .anyContaining(.instance), canBanFrom: .instanceOnly),
              (bannedFrom: .both, canBanFrom: .both):
-            label = .init(
+            base = .init(
                 "Unban",
                 icon: .lemmy.unbanFromInstance,
                 color: .themedPositive
@@ -123,7 +122,7 @@ extension BanAction {
 
         case (bannedFrom: .instanceOnly, canBanFrom: .both),
              (bannedFrom: .communityOnly, canBanFrom: .both):
-            label = .init(
+            base = .init(
                 "Ban...",
                 icon: .lemmy.banFromInstance,
                 color: .themedNegative,
@@ -131,20 +130,20 @@ extension BanAction {
             )
 
         case (bannedFrom: .anyContaining(.community), canBanFrom: .communityOnly):
-            label = .init(
+            base = .init(
                 "Unban",
                 icon: .lemmy.unbanFromCommunity,
                 color: .themedPositive
             )
 
         case (bannedFrom: .anyNotContaining(.community), canBanFrom: .communityOnly):
-            label = Self.label
+            base = Self.appearance
 
         default:
-            return Self.label.withVisibility(.hidden)
+            return Self.appearance.withVisibility(.hidden)
         }
 
-        return label.withVisibility(visibility(environment))
+        return base.withVisibility(visibility(environment))
     }
 
     /// Get the scopes that the target is current banned within.

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -167,7 +167,8 @@ extension BlockAction {
         case .unblock: .init(
             currentStateLabel: .init(titles.currentState, icon: .lemmy.blocked.representingState(active: true)),
             stateTransitionLabel: .init(titles.stateTransition, icon: .lemmy.unblock),
-            color: .themedPositive
+            color: .themedPositive,
+            prominent: true
         )
         }
     }

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -56,7 +56,7 @@ private extension [Blockable] {
 extension ActionSeed {
     static let block = ActionSeed(
         "block",
-        label: BlockAction.createLabel(relationship: .direct, mode: .block, contentType: .multi)
+        appearance: BlockAction.createAppearance(relationship: .direct, mode: .block, contentType: .multi)
     ) { entity in
         switch entity {
         case let entity as any Blockable: BlockAction(content: [entity], relationship: .direct)
@@ -66,7 +66,7 @@ extension ActionSeed {
 
     static let blockCreator = ActionSeed(
         "blockCreator",
-        label: BlockAction.createLabel(relationship: .indirect, mode: .block, contentType: .multi)
+        appearance: BlockAction.createAppearance(relationship: .indirect, mode: .block, contentType: .multi)
     ) { entity in
         switch entity {
         case let entity as Comment:
@@ -96,8 +96,8 @@ extension BlockAction {
     enum Mode { case block, unblock }
 
     // swiftlint:disable:next cyclomatic_complexity
-    static func createLabel(relationship: Relationship, mode: Mode, contentType: ContentType) -> ActionLabel {
-        let label: LocalizedStringResource = switch (relationship, mode, contentType) {
+    static func createAppearance(relationship: Relationship, mode: Mode, contentType: ContentType) -> ActionAppearance {
+        let title: LocalizedStringResource = switch (relationship, mode, contentType) {
         case (.direct, .block, _): "Block"
         case (.direct, .unblock, _): "Unblock"
         case (.indirect, .block, .personOnly): "Block User"
@@ -113,21 +113,21 @@ extension BlockAction {
 
         return switch mode {
         case .block: .init(
-            label,
+            title,
             icon: .lemmy.block,
             color: .themedNegative,
             isDestructive: true
         )
         case .unblock: .init(
-            label,
+            title,
             icon: .lemmy.unblock,
             color: .themedPositive
         )
         }
     }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        return Self.createLabel(
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.createAppearance(
             relationship: self.relationship,
             mode: content.first!.blocked(environment: environment) ? .unblock : .block,
             contentType: availableContent.contentType
@@ -188,14 +188,14 @@ extension BlockAction {
             let callback = {
                 submit(entity: item, environment: environment)
             }
-            let label = Self.createLabel(
+            let appearance = Self.createAppearance(
                 relationship: .indirect,
                 mode: item.blocked(environment: environment) ? .unblock : .block,
-                contentType: item is Person ? .personOnly: .communityOnly
+                contentType: item is Person ? .personOnly : .communityOnly
             )
             return .init(
-                title: label.title,
-                isDestructive: label.isDestructive,
+                title: appearance.title,
+                isDestructive: appearance.isDestructive,
                 callback: callback
             )
         }

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -194,7 +194,7 @@ extension BlockAction {
                 contentType: item is Person ? .personOnly : .communityOnly
             )
             return .init(
-                title: appearance.title,
+                title: appearance.label(describing: .stateTransition).title,
                 isDestructive: appearance.isDestructive,
                 callback: callback
             )

--- a/Mlem/App/Actions/BlockAction.swift
+++ b/Mlem/App/Actions/BlockAction.swift
@@ -95,32 +95,78 @@ extension ActionSeed {
 extension BlockAction {
     enum Mode { case block, unblock }
 
-    // swiftlint:disable:next cyclomatic_complexity
+    typealias Titles = (currentState: LocalizedStringResource, stateTransition: LocalizedStringResource)
+
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     static func createAppearance(relationship: Relationship, mode: Mode, contentType: ContentType) -> ActionAppearance {
-        let title: LocalizedStringResource = switch (relationship, mode, contentType) {
-        case (.direct, .block, _): "Block"
-        case (.direct, .unblock, _): "Unblock"
-        case (.indirect, .block, .personOnly): "Block User"
-        case (.indirect, .unblock, .personOnly): "Unblock User"
-        case (.indirect, .block, .communityOnly): "Block Community"
-        case (.indirect, .unblock, .communityOnly): "Unblock Community"
-        case (.indirect, .block, .instanceOnly): "Block Instance"
-        case (.indirect, .unblock, .instanceOnly): "Unblock Instance"
-        case (.indirect, .block, .multi): "Block..."
-        case (.indirect, .unblock, .multi): "Unblock..."
-        case (_, _, .other): "Block..."
+        let titles: Titles = switch (relationship, mode, contentType) {
+        case (.direct, .block, _):
+            (
+            currentState: "Unblocked",
+            stateTransition: "Block"
+            )
+        case (.direct, .unblock, _):
+            (
+            currentState: "Blocked",
+            stateTransition: "Unblock"
+            )
+        case (.indirect, .block, .personOnly):
+            (
+            currentState: "User Unblocked",
+            stateTransition: "Block User"
+            )
+        case (.indirect, .unblock, .personOnly):
+            (
+            currentState: "User Blocked",
+            stateTransition: "Unblock User"
+            )
+        case (.indirect, .block, .communityOnly):
+            (
+            currentState: "Community Unblocked",
+            stateTransition: "Block Community"
+            )
+        case (.indirect, .unblock, .communityOnly):
+            (
+            currentState: "Community Blocked",
+            stateTransition: "Unblock Community"
+            )
+        case (.indirect, .block, .instanceOnly):
+            (
+            currentState: "Instance Unblocked",
+            stateTransition: "Block Instance"
+            )
+        case (.indirect, .unblock, .instanceOnly):
+            (
+            currentState: "Instance Blocked",
+            stateTransition: "Unblock Instance"
+            )
+        case (.indirect, .block, .multi):
+            (
+            currentState: "Block...",
+            stateTransition: "Block..."
+            )
+        case (.indirect, .unblock, .multi):
+            (
+            currentState: "Unblock...",
+            stateTransition: "Unblock..."
+            )
+        case (_, _, .other):
+            (
+            currentState: "Block...",
+            stateTransition: "Block..."
+            )
         }
 
         return switch mode {
         case .block: .init(
-            title,
-            icon: .lemmy.block,
+            currentStateLabel: .init(titles.currentState, icon: .lemmy.blocked.representingState(active: false)),
+            stateTransitionLabel: .init(titles.stateTransition, icon: .lemmy.block),
             color: .themedNegative,
             isDestructive: true
         )
         case .unblock: .init(
-            title,
-            icon: .lemmy.unblock,
+            currentStateLabel: .init(titles.currentState, icon: .lemmy.blocked.representingState(active: true)),
+            stateTransitionLabel: .init(titles.stateTransition, icon: .lemmy.unblock),
             color: .themedPositive
         )
         }

--- a/Mlem/App/Actions/CollapseAction.swift
+++ b/Mlem/App/Actions/CollapseAction.swift
@@ -27,29 +27,29 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension CollapseAction {
-    static let collapseLabel: ActionLabel = .init(
+    static let collapseAppearance: ActionAppearance = .init(
         "Collapse",
         icon: .general.collapse,
         color: .themedColorfulAccent(0)
     )
 
-    static let expandLabel: ActionLabel = .init(
+    static let expandAppearance: ActionAppearance = .init(
         "Expand",
         icon: .general.expand,
         color: .themedColorfulAccent(0)
     )
 
-   static var label: ActionLabel { collapseLabel }
+    static var appearance: ActionAppearance { collapseAppearance }
 
-   func createLabel(environment: EnvironmentValues) -> ActionLabel {
-       guard let node = environment.commentTreeTracker?.getNode(actorId: entity.actorId) else {
-           return Self.label.withVisibility(.hidden)
-       } 
-       if node.collapsed {
-           return Self.expandLabel
-       } else {
-           return Self.collapseLabel
-       }
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        guard let node = environment.commentTreeTracker?.getNode(actorId: entity.actorId) else {
+            return Self.appearance.withVisibility(.hidden)
+        }
+        if node.collapsed {
+            return Self.expandAppearance
+        } else {
+            return Self.collapseAppearance
+        }
     }
 }
 

--- a/Mlem/App/Actions/CollapseAction.swift
+++ b/Mlem/App/Actions/CollapseAction.swift
@@ -28,15 +28,14 @@ extension ActionSeed {
 
 extension CollapseAction {
     static let collapseAppearance: ActionAppearance = .init(
-        "Collapse",
-        icon: .general.collapse,
+        currentStateLabel: .init("Expanded", icon: .general.expand),
+        stateTransitionLabel: .init("Collapse", icon: .general.collapse),
         color: .themedColorfulAccent(0)
     )
 
     static let expandAppearance: ActionAppearance = .init(
-        "Expand",
-        icon: .general.expand,
-        color: .themedColorfulAccent(0)
+        currentStateLabel: .init("Collapsed", icon: .general.collapse),
+        stateTransitionLabel: .init("Expand", icon: .general.expand),
     )
 
     static var appearance: ActionAppearance { collapseAppearance }

--- a/Mlem/App/Actions/CollapseAction.swift
+++ b/Mlem/App/Actions/CollapseAction.swift
@@ -36,6 +36,8 @@ extension CollapseAction {
     static let expandAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Collapsed", icon: .general.collapse),
         stateTransitionLabel: .init("Expand", icon: .general.expand),
+        color: .themedColorfulAccent(0),
+        prominent: true
     )
 
     static var appearance: ActionAppearance { collapseAppearance }

--- a/Mlem/App/Actions/CollapseParentAction.swift
+++ b/Mlem/App/Actions/CollapseParentAction.swift
@@ -27,14 +27,14 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension CollapseParentAction {
-    static let label: ActionLabel = .init(
+    static let appearance: ActionAppearance = .init(
         "Collapse Parent",
         icon: .lemmy.collapseParent,
         color: .themedColorfulAccent(0)
     )
 
-   func createLabel(environment: EnvironmentValues) -> ActionLabel {
-       return Self.label.withVisibility(visibility(environment: environment))
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance.withVisibility(visibility(environment: environment))
     }
 
     func visibility(environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/CollapseToTopAction.swift
+++ b/Mlem/App/Actions/CollapseToTopAction.swift
@@ -27,14 +27,14 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension CollapseToTopAction {
-    static let label: ActionLabel = .init(
+    static let appearance: ActionAppearance = .init(
         "Collapse to Top",
         icon: .lemmy.collapseToTop,
         color: .themedColorfulAccent(0)
     )
 
-   func createLabel(environment: EnvironmentValues) -> ActionLabel {
-       return Self.label.withVisibility(visibility(environment: environment))
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance.withVisibility(visibility(environment: environment))
     }
 
     func visibility(environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/CopyNameAction.swift
+++ b/Mlem/App/Actions/CopyNameAction.swift
@@ -20,7 +20,7 @@ struct CopyNameAction: Actions.Action {
 extension ActionSeed {
     static let copyName = ActionSeed(
         "copyName",
-        label: CopyNameAction.createLabel(relationship: .identity)
+        appearance: CopyNameAction.createAppearance(relationship: .identity)
     ) { entity in
         switch entity {
         case let entity as Person:
@@ -34,7 +34,7 @@ extension ActionSeed {
 
     static let copyAuthorName = ActionSeed(
         "copyAuthorName",
-        label: CopyNameAction.createLabel(relationship: .author)
+        appearance: CopyNameAction.createAppearance(relationship: .author)
     ) { entity in
         switch entity {
         case let entity as any InteractableProviding:
@@ -52,7 +52,7 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension CopyNameAction {
-    static func createLabel(relationship: Relationship) -> ActionLabel {
+    static func createAppearance(relationship: Relationship) -> ActionAppearance {
         .init(
             relationship == .identity ? "Copy Name" : "Copy Username",
             icon: .general.copy,
@@ -60,8 +60,8 @@ extension CopyNameAction {
         )
     }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.createLabel(relationship: self.relationship)
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.createAppearance(relationship: self.relationship)
     }
 }
 

--- a/Mlem/App/Actions/CreateImageAction.swift
+++ b/Mlem/App/Actions/CreateImageAction.swift
@@ -33,14 +33,14 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension CreateImageAction {
-    static let label: ActionLabel = .init(
+    static let appearance: ActionAppearance = .init(
         "Create Image",
         icon: .general.createImage,
         color: .themedColorfulAccent(5)
     )
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.label.withVisibility(visibility(environment))
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance.withVisibility(visibility(environment))
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/CrosspostAction.swift
+++ b/Mlem/App/Actions/CrosspostAction.swift
@@ -27,14 +27,14 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension CrosspostAction {
-    static let label: ActionLabel = .init(
+    static let appearance: ActionAppearance = .init(
         "Crosspost",
         icon: .lemmy.crosspost,
         color: .themedColorfulAccent(5)
     )
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.label.withVisibility(visibility(environment))
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance.withVisibility(visibility(environment))
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/DeleteAction.swift
+++ b/Mlem/App/Actions/DeleteAction.swift
@@ -27,25 +27,25 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension DeleteAction {
-    static let deleteLabel: ActionLabel = .init(
+    static let deleteAppearance: ActionAppearance = .init(
         "Delete",
         icon: .general.delete,
         color: .themedNegative,
         isDestructive: true
     )
-    static let restoreLabel: ActionLabel = .init(
+    static let restoreAppearance: ActionAppearance = .init(
         "Restore",
         icon: .lemmy.restore,
         color: .themedPositive
     )
-    
-    static var label: ActionLabel { deleteLabel }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+    static var appearance: ActionAppearance { deleteAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         if entity.deleted {
-            Self.restoreLabel.withVisibility(visibility(environment))
+            Self.restoreAppearance.withVisibility(visibility(environment))
         } else {
-            Self.deleteLabel.withVisibility(visibility(environment))
+            Self.deleteAppearance.withVisibility(visibility(environment))
         }
     }
     

--- a/Mlem/App/Actions/DeleteAction.swift
+++ b/Mlem/App/Actions/DeleteAction.swift
@@ -36,7 +36,8 @@ extension DeleteAction {
     static let restoreAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Deleted", icon: .general.deleted.representingState(active: true)),
         stateTransitionLabel: .init("Restore", icon: .lemmy.restore),
-        color: .themedPositive
+        color: .themedPositive,
+        prominent: true
     )
 
     static var appearance: ActionAppearance { deleteAppearance }

--- a/Mlem/App/Actions/DeleteAction.swift
+++ b/Mlem/App/Actions/DeleteAction.swift
@@ -28,14 +28,14 @@ extension ActionSeed {
 
 extension DeleteAction {
     static let deleteAppearance: ActionAppearance = .init(
-        "Delete",
-        icon: .general.delete,
+        currentStateLabel: .init("Not Deleted", icon: .general.deleted.representingState(active: false)),
+        stateTransitionLabel: .init("Delete", icon: .general.delete),
         color: .themedNegative,
         isDestructive: true
     )
     static let restoreAppearance: ActionAppearance = .init(
-        "Restore",
-        icon: .lemmy.restore,
+        currentStateLabel: .init("Deleted", icon: .general.deleted.representingState(active: true)),
+        stateTransitionLabel: .init("Restore", icon: .lemmy.restore),
         color: .themedPositive
     )
 

--- a/Mlem/App/Actions/DetailsAction.swift
+++ b/Mlem/App/Actions/DetailsAction.swift
@@ -31,7 +31,7 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension DetailsAction {
-    static var label: Actions.ActionLabel {
+    static var appearance: ActionAppearance {
         .init(
             "Details",
             icon: .general.info,

--- a/Mlem/App/Actions/EditAction.swift
+++ b/Mlem/App/Actions/EditAction.swift
@@ -43,10 +43,10 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension EditAction {
-    static let label: ActionLabel = .init("Edit", icon: .general.edit)
-    
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.label.withVisibility(visibility(environment))
+    static let appearance: ActionAppearance = .init("Edit", icon: .general.edit)
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance.withVisibility(visibility(environment))
     }
     
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/EditNoteAction.swift
+++ b/Mlem/App/Actions/EditNoteAction.swift
@@ -18,7 +18,7 @@ struct EditNoteAction: Actions.Action {
 extension ActionSeed {
     static let editNote = ActionSeed(
         "editNote",
-        label: EditNoteAction.createLabel(noteExists: true)
+        appearance: EditNoteAction.createAppearance(noteExists: true)
     ) { entity in
         switch entity {
         case let entity as Person: EditNoteAction(entity: entity)
@@ -30,7 +30,7 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension EditNoteAction {
-    static func createLabel(noteExists: Bool) -> ActionLabel {
+    static func createAppearance(noteExists: Bool) -> ActionAppearance {
         if noteExists {
             .init("Edit Note", icon: .lemmy.editNote)
         } else {
@@ -38,8 +38,8 @@ extension EditNoteAction {
         }
     }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.createLabel(noteExists: entity.note != nil)
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.createAppearance(noteExists: entity.note != nil)
             .withVisibility(entity.api.supports(.userNotes, defaultValue: false) ? .enabled : .hidden)
     }
 }

--- a/Mlem/App/Actions/FavoriteAction.swift
+++ b/Mlem/App/Actions/FavoriteAction.swift
@@ -35,7 +35,8 @@ extension FavoriteAction {
     static let unfavoriteAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Favorited", icon: .lemmy.favorited.representingState(active: true)),
         stateTransitionLabel: .init("Favorite", icon: .lemmy.unfavorite),
-        color: .themedFavorite
+        color: .themedFavorite,
+        prominent: true
     )
 
     static var appearance: ActionAppearance { favoriteAppearance }

--- a/Mlem/App/Actions/FavoriteAction.swift
+++ b/Mlem/App/Actions/FavoriteAction.swift
@@ -28,13 +28,13 @@ extension ActionSeed {
 
 extension FavoriteAction {
     static let favoriteAppearance: ActionAppearance = .init(
-        "Favorite",
-        icon: .lemmy.favorite,
+        currentStateLabel: .init("Unfavorited", icon: .lemmy.favorited.representingState(active: false)),
+        stateTransitionLabel: .init("Favorite", icon: .lemmy.favorite),
         color: .themedFavorite
     )
     static let unfavoriteAppearance: ActionAppearance = .init(
-        "Unfavorite",
-        icon: .lemmy.unfavorite,
+        currentStateLabel: .init("Favorited", icon: .lemmy.favorited.representingState(active: true)),
+        stateTransitionLabel: .init("Favorite", icon: .lemmy.unfavorite),
         color: .themedFavorite
     )
 

--- a/Mlem/App/Actions/FavoriteAction.swift
+++ b/Mlem/App/Actions/FavoriteAction.swift
@@ -27,24 +27,24 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension FavoriteAction {
-    static let favoriteLabel: ActionLabel = .init(
+    static let favoriteAppearance: ActionAppearance = .init(
         "Favorite",
         icon: .lemmy.favorite,
         color: .themedFavorite
     )
-    static let unfavoriteLabel: ActionLabel = .init(
+    static let unfavoriteAppearance: ActionAppearance = .init(
         "Unfavorite",
         icon: .lemmy.unfavorite,
         color: .themedFavorite
     )
-    
-    static var label: ActionLabel { favoriteLabel }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+    static var appearance: ActionAppearance { favoriteAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         if entity.favorited {
-            return Self.unfavoriteLabel.withVisibility(visibility(environment))
+            return Self.unfavoriteAppearance.withVisibility(visibility(environment))
         } else {
-            return Self.favoriteLabel.withVisibility(visibility(environment))
+            return Self.favoriteAppearance.withVisibility(visibility(environment))
         }
     }
 

--- a/Mlem/App/Actions/GoToInstanceAction.swift
+++ b/Mlem/App/Actions/GoToInstanceAction.swift
@@ -35,7 +35,7 @@ extension GoToInstanceAction {
 
     func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         var appearance = Self.appearance
-        appearance.title = entity.host
+        appearance.labels = .basic(.init(entity.host, icon: .lemmy.instance))
         return appearance
     }
 }

--- a/Mlem/App/Actions/GoToInstanceAction.swift
+++ b/Mlem/App/Actions/GoToInstanceAction.swift
@@ -27,14 +27,14 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension GoToInstanceAction {
-    static let label: ActionLabel = .init(
+    static let appearance: ActionAppearance = .init(
         "Go to Instance",
         icon: .lemmy.instance,
         color: .themedInstanceAccent
     )
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.label.withTitle(entity.host)
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance.withTitle(entity.host)
     }
 }
 

--- a/Mlem/App/Actions/GoToInstanceAction.swift
+++ b/Mlem/App/Actions/GoToInstanceAction.swift
@@ -34,7 +34,9 @@ extension GoToInstanceAction {
     )
 
     func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
-        Self.appearance.withTitle(entity.host)
+        var appearance = Self.appearance
+        appearance.title = entity.host
+        return appearance
     }
 }
 

--- a/Mlem/App/Actions/HideAction.swift
+++ b/Mlem/App/Actions/HideAction.swift
@@ -28,14 +28,14 @@ extension ActionSeed {
 
 extension HideAction {
     static let hideAppearance: ActionAppearance = .init(
-        "Hide",
-        icon: .general.hide,
+        currentStateLabel: .init("Shown", icon: .general.hidden.representingState(active: false)),
+        stateTransitionLabel: .init("Hide", icon: .general.hide),
         color: .themedColorfulAccent(4)
     )
 
     static let showAppearance: ActionAppearance = .init(
-        "Show",
-        icon: .general.show,
+        currentStateLabel: .init("Hidden", icon: .general.hidden.representingState(active: true)),
+        stateTransitionLabel: .init("Show", icon: .general.show),
         color: .themedColorfulAccent(4)
     )
 

--- a/Mlem/App/Actions/HideAction.swift
+++ b/Mlem/App/Actions/HideAction.swift
@@ -27,26 +27,26 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension HideAction {
-    static let hideLabel: ActionLabel = .init(
+    static let hideAppearance: ActionAppearance = .init(
         "Hide",
         icon: .general.hide,
         color: .themedColorfulAccent(4)
     )
 
-    static let showLabel: ActionLabel = .init(
+    static let showAppearance: ActionAppearance = .init(
         "Show",
         icon: .general.show,
         color: .themedColorfulAccent(4)
     )
-    
-    static var label: ActionLabel { hideLabel }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        guard let hidden = entity.hidden.value else { return Self.showLabel.withVisibility(.hidden) }
+    static var appearance: ActionAppearance { hideAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        guard let hidden = entity.hidden.value else { return Self.showAppearance.withVisibility(.hidden) }
         if hidden {
-            return Self.showLabel.withVisibility(visibility(environment))
+            return Self.showAppearance.withVisibility(visibility(environment))
         } else {
-            return Self.hideLabel.withVisibility(visibility(environment))
+            return Self.hideAppearance.withVisibility(visibility(environment))
         }
     }
 

--- a/Mlem/App/Actions/HideAction.swift
+++ b/Mlem/App/Actions/HideAction.swift
@@ -36,7 +36,8 @@ extension HideAction {
     static let showAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Hidden", icon: .general.hidden.representingState(active: true)),
         stateTransitionLabel: .init("Show", icon: .general.show),
-        color: .themedColorfulAccent(4)
+        color: .themedColorfulAccent(4),
+        prominent: true
     )
 
     static var appearance: ActionAppearance { hideAppearance }

--- a/Mlem/App/Actions/LockAction.swift
+++ b/Mlem/App/Actions/LockAction.swift
@@ -27,25 +27,25 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension LockAction {
-    static let lockLabel: ActionLabel = .init(
+    static let lockAppearance: ActionAppearance = .init(
         "Lock",
         icon: .lemmy.addLock,
         color: .themedLockAccent
     )
 
-    static let unlockLabel: ActionLabel = .init(
+    static let unlockAppearance: ActionAppearance = .init(
         "Unlock",
         icon: .lemmy.removeLock,
         color: .themedLockAccent
     )
-    
-    static var label: ActionLabel { lockLabel }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+    static var appearance: ActionAppearance { lockAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         if entity.locked {
-            Self.unlockLabel.withVisibility(visibility(environment))
+            Self.unlockAppearance.withVisibility(visibility(environment))
         } else {
-            Self.lockLabel.withVisibility(visibility(environment))
+            Self.lockAppearance.withVisibility(visibility(environment))
         }
     }
 

--- a/Mlem/App/Actions/LockAction.swift
+++ b/Mlem/App/Actions/LockAction.swift
@@ -36,7 +36,8 @@ extension LockAction {
     static let unlockAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Locked", icon: .lemmy.locked.representingState(active: true)),
         stateTransitionLabel: .init("Unlock", icon: .lemmy.removeLock),
-        color: .themedLockAccent
+        color: .themedLockAccent,
+        prominent: true
     )
 
     static var appearance: ActionAppearance { lockAppearance }

--- a/Mlem/App/Actions/LockAction.swift
+++ b/Mlem/App/Actions/LockAction.swift
@@ -28,14 +28,14 @@ extension ActionSeed {
 
 extension LockAction {
     static let lockAppearance: ActionAppearance = .init(
-        "Lock",
-        icon: .lemmy.addLock,
+        currentStateLabel: .init("Unlocked", icon: .lemmy.locked.representingState(active: false)),
+        stateTransitionLabel: .init("Lock", icon: .lemmy.addLock),
         color: .themedLockAccent
     )
 
     static let unlockAppearance: ActionAppearance = .init(
-        "Unlock",
-        icon: .lemmy.removeLock,
+        currentStateLabel: .init("Locked", icon: .lemmy.locked.representingState(active: true)),
+        stateTransitionLabel: .init("Unlock", icon: .lemmy.removeLock),
         color: .themedLockAccent
     )
 

--- a/Mlem/App/Actions/LogInAction.swift
+++ b/Mlem/App/Actions/LogInAction.swift
@@ -27,7 +27,7 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension LogInAction {
-    static let label: ActionLabel = .init("Log In", icon: .lemmy.logIn)
+    static let appearance: ActionAppearance = .init("Log In", icon: .lemmy.logIn)
 }
 
 // MARK: - Behavior

--- a/Mlem/App/Actions/MarkNsfwAction.swift
+++ b/Mlem/App/Actions/MarkNsfwAction.swift
@@ -27,25 +27,25 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension MarkNsfwAction {
-    static let addLabel: ActionLabel = .init(
+    static let addAppearance: ActionAppearance = .init(
         "Add NSFW Tag",
         icon: .settings.blurNsfw,
         color: .themedNegative
     )
 
-    static let removeLabel: ActionLabel = .init(
+    static let removeAppearance: ActionAppearance = .init(
         "Remove NSFW Tag",
         icon: .settings.blurNsfw,
         color: .themedNegative
     )
-    
-    static var label: ActionLabel { addLabel }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+    static var appearance: ActionAppearance { addAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         if entity.nsfw {
-            Self.removeLabel.withVisibility(visibility(environment))
+            Self.removeAppearance.withVisibility(visibility(environment))
         } else {
-            Self.addLabel.withVisibility(visibility(environment))
+            Self.addAppearance.withVisibility(visibility(environment))
         }
     }
 

--- a/Mlem/App/Actions/MarkNsfwAction.swift
+++ b/Mlem/App/Actions/MarkNsfwAction.swift
@@ -28,14 +28,14 @@ extension ActionSeed {
 
 extension MarkNsfwAction {
     static let addAppearance: ActionAppearance = .init(
-        "Add NSFW Tag",
-        icon: .settings.blurNsfw,
+        currentStateLabel: .init("Not Marked NSFW", icon: .settings.blurNsfw.representingState(active: false)),
+        stateTransitionLabel: .init("Add NSFW Tag", icon: .settings.blurNsfw),
         color: .themedNegative
     )
 
     static let removeAppearance: ActionAppearance = .init(
-        "Remove NSFW Tag",
-        icon: .settings.blurNsfw,
+        currentStateLabel: .init("Marked NSFW", icon: .settings.blurNsfw.representingState(active: false)),
+        stateTransitionLabel: .init("Remove NSFW Tag", icon: .settings.blurNsfw),
         color: .themedNegative
     )
 

--- a/Mlem/App/Actions/MarkNsfwAction.swift
+++ b/Mlem/App/Actions/MarkNsfwAction.swift
@@ -36,7 +36,8 @@ extension MarkNsfwAction {
     static let removeAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Marked NSFW", icon: .settings.blurNsfw.representingState(active: false)),
         stateTransitionLabel: .init("Remove NSFW Tag", icon: .settings.blurNsfw),
-        color: .themedNegative
+        color: .themedNegative,
+        prominent: true
     )
 
     static var appearance: ActionAppearance { addAppearance }

--- a/Mlem/App/Actions/MarkReadAction.swift
+++ b/Mlem/App/Actions/MarkReadAction.swift
@@ -27,24 +27,24 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension MarkReadAction {
-    static let markReadLabel: ActionLabel = .init(
+    static let markReadAppearance: ActionAppearance = .init(
         "Mark Read",
         icon: .lemmy.markRead,
         color: .themedRead
     )
-    static let markUnreadLabel: ActionLabel = .init(
+    static let markUnreadAppearance: ActionAppearance = .init(
         "Mark Unread",
         icon: .lemmy.markUnread,
         color: .themedRead
     )
-    
-    static var label: ActionLabel { markReadLabel }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+    static var appearance: ActionAppearance { markReadAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         if notification.read {
-            Self.markUnreadLabel.withVisibility(visibility(environment))
+            Self.markUnreadAppearance.withVisibility(visibility(environment))
         } else {
-            Self.markReadLabel.withVisibility(visibility(environment))
+            Self.markReadAppearance.withVisibility(visibility(environment))
         }
     }
 

--- a/Mlem/App/Actions/MarkReadAction.swift
+++ b/Mlem/App/Actions/MarkReadAction.swift
@@ -35,7 +35,8 @@ extension MarkReadAction {
     static let markUnreadAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Read", icon: .lemmy.markedRead.representingState(active: true)),
         stateTransitionLabel: .init("Mark Unread", icon: .lemmy.markUnread),
-        color: .themedRead
+        color: .themedRead,
+        prominent: true
     )
 
     static var appearance: ActionAppearance { markReadAppearance }

--- a/Mlem/App/Actions/MarkReadAction.swift
+++ b/Mlem/App/Actions/MarkReadAction.swift
@@ -28,13 +28,13 @@ extension ActionSeed {
 
 extension MarkReadAction {
     static let markReadAppearance: ActionAppearance = .init(
-        "Mark Read",
-        icon: .lemmy.markRead,
+        currentStateLabel: .init("Unread", icon: .lemmy.markedRead.representingState(active: false)),
+        stateTransitionLabel: .init("Mark Read", icon: .lemmy.markRead),
         color: .themedRead
     )
     static let markUnreadAppearance: ActionAppearance = .init(
-        "Mark Unread",
-        icon: .lemmy.markUnread,
+        currentStateLabel: .init("Read", icon: .lemmy.markedRead.representingState(active: true)),
+        stateTransitionLabel: .init("Mark Unread", icon: .lemmy.markUnread),
         color: .themedRead
     )
 

--- a/Mlem/App/Actions/NewPostAction.swift
+++ b/Mlem/App/Actions/NewPostAction.swift
@@ -27,13 +27,13 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension NewPostAction {
-    static let label: ActionLabel = .init("New Post", icon: .lemmy.send)
+    static let appearance: ActionAppearance = .init("New Post", icon: .lemmy.send)
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         if entity.api.canInteract(appState: environment.appState) {
-            Self.label.withVisibility(.enabled)
+            Self.appearance.withVisibility(.enabled)
         } else {
-            Self.label.withVisibility(.hidden)
+            Self.appearance.withVisibility(.hidden)
         }
     }
 }

--- a/Mlem/App/Actions/OpenInBrowserAction.swift
+++ b/Mlem/App/Actions/OpenInBrowserAction.swift
@@ -28,7 +28,7 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension OpenInBrowserAction {
-    static let label: ActionLabel = .init("Open in Browser", icon: .general.browser)
+    static let appearance: ActionAppearance = .init("Open in Browser", icon: .general.browser)
 }
 
 // MARK: - Behavior

--- a/Mlem/App/Actions/OpenModlogAction.swift
+++ b/Mlem/App/Actions/OpenModlogAction.swift
@@ -25,7 +25,7 @@ struct OpenModlogAction: Actions.Action {
 extension ActionSeed {
     static let openModlog = ActionSeed(
         "openModlog",
-        label: OpenModlogAction.createLabel(relationship: .identity)
+        appearance: OpenModlogAction.createAppearance(relationship: .identity)
     ) { entity in
         switch entity {
         case let entity as Person: OpenModlogAction(content: .person(entity), relationship: .identity)
@@ -35,7 +35,7 @@ extension ActionSeed {
 
     static let openCreatorModlog = ActionSeed(
         "openCreatorModlog",
-        label: OpenModlogAction.createLabel(relationship: .author)
+        appearance: OpenModlogAction.createAppearance(relationship: .author)
     ) { entity in
         switch entity {
         case let entity as any InteractableProviding:
@@ -52,7 +52,7 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension OpenModlogAction {
-    static func createLabel(relationship: Relationship) -> ActionLabel {
+    static func createAppearance(relationship: Relationship) -> ActionAppearance {
         .init(
             relationship == .identity ? "Modlog" : "User Modlog",
             icon: .lemmy.modlog,
@@ -60,8 +60,8 @@ extension OpenModlogAction {
         )
     }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        return Self.createLabel(relationship: relationship)
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.createAppearance(relationship: relationship)
     }
 }
 

--- a/Mlem/App/Actions/PinAction.swift
+++ b/Mlem/App/Actions/PinAction.swift
@@ -36,7 +36,8 @@ extension PinAction {
     static let unpinAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Pinned", icon: .lemmy.pinned.representingState(active: true)),
         stateTransitionLabel: .init("Unpin", icon: .lemmy.removePin),
-        color: .themedModeration
+        color: .themedModeration,
+        prominent: true
     )
 
     static let pinDetailsAppearance: ActionAppearance = .init(

--- a/Mlem/App/Actions/PinAction.swift
+++ b/Mlem/App/Actions/PinAction.swift
@@ -28,14 +28,14 @@ extension ActionSeed {
 
 extension PinAction {
     static let pinAppearance: ActionAppearance = .init(
-        "Pin",
-        icon: .lemmy.addPin,
+        currentStateLabel: .init("Unpinned", icon: .lemmy.pinned.representingState(active: false)),
+        stateTransitionLabel: .init("Pin", icon: .lemmy.addPin),
         color: .themedModeration
     )
 
     static let unpinAppearance: ActionAppearance = .init(
-        "Unpin",
-        icon: .lemmy.removePin,
+        currentStateLabel: .init("Pinned", icon: .lemmy.pinned.representingState(active: true)),
+        stateTransitionLabel: .init("Unpin", icon: .lemmy.removePin),
         color: .themedModeration
     )
 

--- a/Mlem/App/Actions/PinAction.swift
+++ b/Mlem/App/Actions/PinAction.swift
@@ -27,45 +27,39 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension PinAction {
-    static let pinLabel: ActionLabel = .init(
+    static let pinAppearance: ActionAppearance = .init(
         "Pin",
         icon: .lemmy.addPin,
         color: .themedModeration
     )
 
-    static let unpinLabel: ActionLabel = .init(
+    static let unpinAppearance: ActionAppearance = .init(
         "Unpin",
         icon: .lemmy.removePin,
         color: .themedModeration
     )
 
-    static let pinDetailsLabel: ActionLabel = .init(
+    static let pinDetailsAppearance: ActionAppearance = .init(
         "Pin...",
         icon: .lemmy.addPin,
         color: .themedModeration
     )
-    
-    static var label: ActionLabel { pinLabel }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        let label: ActionLabel = if entity.api.isAdmin {
+    static var appearance: ActionAppearance { pinAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        baseAppearance().withVisibility(visibility(environment))
+    }
+
+    private func baseAppearance() -> ActionAppearance {
+        if entity.api.isAdmin {
             switch (entity.pinnedInstance, entity.pinnedCommunity) {
-            case (true, true):
-                Self.unpinLabel
-            case (true, false), (false, true):
-                Self.pinDetailsLabel
-            case (false, false):
-                Self.pinLabel
-            }
-        } else {
-            if entity.pinnedCommunity {
-                Self.unpinLabel
-            } else {
-                Self.pinLabel
+            case (true, true): return Self.unpinAppearance
+            case (true, false), (false, true): return Self.pinDetailsAppearance
+            default: return Self.pinAppearance
             }
         }
-
-        return label.withVisibility(visibility(environment))
+        return entity.pinnedCommunity ? Self.unpinAppearance : Self.pinAppearance
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/PurgeAction.swift
+++ b/Mlem/App/Actions/PurgeAction.swift
@@ -19,14 +19,14 @@ struct PurgeAction: Actions.Action {
 // MARK: - Configurability
 
 extension ActionSeed {
-    static let purge = ActionSeed("purge", label: PurgeAction.createLabel(relationship: .identity)) { entity in
+    static let purge = ActionSeed("purge", appearance: PurgeAction.createAppearance(relationship: .identity)) { entity in
         switch entity {
         case let entity as any PurgableProviding: PurgeAction(entity: entity, relationship: .identity)
         default: nil
         }
     }
 
-    static let purgeCreator = ActionSeed("purgeCreator", label: PurgeAction.createLabel(relationship: .author)) { entity in
+    static let purgeCreator = ActionSeed("purgeCreator", appearance: PurgeAction.createAppearance(relationship: .author)) { entity in
         switch entity {
         case let entity as any InteractableProviding:
             if let creator = entity.creator.value {
@@ -42,7 +42,7 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension PurgeAction {
-    static func createLabel(relationship: Relationship) -> ActionLabel {
+    static func createAppearance(relationship: Relationship) -> ActionAppearance {
         .init(
             relationship == .identity ? "Purge" : "Purge User",
             icon: .lemmy.purge,
@@ -50,9 +50,9 @@ extension PurgeAction {
             isDestructive: true
         )
     }
-    
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        return Self.createLabel(relationship: self.relationship).withVisibility(visibility(environment))
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.createAppearance(relationship: self.relationship).withVisibility(visibility(environment))
     }
     
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/RemoveAction.swift
+++ b/Mlem/App/Actions/RemoveAction.swift
@@ -36,7 +36,8 @@ extension RemoveAction {
     static let restoreAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Removed", icon: .lemmy.removed.representingState(active: true)),
         stateTransitionLabel: .init("Restore", icon: .lemmy.restore),
-        color: .themedPositive
+        color: .themedPositive,
+        prominent: true
     )
 
     static var appearance: ActionAppearance { removeAppearance }

--- a/Mlem/App/Actions/RemoveAction.swift
+++ b/Mlem/App/Actions/RemoveAction.swift
@@ -28,14 +28,14 @@ extension ActionSeed {
 
 extension RemoveAction {
     static let removeAppearance: ActionAppearance = .init(
-        "Remove",
-        icon: .lemmy.remove,
+        currentStateLabel: .init("Unremoved", icon: .lemmy.removed.representingState(active: false)),
+        stateTransitionLabel: .init("Remove", icon: .lemmy.remove),
         color: .themedNegative,
         isDestructive: true
     )
     static let restoreAppearance: ActionAppearance = .init(
-        "Restore",
-        icon: .lemmy.restore,
+        currentStateLabel: .init("Removed", icon: .lemmy.removed.representingState(active: true)),
+        stateTransitionLabel: .init("Restore", icon: .lemmy.restore),
         color: .themedPositive
     )
 

--- a/Mlem/App/Actions/RemoveAction.swift
+++ b/Mlem/App/Actions/RemoveAction.swift
@@ -27,25 +27,25 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension RemoveAction {
-    static let removeLabel: ActionLabel = .init(
+    static let removeAppearance: ActionAppearance = .init(
         "Remove",
         icon: .lemmy.remove,
         color: .themedNegative,
         isDestructive: true
     )
-    static let restoreLabel: ActionLabel = .init(
+    static let restoreAppearance: ActionAppearance = .init(
         "Restore",
         icon: .lemmy.restore,
         color: .themedPositive
     )
-    
-    static var label: ActionLabel { removeLabel }
-    
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+
+    static var appearance: ActionAppearance { removeAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         if entity.removed {
-            Self.restoreLabel.withVisibility(visibility(environment))
+            Self.restoreAppearance.withVisibility(visibility(environment))
         } else {
-            Self.removeLabel.withVisibility(visibility(environment))
+            Self.removeAppearance.withVisibility(visibility(environment))
         }
     }
     

--- a/Mlem/App/Actions/ReplyAction.swift
+++ b/Mlem/App/Actions/ReplyAction.swift
@@ -43,10 +43,10 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension ReplyAction {
-    static let label: ActionLabel = .init("Reply", icon: .lemmy.reply)
+    static let appearance: ActionAppearance = .init("Reply", icon: .lemmy.reply)
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.label.withVisibility(visibility(environment))
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance.withVisibility(visibility(environment))
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/ReportAction.swift
+++ b/Mlem/App/Actions/ReportAction.swift
@@ -27,15 +27,15 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension ReportAction {
-    static let label: ActionLabel = .init(
+    static let appearance: ActionAppearance = .init(
         "Report",
         icon: .lemmy.report,
         color: .themedNegative,
         isDestructive: true
     )
-    
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.label.withVisibility(visibility(environment))
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance.withVisibility(visibility(environment))
     }
     
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/ResolveAction.swift
+++ b/Mlem/App/Actions/ResolveAction.swift
@@ -36,7 +36,8 @@ extension ResolveAction {
     static let unresolveAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Resolved", icon: .lemmy.resolved.representingState(active: true)),
         stateTransitionLabel: .init("Unresolve", icon: .lemmy.unresolve),
-        color: .themedNegative
+        color: .themedNegative,
+        prominent: true
     )
 
     static var appearance: ActionAppearance { resolveAppearance }

--- a/Mlem/App/Actions/ResolveAction.swift
+++ b/Mlem/App/Actions/ResolveAction.swift
@@ -28,14 +28,14 @@ extension ActionSeed {
 
 extension ResolveAction {
     static let resolveAppearance: ActionAppearance = .init(
-        "Resolve",
-        icon: .init("checkmark.circle"),
+        currentStateLabel: .init("Unresolved", icon: .lemmy.resolved.representingState(active: false)),
+        stateTransitionLabel: .init("Resolve", icon: .lemmy.resolve),
         color: .themedPositive
     )
 
     static let unresolveAppearance: ActionAppearance = .init(
-        "Unresolve",
-        icon: .init("xmark.circle"),
+        currentStateLabel: .init("Resolved", icon: .lemmy.resolved.representingState(active: true)),
+        stateTransitionLabel: .init("Unresolve", icon: .lemmy.unresolve),
         color: .themedNegative
     )
 

--- a/Mlem/App/Actions/ResolveAction.swift
+++ b/Mlem/App/Actions/ResolveAction.swift
@@ -27,22 +27,22 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension ResolveAction {
-    static let resolveLabel: ActionLabel = .init(
+    static let resolveAppearance: ActionAppearance = .init(
         "Resolve",
         icon: .init("checkmark.circle"),
         color: .themedPositive
     )
-    
-    static let unresolveLabel: ActionLabel = .init(
+
+    static let unresolveAppearance: ActionAppearance = .init(
         "Unresolve",
         icon: .init("xmark.circle"),
         color: .themedNegative
     )
-    
-    static var label: ActionLabel { resolveLabel }
-    
-    func createLabel(environment: EnvironmentValues) -> Actions.ActionLabel {
-        entity.resolved ? Self.unresolveLabel : Self.resolveLabel
+
+    static var appearance: ActionAppearance { resolveAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        entity.resolved ? Self.unresolveAppearance : Self.resolveAppearance
     }
     
     func execute(environment: EnvironmentValues) {

--- a/Mlem/App/Actions/SaveAction.swift
+++ b/Mlem/App/Actions/SaveAction.swift
@@ -35,7 +35,8 @@ extension SaveAction {
     static let unsaveAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Saved", icon: .lemmy.saved.representingState(active: true)),
         stateTransitionLabel: .init("Unsave", icon: .lemmy.removeSave),
-        color: .themedSave
+        color: .themedSave,
+        prominent: true
     )
 
     static var appearance: ActionAppearance { saveAppearance }

--- a/Mlem/App/Actions/SaveAction.swift
+++ b/Mlem/App/Actions/SaveAction.swift
@@ -28,13 +28,13 @@ extension ActionSeed {
 
 extension SaveAction {
     static let saveAppearance: ActionAppearance = .init(
-        "Save",
-        icon: .lemmy.saved.representingState(active: false),
+        currentStateLabel: .init("Unsaved", icon: .lemmy.saved.representingState(active: false)),
+        stateTransitionLabel: .init("Save", icon: .lemmy.addSave),
         color: .themedSave
     )
     static let unsaveAppearance: ActionAppearance = .init(
-        "Saved",
-        icon: .lemmy.saved.representingState(active: true),
+        currentStateLabel: .init("Saved", icon: .lemmy.saved.representingState(active: true)),
+        stateTransitionLabel: .init("Unsave", icon: .lemmy.removeSave),
         color: .themedSave
     )
 

--- a/Mlem/App/Actions/SaveAction.swift
+++ b/Mlem/App/Actions/SaveAction.swift
@@ -27,25 +27,25 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension SaveAction {
-    static let saveLabel: ActionLabel = .init(
+    static let saveAppearance: ActionAppearance = .init(
         "Save",
         icon: .lemmy.saved.representingState(active: false),
         color: .themedSave
     )
-    static let unsaveLabel: ActionLabel = .init(
+    static let unsaveAppearance: ActionAppearance = .init(
         "Saved",
         icon: .lemmy.saved.representingState(active: true),
         color: .themedSave
     )
-    
-    static var label: ActionLabel { saveLabel }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        guard let saved = entity.saved.value else { return Self.saveLabel.withVisibility(.hidden) }
+    static var appearance: ActionAppearance { saveAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        guard let saved = entity.saved.value else { return Self.saveAppearance.withVisibility(.hidden) }
         if saved {
-            return Self.unsaveLabel.withVisibility(visibility(environment))
+            return Self.unsaveAppearance.withVisibility(visibility(environment))
         } else {
-            return Self.saveLabel.withVisibility(visibility(environment))
+            return Self.saveAppearance.withVisibility(visibility(environment))
         }
     }
 

--- a/Mlem/App/Actions/SelectTextAction.swift
+++ b/Mlem/App/Actions/SelectTextAction.swift
@@ -10,7 +10,7 @@ import MlemMiddleware
 import SwiftUI
 
 struct SelectTextAction: Actions.SimpleLabelAction {
-    static let label: ActionLabel = .init("Select Text", icon: .general.select)
+    static let appearance: ActionAppearance = .init("Select Text", icon: .general.select)
     
     let text: String
     

--- a/Mlem/App/Actions/SendMessageAction.swift
+++ b/Mlem/App/Actions/SendMessageAction.swift
@@ -42,10 +42,10 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension SendMessageAction {
-    static let label: ActionLabel = .init("Send Message", icon: .lemmy.message)
+    static let appearance: ActionAppearance = .init("Send Message", icon: .lemmy.message)
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.label.withVisibility(visibility(environment))
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance.withVisibility(visibility(environment))
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/ShareAction.swift
+++ b/Mlem/App/Actions/ShareAction.swift
@@ -27,7 +27,7 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension ShareAction {
-    static let label: ActionLabel = .init(
+    static let appearance: ActionAppearance = .init(
         "Share...",
         icon: .general.share,
         color: .themedColorfulAccent(3)

--- a/Mlem/App/Actions/SignUpAction.swift
+++ b/Mlem/App/Actions/SignUpAction.swift
@@ -27,7 +27,7 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension SignUpAction {
-    static let label: ActionLabel = .init("Sign Up", icon: .lemmy.signUp)
+    static let appearance: ActionAppearance = .init("Sign Up", icon: .lemmy.signUp)
 }
 
 // MARK: - Behavior

--- a/Mlem/App/Actions/SubscribeAction.swift
+++ b/Mlem/App/Actions/SubscribeAction.swift
@@ -35,7 +35,8 @@ extension SubscribeAction {
     static let unsubscribeAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Subscribed", icon: .lemmy.subscribed.representingState(active: true)),
         stateTransitionLabel: .init("Unsubscribe", icon: .lemmy.unsubscribe),
-        color: .themedNegative
+        color: .themedNegative,
+        prominent: true
     )
 
     static var appearance: ActionAppearance { subscribeAppearance }

--- a/Mlem/App/Actions/SubscribeAction.swift
+++ b/Mlem/App/Actions/SubscribeAction.swift
@@ -28,13 +28,13 @@ extension ActionSeed {
 
 extension SubscribeAction {
     static let subscribeAppearance: ActionAppearance = .init(
-        "Subscribe",
-        icon: .lemmy.subscribe,
+        currentStateLabel: .init("Unsubscribed", icon: .lemmy.subscribed.representingState(active: false)),
+        stateTransitionLabel: .init("Subscribe", icon: .lemmy.subscribe),
         color: .themedPositive
     )
     static let unsubscribeAppearance: ActionAppearance = .init(
-        "Unsubscribe",
-        icon: .lemmy.unsubscribe,
+        currentStateLabel: .init("Subscribed", icon: .lemmy.subscribed.representingState(active: true)),
+        stateTransitionLabel: .init("Unsubscribe", icon: .lemmy.unsubscribe),
         color: .themedNegative
     )
 

--- a/Mlem/App/Actions/SubscribeAction.swift
+++ b/Mlem/App/Actions/SubscribeAction.swift
@@ -27,27 +27,27 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension SubscribeAction {
-    static let subscribeLabel: ActionLabel = .init(
+    static let subscribeAppearance: ActionAppearance = .init(
         "Subscribe",
         icon: .lemmy.subscribe,
         color: .themedPositive
     )
-    static let unsubscribeLabel: ActionLabel = .init(
+    static let unsubscribeAppearance: ActionAppearance = .init(
         "Unsubscribe",
         icon: .lemmy.unsubscribe,
         color: .themedNegative
     )
-    
-    static var label: ActionLabel { subscribeLabel }
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        guard let subscription = entity.subscription.value  else {
-            return Self.subscribeLabel.withVisibility(.hidden)
+    static var appearance: ActionAppearance { subscribeAppearance }
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        guard let subscription = entity.subscription.value else {
+            return Self.subscribeAppearance.withVisibility(.hidden)
         }
         if subscription.subscribed {
-            return Self.unsubscribeLabel.withVisibility(visibility(environment))
+            return Self.unsubscribeAppearance.withVisibility(visibility(environment))
         } else {
-            return Self.subscribeLabel.withVisibility(visibility(environment))
+            return Self.subscribeAppearance.withVisibility(visibility(environment))
         }
     }
 

--- a/Mlem/App/Actions/ToggleNotificationsAction.swift
+++ b/Mlem/App/Actions/ToggleNotificationsAction.swift
@@ -27,32 +27,32 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension ToggleNotificationsAction {
-    static let enableLabel: ActionLabel = .init(
+    static let enableAppearance: ActionAppearance = .init(
         "Enable Notifications",
         icon: .lemmy.enableNotifications,
         color: .themedColorfulAccent(4)
     )
 
-    static let disableLabel: ActionLabel = .init(
+    static let disableAppearance: ActionAppearance = .init(
         "Disable Notifications",
         icon: .lemmy.disableNotifications,
         color: .themedColorfulAccent(4)
     )
-    
-    static let label: ActionLabel = .init(
+
+    static let appearance: ActionAppearance = .init(
         "Toggle Notifications",
         icon: .lemmy.notification,
         color: .themedColorfulAccent(4)
     )
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         guard let notificationsEnabled = entity.notificationsEnabled.value else {
-            return Self.enableLabel.withVisibility(.hidden)
+            return Self.enableAppearance.withVisibility(.hidden)
         }
         if notificationsEnabled {
-            return Self.disableLabel.withVisibility(visibility(environment))
+            return Self.disableAppearance.withVisibility(visibility(environment))
         } else {
-            return Self.enableLabel.withVisibility(visibility(environment))
+            return Self.enableAppearance.withVisibility(visibility(environment))
         }
     }
 

--- a/Mlem/App/Actions/ToggleNotificationsAction.swift
+++ b/Mlem/App/Actions/ToggleNotificationsAction.swift
@@ -36,7 +36,8 @@ extension ToggleNotificationsAction {
     static let disableAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Notifications Enabled", icon: .lemmy.notification.representingState(active: true)),
         stateTransitionLabel: .init("Disable Notifications", icon: .lemmy.disableNotifications),
-        color: .themedColorfulAccent(4)
+        color: .themedColorfulAccent(4),
+        prominent: true
     )
 
     static let appearance: ActionAppearance = .init(

--- a/Mlem/App/Actions/ToggleNotificationsAction.swift
+++ b/Mlem/App/Actions/ToggleNotificationsAction.swift
@@ -28,14 +28,14 @@ extension ActionSeed {
 
 extension ToggleNotificationsAction {
     static let enableAppearance: ActionAppearance = .init(
-        "Enable Notifications",
-        icon: .lemmy.enableNotifications,
+        currentStateLabel: .init("Notifications Disabled", icon: .lemmy.notification.representingState(active: false)),
+        stateTransitionLabel: .init("Enable Notifications", icon: .lemmy.enableNotifications),
         color: .themedColorfulAccent(4)
     )
 
     static let disableAppearance: ActionAppearance = .init(
-        "Disable Notifications",
-        icon: .lemmy.disableNotifications,
+        currentStateLabel: .init("Notifications Enabled", icon: .lemmy.notification.representingState(active: true)),
+        stateTransitionLabel: .init("Disable Notifications", icon: .lemmy.disableNotifications),
         color: .themedColorfulAccent(4)
     )
 

--- a/Mlem/App/Actions/TranslateAction.swift
+++ b/Mlem/App/Actions/TranslateAction.swift
@@ -29,27 +29,27 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension TranslateAction {
-    static let translateLabel: ActionLabel = .init(
+    static let translateAppearance: ActionAppearance = .init(
         "Translate",
         icon: .general.translate,
         color: .themedTranslationAccent
     )
 
-    static let showOriginalLabel: ActionLabel = .init(
+    static let showOriginalAppearance: ActionAppearance = .init(
         "Show Original",
         icon: .general.translate,
         color: .themedTranslationAccent
     )
 
-   static var label: ActionLabel { translateLabel }
+    static var appearance: ActionAppearance { translateAppearance }
 
-   func createLabel(environment: EnvironmentValues) -> ActionLabel {
-       if self.entity.content.translated == .untranslated {
-           Self.translateLabel
-       } else {
-           Self.showOriginalLabel
-       }
-   }
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        if self.entity.content.translated == .untranslated {
+            Self.translateAppearance
+        } else {
+            Self.showOriginalAppearance
+        }
+    }
 }
 
 // MARK: - Behavior

--- a/Mlem/App/Actions/ViewVotesAction.swift
+++ b/Mlem/App/Actions/ViewVotesAction.swift
@@ -28,14 +28,14 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension ViewVotesAction {
-    static let label: ActionLabel = .init(
+    static let appearance: ActionAppearance = .init(
         "View Votes",
         icon: .lemmy.votes,
         color: .themedColorfulAccent(4)
     )
-    
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.label.withVisibility(visibility(environment))
+
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance.withVisibility(visibility(environment))
     }
     
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Actions/VisitAction.swift
+++ b/Mlem/App/Actions/VisitAction.swift
@@ -27,13 +27,12 @@ extension ActionSeed {
 // MARK: - Appearance
 
 extension VisitAction {
-    static let label: ActionLabel = .init("Visit", icon: .lemmy.visitInstance)
+    static let appearance: ActionAppearance = .init("Visit", icon: .lemmy.visitInstance)
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
         let api = environment.appState.firstApi
         let isVisiting = api.host == instance.actorId.host && api.token == nil
-
-        return Self.label.withVisibility(isVisiting ? .disabled : .enabled)
+        return Self.appearance.withVisibility(isVisiting ? .disabled : .enabled)
     }
 }
 

--- a/Mlem/App/Actions/VoteAction.swift
+++ b/Mlem/App/Actions/VoteAction.swift
@@ -43,7 +43,8 @@ extension VoteAction {
     static let downvoteAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Not Downvoted", icon: .lemmy.downvoted.representingState(active: false)),
         stateTransitionLabel: .init("Downvote", icon: .lemmy.addDownvote),
-        color: .themedDownvote
+        color: .themedDownvote,
+        prominent: true
     )
     static let removeUpvoteAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Upvoted", icon: .lemmy.upvoted.representingState(active: true)),
@@ -53,7 +54,8 @@ extension VoteAction {
     static let removeDownvoteAppearance: ActionAppearance = .init(
         currentStateLabel: .init("Downvote", icon: .lemmy.downvoted.representingState(active: true)),
         stateTransitionLabel: .init("Remove Downvote", icon: .lemmy.removeDownvote),
-        color: .themedDownvote
+        color: .themedDownvote,
+        prominent: true
     )
 
     func createAppearance(environment: EnvironmentValues) -> ActionAppearance {

--- a/Mlem/App/Actions/VoteAction.swift
+++ b/Mlem/App/Actions/VoteAction.swift
@@ -36,23 +36,23 @@ private func createVoteAction(_ entity: Any, type: ScoringOperation) -> VoteActi
 
 extension VoteAction {
     static let upvoteAppearance: ActionAppearance = .init(
-        "Upvote",
-        icon: .lemmy.upvoted.representingState(active: false),
+        currentStateLabel: .init("Not Upvoted", icon: .lemmy.upvoted.representingState(active: false)),
+        stateTransitionLabel: .init("Upvote", icon: .lemmy.addUpvote),
         color: .themedUpvote
     )
     static let downvoteAppearance: ActionAppearance = .init(
-        "Downvote",
-        icon: .lemmy.downvoted.representingState(active: false),
+        currentStateLabel: .init("Not Downvoted", icon: .lemmy.downvoted.representingState(active: false)),
+        stateTransitionLabel: .init("Downvote", icon: .lemmy.addDownvote),
         color: .themedDownvote
     )
     static let removeUpvoteAppearance: ActionAppearance = .init(
-        "Upvoted",
-        icon: .lemmy.upvoted.representingState(active: true),
+        currentStateLabel: .init("Upvoted", icon: .lemmy.upvoted.representingState(active: true)),
+        stateTransitionLabel: .init("Remove Upvote", icon: .lemmy.removeUpvote),
         color: .themedUpvote
     )
     static let removeDownvoteAppearance: ActionAppearance = .init(
-        "Downvoted",
-        icon: .lemmy.downvoted.representingState(active: true),
+        currentStateLabel: .init("Downvote", icon: .lemmy.downvoted.representingState(active: true)),
+        stateTransitionLabel: .init("Remove Downvote", icon: .lemmy.removeDownvote),
         color: .themedDownvote
     )
 

--- a/Mlem/App/Actions/VoteAction.swift
+++ b/Mlem/App/Actions/VoteAction.swift
@@ -17,10 +17,10 @@ struct VoteAction: Actions.Action {
 // MARK: - Configurability
 
 extension ActionSeed {
-    static let upvote = ActionSeed("upvote", label: VoteAction.upvoteLabel) {
+    static let upvote = ActionSeed("upvote", appearance: VoteAction.upvoteAppearance) {
         createVoteAction($0, type: .upvote)
     }
-    static let downvote = ActionSeed("downvote", label: VoteAction.downvoteLabel) {
+    static let downvote = ActionSeed("downvote", appearance: VoteAction.downvoteAppearance) {
         createVoteAction($0, type: .downvote)
     }
 }
@@ -35,45 +35,47 @@ private func createVoteAction(_ entity: Any, type: ScoringOperation) -> VoteActi
 // MARK: - Appearance
 
 extension VoteAction {
-    static let upvoteLabel: ActionLabel = .init(
+    static let upvoteAppearance: ActionAppearance = .init(
         "Upvote",
         icon: .lemmy.upvoted.representingState(active: false),
         color: .themedUpvote
     )
-    static let downvoteLabel: ActionLabel = .init(
+    static let downvoteAppearance: ActionAppearance = .init(
         "Downvote",
         icon: .lemmy.downvoted.representingState(active: false),
         color: .themedDownvote
     )
-    static let removeUpvoteLabel: ActionLabel = .init(
+    static let removeUpvoteAppearance: ActionAppearance = .init(
         "Upvoted",
         icon: .lemmy.upvoted.representingState(active: true),
         color: .themedUpvote
     )
-    static let removeDownvoteLabel: ActionLabel = .init(
+    static let removeDownvoteAppearance: ActionAppearance = .init(
         "Downvoted",
         icon: .lemmy.downvoted.representingState(active: true),
         color: .themedDownvote
     )
 
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        guard let votes = entity.votes.value else { return Self.upvoteLabel.withVisibility(.hidden) }
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        guard let votes = entity.votes.value else { return Self.upvoteAppearance.withVisibility(.hidden) }
         let hasMatchingVote = votes.myVote == type
 
         guard type != .none else {
             assertionFailure()
-            return Self.upvoteLabel
+            return Self.upvoteAppearance
         }
 
-        let label = switch (type, hasMatchingVote) {
-        case (.upvote, false): Self.upvoteLabel
-        case (.upvote, true): Self.removeUpvoteLabel
-        case (.downvote, false): Self.downvoteLabel
-        case (.downvote, true): Self.removeDownvoteLabel
-        default: Self.upvoteLabel
-        }
+        return baseAppearance(hasMatchingVote: hasMatchingVote).withVisibility(visibility(environment))
+    }
 
-        return label.withVisibility(visibility(environment))
+    private func baseAppearance(hasMatchingVote: Bool) -> ActionAppearance {
+        switch (type, hasMatchingVote) {
+        case (.upvote, false): return Self.upvoteAppearance
+        case (.upvote, true): return Self.removeUpvoteAppearance
+        case (.downvote, false): return Self.downvoteAppearance
+        case (.downvote, true): return Self.removeDownvoteAppearance
+        default: return Self.upvoteAppearance
+        }
     }
 
     private func visibility(_ environment: EnvironmentValues) -> ActionVisiblity {

--- a/Mlem/App/Enums/Interaction/CommentBarConfiguration+Types.swift
+++ b/Mlem/App/Enums/Interaction/CommentBarConfiguration+Types.swift
@@ -43,7 +43,7 @@ extension CommentBarConfiguration {
             .ban
         ] }
         
-        var appearance: ActionAppearance {
+        var appearance: LegacyActionAppearance {
             switch self {
             case .upvote: .upvote(isOn: false)
             case .downvote: .downvote(isOn: false)

--- a/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
+++ b/Mlem/App/Enums/Interaction/InteractionBarConfiguration.swift
@@ -113,7 +113,7 @@ enum InteractionConfigurationItem<ActionType: ActionTypeProviding>: Codable, Has
 protocol ActionTypeProviding: Codable, CaseIterable, Hashable, RawRepresentable where RawValue == String {
     associatedtype Configuration: InteractionBarConfiguration
     
-    var appearance: ActionAppearance { get }
+    var appearance: LegacyActionAppearance { get }
     
     static var defaultWidgets: [Self] { get }
     

--- a/Mlem/App/Enums/Interaction/PostBarConfiguration+Types.swift
+++ b/Mlem/App/Enums/Interaction/PostBarConfiguration+Types.swift
@@ -48,7 +48,7 @@ extension PostBarConfiguration {
             .ban
         ] }
         
-        var appearance: ActionAppearance {
+        var appearance: LegacyActionAppearance {
             switch self {
             case .upvote: .upvote(isOn: false)
             case .downvote: .downvote(isOn: false)

--- a/Mlem/App/Enums/Interaction/ReplyBarConfiguration+Types.swift
+++ b/Mlem/App/Enums/Interaction/ReplyBarConfiguration+Types.swift
@@ -30,7 +30,7 @@ extension ReplyBarConfiguration {
             .markRead
         ] }
         
-        var appearance: ActionAppearance {
+        var appearance: LegacyActionAppearance {
             switch self {
             case .upvote: .upvote(isOn: false)
             case .downvote: .downvote(isOn: false)

--- a/Mlem/App/Models/Action/Action.swift
+++ b/Mlem/App/Models/Action/Action.swift
@@ -9,5 +9,5 @@ import SwiftUI
 
 protocol Action: Identifiable {
     var id: String { get }
-    var appearance: ActionAppearance { get }
+    var appearance: LegacyActionAppearance { get }
 }

--- a/Mlem/App/Models/Action/ActionGroup.swift
+++ b/Mlem/App/Models/Action/ActionGroup.swift
@@ -13,7 +13,7 @@ struct ActionGroup: Action {
     }
     
     let id: String = UUID().uuidString
-    let appearance: ActionAppearance
+    let appearance: LegacyActionAppearance
 
     let prompt: String?
     
@@ -24,7 +24,7 @@ struct ActionGroup: Action {
     let displayMode: DisplayMode
     
     init(
-        appearance: ActionAppearance = .groupDefault,
+        appearance: LegacyActionAppearance = .groupDefault,
         prompt: LocalizedStringResource? = nil,
         disabled: Bool? = nil,
         displayMode: DisplayMode = .section,
@@ -47,7 +47,7 @@ struct ActionGroup: Action {
     
     @_disfavoredOverload
     init(
-        appearance: ActionAppearance = .groupDefault,
+        appearance: LegacyActionAppearance = .groupDefault,
         prompt: String? = nil,
         disabled: Bool? = nil,
         displayMode: DisplayMode = .section,
@@ -69,6 +69,6 @@ struct ActionGroup: Action {
     }
 }
 
-private extension ActionAppearance {
+private extension LegacyActionAppearance {
     static let groupDefault: Self = .init(label: "More...", color: .themedNeutralAccent, icon: Icons.menuCircle)
 }

--- a/Mlem/App/Models/Action/BasicAction.swift
+++ b/Mlem/App/Models/Action/BasicAction.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct BasicAction: Action {
     let id: String
-    let appearance: ActionAppearance
+    let appearance: LegacyActionAppearance
     
     let confirmationPrompt: String?
 
@@ -24,7 +24,7 @@ struct BasicAction: Action {
     /// If you don't do this, SwiftUI can get confused in a lazy view.
     init(
         id: String,
-        appearance: ActionAppearance,
+        appearance: LegacyActionAppearance,
         confirmationPrompt: LocalizedStringResource? = nil,
         enabled: Bool = true,
         callback: (@MainActor () -> Void)? = nil

--- a/Mlem/App/Models/Action/CounterAppearance.swift
+++ b/Mlem/App/Models/Action/CounterAppearance.swift
@@ -9,8 +9,8 @@ import Foundation
 
 struct CounterAppearance {
     let value: Int?
-    let leading: ActionAppearance?
-    let trailing: ActionAppearance?
+    let leading: LegacyActionAppearance?
+    let trailing: LegacyActionAppearance?
     let label: LocalizedStringResource
     let singleIcon: String
 }

--- a/Mlem/App/Models/Action/LegacyActionAppearance+StaticValues.swift
+++ b/Mlem/App/Models/Action/LegacyActionAppearance+StaticValues.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-extension ActionAppearance {
+extension LegacyActionAppearance {
     static func upvote(isOn: Bool) -> Self {
         .init(
             label: isOn ? "Undo Upvote" : "Upvote",

--- a/Mlem/App/Models/Action/LegacyActionAppearance.swift
+++ b/Mlem/App/Models/Action/LegacyActionAppearance.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import Theming
 
-struct ActionAppearance {
+struct LegacyActionAppearance {
     let label: String
     let isOn: Bool
     let isInProgress: Bool

--- a/Mlem/App/Models/Action/ShareActivity.swift
+++ b/Mlem/App/Models/Action/ShareActivity.swift
@@ -8,10 +8,10 @@
 import UIKit
 
 class ShareActivity: UIActivity {
-    let appearance: ActionAppearance
+    let appearance: LegacyActionAppearance
     let action: @MainActor () -> Void
     
-    init(appearance: ActionAppearance, performAction: @escaping @MainActor () -> Void) {
+    init(appearance: LegacyActionAppearance, performAction: @escaping @MainActor () -> Void) {
         self.appearance = appearance
         self.action = performAction
         super.init()

--- a/Mlem/App/Utility/Extensions/QuickSwipeAction+Actions.swift
+++ b/Mlem/App/Utility/Extensions/QuickSwipeAction+Actions.swift
@@ -13,8 +13,9 @@ import SwiftUI
 private extension QuickSwipeAction {
     init?(appearance: ActionAppearance, callback: @escaping () -> Void) {
         if appearance.visibility == .hidden { return nil }
+        let label = appearance.label(describing: .stateTransition)
         self.init(
-            icon: appearance.icon,
+            icon: label.icon,
             color: appearance.color,
             enabled: appearance.visibility == .enabled,
             confirmationPrompt: nil,

--- a/Mlem/App/Utility/Extensions/QuickSwipeAction+Actions.swift
+++ b/Mlem/App/Utility/Extensions/QuickSwipeAction+Actions.swift
@@ -11,12 +11,12 @@ import QuickSwipes
 import SwiftUI
 
 private extension QuickSwipeAction {
-    init?(label: ActionLabel, callback: @escaping () -> Void) {
-        if label.visibility == .hidden { return nil }
+    init?(appearance: ActionAppearance, callback: @escaping () -> Void) {
+        if appearance.visibility == .hidden { return nil }
         self.init(
-            icon: label.icon,
-            color: label.color,
-            enabled: label.visibility == .enabled,
+            icon: appearance.icon,
+            color: appearance.color,
+            enabled: appearance.visibility == .enabled,
             confirmationPrompt: nil,
             callback: callback
         )
@@ -45,7 +45,7 @@ private struct QuickSwipesActionsViewModifier: ViewModifier {
 
     func createAction(_ action: any Actions.Action) -> QuickSwipeAction? {
         .init(
-            label: action.createLabel(environment: environment),
+            appearance: action.createAppearance(environment: environment),
             callback: { action.execute(environment: environment) }
         )
     }

--- a/Mlem/App/Utility/Extensions/QuickSwipeAction+Extensions.swift
+++ b/Mlem/App/Utility/Extensions/QuickSwipeAction+Extensions.swift
@@ -60,7 +60,7 @@ extension QuickSwipeChoice {
 
 // Temporary shim. Eventually the action system will use Icon rather than String and this can be removed
 private extension Icon {
-    init(from appearance: ActionAppearance) {
+    init(from appearance: LegacyActionAppearance) {
         self = .custom { variant in
             switch variant {
             case .active:

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -16,8 +16,8 @@ struct ContextMenuSettingsView<Configuration: ContextMenuConfiguration>: View {
     var body: some View {
         Form {
             ForEach(configuration, id: \.key) { seed in
-                Label(seed.label)
-                    .foregroundStyle(seed.label.isDestructive ? .themedWarning : .themedPrimary)
+                Label(seed.appearance)
+                    .foregroundStyle(seed.appearance.isDestructive ? .themedWarning : .themedPrimary)
             }
             .onMove { fromOffsets, toOffset in
                 configuration.move(fromOffsets: fromOffsets, toOffset: toOffset)
@@ -54,8 +54,8 @@ struct ContextMenuSettingsView<Configuration: ContextMenuConfiguration>: View {
             }
         } label: {
             HStack {
-                Label(seed.label)
-                    .foregroundStyle(seed.label.isDestructive ? .themedWarning : .themedPrimary)
+                Label(seed.appearance)
+                    .foregroundStyle(seed.appearance.isDestructive ? .themedWarning : .themedPrimary)
                 Spacer()
                 if !configuration.contains(seed) {
                     Image(icon: .general.add)

--- a/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/ContextMenuSettingsView.swift
@@ -16,7 +16,7 @@ struct ContextMenuSettingsView<Configuration: ContextMenuConfiguration>: View {
     var body: some View {
         Form {
             ForEach(configuration, id: \.key) { seed in
-                Label(seed.appearance)
+                Label(seed.appearance, describing: .stateTransition)
                     .foregroundStyle(seed.appearance.isDestructive ? .themedWarning : .themedPrimary)
             }
             .onMove { fromOffsets, toOffset in
@@ -54,7 +54,7 @@ struct ContextMenuSettingsView<Configuration: ContextMenuConfiguration>: View {
             }
         } label: {
             HStack {
-                Label(seed.appearance)
+                Label(seed.appearance, describing: .stateTransition)
                     .foregroundStyle(seed.appearance.isDestructive ? .themedWarning : .themedPrimary)
                 Spacer()
                 if !configuration.contains(seed) {

--- a/Mlem/App/Views/Root/Tabs/Settings/SwipeActionEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SwipeActionEditorView.swift
@@ -87,7 +87,7 @@ private struct ActionListView: View {
         Section(title) {
             ForEach(actions, id: \.hashValue) { action in
                 HStack {
-                    Label(action.appearance.title, icon: action.appearance.icon)
+                    Label(action.appearance, describing: .stateTransition)
                         .symbolVariant(.fill)
                         .gradientTint(action.appearance.color)
                     Spacer()
@@ -110,7 +110,7 @@ private struct ActionListView: View {
     var addButtonView: some View {
         Menu("Add", icon: .general.add) {
             ForEach(allActions, id: \.self) { action in
-                Button(action.appearance.title, icon: action.appearance.icon) {
+                Button(action.appearance, describing: .stateTransition) {
                     actions.append(action)
                 }
                 .disabled(actions.contains(action))

--- a/Mlem/App/Views/Root/Tabs/Settings/SwipeActionEditorView.swift
+++ b/Mlem/App/Views/Root/Tabs/Settings/SwipeActionEditorView.swift
@@ -87,9 +87,9 @@ private struct ActionListView: View {
         Section(title) {
             ForEach(actions, id: \.hashValue) { action in
                 HStack {
-                    Label(action.label.title, icon: action.label.icon)
+                    Label(action.appearance.title, icon: action.appearance.icon)
                         .symbolVariant(.fill)
-                        .gradientTint(action.label.color)
+                        .gradientTint(action.appearance.color)
                     Spacer()
                 }
                 .tag(action)
@@ -110,7 +110,7 @@ private struct ActionListView: View {
     var addButtonView: some View {
         Menu("Add", icon: .general.add) {
             ForEach(allActions, id: \.self) { action in
-                Button(action.label.title, icon: action.label.icon) {
+                Button(action.appearance.title, icon: action.appearance.icon) {
                     actions.append(action)
                 }
                 .disabled(actions.contains(action))

--- a/Mlem/App/Views/Shared/InteractionBar/InteractionBarActionLabelView.swift
+++ b/Mlem/App/Views/Shared/InteractionBar/InteractionBarActionLabelView.swift
@@ -13,9 +13,9 @@ struct InteractionBarActionLabelView: View {
 
     @Setting(\.a11y_showInteractionBarButtonBackground) var showInteractionBarButtonBackground
         
-    let appearance: ActionAppearance
+    let appearance: LegacyActionAppearance
     
-    init(_ appearance: ActionAppearance) {
+    init(_ appearance: LegacyActionAppearance) {
         self.appearance = appearance
     }
     

--- a/Mlem/Packages/Actions/Sources/Actions/Action.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Action.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public protocol Action {
-    func createLabel(environment: EnvironmentValues) -> ActionLabel
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance
     
     @MainActor
     func execute(environment: EnvironmentValues)

--- a/Mlem/Packages/Actions/Sources/Actions/ActionAppearance.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionAppearance.swift
@@ -61,17 +61,4 @@ public struct ActionAppearance {
         new.prominent = prominent
         return new
     }
-
-    public func withTitle(_ title: LocalizedStringResource) -> ActionAppearance {
-        var new = self
-        new.title = .init(localized: title)
-        return new
-    }
-
-    @_disfavoredOverload
-    public func withTitle(_ title: some StringProtocol) -> ActionAppearance {
-        var new = self
-        new.title = String(title)
-        return new
-    }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/ActionAppearance.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionAppearance.swift
@@ -9,7 +9,7 @@ import Foundation
 import Icons
 import Theming
 
-public struct ActionLabel {
+public struct ActionAppearance {
     public var title: String
     public var icon: Icon
     public var color: ThemedColor
@@ -50,26 +50,26 @@ public struct ActionLabel {
         self.prominent = prominent
     }
     
-    public func withVisibility(_ visibility: ActionVisiblity) -> ActionLabel {
+    public func withVisibility(_ visibility: ActionVisiblity) -> ActionAppearance {
         var new = self
         new.visibility = visibility
         return new
     }
 
-    public func withProminent(_ value: Bool) -> ActionLabel {
+    public func withProminent(_ value: Bool) -> ActionAppearance {
         var new = self
         new.prominent = prominent
         return new
     }
 
-    public func withTitle(_ title: LocalizedStringResource) -> ActionLabel {
+    public func withTitle(_ title: LocalizedStringResource) -> ActionAppearance {
         var new = self
         new.title = .init(localized: title)
         return new
     }
 
     @_disfavoredOverload
-    public func withTitle(_ title: some StringProtocol) -> ActionLabel {
+    public func withTitle(_ title: some StringProtocol) -> ActionAppearance {
         var new = self
         new.title = String(title)
         return new

--- a/Mlem/Packages/Actions/Sources/Actions/ActionAppearance.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionAppearance.swift
@@ -10,8 +10,7 @@ import Icons
 import Theming
 
 public struct ActionAppearance {
-    public var title: String
-    public var icon: Icon
+    public var labels: ActionLabels
     public var color: ThemedColor
     public var isDestructive: Bool
     public var visibility: ActionVisiblity
@@ -25,8 +24,7 @@ public struct ActionAppearance {
         visibility: ActionVisiblity = .enabled,
         prominent: Bool = false
     ) {
-        self.title = .init(localized: title)
-        self.icon = icon
+        self.labels = .basic(.init(title, icon: icon))
         self.color = color
         self.isDestructive = isDestructive
         self.visibility = visibility
@@ -42,8 +40,7 @@ public struct ActionAppearance {
         visibility: ActionVisiblity = .enabled,
         prominent: Bool = false
     ) {
-        self.title = String(title)
-        self.icon = icon
+        self.labels = .basic(.init(title, icon: icon))
         self.color = color
         self.isDestructive = isDestructive
         self.visibility = visibility
@@ -60,5 +57,13 @@ public struct ActionAppearance {
         var new = self
         new.prominent = prominent
         return new
+    }
+
+    public func label(describing type: ActionLabelType) -> ActionLabel {
+        switch (self.labels, type) {
+        case let (.basic(label), _): label
+        case let (.stateChange(current, _), .currentState): current
+        case let (.stateChange(_, transition), .stateTransition): transition
+        }
     }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/ActionAppearance.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionAppearance.swift
@@ -47,6 +47,24 @@ public struct ActionAppearance {
         self.prominent = prominent
     }
     
+    public init(
+        currentStateLabel: ActionLabel,
+        stateTransitionLabel: ActionLabel,
+        color: ThemedColor = .themedAccent,
+        isDestructive: Bool = false,
+        visibility: ActionVisiblity = .enabled,
+        prominent: Bool = false
+    ) {
+        self.labels = .stateChange(
+            currentState: currentStateLabel,
+            transition: stateTransitionLabel
+        )
+        self.color = color
+        self.isDestructive = isDestructive
+        self.visibility = visibility
+        self.prominent = prominent 
+    }
+    
     public func withVisibility(_ visibility: ActionVisiblity) -> ActionAppearance {
         var new = self
         new.visibility = visibility

--- a/Mlem/Packages/Actions/Sources/Actions/ActionLabel.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionLabel.swift
@@ -15,19 +15,22 @@ public struct ActionLabel {
     public var color: ThemedColor
     public var isDestructive: Bool
     public var visibility: ActionVisiblity
+    public var prominent: Bool
     
     public init(
         _ title: LocalizedStringResource,
         icon: Icon,
         color: ThemedColor = .themedAccent,
         isDestructive: Bool = false,
-        visibility: ActionVisiblity = .enabled
+        visibility: ActionVisiblity = .enabled,
+        prominent: Bool = false
     ) {
         self.title = .init(localized: title)
         self.icon = icon
         self.color = color
         self.isDestructive = isDestructive
         self.visibility = visibility
+        self.prominent = prominent 
     }
     
     @_disfavoredOverload
@@ -36,18 +39,26 @@ public struct ActionLabel {
         icon: Icon,
         color: ThemedColor = .themedAccent,
         isDestructive: Bool = false,
-        visibility: ActionVisiblity = .enabled
+        visibility: ActionVisiblity = .enabled,
+        prominent: Bool = false
     ) {
         self.title = String(title)
         self.icon = icon
         self.color = color
         self.isDestructive = isDestructive
         self.visibility = visibility
+        self.prominent = prominent
     }
     
     public func withVisibility(_ visibility: ActionVisiblity) -> ActionLabel {
         var new = self
         new.visibility = visibility
+        return new
+    }
+
+    public func withProminent(_ value: Bool) -> ActionLabel {
+        var new = self
+        new.prominent = prominent
         return new
     }
 

--- a/Mlem/Packages/Actions/Sources/Actions/ActionLabel.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionLabel.swift
@@ -1,0 +1,25 @@
+//
+//  ActionLabel.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-07-25.
+//
+
+import Foundation
+import Icons
+
+public struct ActionLabel {
+    public let title: String
+    public let icon: Icon
+
+    public init(_ title: LocalizedStringResource, icon: Icon) {
+        self.title = .init(localized: title)
+        self.icon = icon
+    }
+    
+    @_disfavoredOverload
+    public init(_ title: some StringProtocol, icon: Icon) {
+        self.title = String(title)
+        self.icon = icon
+    }
+}

--- a/Mlem/Packages/Actions/Sources/Actions/ActionLabelType.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionLabelType.swift
@@ -1,0 +1,10 @@
+//
+//  ActionLabelType.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-07-25.
+//
+
+public enum ActionLabelType {
+    case currentState, stateTransition
+}

--- a/Mlem/Packages/Actions/Sources/Actions/ActionLabels.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionLabels.swift
@@ -1,0 +1,13 @@
+//
+//  ActionLabels.swift
+//  Mlem
+//
+//  Created by Sjmarf on 2026-07-25.
+//
+
+import Foundation
+
+public enum ActionLabels {
+    case basic(ActionLabel)
+    case stateChange(currentState: ActionLabel, transition: ActionLabel)
+}

--- a/Mlem/Packages/Actions/Sources/Actions/ActionSeed.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/ActionSeed.swift
@@ -11,16 +11,16 @@ public final class ActionSeed: Hashable, Encodable {
     public let key: String
     private let actionType: any Action.Type
     
-    public let label: ActionLabel
+    public let appearance: ActionAppearance
     public let createAction: (Any) -> (any Action)?
-    
+
     public init<T: Action>(
         _ key: String,
-        label: ActionLabel,
+        appearance: ActionAppearance,
         createAction: @escaping (Any) -> T?
     ) {
         self.key = key
-        self.label = label
+        self.appearance = appearance
         self.createAction = createAction
         self.actionType = T.self
     }
@@ -29,7 +29,7 @@ public final class ActionSeed: Hashable, Encodable {
         _ key: String,
         createAction: @escaping (Any) -> T?
     ) {
-        self.init(key, label: T.label, createAction: createAction)
+        self.init(key, appearance: T.appearance, createAction: createAction)
     }
     
     public static func == (lhs: ActionSeed, rhs: ActionSeed) -> Bool {

--- a/Mlem/Packages/Actions/Sources/Actions/BasicAction.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/BasicAction.swift
@@ -17,29 +17,29 @@ import SwiftUI
 /// ```
 ///
 public struct BasicAction: Action {
-    private let label: ActionLabel
+    private let appearance: ActionAppearance
     private let callback: () -> Void
-    
+
     public init(
         _ title: LocalizedStringResource,
         icon: Icon,
         callback: @escaping () -> Void
     ) {
-        self.label = .init(title, icon: icon)
+        self.appearance = .init(title, icon: icon)
         self.callback = callback
     }
-    
+
     @_disfavoredOverload
     public init(
         _ title: String,
         icon: Icon,
         callback: @escaping () -> Void
     ) {
-        self.label = .init(title, icon: icon)
+        self.appearance = .init(title, icon: icon)
         self.callback = callback
     }
 
-    public func createLabel(environment: EnvironmentValues) -> ActionLabel { label }
+    public func createAppearance(environment: EnvironmentValues) -> ActionAppearance { appearance }
     
     public func execute(environment: EnvironmentValues) { callback() }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/SimpleLabelAction.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/SimpleLabelAction.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 public protocol SimpleLabelAction: Action {
-    static var label: ActionLabel { get }
+    static var appearance: ActionAppearance { get }
 }
 
 public extension SimpleLabelAction {
-    func createLabel(environment: EnvironmentValues) -> ActionLabel {
-        Self.label
+    func createAppearance(environment: EnvironmentValues) -> ActionAppearance {
+        Self.appearance
     }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtonWithVisibilityControl.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtonWithVisibilityControl.swift
@@ -17,17 +17,17 @@ public struct ActionButtonWithVisibilityControl: View {
     }
     
     public var body: some View {
-        let label = action.createLabel(environment: environment)
-        if label.visibility != .hidden {
-            Button(label) {
+        let appearance = action.createAppearance(environment: environment)
+        if appearance.visibility != .hidden {
+            Button(appearance) {
                 action.execute(environment: environment)
             }
-            .disabled(label.visibility == .disabled)
+            .disabled(appearance.visibility == .disabled)
 
             // Without this, destructive items appear black in the
             // subscription list due to a shim we've got in there #2374.
             // Intentionally unthemed.
-            .tint(label.isDestructive ? .red : .primary)
+            .tint(appearance.isDestructive ? .red : .primary)
         }
     }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtonWithVisibilityControl.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtonWithVisibilityControl.swift
@@ -11,15 +11,17 @@ public struct ActionButtonWithVisibilityControl: View {
     @Environment(\.self) private var environment
     
     private let action: any Action
+    private let labelType: ActionLabelType
     
-    public init(_ action: any Action) {
+    public init(_ action: any Action, describing labelType: ActionLabelType) {
         self.action = action
+        self.labelType = labelType
     }
     
     public var body: some View {
         let appearance = action.createAppearance(environment: environment)
         if appearance.visibility != .hidden {
-            Button(appearance) {
+            Button(appearance, describing: labelType) {
                 action.execute(environment: environment)
             }
             .disabled(appearance.visibility == .disabled)

--- a/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtons.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/ActionButtons.swift
@@ -15,13 +15,15 @@ public struct ActionButtons: View {
     
     let actions: (EnvironmentValues) -> [any Actions.Action]
     
-    public init(_ actions: @escaping (EnvironmentValues) -> [any Actions.Action]) {
+    public init(
+        _ actions: @escaping (EnvironmentValues) -> [any Actions.Action]
+    ) {
         self.actions = actions
     }
 
     public var body: some View {
         ForEach(Array(actions(environment).enumerated()), id: \.offset) { _, action in
-            ActionButtonWithVisibilityControl(action)
+            ActionButtonWithVisibilityControl(action, describing: .stateTransition)
         }
     }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/Views/Button+Extensions.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/Button+Extensions.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 public extension Button {
-    // Remeber to handle ActionLabel visibility when you use this
+    // Remember to handle ActionAppearance visibility when you use this
     init(
-        _ label: ActionLabel,
+        _ appearance: ActionAppearance,
         callback: @escaping () -> Void
     ) where Label == SwiftUI.Label<Text, Image> {
-        self.init(role: label.isDestructive ? .destructive : nil, action: callback) {
-            Label(label)
+        self.init(role: appearance.isDestructive ? .destructive : nil, action: callback) {
+            Label(appearance)
         }
     }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/Views/Button+Extensions.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/Button+Extensions.swift
@@ -11,10 +11,11 @@ public extension Button {
     // Remember to handle ActionAppearance visibility when you use this
     init(
         _ appearance: ActionAppearance,
+        describing type: ActionLabelType,
         callback: @escaping () -> Void
     ) where Label == SwiftUI.Label<Text, Image> {
         self.init(role: appearance.isDestructive ? .destructive : nil, action: callback) {
-            Label(appearance)
+            Label(appearance, describing: type)
         }
     }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/Views/Label+Extensions.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/Label+Extensions.swift
@@ -10,7 +10,12 @@ import SwiftUI
 
 public extension Label where Title == Text, Icon == Image {
     @inlinable
-    init(_ appearance: ActionAppearance) {
-        self.init(appearance.title, icon: appearance.icon)
+    init(_ appearance: ActionAppearance, describing type: ActionLabelType) {
+        self.init(appearance.label(describing: type))
+    }
+
+    @inlinable
+    init(_ label: ActionLabel) {
+        self.init(label.title, icon: label.icon)
     }
 }

--- a/Mlem/Packages/Actions/Sources/Actions/Views/Label+Extensions.swift
+++ b/Mlem/Packages/Actions/Sources/Actions/Views/Label+Extensions.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 public extension Label where Title == Text, Icon == Image {
     @inlinable
-    init(_ actionLabel: ActionLabel) {
-        self.init(actionLabel.title, icon: actionLabel.icon)
+    init(_ appearance: ActionAppearance) {
+        self.init(appearance.title, icon: appearance.icon)
     }
 }

--- a/Mlem/Packages/Icons/Sources/Icons/Icon+General.swift
+++ b/Mlem/Packages/Icons/Sources/Icons/Icon+General.swift
@@ -17,6 +17,7 @@ public extension Icon {
         public let warning: Icon = .init("exclamationmark.triangle")
         public let error: Icon = .init("exclamationmark.circle")
         
+        @inlinable public var hidden: Icon { hide }
         public let hide: Icon = .init("eye.slash")
         public let show: Icon = .init("eye")
         
@@ -48,7 +49,9 @@ public extension Icon {
         public let `import`: Icon = .init("square.and.arrow.down")
         public let export: Icon = .init("square.and.arrow.up")
         public let edit: Icon = .applyCircle("pencil")
-        public let delete: Icon = .init("trash")
+
+        @inlinable public var deleted: Icon { delete }
+        public let delete: Icon = .init("trash") 
         public let undelete: Icon = .init("trash.slash")
         
         public let copy: Icon = .init("doc.on.doc")
@@ -72,6 +75,8 @@ public extension Icon {
         @inlinable public var muted: Icon { mute }
         public let mute: Icon = .init("speaker.slash")
         public let unmute: Icon = .init("speaker.wave.2")
+
+        @inlinable var collapsed: Icon { collapse }
         
         public let collapse: Icon = .custom { variant in
             switch variant {

--- a/Mlem/Packages/Icons/Sources/Icons/Icon+Lemmy.swift
+++ b/Mlem/Packages/Icons/Sources/Icons/Icon+Lemmy.swift
@@ -55,11 +55,13 @@ public extension Icon {
         
         // MARK: - Mark Read
         
+        @inlinable public var markedRead: Icon { markUnread }
         public let markRead: Icon = .init("envelope.open")
         public let markUnread: Icon = .init("envelope")
         
         // MARK: - Block
         
+        @inlinable public var blocked: Icon { block }
         public let block: Icon = .init("hand.raised")
         public let unblock: Icon = .init("hand.raised.slash")
         
@@ -94,6 +96,12 @@ public extension Icon {
         @inlinable public var bannedFromCommunity: Icon { banFromCommunity }
         public let banFromCommunity: Icon = .init("xmark.shield")
         public let unbanFromCommunity: Icon = .init("checkmark.shield")
+
+        // MARK: - Resolve
+        
+        @inlinable public var resolved: Icon { resolve }
+        public let resolve: Icon = .init("checkmark.circle")
+        public let unresolve: Icon = .init("xmark.circle")
 
         // MARK: - Subscribe
 


### PR DESCRIPTION
This is prep work for rewriting the interaction bar.

# The problem

In some cases, we want an action's label to describe a _transition between states_. For example:
```swift
// When unsaved
Label("Save", systemImage: "bookmark")
// When saved
Label("Unsave", systemImage: "bookmark.slash")
```

However, in the interaction bar, we want the label to describe the _current state_. For example:
```swift
// When unsaved
Label("Unsaved", systemImage: "bookmark")
// When saved
Label("Saved", systemImage: "bookmark.fill")
```

# The solution

Currently, `Action` only supports the "state transition" label and not the "current state" label. In this PR, you can now (optionally) specify two labels when creating an action's appearance:

```swift
static let saveAppearance: ActionAppearance = .init(
    currentStateLabel: .init("Unsaved", icon: .lemmy.saved.representingState(active: false)),
    stateTransitionLabel: .init("Save", icon: .lemmy.addSave),
    color: .themedSave
)
static let unsaveAppearance: ActionAppearance = .init(
    currentStateLabel: .init("Saved", icon: .lemmy.saved.representingState(active: true)),
    stateTransitionLabel: .init("Unsave", icon: .lemmy.removeSave),
    color: .themedSave,
    prominent: true
)
```

# Other changes

I renamed `ActionLabel` -> `ActionAppearance`. This frees up the term `ActionLabel` for use in the new struct. 

```swift
public struct ActionLabel {
    public let title: String
    public let icon: Icon
}
```

The old action system also had a struct called, `ActionAppearance`, which I've renamed to `LegacyActionAppearance`.

I added a `prominent: Bool` property to the new `ActionAppearance`, which will be used to control whether an interaction bar item appears "on". This is equivalent to `isOn` in the old system.

The icons for `VoteAction` and `SaveAction` have been changed. Previously, they reflected current state. They now reflect state transitions, in line with the other actions. `VoteAction` also no longer has squared icons.

<table>
  <tr>
    <td> Before  </td>
    <td> After  </td>
   </tr> 
   <tr>
      <td><img src="https://github.com/user-attachments/assets/a36ccc18-adc5-448c-8d73-5fb0c7dbaca0" />
  </td>
      <td><img  src="https://github.com/user-attachments/assets/9fa8377e-b0a4-42b0-8304-6e270c43f1bb" />
  </td>
  </tr>
</table>