### PR TITLE
Parallelize initial MultiFetcher fetch

### DIFF
--- a/Mlem/Localizable.xcstrings
+++ b/Mlem/Localizable.xcstrings
@@ -810,6 +810,7 @@
       }
     },
     "Actions" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -1662,6 +1663,9 @@
         }
       }
     },
+    "Banned" : {
+
+    },
     "Banned from Community" : {
       "localizations" : {
         "fr" : {
@@ -1759,6 +1763,7 @@
       }
     },
     "Block Instance" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -2518,6 +2523,9 @@
           }
         }
       }
+    },
+    "Collapsed" : {
+
     },
     "Color Scheme" : {
       "localizations" : {
@@ -4269,6 +4277,9 @@
         }
       }
     },
+    "Expanded" : {
+
+    },
     "Expires:" : {
       "localizations" : {
         "fr" : {
@@ -5932,6 +5943,9 @@
         }
       }
     },
+    "Marked NSFW" : {
+
+    },
     "Matrix Room" : {
       "localizations" : {
         "fr" : {
@@ -6622,6 +6636,12 @@
         }
       }
     },
+    "Not Deleted" : {
+
+    },
+    "Not Downvoted" : {
+
+    },
     "Not Guaranteed" : {
       "localizations" : {
         "fr" : {
@@ -6631,6 +6651,12 @@
           }
         }
       }
+    },
+    "Not Marked NSFW" : {
+
+    },
+    "Not Upvoted" : {
+
     },
     "Note" : {
       "localizations" : {
@@ -7184,6 +7210,7 @@
       }
     },
     "Pin to Community or Instance?" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -7232,6 +7259,9 @@
           }
         }
       }
+    },
+    "Pinned" : {
+
     },
     "Pinned to Community" : {
       "localizations" : {
@@ -8323,6 +8353,9 @@
         }
       }
     },
+    "Remove Downvote" : {
+
+    },
     "Remove Moderator" : {
       "localizations" : {
         "fr" : {
@@ -8362,6 +8395,9 @@
           }
         }
       }
+    },
+    "Remove Upvote" : {
+
     },
     "Removed" : {
       "localizations" : {
@@ -10557,6 +10593,9 @@
         }
       }
     },
+    "TODO" : {
+
+    },
     "Toggle Developer Tools" : {
       "localizations" : {
         "fr" : {
@@ -10867,6 +10906,9 @@
         }
       }
     },
+    "Unbanned" : {
+
+    },
     "Unbanned: %@\nFrom: %@" : {
       "localizations" : {
         "en" : {
@@ -10904,6 +10946,7 @@
       }
     },
     "Unblock Community" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -10914,6 +10957,7 @@
       }
     },
     "Unblock Instance" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -10924,6 +10968,7 @@
       }
     },
     "Unblock User" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -10934,6 +10979,7 @@
       }
     },
     "Unblock..." : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -11005,6 +11051,7 @@
       }
     },
     "Unfavorite" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en-GB" : {
           "stringUnit" : {
@@ -11096,6 +11143,9 @@
         }
       }
     },
+    "Unlocked" : {
+
+    },
     "Unmute" : {
       "localizations" : {
         "fr" : {
@@ -11156,6 +11206,9 @@
         }
       }
     },
+    "Unpinned" : {
+
+    },
     "Unread" : {
       "localizations" : {
         "fr" : {
@@ -11165,6 +11218,9 @@
           }
         }
       }
+    },
+    "Unremoved" : {
+
     },
     "Unresolve" : {
       "localizations" : {
@@ -11176,6 +11232,9 @@
         }
       }
     },
+    "Unresolved" : {
+
+    },
     "Unsave" : {
       "localizations" : {
         "fr" : {
@@ -11185,6 +11244,9 @@
           }
         }
       }
+    },
+    "Unsaved" : {
+
     },
     "Unsubscribe" : {
       "localizations" : {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
@@ -27,6 +27,7 @@ class MultiFetcher<Item: FeedLoadable>: Fetcher<Item> {
                     do {
                         try await source.loadMoreItems()
                     } catch {
+                        self.log.error("\(error.localizedDescription)")
                         // noop - if the error recurs it will be caught by normal error handling below.
                         // prefetch is not required to succeed for loading to work
                     }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
@@ -21,13 +21,15 @@ class MultiFetcher<Item: FeedLoadable>: Fetcher<Item> {
     
     override func fetch() async throws -> LoadingResponse<Item> {
         // preemptively trigger loading on all child feed loaders if they have not loaded anything yet
-        for source in sources where source.fetcher.location == .start {
-            Task {
-                do {
-                    try await source.loadMoreItems()
-                } catch {
-                    // noop - if the error recurs it will be caught by normal error handling below.
-                    // prefetch is not required to succeed for loading to work
+        await withTaskGroup(of: Void.self) { taskGroup in
+            for source in sources where source.fetcher.location == .start {
+                taskGroup.addTask {
+                    do {
+                        try await source.loadMoreItems()
+                    } catch {
+                        // noop - if the error recurs it will be caught by normal error handling below.
+                        // prefetch is not required to succeed for loading to work
+                    }
                 }
             }
         }

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
@@ -20,6 +20,13 @@ class MultiFetcher<Item: FeedLoadable>: Fetcher<Item> {
     }
     
     override func fetch() async throws -> LoadingResponse<Item> {
+        // preemptively trigger loading on all child feed loaders if they have not loaded anything yet
+        for source in sources where source.fetcher.location == .start {
+            Task {
+                try await source.loadMoreItems()
+            }
+        }
+        
         var newItems: [Item] = .init()
         
         while newItems.count < pageSize {

--- a/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
+++ b/Mlem/Packages/MlemMiddleware/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
@@ -23,7 +23,12 @@ class MultiFetcher<Item: FeedLoadable>: Fetcher<Item> {
         // preemptively trigger loading on all child feed loaders if they have not loaded anything yet
         for source in sources where source.fetcher.location == .start {
             Task {
-                try await source.loadMoreItems()
+                do {
+                    try await source.loadMoreItems()
+                } catch {
+                    // noop - if the error recurs it will be caught by normal error handling below.
+                    // prefetch is not required to succeed for loading to work
+                }
             }
         }
         


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

We assume you have read CONTRIBUTING.md. If you have not, do not be surprised if your PR is rejected for reasons listed therein.

Please note that if your PR does not address an issue that was assigned to you, you are still welcome to open it; however, it will not receive merge priority and may be rejected for scope reasons.
-->

## Issues

- closes #2808 

## Description

`MultiFetcher.fetch` now triggers all empty child sources to load their first page in parallel. This should reduce the loading time of the first aggregate page from the sum of all source loading times to the maximum individual source loading time.