### PR TITLE
Fix image sharing regression

### DIFF
--- a/Mlem/App/Logic/ImageFunctions.swift
+++ b/Mlem/App/Logic/ImageFunctions.swift
@@ -82,7 +82,7 @@ private func getFileName(url: URL, data: Data) throws(FileDownloadError) -> Stri
     let url = url.unwrapProxy()
 
     if !url.pathExtension.isEmpty {
-        return url.pathExtension
+        return url.lastPathComponent
     }
 
     // Infer file type from the image data


### PR DESCRIPTION
Fix regression introduced in #2876. When sharing an image, the file name would be /just/ the file extension, rather than the last path component as was intended